### PR TITLE
CI: Push non-opt benchmarks to GH pages

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -110,6 +110,6 @@ jobs:
       archflags: ${{ matrix.target.archflags }}
       cflags: ${{ matrix.target.cflags }}
       opt: ${{ matrix.opt.value }}
-      store_results: ${{ matrix.opt.value && github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
-      name: ${{ matrix.target.name }}
+      store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
+      name: ${{ matrix.target.name }}${{ !matrix.opt.value && " (no-opt)" }}
     secrets: inherit

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -46,6 +46,9 @@ on:
 jobs:
   bench-ec2-any:
     name: Ad-hoc benchmark on $${{ inputs.ec2_instance_type }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     uses: ./.github/workflows/bench_ec2_reusable.yml
     with:
       ec2_instance_type: ${{ inputs.ec2_instance_type }}


### PR DESCRIPTION
Until now, we only pushed benchmarks for optimized code to the github pages. That was the wrong decision, as we are now curious to understand (a) where mlkem-native's pure-C performance stands in comparison to the reference implementation, and (b) how it has evolved over time, esp. in light of restructurings we made for the CBMC proofs.

Ultimately, we should retroactively conduct & push non-opt benchmarks. For now, this commit merely enables pushing benchmarking results to GH pages for non-optimized code.

Care needs to be taken to not mess up with existing optimized benchmarks by changing their name. Thus, we keep the previous names (which matched the target name, e.g. "Graviton 3"), but append " (no-opt)" in case we benchmarked the C backend.

* Resolves #406 