### PR TITLE
CBMC: Add proof for crypto_kem_enc[_derand], crypto_kem_keypair, crypto_kem_dec

### DIFF
--- a/cbmc/proofs/cmov/Makefile
+++ b/cbmc/proofs/cmov/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = cmov_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = cmov
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/verify.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)cmov
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)cmov
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/cmov/cbmc-proof.txt
+++ b/cbmc/proofs/cmov/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/cmov/cmov_harness.c
+++ b/cbmc/proofs/cmov/cmov_harness.c
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0 AND Apache-2.0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file cmov_harness.c
+ * @brief Implements the proof harness for cmov function.
+ */
+#include "verify.h"
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t *x, *y;
+  size_t len;
+  uint8_t b;
+  cmov(x, y, len, b);
+}

--- a/cbmc/proofs/crypto_kem_dec/Makefile
+++ b/cbmc/proofs/crypto_kem_dec/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_kem_dec_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_kem_dec
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/kem.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)dec
+USE_FUNCTION_CONTRACTS= $(FIPS202_NAMESPACE)sha3_512 $(FIPS202_NAMESPACE)sha3_256 $(MLKEM_NAMESPACE)indcpa_enc $(MLKEM_NAMESPACE)indcpa_dec $(MLKEM_NAMESPACE)mlkem_shake256_rkprf $(MLKEM_NAMESPACE)verify $(MLKEM_NAMESPACE)cmov memcmp
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)dec
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 10
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hdece, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/crypto_kem_dec/cbmc-proof.txt
+++ b/cbmc/proofs/crypto_kem_dec/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/crypto_kem_dec/crypto_kem_dec_harness.c
+++ b/cbmc/proofs/crypto_kem_dec/crypto_kem_dec_harness.c
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file crypto_kem_dec_harness.c
+ * @brief Implements the proof harness for crypto_kem_dec function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <kem.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t *a, *b, *c;
+  crypto_kem_dec(a, b, c);
+}

--- a/cbmc/proofs/crypto_kem_enc/Makefile
+++ b/cbmc/proofs/crypto_kem_enc/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_kem_enc_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_kem_enc
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/kem.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)enc
+USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)enc_derand randombytes
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)enc
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 10
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/crypto_kem_enc/cbmc-proof.txt
+++ b/cbmc/proofs/crypto_kem_enc/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/crypto_kem_enc/crypto_kem_enc_harness.c
+++ b/cbmc/proofs/crypto_kem_enc/crypto_kem_enc_harness.c
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file crypto_kem_enc_harness.c
+ * @brief Implements the proof harness for crypto_kem_enc function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <kem.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t *a, *b, *c;
+  crypto_kem_enc(a, b, c);
+}

--- a/cbmc/proofs/crypto_kem_enc_derand/Makefile
+++ b/cbmc/proofs/crypto_kem_enc_derand/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = crypto_kem_enc_derand_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = crypto_kem_enc_derand
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/kem.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)enc_derand
+USE_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)sha3_256 $(FIPS202_NAMESPACE)sha3_512 $(MLKEM_NAMESPACE)indcpa_enc $(MLKEM_NAMESPACE)polyvec_frombytes $(MLKEM_NAMESPACE)polyvec_reduce $(MLKEM_NAMESPACE)polyvec_tobytes pk_cmp_polyvec
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)enc_derand
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 10
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/crypto_kem_enc_derand/cbmc-proof.txt
+++ b/cbmc/proofs/crypto_kem_enc_derand/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/crypto_kem_enc_derand/crypto_kem_enc_derand_harness.c
+++ b/cbmc/proofs/crypto_kem_enc_derand/crypto_kem_enc_derand_harness.c
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file crypto_kem_enc_derand_harness.c
+ * @brief Implements the proof harness for crypto_kem_enc_derand function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <kem.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t *a, *b, *c, *d;
+  crypto_kem_enc_derand(a, b, c, d);
+}

--- a/cbmc/proofs/crypto_kem_keypair/Makefile
+++ b/cbmc/proofs/crypto_kem_keypair/Makefile
@@ -3,11 +3,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = crypto_kem_enc_derand_harness
+HARNESS_FILE = crypto_kem_keypair_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = crypto_kem_enc_derand
+PROOF_UID = crypto_kem_keypair
 
 DEFINES +=
 INCLUDES +=
@@ -18,8 +18,8 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/kem.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)enc_derand
-USE_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)sha3_256 $(FIPS202_NAMESPACE)sha3_512 $(MLKEM_NAMESPACE)indcpa_enc $(MLKEM_NAMESPACE)polyvec_frombytes $(MLKEM_NAMESPACE)polyvec_reduce $(MLKEM_NAMESPACE)polyvec_tobytes memcmp
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)keypair
+USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)keypair_derand randombytes
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
 
