### PR TITLE
Properly set $CC in nix shell for different architecture

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
               '';
             });
 
+          # NOTE: idiomatic nix way of properly setting the $CC in a nix shell
           mkShellWithCC = cc: pkgs.mkShellNoCC.override { stdenv = pkgs.overrideCC pkgs.stdenv cc; };
           mkShell = mkShellWithCC native-gcc;
         in
@@ -128,11 +129,11 @@
           devShells.ci-cbmc-cross = wrapShell mkShell { packages = core { } ++ [ config.packages.cbmc ]; };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = [ config.packages.linters ]; };
 
-          devShells.ci_clang18 = wrapShell pkgs.mkShellNoCC { packages = [ config.packages.base pkgs.clang_18 ]; };
-          devShells.ci_gcc48 = wrapShell pkgs.mkShellNoCC { packages = [ config.packages.base pkgs.gcc48 ]; };
-          devShells.ci_gcc49 = wrapShell pkgs.mkShellNoCC { packages = [ config.packages.base pkgs.gcc49 ]; };
-          devShells.ci_gcc7 = wrapShell pkgs.mkShellNoCC { packages = [ config.packages.base pkgs.gcc7 ]; };
-          devShells.ci_gcc11 = wrapShell pkgs.mkShellNoCC { packages = [ config.packages.base pkgs.gcc11 ]; };
+          devShells.ci_clang18 = wrapShell (mkShellWithCC pkgs.clang_18) { packages = [ config.packages.base ]; };
+          devShells.ci_gcc48 = wrapShell (mkShellWithCC pkgs.gcc48) { packages = [ config.packages.base ]; };
+          devShells.ci_gcc49 = wrapShell (mkShellWithCC pkgs.gcc49) { packages = [ config.packages.base ]; };
+          devShells.ci_gcc7 = wrapShell (mkShellWithCC pkgs.gcc7) { packages = [ config.packages.base ]; };
+          devShells.ci_gcc11 = wrapShell (mkShellWithCC pkgs.gcc11) { packages = [ config.packages.base ]; };
         };
       flake = {
         # The usual flake attributes can be defined here, including system-


### PR DESCRIPTION
This PR properly set $CC in Nix shells when using multiple GCC versions (the last GCC in the package list overwrites $CC), thus avoiding cumbersome nix setup.

1. Properly Set $CC:
- Overridden in stdenv to ensure consistent behavior across platforms.
- Explicitly set via shellHook on Darwin, where GCC is not installed via Nix.

2. Refactor GCC Configuration:
- Introduced native-gcc to streamline platform-specific logic (null on Darwin, wraps pkgs elsewhere).
- Simplified code by merging default_gcc into core and removing redundant checks.

These changes eliminate the need for manual workarounds and simplify working with GCC toolchains in Nix, and make it easier to integrate additional toolchains:
- see #449 

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
