### PR TITLE
Build: Never use -flto for verify.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ to be readable and micro-optimization deferred to automated tooling such as
 implementations for which the C-code is verified to be free of undefined behaviour, and where all assembly is
 functionally verified.
 
+### Intended use
+
+**mlkem-native** is currently intended to be used as a code package, where source files of **mlkem-native**
+are imported into a consuming project's source tree and built using that project's build system. The build system
+provided in this repository is for experimental and development purposes only.
+
+#### Secure Compilation
+
+**mlkem-native** includes functions that are susceptible to compiler-induced variable-time code when inlined into
+their call-sites. Those functions are contained in [`mlkem/verify.c`](mlkem/verify.c). To ensure secure compilation, you
+MUST NOT enable link time optimization (LTO) for `mlkem/verify.c`. To the best of our knowledge, it is safe to compile
+the rest of the source tree with LTO.
+
 ### Current state
 
 **mlkem-native** is work in progress. **WE DO NOT CURRENTLY RECOMMEND RELYING ON THIS LIBRARY IN A PRODUCTION

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -13,6 +13,11 @@ MLKEM512_DIR = $(BUILD_DIR)/mlkem512
 MLKEM768_DIR = $(BUILD_DIR)/mlkem768
 MLKEM1024_DIR = $(BUILD_DIR)/mlkem1024
 
+# Even when link-time optimization is used for the rest of the code,
+# make sure not to use it for verify.c: Those are functions which, when
+# inlined, can be subject to compiler-induced variable-time code.
+%/verify.c.o: CPPFLAGS += -fno-lto
+
 $(MLKEM512_DIR)/bin/%: CPPFLAGS += -DMLKEM_K=2
 $(ALL_TESTS:%=$(MLKEM512_DIR)/bin/%512):$(MLKEM512_DIR)/bin/%512: $(MLKEM512_DIR)/test/%.c.o $(call MAKE_OBJS,$(MLKEM512_DIR), $(SOURCES))
 

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -3,6 +3,17 @@
 #include <stddef.h>
 #include <stdint.h>
 
+//
+// WARNING:
+//
+// The functions in this compilation unit may be susceptible to
+// compiler-induced variable-time code when inlined into their call-sites.
+// The purpose of having a separate compilation here is to prevent
+// such potentially insecure inlining.
+//
+// You MUST NOT compile this file using link time optimization.
+//
+
 int verify(const uint8_t *a, const uint8_t *b, const size_t len) {
   uint8_t r = 0;
   uint64_t u;


### PR DESCRIPTION
verify.c contains various functions which must not be inlined because compilers are tempted to compile them into code that's not constant time and thereby leaks something about the secret data being processed.

If `-flto` is used as a compile-time flag, verify.c is likely to be inlined.

This commit modifies the Makefile to force `-fno-lto` for verify.c, overwriting `-flto` if present.

This in particular affects our CI benchmarks, which do compile with `-flto`.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
