### PR TITLE
EC2 bench: c6a.medium -> c6a.large

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -98,7 +98,7 @@ jobs:
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
-            ec2_instance_type: c6a.medium
+            ec2_instance_type: c6a.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes
             cflags: "-flto -DFORCE_X86_64"


### PR DESCRIPTION
c6a.medium is not a valid instance type.

#431 was wrong. Sorry about that. 