### PR TITLE
CI: restirct EC2 benchmarking to one instance

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,13 +11,12 @@ on:
     branches: ["main"]
     types: [ "labeled" ]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   bench:
     name: ${{ matrix.target.name }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: true
       matrix:
@@ -58,6 +57,9 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+    concurrency:
+      group: ec2-bench
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Experimenting with restricting the benchmarking jobs to only launch a single instance so we can potentially switch to beefier boxes.  