-FUNCTION_NAME = $(MLKEM_NAMESPACE)enc_derand
+FUNCTION_NAME = $(MLKEM_NAMESPACE)keypair
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/crypto_kem_keypair/cbmc-proof.txt
+++ b/cbmc/proofs/crypto_kem_keypair/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/crypto_kem_keypair/crypto_kem_keypair_harness.c
+++ b/cbmc/proofs/crypto_kem_keypair/crypto_kem_keypair_harness.c
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file crypto_kem_keypair_harness.c
+ * @brief Implements the proof harness for crypto_kem_keypair function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <kem.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t *a, *b;
+  crypto_kem_keypair(a, b);
+}

--- a/cbmc/proofs/verify/Makefile
+++ b/cbmc/proofs/verify/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = verify_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = verify
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/verify.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)verify
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)verify
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/verify/cbmc-proof.txt
+++ b/cbmc/proofs/verify/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/verify/verify_harness.c
+++ b/cbmc/proofs/verify/verify_harness.c
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0 AND Apache-2.0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file verify_harness.c
+ * @brief Implements the proof harness for verify function.
+ */
+#include "verify.h"
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t *x, *y;
+  size_t len;
+  verify(x, y, len);
+}

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -131,24 +131,6 @@ int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
   return crypto_kem_enc_derand(ct, ss, pk, coins);
 }
 
-/*************************************************
- * Name:        crypto_kem_dec
- *
- * Description: Generates shared secret for given
- *              cipher text and private key
- *
- * Arguments:   - uint8_t *ss: pointer to output shared secret
- *                (an already allocated array of MLKEM_SSBYTES bytes)
- *              - const uint8_t *ct: pointer to input cipher text
- *                (an already allocated array of MLKEM_CIPHERTEXTBYTES bytes)
- *              - const uint8_t *sk: pointer to input private key
- *                (an already allocated array of MLKEM_SECRETKEYBYTES bytes)
- *
- * Returns 0 on success, and -1 if the secret key hash check (see Section 7.3 of
- * FIPS203) fails.
- *
- * On failure, ss will contain a pseudo-random value.
- **************************************************/
 int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
   int fail;
   uint8_t buf[2 * MLKEM_SYMBYTES] ALIGN;

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -33,11 +33,60 @@ int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk,
 int crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
 
 #define crypto_kem_enc_derand MLKEM_NAMESPACE(enc_derand)
+/*************************************************
+ * Name:        crypto_kem_enc_derand
+ *
+ * Description: Generates cipher text and shared
+ *              secret for given public key
+ *
+ * Arguments:   - uint8_t *ct: pointer to output cipher text
+ *                (an already allocated array of MLKEM_CIPHERTEXTBYTES bytes)
+ *              - uint8_t *ss: pointer to output shared secret
+ *                (an already allocated array of MLKEM_SSBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                (an already allocated array of MLKEM_PUBLICKEYBYTES bytes)
+ *              - const uint8_t *coins: pointer to input randomness
+ *                (an already allocated array filled with MLKEM_SYMBYTES random
+ *bytes)
+ **
+ * Returns 0 on success, and -1 if the public key modulus check (see Section 7.2
+ * of FIPS203) fails.
+ **************************************************/
 int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
-                          const uint8_t *coins);
+                          const uint8_t *coins)  // clang-format off
+  REQUIRES(IS_FRESH(ct, MLKEM_CIPHERTEXTBYTES))
+  REQUIRES(IS_FRESH(ss, MLKEM_SSBYTES))
+  REQUIRES(IS_FRESH(pk, MLKEM_PUBLICKEYBYTES))
+  REQUIRES(IS_FRESH(coins, MLKEM_SYMBYTES))
+  ASSIGNS(OBJECT_WHOLE(ct))
+  ASSIGNS(OBJECT_WHOLE(ss));
+// clang-format on
 
 #define crypto_kem_enc MLKEM_NAMESPACE(enc)
