### PR TITLE
Adjust makefile for support -flto in nix shell

### DIFF
--- a/mk/bench.mk
+++ b/mk/bench.mk
@@ -1,5 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-LIBDEPS += $(LIB_DIR)/libhal.a
-LDLIBS += -lhal
 CPPFLAGS += -Itest/hal
-$(LIB_DIR)/libhal.a: $(call OBJS,$(wildcard test/hal/*.c))
+SOURCES += $(wildcard test/hal/*.c)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -41,8 +41,6 @@ CFLAGS += \
 	-MMD \
 	$(CPPFLAGS)
 
-LINKDEPS += $(LIBDEPS)
-
 ##################
 # Some Variables #
 ##################
@@ -83,7 +81,6 @@ include mk/auto.mk
 endif
 
 BUILD_DIR := test/build
-LIB_DIR := $(BUILD_DIR)/lib
 
 MAKE_OBJS = $(2:%=$(1)/%.o)
 OBJS = $(call MAKE_OBJS,$(BUILD_DIR),$(1))

--- a/mk/crypto.mk
+++ b/mk/crypto.mk
@@ -1,14 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-LDLIBS += -L$(LIB_DIR)
-
-LIBDEPS += $(LIB_DIR)/libfips202.a
-LDLIBS += -lfips202
 CPPFLAGS += -Ifips202 -Ifips202/native
 
-FIPS202_SRCS = $(wildcard fips202/*.c)
+SOURCES += $(wildcard fips202/*.c)
 ifeq ($(OPT),1)
-	FIPS202_SRCS += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
-	CPPFLAGS += -DMLKEM_USE_NATIVE
+	SOURCES += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
 endif
-
-$(LIB_DIR)/libfips202.a: $(call OBJS, $(FIPS202_SRCS))

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -1,24 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
-$(BUILD_DIR)/mlkem512/bin/%: $(LINKDEPS) $(CONFIG)
+$(BUILD_DIR)/mlkem512/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^)
 
-$(BUILD_DIR)/mlkem768/bin/%: $(LINKDEPS) $(CONFIG)
+$(BUILD_DIR)/mlkem768/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^)
 
-$(BUILD_DIR)/mlkem1024/bin/%: $(LINKDEPS) $(CONFIG)
+$(BUILD_DIR)/mlkem1024/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
-
-$(LIB_DIR)/%.a: $(CONFIG)
-	$(Q)echo "  AR      $@"
-	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(Q)rm -f $@
-	$(Q)$(AR) rcs $@ $(filter %.o,$^)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^)
 
 $(BUILD_DIR)/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-SOURCES = $(wildcard mlkem/*.c) $(wildcard mlkem/debug/*.c)
+SOURCES += $(wildcard mlkem/*.c) $(wildcard mlkem/debug/*.c)
 ifeq ($(OPT),1)
 	SOURCES += $(wildcard mlkem/native/aarch64/*.[csS]) $(wildcard mlkem/native/x86_64/*.[csS])
 	CPPFLAGS += -DMLKEM_USE_NATIVE

--- a/scripts/ci/check-namespace
+++ b/scripts/ci/check-namespace
@@ -65,7 +65,9 @@ def run():
     check_folder("test/build/mlkem512/mlkem", "PQCP_MLKEM_NATIVE_MLKEM512_")
     check_folder("test/build/mlkem768/mlkem", "PQCP_MLKEM_NATIVE_MLKEM768_")
     check_folder("test/build/mlkem1024/mlkem", "PQCP_MLKEM_NATIVE_MLKEM1024_")
-    check_folder("test/build/fips202", "PQCP_MLKEM_NATIVE_FIPS202_")
+    check_folder("test/build/mlkem512/fips202", "PQCP_MLKEM_NATIVE_FIPS202_")
+    check_folder("test/build/mlkem768/fips202", "PQCP_MLKEM_NATIVE_FIPS202_")
+    check_folder("test/build/mlkem1024/fips202", "PQCP_MLKEM_NATIVE_FIPS202_")
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Currently in nix shell, the build system won't properly linked if `-flto` is set.

This is due to that nix `gcc` comes with lto library, binutils like `ar` doesn't seem to
properly configured regarding this.

The easiest workaround to make `-flto` work is therefore to avoid building
libraries, let `gcc` take over everything.

Namespace checking needed to be updated as well, due to the new build system compiles fips202 artifact to `test/build/mlkemxxx/fips202` now.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
