### PR TITLE
Enable rej_uniform native implementation in x86_64

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -145,11 +145,10 @@ void gen_matrix_entry_x4(poly *vec, uint8_t *seed[4])  // clang-format off
 // clang-format on
 {
   // Temporary buffers for XOF output before rejection sampling
-  // padding so we can load full 16-byte vectors in native implementations
-  uint8_t buf0[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
-  uint8_t buf1[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
-  uint8_t buf2[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
-  uint8_t buf3[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
+  uint8_t buf0[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf1[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf2[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf3[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
 
   // Tracks the number of coefficients we have already sampled
   unsigned int ctr[KECCAK_WAY];
@@ -205,8 +204,7 @@ void gen_matrix_entry(poly *entry,
   ENSURES(ARRAY_BOUND(entry->coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
 {  // clang-format on
   shake128ctx state;
-  // padding so we can load full 16-byte vectors in native implementations
-  uint8_t buf[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
+  uint8_t buf[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
   unsigned int ctr, buflen;
 
   shake128_absorb(&state, seed, MLKEM_SYMBYTES + 2);

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -145,10 +145,11 @@ void gen_matrix_entry_x4(poly *vec, uint8_t *seed[4])  // clang-format off
 // clang-format on
 {
   // Temporary buffers for XOF output before rejection sampling
-  uint8_t buf0[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-  uint8_t buf1[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-  uint8_t buf2[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-  uint8_t buf3[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  // padding so we can load full 16-byte vectors in native implementations
+  uint8_t buf0[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
+  uint8_t buf1[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
+  uint8_t buf2[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
+  uint8_t buf3[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
 
   // Tracks the number of coefficients we have already sampled
   unsigned int ctr[KECCAK_WAY];
@@ -204,7 +205,8 @@ void gen_matrix_entry(poly *entry,
   ENSURES(ARRAY_BOUND(entry->coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
 {  // clang-format on
   shake128ctx state;
-  uint8_t buf[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  // padding so we can load full 16-byte vectors in native implementations
+  uint8_t buf[GEN_MATRIX_NBLOCKS * SHAKE128_RATE + 8];
   unsigned int ctr, buflen;
 
   shake128_absorb(&state, seed, MLKEM_SYMBYTES + 2);

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -61,12 +61,12 @@ static unsigned int rej_uniform_scalar(int16_t *r, unsigned int target,
   return ctr;
 }
 
-#if !defined(MLKEM_USE_NATIVE_AARCH64)
+#if !defined(MLKEM_USE_NATIVE_REJ_UNIFORM)
 unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
                          const uint8_t *buf, unsigned int buflen) {
   return rej_uniform_scalar(r, target, offset, buf, buflen);
 }
-#else  /* MLKEM_USE_NATIVE_AARCH64 */
+#else  /* MLKEM_USE_NATIVE_REJ_UNIFORM */
 
 unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
                          const uint8_t *buf, unsigned int buflen) {
@@ -79,4 +79,4 @@ unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
 
   return rej_uniform_scalar(r, target, offset, buf, buflen);
 }
-#endif /* MLKEM_USE_NATIVE_AARCH64 */
+#endif /* MLKEM_USE_NATIVE_REJ_UNIFORM */


### PR DESCRIPTION
This fixes a bug that caused our rej_uniform implementation to always use the C version instead of correctly using the native implementation when it should.
This bug was introduced, when we added the x86_64 backend as the flag for enabling it was renamed from MLKEM_USE_NATIVE_AARCH64 to MLKEM_USE_NATIVE_REJ_UNIFORM. This was not correctly changed in the rej_uniform.c.

Below are the performance results on my 13th Gen Intel i7-1360P (Raptor Lake) using gcc 14.2.1 from the Arch Linux repo.

Before (6aa6118e):

ML-KEM-512: 22353, 27820, 35663
ML-KEM-768: 39626, 43605, 54916
ML-KEM-1024: 58983, 65402, 80370

After:

ML-KEM-512:  19652, 25165, 32945
ML-KEM-768: 33383, 37343, 48652
ML-KEM-1024: 47658, 54087, 69003

#224 