-int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+/*************************************************
+ * Name:        crypto_kem_enc
+ *
+ * Description: Generates cipher text and shared
+ *              secret for given public key
+ *
+ * Arguments:   - uint8_t *ct: pointer to output cipher text
+ *                (an already allocated array of MLKEM_CIPHERTEXTBYTES bytes)
+ *              - uint8_t *ss: pointer to output shared secret
+ *                (an already allocated array of MLKEM_SSBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                (an already allocated array of MLKEM_PUBLICKEYBYTES bytes)
+ *
+ * Returns 0 on success, and -1 if the public key modulus check (see Section 7.2
+ * of FIPS203) fails.
+ **************************************************/
+int crypto_kem_enc(uint8_t *ct, uint8_t *ss,
+                   const uint8_t *pk)  // clang-format off
+  REQUIRES(IS_FRESH(ct, MLKEM_CIPHERTEXTBYTES))
+  REQUIRES(IS_FRESH(ss, MLKEM_SSBYTES))
+  REQUIRES(IS_FRESH(pk, MLKEM_PUBLICKEYBYTES))
+  ASSIGNS(OBJECT_WHOLE(ct))
+  ASSIGNS(OBJECT_WHOLE(ss));
+// clang-format on
 
 #define crypto_kem_dec MLKEM_NAMESPACE(dec)
 int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -107,6 +107,30 @@ int crypto_kem_enc(uint8_t *ct, uint8_t *ss,
 // clang-format on
 
 #define crypto_kem_dec MLKEM_NAMESPACE(dec)
-int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+/*************************************************
+ * Name:        crypto_kem_dec
+ *
+ * Description: Generates shared secret for given
+ *              cipher text and private key
+ *
+ * Arguments:   - uint8_t *ss: pointer to output shared secret
+ *                (an already allocated array of MLKEM_SSBYTES bytes)
+ *              - const uint8_t *ct: pointer to input cipher text
+ *                (an already allocated array of MLKEM_CIPHERTEXTBYTES bytes)
+ *              - const uint8_t *sk: pointer to input private key
+ *                (an already allocated array of MLKEM_SECRETKEYBYTES bytes)
+ *
+ * Returns 0 on success, and -1 if the secret key hash check (see Section 7.3 of
+ * FIPS203) fails.
+ *
+ * On failure, ss will contain a pseudo-random value.
+ **************************************************/
+int crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
+                   const uint8_t *sk)  // clang-format off
+  REQUIRES(IS_FRESH(ss, MLKEM_SSBYTES))
+  REQUIRES(IS_FRESH(ct, MLKEM_CIPHERTEXTBYTES))
+  REQUIRES(IS_FRESH(sk, MLKEM_SECRETKEYBYTES))
+  ASSIGNS(OBJECT_WHOLE(ss));
+// clang-format on
 
 #endif

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -30,7 +30,25 @@ int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk,
 // clang-format on
 
 #define crypto_kem_keypair MLKEM_NAMESPACE(keypair)
-int crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
+/*************************************************
+ * Name:        crypto_kem_keypair
+ *
+ * Description: Generates public and private key
+ *              for CCA-secure ML-KEM key encapsulation mechanism
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                (an already allocated array of MLKEM_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                (an already allocated array of MLKEM_SECRETKEYBYTES bytes)
+ *
+ * Returns 0 (success)
+ **************************************************/
+int crypto_kem_keypair(uint8_t *pk, uint8_t *sk)  // clang-format off
+  REQUIRES(IS_FRESH(pk, MLKEM_PUBLICKEYBYTES))
+  REQUIRES(IS_FRESH(sk, MLKEM_SECRETKEYBYTES))
+  ASSIGNS(OBJECT_WHOLE(pk))
+  ASSIGNS(OBJECT_WHOLE(sk));
+// clang-format on
 
 #define crypto_kem_enc_derand MLKEM_NAMESPACE(enc_derand)
 /*************************************************

--- a/mlkem/randombytes.h
+++ b/mlkem/randombytes.h
@@ -5,6 +5,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-void randombytes(uint8_t *out, size_t outlen);
+#include "cbmc.h"
+
+void randombytes(uint8_t *out, size_t outlen)  // clang-format off
+  REQUIRES(IS_FRESH(out, outlen))
+  ASSIGNS(OBJECT_UPTO(out, outlen));
+// clang-format on
 
 #endif

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -3,17 +3,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/*************************************************
- * Name:        verify
- *
- * Description: Compare two arrays for equality in constant time.
- *
- * Arguments:   const uint8_t *a: pointer to first byte array
- *              const uint8_t *b: pointer to second byte array
- *              size_t len:       length of the byte arrays
- *
- * Returns 0 if the byte arrays are equal, 1 otherwise
- **************************************************/
 int verify(const uint8_t *a, const uint8_t *b, size_t len) {
   size_t i;
   uint8_t r = 0;
@@ -25,19 +14,6 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len) {
   return (-(uint64_t)r) >> 63;
 }
 
