### PR TITLE
Add Windows build + functional test (using nmake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,18 @@ jobs:
       - name: check namespacing
         run: |
           ./scripts/ci/check-namespace
+  quickcheck-windows:
+    name: Quickcheck windows-latest
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Build test
+        shell: powershell
+        run: |
+          # print compiler version
+          cl
+          nmake /f ./Makefile.Microsoft_nmake quickcheck
   build_kat:
     needs: quickcheck
     strategy:

--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CFLAGS = /nologo /O2 /Imlkem /Ifips202 /Ifips202/native /Imlkem/sys /Imlkem/native
+
+OBJ_FILES = .\mlkem\*.obj \
+            .\fips202\*.obj \
+
+BUILD_DIR = test\build
+MLKEM512_BUILD_DIR = $(BUILD_DIR)\mlkem512
+MLKEM768_BUILD_DIR = $(BUILD_DIR)\mlkem768
+MLKEM1024_BUILD_DIR = $(BUILD_DIR)\mlkem1024
+
+OBJ_FILES_512 = $(subst .\,$(MLKEM512_BUILD_DIR)\,$(OBJ_FILES))
+OBJ_FILES_768 = $(subst .\,$(MLKEM768_BUILD_DIR)\,$(OBJ_FILES))
+OBJ_FILES_1024 = $(subst .\,$(MLKEM1024_BUILD_DIR)\,$(OBJ_FILES))
+
+# NOTE: We currently only build code for non-opt code, as we haven't yet made the assembly compatible on Windows
+!IFNDEF OPT
+OPT = 0
+!ENDIF
+
+{test/notrandombytes}.c{$(BUILD_DIR)\randombytes}.obj::
+	@if NOT EXIST $(BUILD_DIR)\randombytes mkdir $(BUILD_DIR)\randombytes
+    $(CC) $(CFLAGS) /c /Fo$(BUILD_DIR)\randombytes\ $<
+
+# compilation for mlkem512
+{mlkem}.c{$(MLKEM512_BUILD_DIR)\mlkem}.obj::
+    @if NOT EXIST $(MLKEM512_BUILD_DIR)\mlkem mkdir $(MLKEM512_BUILD_DIR)\mlkem
+    $(CC) $(CFLAGS) /D MLKEM_K=2 /c /Fo$(MLKEM512_BUILD_DIR)\mlkem\ $<
+
+{fips202}.c{$(MLKEM512_BUILD_DIR)\fips202}.obj::
+    @if NOT EXIST $(MLKEM512_BUILD_DIR)\fips202 mkdir $(MLKEM512_BUILD_DIR)\fips202
+    $(CC) $(CFLAGS) /D MLKEM_K=2 /c /Fo$(MLKEM512_BUILD_DIR)\fips202\ $<
+
+{test}.c{$(MLKEM512_BUILD_DIR)\test}.obj::
+    @if NOT EXIST $(MLKEM512_BUILD_DIR)\test mkdir $(MLKEM512_BUILD_DIR)\test
+    $(CC) $(CFLAGS) /D MLKEM_K=2 /c /Fo$(MLKEM512_BUILD_DIR)\test\ $<
+
+# compilation for mlkem768
+{mlkem}.c{$(MLKEM768_BUILD_DIR)\mlkem}.obj::
+    @if NOT EXIST $(MLKEM768_BUILD_DIR)\mlkem mkdir $(MLKEM768_BUILD_DIR)\mlkem
+    $(CC) $(CFLAGS) /D MLKEM_K=3 /c /Fo$(MLKEM768_BUILD_DIR)\mlkem\ $<
+
+{fips202}.c{$(MLKEM768_BUILD_DIR)\fips202}.obj::
+    @if NOT EXIST $(MLKEM768_BUILD_DIR)\fips202 mkdir $(MLKEM768_BUILD_DIR)\fips202
+    $(CC) $(CFLAGS) /D MLKEM_K=3 /c /Fo$(MLKEM768_BUILD_DIR)\fips202\ $<
+
+{test}.c{$(MLKEM768_BUILD_DIR)\test}.obj::
+    @if NOT EXIST $(MLKEM768_BUILD_DIR)\test mkdir $(MLKEM768_BUILD_DIR)\test
+    $(CC) $(CFLAGS) /D MLKEM_K=3 /c /Fo$(MLKEM768_BUILD_DIR)\test\ $<
+
+# compilation for mlkem1024
+{mlkem}.c{$(MLKEM1024_BUILD_DIR)\mlkem}.obj::
+    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\mlkem mkdir $(MLKEM1024_BUILD_DIR)\mlkem
+    $(CC) $(CFLAGS) /D MLKEM_K=4 /c /Fo$(MLKEM1024_BUILD_DIR)\mlkem\ $<
+
+{fips202}.c{$(MLKEM1024_BUILD_DIR)\fips202}.obj::
+    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\fips202 mkdir $(MLKEM1024_BUILD_DIR)\fips202
+    $(CC) $(CFLAGS) /D MLKEM_K=4 /c /Fo$(MLKEM1024_BUILD_DIR)\fips202\ $<
+
+{test}.c{$(MLKEM1024_BUILD_DIR)\test}.obj::
+    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\test mkdir $(MLKEM1024_BUILD_DIR)\test
+    $(CC) $(CFLAGS) /D MLKEM_K=4 /c /Fo$(MLKEM1024_BUILD_DIR)\test\ $<
+
+
+# compile functional test for mlkem512
+test_mlkem512: $(OBJ_FILES_512) $(MLKEM512_BUILD_DIR)\test\test_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLKEM512_BUILD_DIR)\bin mkdir $(MLKEM512_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLKEM_K=2 /Fe$(MLKEM512_BUILD_DIR)\bin\test_mlkem512 $** /link
+
+# compile functional test for mlkem768
+test_mlkem768: $(OBJ_FILES_768) $(MLKEM768_BUILD_DIR)\test\test_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLKEM768_BUILD_DIR)\bin mkdir $(MLKEM768_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLKEM_K=3 /Fe$(MLKEM768_BUILD_DIR)\bin\test_mlkem768 $** /link
+
+# compile functional test for mlkem1024
+test_mlkem1024: $(OBJ_FILES_1024) $(MLKEM1024_BUILD_DIR)\test\test_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\bin mkdir $(MLKEM1024_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLKEM_K=4 /Fe$(MLKEM1024_BUILD_DIR)\bin\test_mlkem1024 $** /link
+
+quickcheck: test_mlkem512 test_mlkem768 test_mlkem1024
+    $(MLKEM512_BUILD_DIR)\bin\test_mlkem512.exe
+	$(MLKEM768_BUILD_DIR)\bin\test_mlkem768.exe
+	$(MLKEM1024_BUILD_DIR)\bin\test_mlkem1024.exe
+
+clean:
+    -DEL $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ make kat
 
 The resulting binaries can be found in [test/build](test/build).
 
+### Windows
+
+You can also build **mlkem-native** on Windows using `nmake` and an MSVC compiler.
+
+To build and run the tests (only support functional testing for non-opt implementation for now), use the following `nmake` targets:
+```powershell
+nmke /f .\Makefile.Microsoft_nmake quickcheck
+```
+
 ### Using `tests` script
 
 We recommend compiling and running tests and benchmarks using the [`./scripts/tests`](scripts/tests) script. For

--- a/fips202/keccakf1600.h
+++ b/fips202/keccakf1600.h
@@ -16,7 +16,7 @@
 //
 // The struct is only exposed here to allow its construction on the stack.
 //
-typedef uint64_t keccakx4_state[KECCAK_WAY * KECCAK_LANES] ALIGN;
+typedef ALIGN uint64_t keccakx4_state[KECCAK_WAY * KECCAK_LANES];
 
 #define KeccakF1600_StateExtractBytes \
   FIPS202_NAMESPACE(KeccakF1600_StateExtractBytes)

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -3,8 +3,12 @@
 #define COMMON_H
 
 #define DEFAULT_ALIGN 32
+#if defined(_WIN32)
+#define ALWAYS_INLINE __forceinline
+#else
 #define ALIGN __attribute__((aligned(DEFAULT_ALIGN)))
 #define ALWAYS_INLINE __attribute__((always_inline))
+#endif
 
 #define MLKEM_CONCAT_(left, right) left##right
 #define MLKEM_CONCAT(left, right) MLKEM_CONCAT_(left, right)

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -4,6 +4,7 @@
 
 #define DEFAULT_ALIGN 32
 #if defined(_WIN32)
+#define ALIGN __declspec(align(DEFAULT_ALIGN))
 #define ALWAYS_INLINE __forceinline
 #else
 #define ALIGN __attribute__((aligned(DEFAULT_ALIGN)))

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -215,7 +215,7 @@ void gen_matrix_entry(poly *entry,
   buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
   ctr = rej_uniform(entry->coeffs, MLKEM_N, 0, buf, buflen);
 
-  // Squeeze + sampel one more block a time until we're done
+  // Squeeze + sample one more block a time until we're done
   buflen = SHAKE128_RATE;
   while (ctr < MLKEM_N)  // clang-format off
     ASSIGNS(ctr, state, OBJECT_UPTO(entry, sizeof(poly)), OBJECT_WHOLE(buf))
@@ -249,10 +249,10 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES],
   // We generate four separate seed arrays rather than a single one to work
   // around limitations in CBMC function contracts dealing with disjoint slices
   // of the same parent object.
-  uint8_t seed0[MLKEM_SYMBYTES + 2] ALIGN;
-  uint8_t seed1[MLKEM_SYMBYTES + 2] ALIGN;
-  uint8_t seed2[MLKEM_SYMBYTES + 2] ALIGN;
-  uint8_t seed3[MLKEM_SYMBYTES + 2] ALIGN;
+  ALIGN uint8_t seed0[MLKEM_SYMBYTES + 2];
+  ALIGN uint8_t seed1[MLKEM_SYMBYTES + 2];
+  ALIGN uint8_t seed2[MLKEM_SYMBYTES + 2];
+  ALIGN uint8_t seed3[MLKEM_SYMBYTES + 2];
   uint8_t *seedxy[] = {seed0, seed1, seed2, seed3};
 
   for (unsigned j = 0; j < KECCAK_WAY; j++) {
@@ -369,13 +369,13 @@ STATIC_ASSERT(NTT_BOUND + MLKEM_Q < INT16_MAX, indcpa_enc_bound_0)
 void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
                            const uint8_t coins[MLKEM_SYMBYTES]) {
-  uint8_t buf[2 * MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t buf[2 * MLKEM_SYMBYTES];
   const uint8_t *publicseed = buf;
   const uint8_t *noiseseed = buf + MLKEM_SYMBYTES;
   polyvec a[MLKEM_K], e, pkpv, skpv;
   polyvec_mulcache skpv_cache;
 
-  uint8_t coins_with_domain_separator[MLKEM_SYMBYTES + 1] ALIGN;
+  ALIGN uint8_t coins_with_domain_separator[MLKEM_SYMBYTES + 1];
   // Concatenate coins with MLKEM_K for domain separation of security levels
   memcpy(coins_with_domain_separator, coins, MLKEM_SYMBYTES);
   coins_with_domain_separator[MLKEM_SYMBYTES] = MLKEM_K;
@@ -445,7 +445,7 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                 const uint8_t coins[MLKEM_SYMBYTES]) {
-  uint8_t seed[MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t seed[MLKEM_SYMBYTES];
   polyvec sp, pkpv, ep, at[MLKEM_K], b;
   poly v, k, epp;
   polyvec_mulcache sp_cache;

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -96,7 +96,7 @@ int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins) {
 }
 
 int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
-  uint8_t coins[2 * MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t coins[2 * MLKEM_SYMBYTES];
   randombytes(coins, 2 * MLKEM_SYMBYTES);
   crypto_kem_keypair_derand(pk, sk, coins);
   return 0;
@@ -104,9 +104,9 @@ int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
 
 int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
                           const uint8_t *coins) {
-  uint8_t buf[2 * MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t buf[2 * MLKEM_SYMBYTES];
   /* Will contain key, coins */
-  uint8_t kr[2 * MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
 
   if (check_pk(pk)) {
     return -1;
@@ -126,17 +126,17 @@ int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
 }
 
 int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
-  uint8_t coins[MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t coins[MLKEM_SYMBYTES];
   randombytes(coins, MLKEM_SYMBYTES);
   return crypto_kem_enc_derand(ct, ss, pk, coins);
 }
 
 int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
   int fail;
-  uint8_t buf[2 * MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t buf[2 * MLKEM_SYMBYTES];
   /* Will contain key, coins */
-  uint8_t kr[2 * MLKEM_SYMBYTES] ALIGN;
-  uint8_t cmp[MLKEM_CIPHERTEXTBYTES + MLKEM_SYMBYTES] ALIGN;
+  ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
+  ALIGN uint8_t cmp[MLKEM_CIPHERTEXTBYTES + MLKEM_SYMBYTES];
   const uint8_t *pk = sk + MLKEM_INDCPA_SECRETKEYBYTES;
 
   if (check_sk(sk)) {

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -224,8 +224,8 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *a) {
 void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                            const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce0,
                            uint8_t nonce1, uint8_t nonce2, uint8_t nonce3) {
-  uint8_t buf[KECCAK_WAY][MLKEM_ETA1 * MLKEM_N / 4] ALIGN;
-  uint8_t extkey[KECCAK_WAY][MLKEM_SYMBYTES + 1] ALIGN;
+  ALIGN uint8_t buf[KECCAK_WAY][MLKEM_ETA1 * MLKEM_N / 4];
+  ALIGN uint8_t extkey[KECCAK_WAY][MLKEM_SYMBYTES + 1];
   memcpy(extkey[0], seed, MLKEM_SYMBYTES);
   memcpy(extkey[1], seed, MLKEM_SYMBYTES);
   memcpy(extkey[2], seed, MLKEM_SYMBYTES);
@@ -249,7 +249,7 @@ void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
 
 void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES],
                         uint8_t nonce) {
-  uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4] ALIGN;
+  ALIGN uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4];
   prf(buf, sizeof(buf), seed, nonce);
   poly_cbd_eta2(r, buf);
 
@@ -260,9 +260,9 @@ void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                               const uint8_t seed[MLKEM_SYMBYTES],
                               uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
                               uint8_t nonce3) {
-  uint8_t buf1[KECCAK_WAY / 2][MLKEM_ETA1 * MLKEM_N / 4] ALIGN;
-  uint8_t buf2[KECCAK_WAY / 2][MLKEM_ETA2 * MLKEM_N / 4] ALIGN;
-  uint8_t extkey[KECCAK_WAY][MLKEM_SYMBYTES + 1] ALIGN;
+  ALIGN uint8_t buf1[KECCAK_WAY / 2][MLKEM_ETA1 * MLKEM_N / 4];
+  ALIGN uint8_t buf2[KECCAK_WAY / 2][MLKEM_ETA2 * MLKEM_N / 4];
+  ALIGN uint8_t extkey[KECCAK_WAY][MLKEM_SYMBYTES + 1];
   memcpy(extkey[0], seed, MLKEM_SYMBYTES);
   memcpy(extkey[1], seed, MLKEM_SYMBYTES);
   memcpy(extkey[2], seed, MLKEM_SYMBYTES);

--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -42,10 +42,10 @@ static int cmp_uint64_t(const void *a, const void *b) {
   printf(txt " cycles=%" PRIu64 "\n", (cyc)[NTESTS >> 1] / NITERERATIONS);
 
 static int bench(void) {
-  uint64_t data0[1024] ALIGN;
-  uint64_t data1[1024] ALIGN;
-  uint64_t data2[1024] ALIGN;
-  uint64_t data3[1024] ALIGN;
+  ALIGN uint64_t data0[1024];
+  ALIGN uint64_t data1[1024];
+  ALIGN uint64_t data2[1024];
+  ALIGN uint64_t data3[1024];
   uint64_t cyc[NTESTS];
 
   unsigned int i, j;

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -24,12 +24,12 @@ static void shake256_absorb(shake256incctx *state, const uint8_t *input,
 }
 
 int main(void) {
-  uint8_t coins[3 * MLKEM_SYMBYTES] ALIGN;
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES] ALIGN;
-  uint8_t sk[CRYPTO_SECRETKEYBYTES] ALIGN;
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES] ALIGN;
-  uint8_t ss1[CRYPTO_BYTES] ALIGN;
-  uint8_t ss2[CRYPTO_BYTES] ALIGN;
+  ALIGN uint8_t coins[3 * MLKEM_SYMBYTES];
+  ALIGN uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  ALIGN uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  ALIGN uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  ALIGN uint8_t ss1[CRYPTO_BYTES];
+  ALIGN uint8_t ss2[CRYPTO_BYTES];
 
   const uint8_t seed[64] = {
       32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,


### PR DESCRIPTION
- Resolves #227
- For simplicity, I only provide a `quickcheck` target in the windows makefile for building and running the functional tests binaries
- Windows nmake command:
  - `nmake /f ./Makefile.Microsoft_nmake quickcheck`
- Built binaries path:
  - `test/build/mlkem512/bin/test_mlkem512.exe`
  - `test/build/mlkem768/bin/test_mlkem768.exe`
  - `test/build/mlkem1024/bin/test_mlkem1024.exe`
- Only support for compiling non-opt implementation, as I don't know how to make the assembly compatible on Windows

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
