### PR TITLE
Refactor Tests Script for preparing ACVP python script Integration

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -72,12 +72,12 @@ runs:
       run: |
         ./scripts/tests bench -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
               --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" \
-              $([[ ${{ inputs.opt }} == "false" ]] && echo "--no-opt")  \
+              --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v --output=output.json ${{ inputs.bench_extra_args }}
 
         ./scripts/tests bench --components -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
               --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" \
-              $([[ ${{ inputs.opt }} == "false" ]] && echo "--no-opt")  \
+              --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v --output=output.json ${{ inputs.bench_extra_args }}
     - name: Check namespace
       shell: ${{ env.SHELL }}

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -26,8 +26,8 @@ inputs:
     description: For auto-determining the default cross-prefix (e.g. native | cross )
     default: "native"
   opt:
-    description: opt flag to pass to test script
-    default: "true"
+    description: Whether to build opt/non-opt binaries or all (all | opt | no_opt)
+    default: "all"
   func:
     description: Determine whether to run functional test or not
     default: "true"
@@ -52,7 +52,6 @@ runs:
           fi
 
           echo _CROSS_PREFIX="$_cross_prefix" >> $GITHUB_ENV
-          echo OPT="${{ inputs.opt == 'true' && 'opt' || 'no-opt' }}" >> $GITHUB_ENV
           echo FUNC="${{ inputs.func == 'true' && 'func' || 'no-func' }}" >> $GITHUB_ENV
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
           echo NISTKAT="${{ inputs.nistkat == 'true' && 'nistkat' || 'no-nistkat' }}" >> $GITHUB_ENV
@@ -84,15 +83,11 @@ runs:
             - $(bash --version | grep -m1 "")
             - $(${_CROSS_PREFIX}${CC} --version | grep -m1 "")
           EOF
-      - name: Compile ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
+      - name: ${{ inputs.mode }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --compile --no-run -v
-      - name: Run ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
-        shell: ${{ env.SHELL }}
-        run: |
-          tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --no-compile --run -v
-      - name: Check namespacing ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
+          tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} -v
+      - name: Check namespacing ${{ inputs.mode }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
           check-namespace

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: all | native | cross
     default: "native"
   opt:
-    description: all | opt | non-opt
+    description: all | opt | no_opt
     default: "all"
   func:
     description: Determine whether to run functional test or not
@@ -40,8 +40,8 @@ inputs:
 runs:
   using: composite
   steps:
-      - name: Native Opt Tests
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'native') && (inputs.opt == 'all' || inputs.opt == 'opt') }}
+      - name: Native Tests
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'native') }}
         uses: ./.github/actions/functest
         with:
           nix-shell: ${{ inputs.nix-shell }}
@@ -51,27 +51,12 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           mode: native
-          opt: true
+          opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
           nistkat: ${{ inputs.nistkat }}
-      - name: Native Non-opt Tests
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'native') && (inputs.opt == 'all' || inputs.opt == 'non-opt') && (success() || failure()) }}
-        uses: ./.github/actions/functest
-        with:
-          nix-shell: ${{ inputs.nix-shell }}
-          nix-cache: ${{ inputs.nix-cache }}
-          nix-verbose: ${{ inputs.nix-verbose }}
-          gh_token: ${{ inputs.gh_token }}
-          custom_shell: ${{ inputs.custom_shell }}
-          cflags: ${{ inputs.cflags }}
-          mode: native
-          opt: false
-          func: ${{ inputs.func }}
-          kat: ${{ inputs.kat }}
-          nistkat: ${{ inputs.nistkat }}
-      - name: Cross Opt Tests
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross') && (inputs.opt == 'all' || inputs.opt == 'opt') && (success() || failure()) }}
+      - name: Cross Tests
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross') && (success() || failure()) }}
         uses: ./.github/actions/functest
         with:
           nix-shell: ${{ inputs.nix-shell }}
