### PR TITLE
CI: Add test for non-standard values of GEN_MATRIX_NBLOCKS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,64 @@ jobs:
           nix-shell: ci-linter
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           cross-prefix: "aarch64-unknown-linux-gnu-"
-
+  # The purpose of this job is to test non-default yet valid configurations
+  config_variations:
+    name: Non-standard configurations
+    needs: quickcheck
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'ubuntu-latest (aarch64)'
+         - runner: pqcp-x64
+           name: 'ubuntu-latest (x86_64)'
+        exclude:
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'ubuntu-latest (aarch64)',
+             }}
+          - {external: true,
+             target: {
+               runner: pqcp-x64,
+               name: 'ubuntu-latest (x86_64)',
+             }}
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: "GEN_MATRIX_NBLOCKS=1"
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DGEN_MATRIX_NBLOCKS=1"
+          func: true
+          nistkat: true
+          kat: false
+          acvp: false
+      - name: "GEN_MATRIX_NBLOCKS=2"
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DGEN_MATRIX_NBLOCKS=2"
+          func: true
+          nistkat: true
+          kat: false
+          acvp: false
+      - name: "GEN_MATRIX_NBLOCKS=4"
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DGEN_MATRIX_NBLOCKS=4"
+          func: true
+          nistkat: true
+          kat: false
+          acvp: false
   ec2_functests:
     needs: quickcheck
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,32 +222,32 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: "GEN_MATRIX_NBLOCKS=1"
+      - name: "MLKEM_GEN_MATRIX_NBLOCKS=1"
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
-          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DGEN_MATRIX_NBLOCKS=1"
+          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DMLKEM_GEN_MATRIX_NBLOCKS=1"
           func: true
           nistkat: true
           kat: false
           acvp: false
-      - name: "GEN_MATRIX_NBLOCKS=2"
+      - name: "MLKEM_GEN_MATRIX_NBLOCKS=2"
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
-          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DGEN_MATRIX_NBLOCKS=2"
+          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DMLKEM_GEN_MATRIX_NBLOCKS=2"
           func: true
           nistkat: true
           kat: false
           acvp: false
-      - name: "GEN_MATRIX_NBLOCKS=4"
+      - name: "MLKEM_GEN_MATRIX_NBLOCKS=4"
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
-          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DGEN_MATRIX_NBLOCKS=4"
+          cflags: "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DMLKEM_GEN_MATRIX_NBLOCKS=4"
           func: true
           nistkat: true
           kat: false

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -124,8 +124,8 @@ static void unpack_ciphertext(polyvec *b, poly *v,
   poly_decompress(v, c + MLKEM_POLYVECCOMPRESSEDBYTES);
 }
 
-#ifndef GEN_MATRIX_NBLOCKS
-#define GEN_MATRIX_NBLOCKS \
+#ifndef MLKEM_GEN_MATRIX_NBLOCKS
+#define MLKEM_GEN_MATRIX_NBLOCKS \
   ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + SHAKE128_RATE) / SHAKE128_RATE)
 #endif
 
@@ -147,10 +147,10 @@ void gen_matrix_entry_x4(poly *vec, uint8_t *seed[4])  // clang-format off
 // clang-format on
 {
   // Temporary buffers for XOF output before rejection sampling
-  uint8_t buf0[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-  uint8_t buf1[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-  uint8_t buf2[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-  uint8_t buf3[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf0[MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf1[MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf2[MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf3[MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
 
   // Tracks the number of coefficients we have already sampled
   unsigned int ctr[KECCAK_WAY];
@@ -161,10 +161,11 @@ void gen_matrix_entry_x4(poly *vec, uint8_t *seed[4])  // clang-format off
   shake128x4_absorb(&statex, seed[0], seed[1], seed[2], seed[3],
                     MLKEM_SYMBYTES + 2);
 
-  // Initially, squeeze heuristic number of GEN_MATRIX_NBLOCKS.
+  // Initially, squeeze heuristic number of MLKEM_GEN_MATRIX_NBLOCKS.
   // This should generate the matrix entries with high probability.
-  shake128x4_squeezeblocks(buf0, buf1, buf2, buf3, GEN_MATRIX_NBLOCKS, &statex);
-  buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
+  shake128x4_squeezeblocks(buf0, buf1, buf2, buf3, MLKEM_GEN_MATRIX_NBLOCKS,
+                           &statex);
+  buflen = MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
   ctr[0] = rej_uniform(vec[0].coeffs, MLKEM_N, 0, buf0, buflen);
   ctr[1] = rej_uniform(vec[1].coeffs, MLKEM_N, 0, buf1, buflen);
   ctr[2] = rej_uniform(vec[2].coeffs, MLKEM_N, 0, buf2, buflen);
@@ -206,15 +207,15 @@ void gen_matrix_entry(poly *entry,
   ENSURES(ARRAY_BOUND(entry->coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
 {  // clang-format on
   shake128ctx state;
-  uint8_t buf[GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  uint8_t buf[MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
   unsigned int ctr, buflen;
 
   shake128_absorb(&state, seed, MLKEM_SYMBYTES + 2);
 
-  // Initially, squeeze + sample heuristic number of GEN_MATRIX_NBLOCKS.
+  // Initially, squeeze + sample heuristic number of MLKEM_GEN_MATRIX_NBLOCKS.
   // This should generate the matrix entry with high probability.
-  shake128_squeezeblocks(buf, GEN_MATRIX_NBLOCKS, &state);
-  buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
+  shake128_squeezeblocks(buf, MLKEM_GEN_MATRIX_NBLOCKS, &state);
+  buflen = MLKEM_GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
   ctr = rej_uniform(entry->coeffs, MLKEM_N, 0, buf, buflen);
 
   // Squeeze + sample one more block a time until we're done

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -124,8 +124,10 @@ static void unpack_ciphertext(polyvec *b, poly *v,
   poly_decompress(v, c + MLKEM_POLYVECCOMPRESSEDBYTES);
 }
 
+#ifndef GEN_MATRIX_NBLOCKS
 #define GEN_MATRIX_NBLOCKS \
   ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + SHAKE128_RATE) / SHAKE128_RATE)
+#endif
 
 // Generate four A matrix entries from a seed, using rejection
 // sampling on the output of a XOF.


### PR DESCRIPTION
GEN_MATRIX_NBLOCKS is a heuristic value estimating the amount of rejection sampling input to sample 256 polynomial coefficients.

While this value is hardcoded to 3 by default, one should be able to set it to any positive value. Moreover, some code-paths are not as easily reached with the default value, and testing a lower value increases the chances of catching bugs in those.

This commit allows the user to specify GEN_MATRIX_NBLOCKS in the CFLAGS, and extends the CI to test the non-standard values 1,2, and 4.

* Fixes #186 

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
