### PR TITLE
CBMC proof of verify()

### DIFF
--- a/cbmc/proofs/verify/Makefile
+++ b/cbmc/proofs/verify/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = $(MLKEM_NAMESPACE)verify
 

--- a/cbmc/proofs/verify/verify_harness.c
+++ b/cbmc/proofs/verify/verify_harness.c
@@ -22,7 +22,9 @@
  *
  */
 void harness(void) {
-  uint8_t *x, *y;
+  uint8_t *a;
+  uint8_t *b;
   size_t len;
-  verify(x, y, len);
+  int r;
+  r = verify(a, b, len);
 }

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -2,6 +2,7 @@
 #ifndef VERIFY_H
 #define VERIFY_H
 
+#include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "cbmc.h"
@@ -19,10 +20,12 @@
  *
  * Returns 0 if the byte arrays are equal, 1 otherwise
  **************************************************/
-int verify(const uint8_t *a, const uint8_t *b, size_t len)  // clang-format off
-  REQUIRES(IS_FRESH(a, len))
-  REQUIRES(IS_FRESH(b, len))
-  ENSURES(RETURN_VALUE == 0 || RETURN_VALUE == 1);
+int verify(const uint8_t *a, const uint8_t *b,
+           const size_t len)  // clang-format off
+REQUIRES(IS_FRESH(a, len))
+REQUIRES(IS_FRESH(b, len))
+REQUIRES(len <= INT_MAX)
+ENSURES(RETURN_VALUE == (1 - FORALL(int, i, 0, ((int)len - 1), (a[i] == b[i]))));
 // clang-format on
 
 #define cmov MLKEM_NAMESPACE(cmov)


### PR DESCRIPTION
Adds proof of type-safety AND partial correctness
of the verify() function.

All tests OK
lint OK
All proofs OK, including calling unit crypto_kem_dec()