@@ -81,22 +66,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           mode: cross
-          opt: true
-          func: ${{ inputs.func }}
-          kat: ${{ inputs.kat }}
-          nistkat: ${{ inputs.nistkat }}
-      - name: Cross Non-opt Tests
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross') && (inputs.opt == 'all' || inputs.opt == 'non-opt') && (success() || failure()) }}
-        uses: ./.github/actions/functest
-        with:
-          nix-shell: ${{ inputs.nix-shell }}
-          nix-cache: ${{ inputs.nix-cache }}
-          nix-verbose: ${{ inputs.nix-verbose }}
-          gh_token: ${{ inputs.gh_token }}
-          custom_shell: ${{ inputs.custom_shell }}
-          cflags: ${{ inputs.cflags }}
-          mode: cross
-          opt: false
+          opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
           nistkat: ${{ inputs.nistkat }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -64,7 +64,7 @@ jobs:
         opt:
           - name: opt
             value: true
-          - name: non-opt
+          - name: no_opt
             value: false
         target:
           - name: Graviton2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
       ec2_ami: ubuntu-latest (custom AMI)
       ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
       compile_mode: native
-      opt: non-opt
+      opt: no_opt
       lint: false
       verbose: true
       functest: true
@@ -268,7 +268,7 @@ jobs:
       ec2_ami: ubuntu-latest (custom AMI)
       ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
       compile_mode: native
-      opt: non-opt
+      opt: no_opt
       lint: false
       verbose: true
       functest: true
@@ -290,7 +290,7 @@ jobs:
       ec2_ami: ubuntu-latest (custom AMI)
       ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
       compile_mode: native
-      opt: non-opt
+      opt: no_opt
       lint: false
       verbose: true
       functest: true

--- a/.github/workflows/ci_ec2_any.yml
+++ b/.github/workflows/ci_ec2_any.yml
@@ -40,12 +40,12 @@ on:
           - none
         default: all
       opt:
-        description: Indicates to compile and run the opt/non-opt binary or both.
+        description: Determine whether to compile and run the opt/no_opt binary or both.
         type: choice
         options:
           - all
           - opt
-          - non-opt
+          - no_opt
         default: all
       cbmc:
         description: Whether to run CBMC proofs

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -36,7 +36,7 @@ on:
         default: all
       opt:
         type: string
-        description: either all, opt or non-opt
+        description: either all, opt or no_opt
         default: all
       functest:
         type: boolean

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode
 .idea
 test/build
+__pycache__/

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import platform
+import os
+import sys
+import io
+import logging
+import subprocess
+from functools import reduce
+from typing import Optional, Callable, TypedDict
+from util import (
+    TEST_TYPES,
+    SCHEME,
+    sha256sum,
+    parse_meta,
+    config_logger,
+    github_summary,
+)
+import copy
+
+
+class State(object):
+
+    def __init__(self):
+        self.verbose = False
+        self.cross_prefix = ""
+        self.cflags = ""
+        self.arch_flags = ""
+        self.auto = True
+        self.compile = True
+        self.run = True
+
+    def compile_schemes(
+        self,
+        test_type: TEST_TYPES,
+        extra_make_envs={},
+        extra_make_args=[],
+    ):
+        """compile or cross compile with some extra environment variables and makefile arguments"""
+
+        def dict2str(dict):
+            s = ""
+            for k, v in dict.items():
+                s += f"{k}={v} "
+            return s
+
+        logging.debug(f"Compiling {test_type}...")
+        args = [
+            "make",
+            f"CROSS_PREFIX={self.cross_prefix}",
+            f"{test_type}",
+        ] + extra_make_args
+
+        logging.info(dict2str(extra_make_envs) + " ".join(args))
+
+        p = subprocess.run(
+            args,
+            stdout=subprocess.DEVNULL if not self.verbose else None,
+            env=os.environ.copy() | extra_make_envs,
+        )
+
+        if p.returncode != 0:
+            logging.error(f"make failed: {p.returncode}")
+            sys.exit(1)
+
+    def run_scheme(
+        self,
+        bin: str,
+        run_as_root=False,
+        exec_wrapper=None,
+    ) -> bytes:
+        """Run the binary in all different ways"""
+        if not os.path.isfile(bin):
+            logging.error(f"{bin} does not exists")
+            sys.exit(1)
+
+        cmd = [f"./{bin}"]
+        if self.cross_prefix and platform.system() != "Darwin":
+            logging.info(f"Emulating {bin} with QEMU")
+            if "x86_64" in self.cross_prefix:
+                cmd = ["qemu-x86_64"] + cmd
+            elif "aarch64" in self.cross_prefix:
+                cmd = ["qemu-aarch64"] + cmd
+            else:
+                logging.info(
+                    f"Emulation for {self.cross_prefix} on {platform.system()} not supported"
+                )
+
+        if run_as_root:
+            logging.info(
+                f"Running {bin} as root -- you may need to enter your root password."
+            )
+            cmd = ["sudo"] + cmd
+
+        if exec_wrapper:
+            logging.info(f"Running {bin} with customized wrapper.")
+            exec_wrapper = exec_wrapper.split(" ")
+            cmd = exec_wrapper + cmd
+
+        logging.info(" ".join(cmd))
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            universal_newlines=False,
+        )
+
+        if result.returncode != 0:
+            logging.error(
+                f"Running '{cmd}' failed: {result.returncode} {result.stderr.decode()}"
+            )
+            sys.exit(1)
+
+        return result.stdout
+
+    def run_schemes(
+        self,
+        test_type: TEST_TYPES,
+        opt: bool,
+        run_as_root=False,
+        exec_wrapper=None,
+        actual_proc: Callable[[bytes], str] = None,
+        expect_proc: Callable[[SCHEME], str] = None,
+    ) -> TypedDict:
+        fail = False
+        results = {}
+        for scheme in SCHEME:
+            result = self.run_scheme(
+                test_type.bin_path(scheme),
+                run_as_root,
+                exec_wrapper,
+            )
+
+            if actual_proc is not None and expect_proc is not None:
+                actual = actual_proc(result)
+                expect = expect_proc(scheme)
+                f = actual != expect
+                fail = fail or f
+                if f:
+                    logging.error(
+                        f"{scheme} failed, expecting {expect}, but getting {actual}"
+                    )
+                else:
+                    logging.info(f"{scheme} passed")
+                results[scheme] = f
+            else:
+                logging.info(f"{scheme}")
+                logging.info(f"\n{result.decode()}")
+                results[scheme] = result.decode()
+
+        if fail:
+            sys.exit(1)
+
+        return results
+
+    def test(
+        self,
+        test_type: TEST_TYPES,
+        opt: bool,
+        extra_make_envs={},
+        extra_make_args=[],
+        actual_proc: Callable[[bytes], str] = None,
+        expect_proc: Callable[[SCHEME], str] = None,
+        run_as_root: bool = False,
+        exec_wrapper: str = None,
+    ):
+        config_logger(self.verbose)
+
+        logging.info(
+            f'{test_type.desc()} ({"cross" if self.cross_prefix else "native"}, {"opt" if opt else "no_opt"})'
+        )
+
+        make_envs = (
+            {"CFLAGS": f"{self.cflags}"} if self.cflags is not None else {}
+        ) | (
+            {"ARCH_FLAGS": f"{self.arch_flags}"} if self.arch_flags is not None else {}
+        )
+        make_envs.update(extra_make_envs)
+
+        if self.compile:
+            self.compile_schemes(
+                test_type,
+                make_envs,
+                extra_make_args
+                + list(
+                    set([f"OPT={int(opt)}", f"AUTO={int(self.auto)}"])
+                    - set(extra_make_args)
+                ),
+            )
+
+        results = None
+        if self.run:
+            results = self.run_schemes(
+                test_type,
+                opt,
+                run_as_root,
+                exec_wrapper,
+                actual_proc,
+                expect_proc,
+            )
+
+            title = (
+                "## "
+                + ("Cross" if self.cross_prefix else "Native")
+                + " "
+                + ("Opt" if opt else "Non-opt")
+                + " Tests"
+            )
+            github_summary(title, test_type, results)
+
+        return results
+
+
+"""
+Underlying functional tests
+
+"""
+
+
+class Tests:
+    def func(self, state: State, opt: bool):
+        """Underlying function for functional test"""
+
+        def expect(scheme: SCHEME) -> str:
+            sk_bytes = parse_meta(scheme, "length-secret-key")
+            pk_bytes = parse_meta(scheme, "length-public-key")
+            ct_bytes = parse_meta(scheme, "length-ciphertext")
+
+            return (
+                f"CRYPTO_SECRETKEYBYTES:  {sk_bytes}\n"
+                + f"CRYPTO_PUBLICKEYBYTES:  {pk_bytes}\n"
+                + f"CRYPTO_CIPHERTEXTBYTES: {ct_bytes}\n"
+            )
+
+        state.test(
+            TEST_TYPES.MLKEM,
+            opt,
+            actual_proc=lambda result: str(result, encoding="utf-8"),
+            expect_proc=expect,
+        )
+
+    def nistkat(self, state: State, opt: bool):
+        """Underlying function for nistkat test"""
+
+        state.test(
+            TEST_TYPES.NISTKAT,
+            opt,
+            actual_proc=sha256sum,
+            expect_proc=lambda scheme: parse_meta(scheme, "nistkat-sha256"),
+        )
+
+    def kat(self, state: State, opt: bool):
+        """Underlying function for kat test"""
+
+        state.test(
+            TEST_TYPES.KAT,
+            opt,
+            actual_proc=sha256sum,
+            expect_proc=lambda scheme: parse_meta(scheme, "kat-sha256"),
+        )
+
+    def bench(
+        self,
+        state: State,
+        opt: bool,
+        cycles: str,
+        output,
+        run_as_root: bool,
+        exec_wrapper: str,
+        mac_taskpolicy,
+        components,
+    ):
+        config_logger(state.verbose)
+
+        if components is False:
+            bench_type = TEST_TYPES.BENCH
+        else:
+            bench_type = TEST_TYPES.BENCH_COMPONENTS
+            output = False
+
+        if mac_taskpolicy:
+            if exec_wrapper:
+                logging.error(f"cannot set both --mac-taskpolicy and --exec-wrapper")
+                sys.exit(1)
+            else:
+                exec_wrapper = f"taskpolicy -c {mac_taskpolicy}"
+
+        results = state.test(
+            bench_type,
+            opt,
+            extra_make_args=[f"CYCLES={cycles}"],
+            run_as_root=run_as_root,
+            exec_wrapper=exec_wrapper,
+        )
+
+        if results is not None and output is not None and components is False:
+            import json
+
+            with open(output, "w") as f:
+                v = []
+                for scheme in results:
+                    schemeStr = str(scheme)
+                    r = results[scheme]
+
+                    # The first 3 lines of the output are expected to be
+                    # keypair cycles=X
+                    # encaps cycles=X
+                    # decaps cycles=X
+
+                    lines = [line for line in r.splitlines() if "=" in line]
+
+                    d = {k.strip(): int(v) for k, v in (l.split("=") for l in lines)}
+                    for primitive in ["keypair", "encaps", "decaps"]:
+                        v.append(
+                            {
+                                "name": f"{schemeStr} {primitive}",
+                                "unit": "cycles",
+                                "value": d[f"{primitive} cycles"],
+                            }
+                        )
+                f.write(json.dumps(v))
+
+    def all(self, state: State, opt: str, func: bool, kat: bool, nistkat: bool):
+        compile_mode = "cross" if state.cross_prefix else "native"
+
+        gh_env = os.environ.get("GITHUB_ENV")
+
+        tests = [
+            *([self.func] if func else []),
+            *([self.nistkat] if nistkat else []),
+            *([self.kat] if kat else []),
+        ]
+
+        exit_code = 0
+
+        if state.compile:
+            _state = copy.deepcopy(state)
+            _state.run = False
+
+            def _compile(opt: bool):
+                opt_label = "opt" if opt else "no-opt"
+                for f in tests:
+                    if gh_env is not None:
+                        print(
+                            f"::group::compile {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
+                        )
+
+                    try:
+                        f(_state, opt)
+                        print("")
+                    except SystemExit as e:
+                        exit_code = exit_code or e
+
+                    if gh_env is not None:
+                        print(f"::endgroup::")
+                    sys.stdout.flush()
+
+            if opt.lower() == "all" or opt.lower() == "no_opt":
+                _compile(False)
+
+            if opt.lower() == "all" or opt.lower() == "opt":
+                _compile(True)
+
+        if state.run:
+            _state = state
+            _state.compile = False
+
+            def _run(f, _state: State, opt: bool):
+                opt_label = "opt" if opt else "no-opt"
+                if gh_env is not None:
+                    print(
+                        f"::group::run {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
+                    )
+
+                try:
+                    f(_state, opt)
+                except SystemExit as e:
+                    exit_code = exit_code or e
+
+                if gh_env is not None:
+                    print(f"::endgroup::")
+                sys.stdout.flush()
+
+            for f in tests:
+                if opt.lower() == "all" or opt.lower() == "no_opt":
+                    _run(f, _state, False)
+                if opt.lower() == "all" or opt.lower() == "opt":
+                    _run(f, _state, True)
+
+        exit(exit_code)

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -159,15 +159,20 @@ def github_summary(title: str, test: TEST_TYPES, results: TypedDict):
 
 
 def config_logger(verbose):