-/*************************************************
- * Name:        cmov
- *
- * Description: Copy len bytes from x to r if b is 1;
- *              don't modify x if b is 0. Requires b to be in {0,1};
- *              assumes two's complement representation of negative integers.
- *              Runs in constant time.
- *
- * Arguments:   uint8_t *r:       pointer to output byte array
- *              const uint8_t *x: pointer to input byte array
- *              size_t len:       Amount of bytes to be copied
- *              uint8_t b:        Condition bit; has to be in {0,1}
- **************************************************/
 void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b) {
   size_t i;
 

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -7,20 +7,42 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len) {
   size_t i;
   uint8_t r = 0;
 
-  for (i = 0; i < len; i++) {
-    r |= a[i] ^ b[i];
-  }
+  for (i = 0; i < len; i++)  // clang-format off
+    ASSIGNS(i, r)
+    INVARIANT(i <= len)
+    // clang-format on
+    {
+      r |= a[i] ^ b[i];
+    }
 
-  return (-(uint64_t)r) >> 63;
+    // Our CBMC setup rejects the conversion of negative signed
+    // numbers to unsigned numbers, even though it's fully defined
+    // by the standard. Disable the check for this check which
+    // requires signed-to-unsigned conversion.
+#ifdef CBMC
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
+#endif
+  int res = (((uint64_t)-r) >> 63);
+#ifdef CBMC
+#pragma CPROVER check pop
+#endif
+  ASSERT((r != 0) == (res == 1), "verify bitfiddling gone wrong");
+  ASSERT((r == 0) == (res == 0), "verify bitfiddling gone wrong");
+  return res;
 }
 
 void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b) {
   size_t i;
 
-  b = -b;
-  for (i = 0; i < len; i++) {
-    r[i] ^= b & (r[i] ^ x[i]);
-  }
+  b = (-b) & 0xFF;
+  for (i = 0; i < len; i++)  // clang-format off
+    ASSIGNS(i, OBJECT_UPTO(r, len))
+    INVARIANT(i <= len)
+    // clang-format on
+    {
+      r[i] ^= b & (r[i] ^ x[i]);
+    }
 }
 
 /*************************************************

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -8,10 +8,42 @@
 #include "params.h"
 
 #define verify MLKEM_NAMESPACE(verify)
-int verify(const uint8_t *a, const uint8_t *b, size_t len);
+/*************************************************
+ * Name:        verify
+ *
+ * Description: Compare two arrays for equality in constant time.
+ *
+ * Arguments:   const uint8_t *a: pointer to first byte array
+ *              const uint8_t *b: pointer to second byte array
+ *              size_t len:       length of the byte arrays
+ *
+ * Returns 0 if the byte arrays are equal, 1 otherwise
+ **************************************************/
+int verify(const uint8_t *a, const uint8_t *b, size_t len)  // clang-format off
+  REQUIRES(IS_FRESH(a, len))
+  REQUIRES(IS_FRESH(b, len))
+  ENSURES(RETURN_VALUE == 0 || RETURN_VALUE == 1);
+// clang-format on
 
 #define cmov MLKEM_NAMESPACE(cmov)
-void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b);
+/*************************************************
+ * Name:        cmov
+ *
+ * Description: Copy len bytes from x to r if b is 1;
+ *              don't modify x if b is 0. Requires b to be in {0,1};
+ *              assumes two's complement representation of negative integers.
+ *              Runs in constant time.
+ *
+ * Arguments:   uint8_t *r:       pointer to output byte array
+ *              const uint8_t *x: pointer to input byte array
+ *              size_t len:       Amount of bytes to be copied
+ *              uint8_t b:        Condition bit; has to be in {0,1}
+ **************************************************/
+void cmov(uint8_t *r, const uint8_t *x, size_t len,
+          uint8_t b)  // clang-format on
+    REQUIRES(IS_FRESH(r, len)) REQUIRES(IS_FRESH(x, len))
+        REQUIRES(b == 0 || b == 1) ASSIGNS(OBJECT_UPTO(r, len));
+// clang-format off
 
 #define cmov_int16 MLKEM_NAMESPACE(cmov_int16)
 /*************************************************

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -40,10 +40,12 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len)  // clang-format off
  *              uint8_t b:        Condition bit; has to be in {0,1}
  **************************************************/
 void cmov(uint8_t *r, const uint8_t *x, size_t len,
-          uint8_t b)  // clang-format on
-    REQUIRES(IS_FRESH(r, len)) REQUIRES(IS_FRESH(x, len))
-        REQUIRES(b == 0 || b == 1) ASSIGNS(OBJECT_UPTO(r, len));
-// clang-format off
+          uint8_t b)  // clang-format off
+  REQUIRES(IS_FRESH(r, len))
+  REQUIRES(IS_FRESH(x, len))
+  REQUIRES(b == 0 || b == 1)
+  ASSIGNS(OBJECT_UPTO(r, len));
+// clang-format on
 
 #define cmov_int16 MLKEM_NAMESPACE(cmov_int16)
 /*************************************************


### PR DESCRIPTION
This PR adds a memory and type safety proofs for `crypto_kem_enc_derand`, `crypto_kem_enc` and `crypto_kem_keypair` using CBMC. This brings together various lower level proofs established before.

Unfortunately, the `memcmp()` invocation in `check_pk()` had to be wrapped manually to prevent CBMC from inlining an implementation of `memcmp()` and somehow getting stuck.

* Resolves #387 
* Resolves #386 
* Resolves #388 

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
