### PR TITLE
fix: tests bench --opt=all and tests all --no-acvp

### DIFF
--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -594,15 +594,23 @@ class Tests:
             else:
                 exec_wrapper = f"taskpolicy -c {mac_taskpolicy}"
 
-        if self.compile:
-            t.compile(self.opt, extra_make_args=[f"CYCLES={cycles}"])
-
-        if self.run:
-            if self.opt.lower() == "all":
-                # NOTE: We haven't yet decided how to output both opt/no-opt benchmark results
+        # NOTE: We haven't yet decided how to output both opt/no-opt benchmark results
+        if self.opt.lower() == "all":
+            if self.compile:
+                t.compile(False, extra_make_args=[f"CYCLES={cycles}"])
+            if self.run:
                 self._run_bench(t, False, run_as_root, exec_wrapper)
+            if self.compile:
+                t.compile(True, extra_make_args=[f"CYCLES={cycles}"])
+            if self.run:
                 resultss = self._run_bench(t, True, run_as_root, exec_wrapper)
-            else:
+        else:
+            if self.compile:
+                t.compile(
+                    True if self.opt.lower() == "opt" else False,
+                    extra_make_args=[f"CYCLES={cycles}"],
+                )
+            if self.run:
                 resultss = self._run_bench(
                     t,
                     True if self.opt.lower() == "opt" else False,
@@ -654,7 +662,7 @@ class Tests:
                     *([self._func.compile] if func else []),
                     *([self._nistkat.compile] if nistkat else []),
                     *([self._kat.compile] if kat else []),
-                    *([self._acvp.compile] if kat else []),
+                    *([self._acvp.compile] if acvp else []),
                 ]
 
                 for f in compiles:


### PR DESCRIPTION
Fix `tests bench --opt=all` only compile the benchmark once and run the binary twice, while it should compile and run the opt benchmark then compile and run the non-opt benchmark instead.

Fix `tests all` flag `--no-acvp` not actually used in function `all`, accidentally acvp tests would be disabled if kat test is disabled.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