+    logging.basicConfig(format="%(levelname)-5s > %(name)-40s %(message)s")
+
+    logger = logging.getLogger()
+
     if verbose:
-        logging.basicConfig(
-            stream=sys.stdout,
-            format="%(levelname)-5s > %(message)s",
-            level=logging.DEBUG,
-        )
+        logger.setLevel(logging.DEBUG)
     else:
-        logging.basicConfig(
-            stream=sys.stdout,
-            format="%(levelname)-5s > %(message)s",
-            level=logging.INFO,
-        )
+        logger.setLevel(logging.INFO)
+
+
+def logger(test_type: TEST_TYPES, scheme: SCHEME, cross_prefix: str, opt: bool):
+    compile_mode = "cross" if cross_prefix else "native"
+    implementation = "opt" if opt else "no_opt"
+
+    return logging.getLogger(
+        f"{test_type.desc():<15} {str(scheme):<11} ({compile_mode:<6}, {implementation:>6})"
+    )

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import hashlib
+import logging
+from enum import IntEnum
+from typing import TypedDict
+from functools import reduce
+import yaml
+
+
+def sha256sum(result: bytes) -> str:
+    m = hashlib.sha256()
+    m.update(result)
+    return m.hexdigest()
+
+
+class SCHEME(IntEnum):
+    MLKEM512 = 1
+    MLKEM768 = 2
+    MLKEM1024 = 3
+
+    def __str__(self):
+        match self:
+            case SCHEME.MLKEM512:
+                return "ML-KEM-512"
+            case SCHEME.MLKEM768:
+                return "ML-KEM-768"
+            case SCHEME.MLKEM1024:
+                return "ML-KEM-1024"
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self + 1
+
+    def suffix(self):
+        return self.name.removeprefix("MLKEM")
+
+
+class TEST_TYPES(IntEnum):
+    MLKEM = 1
+    BENCH = 2
+    NISTKAT = 3
+    KAT = 4
+    BENCH_COMPONENTS = 5
+
+    def __str__(self):
+        return self.name.lower()
+
+    def desc(self):
+        match self:
+            case TEST_TYPES.MLKEM:
+                return "Functional Test"
+            case TEST_TYPES.BENCH:
+                return "Benchmark"
+            case TEST_TYPES.BENCH_COMPONENTS:
+                return "Benchmark Components"
+            case TEST_TYPES.NISTKAT:
+                return "Nistkat Test"
+            case TEST_TYPES.KAT:
+                return "Kat Test"
+
+    def bin(self):
+        match self:
+            case TEST_TYPES.MLKEM:
+                return "test_mlkem"
+            case TEST_TYPES.BENCH:
+                return "bench_mlkem"
+            case TEST_TYPES.BENCH_COMPONENTS:
+                return "bench_components_mlkem"
+            case TEST_TYPES.NISTKAT:
+                return "gen_NISTKAT"
+            case TEST_TYPES.KAT:
+                return "gen_KAT"
+
+    def bin_path(self, scheme: SCHEME):
+        return f"test/build/{scheme.name.lower()}/bin/{self.bin()}{scheme.suffix()}"
+
+
+def parse_meta(scheme: SCHEME, field: str) -> str:
+    with open("META.yml", "r") as f:
+        meta = yaml.safe_load(f)
+    return meta["implementations"][int(scheme) - 1][field]
+
+
+def github_summary(title: str, test: TEST_TYPES, results: TypedDict):
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+
+    res = list(results.values())
+
+    if isinstance(results[SCHEME.MLKEM512], str):
+        summaries = list(
+            map(
+                lambda s: f" {s} |",
+                reduce(
+                    lambda acc, s: [
+                        line1 + " | " + line2 for line1, line2 in zip(acc, s)
+                    ],
+                    [s.splitlines() for s in res],
+                ),
+            )
+        )
+        summaries = [f"| {test.desc()} |" + summaries[0]] + [
+            "| |" + x for x in summaries[1:]
+        ]
+    else:
+        summaries = [
+            reduce(
+                lambda acc, b: f"{acc} " + (":x: |" if b else ":white_check_mark: |"),
+                res,
+                f"| {test.desc()} |",
+            )
+        ]
+
+    def find_last_consecutive_match(l, s):
+        for i, v in enumerate(l[s + 1 :]):
+            if not v.startswith("|") or not v.endswith("|"):
+                return i + 1
+        return len(l)
+
+    def add_summaries(fn, title, summaries):
+        summary_title = "| Tests |"
+        summary_table_format = "| ----- |"
+        for s in SCHEME:
+            summary_title += f" {s} |"
+            summary_table_format += " ----- |"
+
+        with open(fn, "r") as f:
+            pre_summaries = [x for x in f.read().splitlines() if x]
+            if title in pre_summaries:
+                if summary_title not in pre_summaries:
+                    summaries = [summary_title, summary_table_format] + summaries
+                    pre_summaries = (
+                        pre_summaries[: pre_summaries.index(title) + 1]
+                        + summaries
+                        + pre_summaries[pre_summaries.index(title) + 1 :]
+                    )
+                else:
+                    i = find_last_consecutive_match(
+                        pre_summaries, pre_summaries.index(title)
+                    )
+                    pre_summaries = pre_summaries[:i] + summaries + pre_summaries[i:]
+                return ("w", pre_summaries)
+            else:
+                pre_summaries = [
+                    title,
+                    summary_title,
+                    summary_table_format,
+                ] + summaries
+                return ("a", pre_summaries)
+
+    if summary_file is not None:
+        (access_mode, summaries) = add_summaries(summary_file, title, summaries)
+        with open(summary_file, access_mode) as f:
+            print("\n".join(summaries), file=f)
+
+
+def config_logger(verbose):
+    if verbose:
+        logging.basicConfig(
+            stream=sys.stdout,
+            format="%(levelname)-5s > %(message)s",
+            level=logging.DEBUG,
+        )
+    else:
+        logging.basicConfig(
+            stream=sys.stdout,
+            format="%(levelname)-5s > %(message)s",
+            level=logging.INFO,
+        )

