### PR TITLE
CBMC: Increase OBJECT_BITS in poly_invntt_tomont proof

### DIFF
--- a/cbmc/proofs/poly_invntt_tomont/Makefile
+++ b/cbmc/proofs/poly_invntt_tomont/Makefile
@@ -36,7 +36,7 @@ FUNCTION_NAME = poly_invntt_tomont
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 12
+CBMC_OBJECT_BITS = 13
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
We see spurious failures of poly_invntt_tomont, and bumping OBJECT_BITS is an attempt to fix those. It's to be determined whether this is indeed the root cause.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
