### PR TITLE
 EC2 bench: Fix c6a/c6i instance types

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -98,13 +98,13 @@ jobs:
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
-            ec2_instance_type: c7a.medium
+            ec2_instance_type: c6a.medium
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 3rd gen (c6i)
-            ec2_instance_type: c7i.large
+            ec2_instance_type: c6i.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes
             cflags: "-flto -DFORCE_X86_64"


### PR DESCRIPTION
These are wrongly configured. 

After we merge this we should delete the wrong benchmarking data. 