--- a/scripts/tests
+++ b/scripts/tests
@@ -10,7 +10,6 @@ import logging
 import click
 import hashlib
 import yaml
-import asyncio
 from functools import reduce
 from enum import IntEnum
 from typing import Optional, Callable, TypedDict
@@ -259,7 +258,7 @@ class State(object):
             exec_wrapper = exec_wrapper.split(" ")
             cmd = exec_wrapper + cmd
 
-        logging.info(" ".join(cmd))
+        logging.debug(" ".join(cmd))
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -748,7 +747,7 @@ def all(
 
         return code
 
-    async def run(f, _state: State, opt: bool):
+    def run(f, _state: State, opt: bool):
         code = 0
         opt_label = "opt" if opt else "no-opt"
         if gh_env is not None:
@@ -756,14 +755,10 @@ def all(
                 f"::group::run {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
             )
 
-        with redirect_stdout(io.StringIO()) as out:
-            try:
-                f(_state, opt)
-            except SystemExit as e:
-                code = e
-
-        if out:
-            print(out.getvalue())
+        try:
+            f(_state, opt)
+        except SystemExit as e:
+            code = e
 
         if gh_env is not None:
             print(f"::endgroup::")
@@ -771,31 +766,28 @@ def all(
 
         return code
 
-    async def run_all(_state: State, opt: str):
-        ts = []
-        async with asyncio.TaskGroup() as g:
-            for f in tests:
-                if opt.lower() == "all" or opt.lower() == "no_opt":
-                    ts.append(g.create_task(run(f, _state, False)))
-                if opt.lower() == "all" or opt.lower() == "opt":
-                    ts.append(g.create_task(run(f, _state, True)))
-        return reduce(lambda acc, c: acc or c, map(lambda t: t.result(), ts), exit_code)
+    def run_all(_state: State, opt: str):
+        code = 0
+        for f in tests:
+            if opt.lower() == "all" or opt.lower() == "no_opt":
+                code = code or run(f, _state, False)
+            if opt.lower() == "all" or opt.lower() == "opt":
+                code = code or run(f, _state, True)
+        return code
 
     exit_code = 0
 
-    # sequentially compile
     if state.compile:
         _state = copy.deepcopy(state)
         _state.run = False
 
         exit_code = compile_all(_state, opt)
 
-    # parallelly run
     if state.run:
         _state = state
         _state.compile = False
 
-        exit_code = asyncio.run(run_all(_state, opt))
+        exit_code = exit_code or run_all(_state, opt)
 
     exit(exit_code)
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -2,424 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import platform
-import sys
-import io
 import os
-import subprocess
-import logging
+import sys
 import click
-import hashlib
-import yaml
 from functools import reduce
-from enum import IntEnum
-from typing import Optional, Callable, TypedDict
-from contextlib import redirect_stdout, redirect_stderr
-import copy
 
-
-def config_logger(verbose):
-    if verbose:
-        logging.basicConfig(
-            stream=sys.stdout,
-            format="%(levelname)-5s > %(message)s",
-            level=logging.DEBUG,
-        )
-    else:
-        logging.basicConfig(
-            stream=sys.stdout,
-            format="%(levelname)-5s > %(message)s",
-            level=logging.INFO,
-        )
-
-
-def sha256sum(result: bytes) -> str:
-    m = hashlib.sha256()
-    m.update(result)
-    return m.hexdigest()
-
-
-class TEST_TYPES(IntEnum):
-    MLKEM = 1
-    BENCH = 2
-    NISTKAT = 3
-    KAT = 4
-    BENCH_COMPONENTS = 5
-
-    def __str__(self):
-        return self.name.lower()
-
-    def desc(self):
-        match self:
-            case TEST_TYPES.MLKEM:
-                return "Functional Test"
-            case TEST_TYPES.BENCH:
-                return "Benchmark"
-            case TEST_TYPES.BENCH_COMPONENTS:
-                return "Benchmark Components"
-            case TEST_TYPES.NISTKAT:
-                return "Nistkat Test"
-            case TEST_TYPES.KAT:
-                return "Kat Test"
-
-    def bin(self):
-        match self:
-            case TEST_TYPES.MLKEM:
-                return "test_mlkem"
-            case TEST_TYPES.BENCH:
-                return "bench_mlkem"
-            case TEST_TYPES.BENCH_COMPONENTS:
-                return "bench_components_mlkem"
-            case TEST_TYPES.NISTKAT:
-                return "gen_NISTKAT"
-            case TEST_TYPES.KAT:
-                return "gen_KAT"
-
-    def bin_path(self, scheme):
-        return f"test/build/{scheme.name.lower()}/bin/{self.bin()}{scheme.suffix()}"
-
-
-class SCHEME(IntEnum):
-    MLKEM512 = 1
-    MLKEM768 = 2
-    MLKEM1024 = 3
-
-    def __str__(self):
-        match self:
-            case SCHEME.MLKEM512:
-                return "ML-KEM-512"
-            case SCHEME.MLKEM768:
-                return "ML-KEM-768"
-            case SCHEME.MLKEM1024:
-                return "ML-KEM-1024"
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return self + 1
-
-    def suffix(self):
-        return self.name.removeprefix("MLKEM")
-
-
-def parse_meta(scheme: SCHEME, field: str) -> str:
-    with open("META.yml", "r") as f:
-        meta = yaml.safe_load(f)
-    return meta["implementations"][int(scheme) - 1][field]
-
-
-def github_summary(title: str, test: TEST_TYPES, results: TypedDict):
-    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
-
-    res = list(results.values())
-
-    if isinstance(results[SCHEME.MLKEM512], str):
-        summaries = list(
-            map(
-                lambda s: f" {s} |",
-                reduce(
-                    lambda acc, s: [
-                        line1 + " | " + line2 for line1, line2 in zip(acc, s)
-                    ],
-                    [s.splitlines() for s in res],
-                ),
-            )
-        )
-        summaries = [f"| {test.desc()} |" + summaries[0]] + [
-            "| |" + x for x in summaries[1:]
-        ]
-    else:
-        summaries = [
-            reduce(
-                lambda acc, b: f"{acc} " + (":x: |" if b else ":white_check_mark: |"),
-                res,
-                f"| {test.desc()} |",
-            )
-        ]
-
-    def find_last_consecutive_match(l, s):
-        for i, v in enumerate(l[s + 1 :]):
-            if not v.startswith("|") or not v.endswith("|"):
-                return i + 1
-        return len(l)
-
-    def add_summaries(fn, title, summaries):
-        summary_title = "| Tests |"
-        summary_table_format = "| ----- |"
-        for s in SCHEME:
-            summary_title += f" {s} |"
-            summary_table_format += " ----- |"
-
-        with open(fn, "r") as f:
-            pre_summaries = [x for x in f.read().splitlines() if x]
-            if title in pre_summaries:
-                if summary_title not in pre_summaries:
-                    summaries = [summary_title, summary_table_format] + summaries
-                    pre_summaries = (
-                        pre_summaries[: pre_summaries.index(title) + 1]
-                        + summaries
-                        + pre_summaries[pre_summaries.index(title) + 1 :]
-                    )
-                else:
-                    i = find_last_consecutive_match(
-                        pre_summaries, pre_summaries.index(title)
-                    )
-                    pre_summaries = pre_summaries[:i] + summaries + pre_summaries[i:]
-                return ("w", pre_summaries)
-            else:
-                pre_summaries = [
-                    title,
-                    summary_title,
-                    summary_table_format,
-                ] + summaries
-                return ("a", pre_summaries)
-
-    if summary_file is not None:
-        (access_mode, summaries) = add_summaries(summary_file, title, summaries)
-        with open(summary_file, access_mode) as f:
-            print("\n".join(summaries), file=f)
-
-
-class State(object):
-
-    def __init__(self):
-        self.verbose = False
-        self.cross_prefix = ""
-        self.cflags = ""
-        self.arch_flags = ""
-        self.auto = True
-        self.compile = True
-        self.run = True
-
-    def compile_schemes(
-        self,
-        test_type: TEST_TYPES,
-        extra_make_envs={},
-        extra_make_args=[],
-    ):
-        """compile or cross compile with some extra environment variables and makefile arguments"""
-
-        def dict2str(dict):
-            s = ""
-            for k, v in dict.items():
-                s += f"{k}={v} "
-            return s
-
-        logging.debug(f"Compiling {test_type}...")
-        args = [
-            "make",
-            f"CROSS_PREFIX={self.cross_prefix}",
-            f"{test_type}",
-        ] + extra_make_args
-
-        logging.info(dict2str(extra_make_envs) + " ".join(args))
-
-        p = subprocess.run(
-            args,
-            stdout=subprocess.DEVNULL if not self.verbose else None,
-            env=os.environ.copy() | extra_make_envs,
-        )
-
-        if p.returncode != 0:
-            logging.error(f"make failed: {p.returncode}")
-            sys.exit(1)
-
-    def run_scheme(
-        self,
-        bin: str,
-        run_as_root=False,
-        exec_wrapper=None,
-    ) -> bytes:
-        """Run the binary in all different ways"""
-        if not os.path.isfile(bin):
-            logging.error(f"{bin} does not exists")
-            sys.exit(1)
-
-        cmd = [f"./{bin}"]
-        if self.cross_prefix and platform.system() != "Darwin":
-            logging.info(f"Emulating {bin} with QEMU")
-            if "x86_64" in self.cross_prefix:
-                cmd = ["qemu-x86_64"] + cmd
-            elif "aarch64" in self.cross_prefix:
-                cmd = ["qemu-aarch64"] + cmd
-            else:
-                logging.info(
-                    f"Emulation for {self.cross_prefix} on {platform.system()} not supported"
-                )
-
-        if run_as_root:
-            logging.info(
-                f"Running {bin} as root -- you may need to enter your root password."
-            )
-            cmd = ["sudo"] + cmd
-
-        if exec_wrapper:
-            logging.info(f"Running {bin} with customized wrapper.")
-            exec_wrapper = exec_wrapper.split(" ")
-            cmd = exec_wrapper + cmd
-
-        logging.debug(" ".join(cmd))
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            universal_newlines=False,
-        )
-
-        if result.returncode != 0:
-            logging.error(
-                f"Running '{cmd}' failed: {result.returncode} {result.stderr.decode()}"
-            )
-            sys.exit(1)
-
-        return result.stdout
-
-    def run_schemes(
-        self,
-        test_type: TEST_TYPES,
-        opt: bool,
-        run_as_root=False,
-        exec_wrapper=None,
-        actual_proc: Callable[[bytes], str] = None,
-        expect_proc: Callable[[SCHEME], str] = None,
-    ) -> TypedDict:
-        fail = False
-        results = {}
-        for scheme in SCHEME:
-            result = self.run_scheme(
-                test_type.bin_path(scheme),
-                run_as_root,
-                exec_wrapper,
-            )
-
-            if actual_proc is not None and expect_proc is not None:
-                actual = actual_proc(result)
-                expect = expect_proc(scheme)
-                f = actual != expect
-                fail = fail or f
-                if f:
-                    logging.error(
-                        f"{scheme} failed, expecting {expect}, but getting {actual}"
-                    )
-                else:
-                    logging.info(f"{scheme} passed")
-                results[scheme] = f
-            else:
-                logging.info(f"{scheme}")
-                logging.info(f"\n{result.decode()}")
-                results[scheme] = result.decode()
-
-        if fail:
-            sys.exit(1)
-
-        return results
-
-    def test(
-        self,
-        test_type: TEST_TYPES,
-        opt: bool,
-        extra_make_envs={},
-        extra_make_args=[],
-        actual_proc: Callable[[bytes], str] = None,
-        expect_proc: Callable[[SCHEME], str] = None,
-        run_as_root: bool = False,
-        exec_wrapper: str = None,
-    ):
-        config_logger(self.verbose)
-
-        logging.info(
-            f'{test_type.desc()} ({"cross" if self.cross_prefix else "native"}, {"opt" if opt else "no_opt"})'
-        )
-
-        make_envs = (
-            {"CFLAGS": f"{self.cflags}"} if self.cflags is not None else {}
-        ) | (
-            {"ARCH_FLAGS": f"{self.arch_flags}"} if self.arch_flags is not None else {}
-        )
-        make_envs.update(extra_make_envs)
-
-        if self.compile:
-            self.compile_schemes(
-                test_type,
-                make_envs,
-                extra_make_args
-                + list(
-                    set([f"OPT={int(opt)}", f"AUTO={int(self.auto)}"])
-                    - set(extra_make_args)
-                ),
-            )
-
-        results = None
-        if self.run:
-            results = self.run_schemes(
-                test_type,
-                opt,
-                run_as_root,
-                exec_wrapper,
-                actual_proc,
-                expect_proc,
-            )
-
-            title = (
-                "## "
-                + ("Cross" if self.cross_prefix else "Native")
-                + " "
-                + ("Opt" if opt else "Non-opt")
-                + " Tests"
-            )
-            github_summary(title, test_type, results)
-
-        return results
-
-
-"""
-Underlying functional tests
-
-"""
-
-
-def _func(state: State, opt: bool):
-    """Underlying function for functional test"""
-
-    def expect(scheme: SCHEME) -> str:
-        sk_bytes = parse_meta(scheme, "length-secret-key")
-        pk_bytes = parse_meta(scheme, "length-public-key")
-        ct_bytes = parse_meta(scheme, "length-ciphertext")
-
-        return (
-            f"CRYPTO_SECRETKEYBYTES:  {sk_bytes}\n"
-            + f"CRYPTO_PUBLICKEYBYTES:  {pk_bytes}\n"
-            + f"CRYPTO_CIPHERTEXTBYTES: {ct_bytes}\n"
-        )
-
-    state.test(
-        TEST_TYPES.MLKEM,
-        opt,
-        actual_proc=lambda result: str(result, encoding="utf-8"),
-        expect_proc=expect,
-    )
-
-
-def _nistkat(state: State, opt: bool):
-    """Underlying function for nistkat test"""
-
-    state.test(
-        TEST_TYPES.NISTKAT,
-        opt,
-        actual_proc=sha256sum,
-        expect_proc=lambda scheme: parse_meta(scheme, "nistkat-sha256"),
-    )
-
-
-def _kat(state: State, opt: bool):
-    """Underlying function for kat test"""
-
-    state.test(
-        TEST_TYPES.KAT,
-        opt,
-        actual_proc=sha256sum,
-        expect_proc=lambda scheme: parse_meta(scheme, "kat-sha256"),
-    )
-
+sys.path.append(f"{os.path.join(os.path.dirname(__file__), 'lib')}")
+from mlkem_test import *
 
 """
 Click interface configuration
@@ -433,6 +22,11 @@ def __callback(n):
         return value
 
     return callback
+
+
+def add_options(options):
+    """Shortcurt for adding multiple options for Click command"""
+    return lambda func: reduce(lambda f, o: o(f), reversed(options), func)
 
 
 _shared_options = [
@@ -551,10 +145,6 @@ _bench_options = [
 ]
 
 
-def add_options(options):
-    return lambda func: reduce(lambda f, o: o(f), reversed(options), func)
-
-
 @click.group(invoke_without_command=True)
 def cli():
     pass
@@ -568,7 +158,7 @@ def cli():
 @click.make_pass_decorator(State, ensure=True)
 @_opt_option
 def func(state: State, opt: bool):
-    _func(state, opt)
+    Tests().func(state, opt)
 
 
 @cli.command(
@@ -579,7 +169,7 @@ def func(state: State, opt: bool):
 @click.make_pass_decorator(State, ensure=True)
 @_opt_option
 def nistkat(state: State, opt: bool):
-    _nistkat(state, opt)
+    Tests().nistkat(state, opt)
 
 
 @cli.command(
@@ -590,7 +180,7 @@ def nistkat(state: State, opt: bool):
 @click.make_pass_decorator(State, ensure=True)
 @_opt_option
 def kat(state: State, opt: bool):
-    _kat(state, opt)
+    Tests().kat(state, opt)
 
 
 @cli.command(
@@ -611,55 +201,16 @@ def bench(
     mac_taskpolicy,
     components,
 ):
-    config_logger(state.verbose)
-
-    if components is False:
-        bench_type = TEST_TYPES.BENCH
-    else:
-        bench_type = TEST_TYPES.BENCH_COMPONENTS
-        output = False
-
-    if mac_taskpolicy:
-        if exec_wrapper:
-            logging.error(f"cannot set both --mac-taskpolicy and --exec-wrapper")
-            sys.exit(1)
-        else:
-            exec_wrapper = f"taskpolicy -c {mac_taskpolicy}"
-
-    results = state.test(
-        bench_type,
+    Tests().bench(
+        state,
         opt,
-        extra_make_args=[f"CYCLES={cycles}"],
-        run_as_root=run_as_root,
-        exec_wrapper=exec_wrapper,
+        cycles,
+        output,
+        run_as_root,
+        exec_wrapper,
+        mac_taskpolicy,
+        components,
     )
-
-    if results is not None and output is not None and components is False:
-        import json
-
-        with open(output, "w") as f:
-            v = []
-            for scheme in results:
-                schemeStr = str(scheme)
-                r = results[scheme]
-
-                # The first 3 lines of the output are expected to be
-                # keypair cycles=X
-                # encaps cycles=X
-                # decaps cycles=X
-
-                lines = [line for line in r.splitlines() if "=" in line]
-
-                d = {k.strip(): int(v) for k, v in (l.split("=") for l in lines)}
-                for primitive in ["keypair", "encaps", "decaps"]:
-                    v.append(
-                        {
-                            "name": f"{schemeStr} {primitive}",
-                            "unit": "cycles",
-                            "value": d[f"{primitive} cycles"],
-                        }
-                    )
-            f.write(json.dumps(v))
 
 
 @cli.command(
@@ -708,88 +259,7 @@ def all(
     kat: bool,
     nistkat: bool,
 ):
-    compile_mode = "cross" if state.cross_prefix else "native"
-
-    gh_env = os.environ.get("GITHUB_ENV")
-
-    tests = [
-        *([_func] if func else []),
-        *([_nistkat] if nistkat else []),
-        *([_kat] if kat else []),
-    ]
-
-    def compile_all(_state: State, opt: str):
-        code = 0
-
-        def _compile(opt: bool):
-            opt_label = "opt" if opt else "no-opt"
-            for f in tests:
-                if gh_env is not None:
-                    print(
-                        f"::group::compile {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
-                    )
-
-                try:
-                    f(_state, opt)
-                    print("")
-                except SystemExit as e:
-                    code = code or e
-
-                if gh_env is not None:
-                    print(f"::endgroup::")
-                sys.stdout.flush()
-
-        if opt.lower() == "all" or opt.lower() == "no_opt":
-            _compile(False)
-
-        if opt.lower() == "all" or opt.lower() == "opt":
-            _compile(True)
-
-        return code
-
-    def run(f, _state: State, opt: bool):
-        code = 0
-        opt_label = "opt" if opt else "no-opt"
-        if gh_env is not None:
-            print(
-                f"::group::run {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
-            )
-
-        try:
-            f(_state, opt)
-        except SystemExit as e:
-            code = e
-
-        if gh_env is not None:
-            print(f"::endgroup::")
-        sys.stdout.flush()
-
-        return code
-
-    def run_all(_state: State, opt: str):
-        code = 0
-        for f in tests:
-            if opt.lower() == "all" or opt.lower() == "no_opt":
-                code = code or run(f, _state, False)
-            if opt.lower() == "all" or opt.lower() == "opt":
-                code = code or run(f, _state, True)
-        return code
-
-    exit_code = 0
-
-    if state.compile:
-        _state = copy.deepcopy(state)
-        _state.run = False
-
-        exit_code = compile_all(_state, opt)
-
-    if state.run:
-        _state = state
-        _state.compile = False
-
-        exit_code = exit_code or run_all(_state, opt)
-
-    exit(exit_code)
+    Tests().all(state, opt, func, kat, nistkat)
 
 
 if __name__ == "__main__":

--- a/scripts/tests
+++ b/scripts/tests
@@ -17,7 +17,7 @@ Click interface configuration
 
 def __callback(n):
     def callback(ctx, param, value):
-        state = ctx.ensure_object(State)
+        state = ctx.ensure_object(Options)
         state.__dict__[n] = value
         return value
 
@@ -73,6 +73,16 @@ _shared_options = [
         default=True,
         help="Allow makefile to auto configure system specific preprocessor",
         callback=__callback("auto"),
+    ),
+    click.option(
+        "--opt",
+        expose_value=False,
+        nargs=1,
+        type=click.Choice(["ALL", "OPT", "NO_OPT"], case_sensitive=False),
+        show_default=True,
+        default="ALL",
+        help="Determine whether to compile/run the opt/no_opt binary or both",
+        callback=__callback("opt"),
     ),
     click.option(
         "--compile/--no-compile",
@@ -155,10 +165,9 @@ def cli():
     context_settings={"show_default": True},
 )
 @add_options(_shared_options)
-@click.make_pass_decorator(State, ensure=True)
-@_opt_option
-def func(state: State, opt: bool):
-    Tests().func(state, opt)
+@click.make_pass_decorator(Options, ensure=True)
+def func(opts: Options):
+    Tests(opts).func()
 
 
 @cli.command(
@@ -166,10 +175,9 @@ def func(state: State, opt: bool):
     context_settings={"show_default": True},
 )
 @add_options(_shared_options)
-@click.make_pass_decorator(State, ensure=True)
-@_opt_option
-def nistkat(state: State, opt: bool):
-    Tests().nistkat(state, opt)
+@click.make_pass_decorator(Options, ensure=True)
+def nistkat(opts: Options):
+    Tests(opts).nistkat()
 
 
 @cli.command(
@@ -177,10 +185,9 @@ def nistkat(state: State, opt: bool):
     context_settings={"show_default": True},
 )
 @add_options(_shared_options)
-@click.make_pass_decorator(State, ensure=True)
-@_opt_option
-def kat(state: State, opt: bool):
-    Tests().kat(state, opt)
+@click.make_pass_decorator(Options, ensure=True)
+def kat(opts: Options):
+    Tests(opts).kat()
 
 
 @cli.command(
@@ -189,11 +196,9 @@ def kat(state: State, opt: bool):
 )
 @add_options(_shared_options)
 @add_options(_bench_options)
-@click.make_pass_decorator(State, ensure=True)
-@_opt_option
+@click.make_pass_decorator(Options, ensure=True)
 def bench(
-    state: State,
-    opt: bool,
+    opts: Options,
     cycles: str,
     output,
     run_as_root: bool,
@@ -201,9 +206,7 @@ def bench(
     mac_taskpolicy,
     components,
 ):
-    Tests().bench(
-        state,
-        opt,
+    Tests(opts).bench(
         cycles,
         output,
         run_as_root,
@@ -220,14 +223,6 @@ def bench(
 @add_options(_shared_options)
 @add_options(
     [
-        click.option(
-            "--opt",
-            nargs=1,
-            type=click.Choice(["ALL", "OPT", "NO_OPT"], case_sensitive=False),
-            show_default=True,
-            default="ALL",
-            help="Determine whether to compile/run the opt/no_opt binary or both",
-        ),
         click.option(
             "--func/--no-func",
             is_flag=True,
@@ -251,15 +246,14 @@ def bench(
         ),
     ]
 )
-@click.make_pass_decorator(State, ensure=True)
+@click.make_pass_decorator(Options, ensure=True)
 def all(
-    state: State,
-    opt: str,
+    opts: Options,
     func: bool,
     kat: bool,
     nistkat: bool,
 ):
-    Tests().all(state, opt, func, kat, nistkat)
+    Tests(opts).all(func, kat, nistkat)
 
 
 if __name__ == "__main__":

--- a/scripts/tests
+++ b/scripts/tests
@@ -188,7 +188,6 @@ class State(object):
         self.cross_prefix = ""
         self.cflags = ""
         self.arch_flags = ""
-        self.opt = True
         self.auto = True
         self.compile = True
         self.run = True
@@ -278,6 +277,7 @@ class State(object):
     def run_schemes(
         self,
         test_type: TEST_TYPES,
+        opt: bool,
         run_as_root=False,
         exec_wrapper=None,
         actual_proc: Callable[[bytes], str] = None,
@@ -317,6 +317,7 @@ class State(object):
     def test(
         self,
         test_type: TEST_TYPES,
+        opt: bool,
         extra_make_envs={},
         extra_make_args=[],
         actual_proc: Callable[[bytes], str] = None,
@@ -326,7 +327,9 @@ class State(object):
     ):
         config_logger(self.verbose)
 
-        logging.info(f"{test_type.desc()}")
+        logging.info(
+            f'{test_type.desc()} ({"cross" if self.cross_prefix else "native"}, {"opt" if opt else "no_opt"})'
+        )
 
         make_envs = (
             {"CFLAGS": f"{self.cflags}"} if self.cflags is not None else {}
@@ -341,7 +344,7 @@ class State(object):
                 make_envs,
                 extra_make_args
                 + list(
-                    set([f"OPT={int(self.opt)}", f"AUTO={int(self.auto)}"])
+                    set([f"OPT={int(opt)}", f"AUTO={int(self.auto)}"])
                     - set(extra_make_args)
                 ),
             )
@@ -350,6 +353,7 @@ class State(object):
         if self.run:
             results = self.run_schemes(
                 test_type,
+                opt,
                 run_as_root,
                 exec_wrapper,
                 actual_proc,
@@ -360,7 +364,7 @@ class State(object):
                 "## "
                 + ("Cross" if self.cross_prefix else "Native")
                 + " "
-                + ("Opt" if self.opt else "Non-opt")
+                + ("Opt" if opt else "Non-opt")
                 + " Tests"
             )
             github_summary(title, test_type, results)
@@ -374,7 +378,7 @@ Underlying functional tests
 """
 
 
-def _func(state: State):
+def _func(state: State, opt: bool):
     """Underlying function for functional test"""
 
     def expect(scheme: SCHEME) -> str:
@@ -390,26 +394,29 @@ def _func(state: State):
 
     state.test(
         TEST_TYPES.MLKEM,
+        opt,
         actual_proc=lambda result: str(result, encoding="utf-8"),
         expect_proc=expect,
     )
 
 
-def _nistkat(state: State):
+def _nistkat(state: State, opt: bool):
     """Underlying function for nistkat test"""
 
     state.test(
         TEST_TYPES.NISTKAT,
+        opt,
         actual_proc=sha256sum,
         expect_proc=lambda scheme: parse_meta(scheme, "nistkat-sha256"),
     )
 
 
-def _kat(state: State):
+def _kat(state: State, opt: bool):
     """Underlying function for kat test"""
 
     state.test(
         TEST_TYPES.KAT,
+        opt,
         actual_proc=sha256sum,
         expect_proc=lambda scheme: parse_meta(scheme, "kat-sha256"),
     )
@@ -464,15 +471,6 @@ _shared_options = [
         nargs=1,
         help="Extra arch flags to passed in (e.g. '-march=armv8')",
         callback=__callback("arch_flags"),
-    ),
-    click.option(
-        "--opt/--no-opt",
-        expose_value=False,
-        is_flag=True,
-        show_default=True,
-        default=True,
-        help="Choose whether to enable assembly optimizations (if present)",
-        callback=__callback("opt"),
     ),
     click.option(
         "--auto/--no-auto",
@@ -569,8 +567,9 @@ def cli():
 )
 @add_options(_shared_options)
 @click.make_pass_decorator(State, ensure=True)
-def func(state: State):
-    _func(state)
+@_opt_option
+def func(state: State, opt: bool):
+    _func(state, opt)
 
 
 @cli.command(
@@ -579,8 +578,9 @@ def func(state: State):
 )
 @add_options(_shared_options)
 @click.make_pass_decorator(State, ensure=True)
-def nistkat(state: State):
-    _nistkat(state)
+@_opt_option
+def nistkat(state: State, opt: bool):
+    _nistkat(state, opt)
 
 
 @cli.command(
@@ -589,8 +589,9 @@ def nistkat(state: State):
 )
 @add_options(_shared_options)
 @click.make_pass_decorator(State, ensure=True)
-def kat(state: State):
-    _kat(state)
+@_opt_option
+def kat(state: State, opt: bool):
+    _kat(state, opt)
 
 
 @cli.command(
@@ -600,8 +601,10 @@ def kat(state: State):
 @add_options(_shared_options)
 @add_options(_bench_options)
 @click.make_pass_decorator(State, ensure=True)
+@_opt_option
 def bench(
     state: State,
+    opt: bool,
     cycles: str,
     output,
     run_as_root: bool,
@@ -626,6 +629,7 @@ def bench(
 
     results = state.test(
         bench_type,
+        opt,
         extra_make_args=[f"CYCLES={cycles}"],
         run_as_root=run_as_root,
         exec_wrapper=exec_wrapper,
@@ -667,6 +671,14 @@ def bench(
 @add_options(
     [
         click.option(
+            "--opt",
+            nargs=1,
+            type=click.Choice(["ALL", "OPT", "NO_OPT"], case_sensitive=False),
+            show_default=True,
+            default="ALL",
+            help="Determine whether to compile/run the opt/no_opt binary or both",
+        ),
+        click.option(
             "--func/--no-func",
             is_flag=True,
             show_default=True,
@@ -692,11 +704,11 @@ def bench(
 @click.make_pass_decorator(State, ensure=True)
 def all(
     state: State,
+    opt: str,
     func: bool,
     kat: bool,
     nistkat: bool,
 ):
-    opt_label = "opt" if state.opt else "no-opt"
     compile_mode = "cross" if state.cross_prefix else "native"
 
     gh_env = os.environ.get("GITHUB_ENV")
@@ -706,29 +718,39 @@ def all(
         *([_nistkat] if nistkat else []),
         *([_kat] if kat else []),
     ]
-    exit_code = 0
 
-    # sequentially compile
-    _state = copy.deepcopy(state)
-    _state.run = False
-
-    if state.compile:
-        for f in tests:
-            if gh_env is not None:
-                print(f"::group::compile {compile_mode} {opt_label} {opt_label} test")
-
-            try:
-                f(_state)
-                print("")
-            except SystemExit as e:
-                exit_code = exit_code or e
-
-            if gh_env is not None:
-                print(f"::endgroup::")
-
-    # parallelly run
-    async def run(f, _state: State):
+    def compile_all(_state: State, opt: str):
         code = 0
+
+        def _compile(opt: bool):
+            opt_label = "opt" if opt else "no-opt"
+            for f in tests:
+                if gh_env is not None:
+                    print(
+                        f"::group::compile {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
+                    )
+
+                try:
+                    f(_state, opt)
+                    print("")
+                except SystemExit as e:
+                    code = code or e
+
+                if gh_env is not None:
+                    print(f"::endgroup::")
+                sys.stdout.flush()
+
+        if opt.lower() == "all" or opt.lower() == "no_opt":
+            _compile(False)
+
+        if opt.lower() == "all" or opt.lower() == "opt":
+            _compile(True)
+
+        return code
+
+    async def run(f, _state: State, opt: bool):
+        code = 0
+        opt_label = "opt" if opt else "no-opt"
         if gh_env is not None:
             print(
                 f"::group::run {compile_mode} {opt_label} {f.__name__.removeprefix('_')} test"
@@ -736,7 +758,7 @@ def all(
 
         with redirect_stdout(io.StringIO()) as out:
             try:
-                f(_state)
+                f(_state, opt)
             except SystemExit as e:
                 code = e
 
@@ -745,21 +767,35 @@ def all(
 
         if gh_env is not None:
             print(f"::endgroup::")
+        sys.stdout.flush()
 
         return code
 
-    async def run_all(_state: State):
+    async def run_all(_state: State, opt: str):
         ts = []
         async with asyncio.TaskGroup() as g:
             for f in tests:
-                ts.append(g.create_task(run(f, _state)))
+                if opt.lower() == "all" or opt.lower() == "no_opt":
+                    ts.append(g.create_task(run(f, _state, False)))
+                if opt.lower() == "all" or opt.lower() == "opt":
+                    ts.append(g.create_task(run(f, _state, True)))
         return reduce(lambda acc, c: acc or c, map(lambda t: t.result(), ts), exit_code)
 
+    exit_code = 0
+
+    # sequentially compile
+    if state.compile:
+        _state = copy.deepcopy(state)
+        _state.run = False
+
+        exit_code = compile_all(_state, opt)
+
+    # parallelly run
     if state.run:
         _state = state
         _state.compile = False
 
-        exit_code = asyncio.run(run_all(_state))
+        exit_code = asyncio.run(run_all(_state, opt))
 
     exit(exit_code)
 


### PR DESCRIPTION
Refactor `tests` script mainly for preparation to easily integrate acvp into `tests`:
- Split the original tests script into three files: the main `scripts/tests` script now acts as a Click-based CLI interface.
- Moved core testing logic to `scripts/lib/test.py`, providing APIs that the Click commands call for main testing functionality.
- Added scripts/lib/util.py for common type classes and utility functions.
- Rename the `State` class as mentioned in https://github.com/pq-code-package/mlkem-c-aarch64/pull/347#discussion_r1830477719)
- Make `tests func/kat/nistkat/all` interface consistent:
  - `--opt` flags become choice of `ALL | OPT | NO_OPT` (case insensitive)