### PR TITLE
Improve speed of proof of matvec_mul()

### DIFF
--- a/cbmc/proofs/matvec_mul/Makefile
+++ b/cbmc/proofs/matvec_mul/Makefile
@@ -24,7 +24,18 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --no-array-field-sensitivity --arrays-uf-always --slice-formula
+CBMCFLAGS=--smt2
+
+# For this proof we tell CBMC to
+#  1. not decompose arrays into their individual cells
+#  2. to model arrays directly as SMT-lib arrays
+#  3. to slice constraints that are not in the cone of influcence of the proof obligations
+# These options simplify them modelling of arrays and produce much more compact
+# SMT files, leaving all array-type reasoning to the SMT solver.
+#
+# For functions that use large and multi-dimensional arrays, this yields
+# a substantial improvement in proof performance.
+CBMCFLAGS += --no-array-field-sensitivity --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = $(MLKEM_NAMESPACE)matvec_mul
 

--- a/cbmc/proofs/matvec_mul/Makefile
+++ b/cbmc/proofs/matvec_mul/Makefile
@@ -13,19 +13,18 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += matvec_mul.0:4 # Maximum value of MLKEM_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/indcpa.c
 
 CHECK_FUNCTION_CONTRACTS=matvec_mul
-USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)polyvec_mulcache_compute $(MLKEM_NAMESPACE)polyvec_basemul_acc_montgomery_cached
+USE_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)polyvec_basemul_acc_montgomery_cached
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2 --no-array-field-sensitivity --arrays-uf-always --slice-formula
 
 FUNCTION_NAME = $(MLKEM_NAMESPACE)matvec_mul
 
@@ -36,7 +35,7 @@ FUNCTION_NAME = $(MLKEM_NAMESPACE)matvec_mul
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 10
+CBMC_OBJECT_BITS = 8
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -220,7 +220,7 @@ void gen_matrix_entry(poly *entry,
   while (ctr < MLKEM_N)  // clang-format off
     ASSIGNS(ctr, state, OBJECT_UPTO(entry, sizeof(poly)), OBJECT_WHOLE(buf))
     INVARIANT(0 <= ctr && ctr <= MLKEM_N)
-    INVARIANT(ctr > 0 ==> ARRAY_BOUND(entry->coeffs, 0, ctr - 1, 
+    INVARIANT(ctr > 0 ==> ARRAY_BOUND(entry->coeffs, 0, ctr - 1,
                                           0, (MLKEM_Q - 1)))  // clang-format on
     {
       shake128_squeezeblocks(buf, 1, &state);
@@ -342,9 +342,12 @@ void matvec_mul(polyvec *out, const polyvec a[MLKEM_K], const polyvec *v,
   ASSIGNS(OBJECT_WHOLE(out))
 // clang-format on
 {
-  for (int i = 0; i < MLKEM_K; i++) {
-    polyvec_basemul_acc_montgomery_cached(&out->vec[i], &a[i], v, vc);
-  }
+  for (int i = 0; i < MLKEM_K; i++)  // clang-format off
+    ASSIGNS(i, OBJECT_WHOLE(out))
+    INVARIANT(i >= 0 && i <= MLKEM_K)  // clang-format on
+    {
+      polyvec_basemul_acc_montgomery_cached(&out->vec[i], &a[i], v, vc);
+    }
 }
 
 /*************************************************


### PR DESCRIPTION
Adjust modelling of arrays in CBMC for proof of this function, as recommended by CBMC team (See [CBMC Issue 8505](https://github.com/diffblue/cbmc/issues/8505)).

Proof for this function reduces from 70 seconds to about 9 seconds on desktop.

All tests OK
All proofs OK
lint OK



