### PR TITLE
CI: Benchmark opt and non-opt on the same EC2 instance

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,11 +61,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        opt:
-          - name: opt
-            value: true
-          - name: no_opt
-            value: false
         target:
           - name: Graviton2
             ec2_instance_type: t4g.small
@@ -116,8 +111,8 @@ jobs:
       ec2_ami: ${{ matrix.target.ec2_ami }}
       archflags: ${{ matrix.target.archflags }}
       cflags: ${{ matrix.target.cflags }}
-      opt: ${{ matrix.opt.value }}
+      opt: "all"
       store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
-      name: "${{ matrix.target.name }}${{ (!matrix.opt.value && ' (no-opt)') || ''}}"
+      name: ${{ matrix.target.name }}
       perf: ${{ matrix.target.perf }}
     secrets: inherit

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -31,9 +31,12 @@ on:
         description: Custom ARCH flags for compilation
         default: ''
       opt:
-        description: Run with optimized code if enabled
-        type: boolean
-        default: true
+        description: Benchmark optimized, non-optimized, or both
+        type: choice
+        options:
+           - all
+           - opt
+           - no_opt
       bench_extra_args:
         description: Additional command line to be appended to `tests bench` script
         default: ''

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -31,9 +31,9 @@ on:
         description: Custom ARCH flags for compilation
         default: -mcpu=neoverse-n1 -march=armv8.2-a
       opt:
-        type: boolean
-        description: Runs with optimized code if enabled.
-        default: true
+        type: string
+        description: Runs with optimized code if enabled (opt, no_opt, all)
+        default: "opt"
       perf:
         type: string
         description: Method by which clock cycles should be measured (PMU | PERF)
@@ -119,12 +119,25 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'opt' }}
         with:
           nix-verbose: ${{ inputs.verbose }}
           name: ${{ inputs.name }}
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
-          opt: ${{ inputs.opt }}
+          opt: true
+          perf: ${{ inputs.perf }}
+          store_results: ${{ inputs.store_results }}
+          bench_extra_args: ${{ inputs.bench_extra_args }}
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+      - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'no_opt' }}
+        with:
+          nix-verbose: ${{ inputs.verbose }}
+          name: ${{ inputs.name }} (no-opt)
+          cflags: ${{ inputs.cflags }}
+          archflags: ${{ inputs.archflags }}
+          opt: false
           perf: ${{ inputs.perf }}
           store_results: ${{ inputs.store_results }}
           bench_extra_args: ${{ inputs.bench_extra_args }}
@@ -143,6 +156,7 @@ jobs:
         run: |
           echo "CC=${{ inputs.compiler }}" >> "$GITHUB_ENV"
       - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'opt' }}
         with:
           nix-shell: ''
           custom-shell: 'bash'
@@ -151,7 +165,22 @@ jobs:
           name: ${{ inputs.name }} (${{ inputs.compiler }})
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
-          opt: ${{ inputs.opt }}
+          opt: true
+          perf: ${{ inputs.perf }}
+          store_results: ${{ inputs.store_results }}
+          bench_extra_args: ${{ inputs.bench_extra_args }}
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+      - uses: ./.github/actions/bench
+        if: ${{ inputs.opt == 'all' || inputs.opt == 'no_opt' }}
+        with:
+          nix-shell: ''
+          custom-shell: 'bash'
+          nix-cache: false
+          nix-verbose: ${{ inputs.verbose }}
+          name: ${{ inputs.name }} (${{ inputs.compiler }}) (no-opt)
+          cflags: ${{ inputs.cflags }}
+          archflags: ${{ inputs.archflags }}
+          opt: false
           perf: ${{ inputs.perf }}
           store_results: ${{ inputs.store_results }}
           bench_extra_args: ${{ inputs.bench_extra_args }}


### PR DESCRIPTION
Previously, we were spinning up separate instances for benchmarking
optimized and non-optimized code. This is inefficient and incurs
unnecessary cost for very large instances (e.g. metal).

This commit changes the benchmarking CI to benchmark optimized
and non-optimized code on the same EC2 instance.