### PR TITLE
CBMC: Spec + proof `polyvec_[de]compress` 

### DIFF
--- a/cbmc/proofs/polyvec_compress/Makefile
+++ b/cbmc/proofs/polyvec_compress/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_compress_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_compress
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)polyvec_compress
+USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)scalar_compress_d10 $(MLKEM_NAMESPACE)scalar_compress_d11
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)polyvec_compress
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 10
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/polyvec_compress/cbmc-proof.txt
+++ b/cbmc/proofs/polyvec_compress/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/polyvec_compress/cbmc-viewer.json
+++ b/cbmc/proofs/polyvec_compress/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "poly_compress",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/polyvec_compress/polyvec_compress_harness.c
+++ b/cbmc/proofs/polyvec_compress/polyvec_compress_harness.c
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0 AND Apache-2.0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file polyvec_compress_harness.c
+ * @brief Implements the proof harness for polyvec_compress function.
+ */
+#include "poly.h"
+#include "polyvec.h"
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  polyvec *r;
+  uint8_t *a;
+
+  // TODO: remove cbmc-viewer.json
+  // TODO: remove the README for all proofs
+
+  polyvec_compress(a, r);
+}

--- a/cbmc/proofs/polyvec_decompress/Makefile
+++ b/cbmc/proofs/polyvec_decompress/Makefile
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_decompress_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_decompress
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/polyvec.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)polyvec_decompress
+
+ifeq ($(MLKEM_K),4)
+USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)scalar_decompress_d11
+else
+USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)scalar_decompress_d10
+endif
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)polyvec_decompress
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 10
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/polyvec_decompress/cbmc-proof.txt
+++ b/cbmc/proofs/polyvec_decompress/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/polyvec_decompress/cbmc-viewer.json
+++ b/cbmc/proofs/polyvec_decompress/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "poly_compress",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/polyvec_decompress/polyvec_decompress_harness.c
+++ b/cbmc/proofs/polyvec_decompress/polyvec_decompress_harness.c
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0 AND Apache-2.0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file polyvec_decompress_harness.c
+ * @brief Implements the proof harness for polyvec_decompress function.
+ */
+#include "poly.h"
+#include "polyvec.h"
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  polyvec *a;
+  uint8_t *r;
+
+  // TODO: remove cbmc-viewer.json
+  // TODO: remove the README for all proofs
+
+  polyvec_decompress(a, r);
+}

--- a/cbmc/proofs/scalar_decompress_d10/Makefile
+++ b/cbmc/proofs/scalar_decompress_d10/Makefile
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = scalar_decompress_d10_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = scalar_decompress_d10
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)scalar_decompress_d10
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+#VERBOSE=on
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/scalar_decompress_d10/README.md
+++ b/cbmc/proofs/scalar_decompress_d10/README.md
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+scalar_decompress_q_16 proof
+==============
+
+This directory contains a memory safety proof for scalar_decompress_q_16.
+
+To run the proof.
+-------------
+* Follow these [tool installation instructions](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/Installation) to install cbmc and cbmc-viewer.
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open `report/html/index.html` in a web browser.

--- a/cbmc/proofs/scalar_decompress_d10/cbmc-proof.txt
+++ b/cbmc/proofs/scalar_decompress_d10/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/scalar_decompress_d10/cbmc-viewer.json
+++ b/cbmc/proofs/scalar_decompress_d10/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "scalar_decompress_d10",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/scalar_decompress_d10/scalar_decompress_d10_harness.c
+++ b/cbmc/proofs/scalar_decompress_d10/scalar_decompress_d10_harness.c
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file scalar_decompress_d10_harness.c
+ * @brief Implements the proof harness for scalar_decompress_d10 function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <poly.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint32_t u;
+  uint16_t d;
+  d = scalar_decompress_d10(u);
+}

--- a/cbmc/proofs/scalar_decompress_d11/Makefile
+++ b/cbmc/proofs/scalar_decompress_d11/Makefile
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = scalar_decompress_d11_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = scalar_decompress_d11
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)scalar_decompress_d11
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+#VERBOSE=on
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/scalar_decompress_d11/README.md
+++ b/cbmc/proofs/scalar_decompress_d11/README.md
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+scalar_decompress_q_16 proof
+==============
+
+This directory contains a memory safety proof for scalar_decompress_q_16.
+
+To run the proof.
+-------------
+* Follow these [tool installation instructions](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/Installation) to install cbmc and cbmc-viewer.
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open `report/html/index.html` in a web browser.

