### PR TITLE
Benchmark c7i on metal

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -87,7 +87,7 @@ jobs:
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 4th gen (c7i)
-            ec2_instance_type: c7i.large
+            ec2_instance_type: c7i.metal-24xl
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes
             cflags: "-flto -DFORCE_X86_64"

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -58,9 +58,11 @@ on:
         type: string
         description: Additional packages to install when custom compiler is used.
         default: ''
+      aws_region:
+        type: string
+        default: "us-east-1"
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
-  AWS_REGION: us-east-1
   AMI_UBUNTU_LATEST_X86_64: ami-0e86e20dae9224db8
   AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
 jobs:
@@ -100,7 +102,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ inputs.aws_region }}
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: mkannwischer/ec2-github-runner@d15c8804522523d2bac7119a01ffff83b7795d87
@@ -201,7 +203,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ inputs.aws_region }}
       - name: Stop EC2 runner
         uses: mkannwischer/ec2-github-runner@d15c8804522523d2bac7119a01ffff83b7795d87
         with:


### PR DESCRIPTION
Current benchmarks on c7i.large exhibit a high performance variability
that is likely due to virtualization.

This commit switches to a metal instance for c7i to counter this problem.

https://pq-code-package.github.io/mlkem-native/dev/bench/ suggests that 
the issue does not appear for c6a, c6i, c7a, so those are not touched (and
indeed it would be non-trivial to do so because we'd exceed the vCPU quote
with more than one metal instance).