--- a/cbmc/proofs/scalar_decompress_d11/cbmc-proof.txt
+++ b/cbmc/proofs/scalar_decompress_d11/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/scalar_decompress_d11/cbmc-viewer.json
+++ b/cbmc/proofs/scalar_decompress_d11/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "scalar_decompress_d4",
+  "proof-root": "cbmc/proofs"
+}

--- a/cbmc/proofs/scalar_decompress_d11/scalar_decompress_d11_harness.c
+++ b/cbmc/proofs/scalar_decompress_d11/scalar_decompress_d11_harness.c
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file scalar_decompress_d11_harness.c
+ * @brief Implements the proof harness for scalar_decompress_d11 function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <poly.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint32_t u;
+  uint16_t d;
+  d = scalar_decompress_d11(u);
+}

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -7,6 +7,7 @@
 #ifndef CBMC
 
 #define STATIC_TESTABLE static
+#define STATIC_INLINE_TESTABLE static inline
 
 // CBMC top-level contracts are replaced by "" for compilation
 #define ASSIGNS(...)
@@ -21,6 +22,8 @@
 
 // expose certain procedures to CBMC proofs that are static otherwise
 #define STATIC_TESTABLE
+#define STATIC_INLINE_TESTABLE
+
 
 // https://diffblue.github.io/cbmc/contracts-assigns.html
 #define ASSIGNS(...) __CPROVER_assigns(__VA_ARGS__)

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -34,6 +34,8 @@ typedef struct {
 #define scalar_compress_d11 MLKEM_NAMESPACE(scalar_compress_d11)
 #define scalar_decompress_d4 MLKEM_NAMESPACE(scalar_decompress_d4)
 #define scalar_decompress_d5 MLKEM_NAMESPACE(scalar_decompress_d5)
+#define scalar_decompress_d10 MLKEM_NAMESPACE(scalar_decompress_d10)
+#define scalar_decompress_d11 MLKEM_NAMESPACE(scalar_decompress_d11)
 #define scalar_signed_to_unsigned_q MLKEM_NAMESPACE(scalar_signed_to_unsigned_q)
 
 /************************************************************
@@ -195,6 +197,24 @@ uint32_t scalar_compress_d10(uint16_t u)  // clang-format off
 #endif
 
 /************************************************************
+ * Name: scalar_decompress_d10
+ *
+ * Description: Computes round(u * q / 1024)
+ *
+ *              Implements Decompress_d from FIPS203, Eq (4.8),
+ *              for d = 10.
+ *
+ * Arguments: - u: Unsigned canonical modulus modulo 16
+ *                 to be decompressed.
+ ************************************************************/
+static inline uint16_t scalar_decompress_d10(uint32_t u)  // clang-format off
+  REQUIRES(0 <= u && u < 1024)
+  ENSURES(RETURN_VALUE <= (MLKEM_Q - 1))
+{  // clang-format on
+  return ((u * MLKEM_Q) + 512) / 1024;
+}
+
+/************************************************************
  * Name: scalar_compress_d11
  *
  * Description: Computes round(u * 2**11 / q) % 2**11
@@ -226,6 +246,25 @@ uint32_t scalar_compress_d11(uint16_t u)  // clang-format off
 #endif
 
 /************************************************************
+ * Name: scalar_decompress_d11
+ *
+ * Description: Computes round(u * q / 1024)
+ *
+ *              Implements Decompress_d from FIPS203, Eq (4.8),
+ *              for d = 10.
+ *
+ * Arguments: - u: Unsigned canonical modulus modulo 16
+ *                 to be decompressed.
+ ************************************************************/
+STATIC_INLINE_TESTABLE
+uint16_t scalar_decompress_d11(uint32_t u)  // clang-format off
+  REQUIRES(0 <= u && u < 2048)
+  ENSURES(RETURN_VALUE <= (MLKEM_Q - 1))
+{  // clang-format on
+  return ((u * MLKEM_Q) + 1024) / 2048;
+}
+
+/************************************************************
  * Name: scalar_signed_to_unsigned_q
  *
  * Description: converts signed polynomial coefficient
@@ -243,8 +282,8 @@ uint32_t scalar_compress_d11(uint16_t u)  // clang-format off
  *
  * Arguments: c: signed coefficient to be converted
  ************************************************************/
-static inline uint16_t scalar_signed_to_unsigned_q(
-    int16_t c)  // clang-format off
+STATIC_INLINE_TESTABLE
+uint16_t scalar_signed_to_unsigned_q(int16_t c)  // clang-format off
   REQUIRES(c >= -(MLKEM_Q - 1) && c <= (MLKEM_Q - 1))
   ENSURES(RETURN_VALUE >= 0 && RETURN_VALUE <= (MLKEM_Q - 1))
   ENSURES(RETURN_VALUE == (int32_t)c + (((int32_t)c < 0) * MLKEM_Q))

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -179,7 +179,9 @@ static inline uint16_t scalar_decompress_d5(uint32_t u)  // clang-format off
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
-static inline uint32_t scalar_compress_d10(uint16_t u)  // clang-format off
+// TODO: do the same for the other static inline functions
+STATIC_INLINE_TESTABLE
+uint32_t scalar_compress_d10(uint16_t u)  // clang-format off
   REQUIRES(u <= MLKEM_Q - 1)
   ENSURES(RETURN_VALUE < (1u << 10))
   ENSURES(RETURN_VALUE == (((uint32_t)u * (1u << 10) + MLKEM_Q / 2) / MLKEM_Q) % (1 << 10))
@@ -209,7 +211,8 @@ static inline uint32_t scalar_compress_d10(uint16_t u)  // clang-format off
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
-static inline uint32_t scalar_compress_d11(uint16_t u)  // clang-format off
+STATIC_INLINE_TESTABLE
+uint32_t scalar_compress_d11(uint16_t u)  // clang-format off
   REQUIRES(u <= MLKEM_Q - 1)
   ENSURES(RETURN_VALUE < (1u << 11))
   ENSURES(RETURN_VALUE == (((uint32_t)u * (1u << 11) + MLKEM_Q / 2) / MLKEM_Q) % (1 << 11))

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -8,58 +8,86 @@
 #include "poly.h"
 
 #include "debug/debug.h"
-/*************************************************
- * Name:        polyvec_compress
- *
- * Description: Compress and serialize vector of polynomials
- *
- * Arguments:   - uint8_t *r: pointer to output byte array
- *                            (needs space for MLKEM_POLYVECCOMPRESSEDBYTES)
- *              - const polyvec *a: pointer to input vector of polynomials
- **************************************************/
 void polyvec_compress(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES],
                       const polyvec *a) {
   POLYVEC_UBOUND(a, MLKEM_Q);
-  unsigned int i, j, k;
 
 #if (MLKEM_POLYVECCOMPRESSEDBYTES == (MLKEM_K * 352))
   uint16_t t[8];
-  for (i = 0; i < MLKEM_K; i++) {
-    for (j = 0; j < MLKEM_N / 8; j++) {
-      for (k = 0; k < 8; k++) {
-        t[k] = scalar_compress_d11(a->vec[i].coeffs[8 * j + k]);
-      }
+  for (int i = 0; i < MLKEM_K; i++)  // clang-format off
+    ASSIGNS(i, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
+    INVARIANT(i >= 0 && i <= MLKEM_K)  // clang-format on
+    {
+      for (int j = 0; j < MLKEM_N / 8; j++)  // clang-format off
+        ASSIGNS(j, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
+        INVARIANT(j >= 0 && j <= MLKEM_N / 8)
+        {     // clang-format on
+          for (int k = 0; k < 8; k++)  // clang-format off
+            ASSIGNS(k, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
+            INVARIANT(k >= 0 && k <= 8)
+            INVARIANT(FORALL(int, r, 0, k - 1, t[r] < (1u << 11)))
+            {  // clang-format on
+              t[k] = scalar_compress_d11(a->vec[i].coeffs[8 * j + k]);
+            }
 
-      r[0] = (t[0] >> 0);
-      r[1] = (t[0] >> 8) | (t[1] << 3);
-      r[2] = (t[1] >> 5) | (t[2] << 6);
-      r[3] = (t[2] >> 2);
-      r[4] = (t[2] >> 10) | (t[3] << 1);
-      r[5] = (t[3] >> 7) | (t[4] << 4);
-      r[6] = (t[4] >> 4) | (t[5] << 7);
-      r[7] = (t[5] >> 1);
-      r[8] = (t[5] >> 9) | (t[6] << 2);
-      r[9] = (t[6] >> 6) | (t[7] << 5);
-      r[10] = (t[7] >> 3);
-      r += 11;
+          // REF-CHANGE: Use array indexing into
+          // r rather than pointer-arithmetic to simplify verification
+          //
+          // Make all implicit truncation explicit. No data is being
+          // truncated for the LHS's since each t[i] is 11-bit in size.
+          r[11 * (i * (MLKEM_N / 8) + j) + 0] = (t[0] >> 0) & 0xFF;
+          r[11 * (i * (MLKEM_N / 8) + j) + 1] =
+              (t[0] >> 8) | ((t[1] << 3) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 2] =
+              (t[1] >> 5) | ((t[2] << 6) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 3] = (t[2] >> 2) & 0xFF;
+          r[11 * (i * (MLKEM_N / 8) + j) + 4] =
+              (t[2] >> 10) | ((t[3] << 1) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 5] =
+              (t[3] >> 7) | ((t[4] << 4) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 6] =
+              (t[4] >> 4) | ((t[5] << 7) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 7] = (t[5] >> 1) & 0xFF;
+          r[11 * (i * (MLKEM_N / 8) + j) + 8] =
+              (t[5] >> 9) | ((t[6] << 2) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 9] =
+              (t[6] >> 6) | ((t[7] << 5) & 0xFF);
+          r[11 * (i * (MLKEM_N / 8) + j) + 10] = (t[7] >> 3);
+        }
     }
-  }
 #elif (MLKEM_POLYVECCOMPRESSEDBYTES == (MLKEM_K * 320))
   uint16_t t[4];
-  for (i = 0; i < MLKEM_K; i++) {
-    for (j = 0; j < MLKEM_N / 4; j++) {
-      for (k = 0; k < 4; k++) {
-        t[k] = scalar_compress_d10(a->vec[i].coeffs[4 * j + k]);
-      }
+  for (int i = 0; i < MLKEM_K; i++)  // clang-format off
+    ASSIGNS(i, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
+    INVARIANT(i >= 0 && i <= MLKEM_K)
+    {              // clang-format on
+      for (int j = 0; j < MLKEM_N / 4; j++)  // clang-format off
+        ASSIGNS(j, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
+        INVARIANT(j >= 0 && j <= MLKEM_N / 4)
+        {      // clang-format on
+          for (int k = 0; k < 4; k++)  // clang-format off
+            ASSIGNS(k, OBJECT_WHOLE(t))
+            INVARIANT(k >= 0 && k <= 4)
+            INVARIANT(FORALL(int, r, 0, k - 1, t[r] < (1u << 10)))
+            {  // clang-format on
+              t[k] = scalar_compress_d10(a->vec[i].coeffs[4 * j + k]);
+            }
 
-      r[0] = (t[0] >> 0);
-      r[1] = (t[0] >> 8) | (t[1] << 2);
-      r[2] = (t[1] >> 6) | (t[2] << 4);
-      r[3] = (t[2] >> 4) | (t[3] << 6);
-      r[4] = (t[3] >> 2);
-      r += 5;
+          // REF-CHANGE: Use array indexing into
+          // r rather than pointer-arithmetic to simplify verification
+          //
+          // Make all implicit truncation explicit. No data is being
+          // truncated for the LHS's since each t[i] is 10-bit in size.
+          r[5 * (i * (MLKEM_N / 4) + j) + 0] = (t[0] >> 0) & 0xFF;
+          r[5 * (i * (MLKEM_N / 4) + j) + 1] =
+              (t[0] >> 8) | ((t[1] << 2) & 0xFF);
+          r[5 * (i * (MLKEM_N / 4) + j) + 2] =
+              (t[1] >> 6) | ((t[2] << 4) & 0xFF);
+          r[5 * (i * (MLKEM_N / 4) + j) + 3] =
+              (t[2] >> 4) | ((t[3] << 6) & 0xFF);
+          r[5 * (i * (MLKEM_N / 4) + j) + 4] = (t[3] >> 2);
+        }
     }
-  }
 #else
 #error "MLKEM_POLYVECCOMPRESSEDBYTES needs to be in {320*MLKEM_K, 352*MLKEM_K}"
 #endif

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -36,9 +36,16 @@ REQUIRES(FORALL(int, k0, 0, MLKEM_K - 1,
          ARRAY_IN_BOUNDS(int, k1, 0, (MLKEM_N - 1), a->vec[k0].coeffs, 0, (MLKEM_Q - 1))));
 // clang-format on
 
+// clang-format off
 #define polyvec_decompress MLKEM_NAMESPACE(polyvec_decompress)
 void polyvec_decompress(polyvec *r,
-                        const uint8_t a[MLKEM_POLYVECCOMPRESSEDBYTES]);
+                        const uint8_t a[MLKEM_POLYVECCOMPRESSEDBYTES]) // clang-format off
+REQUIRES(IS_FRESH(a, MLKEM_POLYVECCOMPRESSEDBYTES))
+REQUIRES(IS_FRESH(r, sizeof(polyvec)))
+ASSIGNS(OBJECT_WHOLE(r))
+ENSURES(FORALL(int, k0, 0, MLKEM_K - 1,
+         ARRAY_IN_BOUNDS(int, k1, 0, (MLKEM_N - 1), r->vec[k0].coeffs, 0, (MLKEM_Q - 1))));
+// clang-format on
 
 #define polyvec_tobytes MLKEM_NAMESPACE(polyvec_tobytes)
 /*************************************************
@@ -198,7 +205,7 @@ void polyvec_add(polyvec *r, const polyvec *b)  // clang-format off
 REQUIRES(IS_FRESH(r, sizeof(polyvec)))
 REQUIRES(IS_FRESH(b, sizeof(polyvec)))
 REQUIRES(FORALL(int, j0, 0, MLKEM_K - 1,
-          FORALL(int, k0, 0, MLKEM_N - 1, 
+          FORALL(int, k0, 0, MLKEM_N - 1,
             (int32_t)r->vec[j0].coeffs[k0] + b->vec[j0].coeffs[k0] <= INT16_MAX)))
 REQUIRES(FORALL(int, j1, 0, MLKEM_K - 1,
           FORALL(int, k1, 0, MLKEM_N - 1,

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -16,8 +16,26 @@ typedef struct {
 } polyvec_mulcache;
 
 #define polyvec_compress MLKEM_NAMESPACE(polyvec_compress)
+/*************************************************
+ * Name:        polyvec_compress
+ *
+ * Description: Compress and serialize vector of polynomials
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                            (needs space for MLKEM_POLYVECCOMPRESSEDBYTES)
+ *              - const polyvec *a: pointer to input vector of polynomials.
+ *                                  Coefficients must be unsigned canonical,
+ *                                  i.e. in [0,1,..,MLKEM_Q-1].
+ **************************************************/
 void polyvec_compress(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES],
-                      const polyvec *a);
+                      const polyvec *a)  // clang-format off
+REQUIRES(IS_FRESH(r, MLKEM_POLYVECCOMPRESSEDBYTES))
+REQUIRES(IS_FRESH(a, sizeof(polyvec)))
+ASSIGNS(OBJECT_WHOLE(r))
+REQUIRES(FORALL(int, k0, 0, MLKEM_K - 1,
+         ARRAY_IN_BOUNDS(int, k1, 0, (MLKEM_N - 1), a->vec[k0].coeffs, 0, (MLKEM_Q - 1))));
+// clang-format on
+
 #define polyvec_decompress MLKEM_NAMESPACE(polyvec_decompress)
 void polyvec_decompress(polyvec *r,
                         const uint8_t a[MLKEM_POLYVECCOMPRESSEDBYTES]);


### PR DESCRIPTION
This PR adds a largely straightforward spec + proof for polyvec_compress() and poly_decompress(). Care needs to be taken to track the bounds of the compressed data, and to introduce explicit masking when writing out the individual bytes, since in the configuration used by our CI, CBMC fails upon implicit truncation that cannot be proved to be effectless.