### PR TITLE
Add riscv64 toolchain support

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -22,9 +22,9 @@ inputs:
   cflags:
     description: CFLAGS to pass to compilation
     default: ""
-  mode:
-    description: For auto-determining the default cross-prefix (e.g. native | cross )
-    default: "native"
+  cross_prefix:
+    description: Binary prefix for cross compilation
+    default: ""
   opt:
     description: Whether to build opt/non-opt binaries or all (all | opt | no_opt)
     default: "all"
@@ -47,14 +47,7 @@ runs:
         shell: bash
         run: |
           arch=$(uname -m)
-          _cross_prefix=
-          if [[ ${{ inputs.mode }} == "cross" && $arch == "x86_64" ]]; then
-              _cross_prefix="aarch64-unknown-linux-gnu-"
-          elif [[ ${{ inputs.mode }} == "cross" && $arch == "aarch64" ]]; then
-              _cross_prefix="x86_64-unknown-linux-gnu-"
-          fi
-
-          echo _CROSS_PREFIX="$_cross_prefix" >> $GITHUB_ENV
+          echo MODE="${{ inputs.cross_prefix == '' && 'native' || 'cross' }}" >> $GITHUB_ENV
           echo FUNC="${{ inputs.func == 'true' && 'func' || 'no-func' }}" >> $GITHUB_ENV
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
           echo NISTKAT="${{ inputs.nistkat == 'true' && 'nistkat' || 'no-nistkat' }}" >> $GITHUB_ENV
@@ -77,7 +70,7 @@ runs:
             - $(uname -a)
             - $(nix --version)
             - $(bash --version | grep -m1 "")
-            - $(${_CROSS_PREFIX}${CC} --version | grep -m1 "")
+            - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
           EOF
           cat >> $GITHUB_STEP_SUMMARY <<-EOF
             ## Setup
@@ -85,17 +78,17 @@ runs:
             - $(uname -a)
             - $(nix --version)
             - $(bash --version | grep -m1 "")
-            - $(${_CROSS_PREFIX}${CC} --version | grep -m1 "")
+            - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
           EOF
-      - name: ${{ inputs.mode }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
-      - name: Check namespacing ${{ inputs.mode }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
+          tests all  --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
+      - name: Check namespacing ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
           check-namespace
-      - name: Post ${{ inputs.mode }} Tests
+      - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()
         run: |

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: CFLAGS to pass to compilation
     default: ""
   compile_mode:
-    description: all | native | cross-x86_64 | cross-aarch64
+    description: all | native | cross-x86_64 | cross-aarch64 | cross-riscv64
     default: "native"
   opt:
     description: all | opt | no_opt
@@ -85,6 +85,22 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: aarch64-unknown-linux-gnu-
+          opt: ${{ inputs.opt }}
+          func: ${{ inputs.func }}
+          kat: ${{ inputs.kat }}
+          nistkat: ${{ inputs.nistkat }}
+          acvp: ${{ inputs.acvp }}
+      - name: Cross riscv64 Tests
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
+        uses: ./.github/actions/functest
+        with:
+          nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
+          gh_token: ${{ inputs.gh_token }}
+          custom_shell: ${{ inputs.custom_shell }}
+          cflags: ${{ inputs.cflags }}
+          cross_prefix: riscv64-unknown-linux-gnu-
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: CFLAGS to pass to compilation
     default: ""
   compile_mode:
-    description: all | native | cross
+    description: all | native | cross-x86_64 | cross-aarch64
     default: "native"
   opt:
     description: all | opt | no_opt
@@ -53,14 +53,13 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
-          mode: native
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
           nistkat: ${{ inputs.nistkat }}
           acvp: ${{ inputs.acvp }}
-      - name: Cross Tests
-        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross') && (success() || failure()) }}
+      - name: Cross x86_64 Tests
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-x86_64') && (success() || failure()) }}
         uses: ./.github/actions/functest
         with:
           nix-shell: ${{ inputs.nix-shell }}
@@ -69,7 +68,23 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
-          mode: cross
+          cross_prefix: x86_64-unknown-linux-gnu-
+          opt: ${{ inputs.opt }}
+          func: ${{ inputs.func }}
+          kat: ${{ inputs.kat }}
+          nistkat: ${{ inputs.nistkat }}
+          acvp: ${{ inputs.acvp }}
+      - name: Cross aarch64 Tests
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-aarch64') && (success() || failure()) }}
+        uses: ./.github/actions/functest
+        with:
+          nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
+          gh_token: ${{ inputs.gh_token }}
+          custom_shell: ${{ inputs.custom_shell }}
+          cflags: ${{ inputs.cflags }}
+          cross_prefix: aarch64-unknown-linux-gnu-
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
             ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
             compile_mode: native
             opt: all
-    name: Functional tests  (${{ matrix.target.name }})
+    name: Platform tests  (${{ matrix.target.name }})
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,14 +101,14 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
           cflags: "-DMLKEM_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-      - name: cross tests (opt only)
+      - name: cross x86_64 tests (opt only)
         uses: ./.github/actions/multi-functest
-        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
+        if: ${{ matrix.target.runner == 'pqcp-arm64' && (success() || failure()) }}
         with:
           nix-shell: ci-cross
           nix-cache: true
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: cross
+          compile_mode: cross-x86_64
           opt: opt
   compiler_tests:
     name: Compiler tests (${{ matrix.target.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,15 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: cross-x86_64
           opt: opt
+      - name: cross riscv64 tests (opt only)
+        uses: ./.github/actions/multi-functest
+        if: ${{ matrix.target.runner == 'pqcp-arm64' && (success() || failure()) }}
+        with:
+          nix-shell: ci-cross
+          nix-cache: true
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: cross-riscv64
+          opt: opt
   compiler_tests:
     name: Compiler tests (${{ matrix.target.name }})
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           cl
           nmake /f ./Makefile.Microsoft_nmake quickcheck
   build_kat:
-    needs: quickcheck
+    needs: [quickcheck, quickcheck-windows]
     strategy:
       fail-fast: false
       matrix:
@@ -151,6 +151,7 @@ jobs:
           cflags: "-DMLKEM_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
   compiler_tests:
     name: Compiler tests (${{ matrix.target.name }})
+    needs: [quickcheck, quickcheck-windows]
     strategy:
       fail-fast: false
       matrix:
@@ -236,7 +237,7 @@ jobs:
   # The purpose of this job is to test non-default yet valid configurations
   config_variations:
     name: Non-standard configurations
-    needs: quickcheck
+    needs: [quickcheck, quickcheck-windows]
     strategy:
       fail-fast: false
       matrix:
@@ -292,7 +293,7 @@ jobs:
           kat: false
           acvp: false
   ec2_functests:
-    needs: quickcheck
+    needs: [quickcheck, quickcheck-windows]
     strategy:
       fail-fast: false
       matrix:
@@ -342,7 +343,7 @@ jobs:
       verbose: true
     secrets: inherit
   cbmc_k2:
-    needs: quickcheck
+    needs: [quickcheck, quickcheck-windows]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -365,7 +366,7 @@ jobs:
       cbmc_mlkem_k: 2
     secrets: inherit
   cbmc_k3:
-    needs: quickcheck
+    needs: [quickcheck, quickcheck-windows]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -388,7 +389,7 @@ jobs:
       cbmc_mlkem_k: 3
     secrets: inherit
   cbmc_k4:
-    needs: quickcheck
+    needs: [quickcheck, quickcheck-windows]
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,54 +71,84 @@ jobs:
         target:
          - runner: macos-latest
            name: 'MacOS'
+           arch: mac
+           mode: native
          - runner: pqcp-arm64
            name: 'ubuntu-latest (aarch64)'
+           arch: aarch64
+           mode: native
+         - runner: pqcp-arm64
+           name: 'ubuntu-latest (aarch64)'
+           arch: x86_64
+           mode: cross-x86_64
+         - runner: pqcp-arm64
+           name: 'ubuntu-latest (aarch64)'
+           arch: riscv64
+           mode: cross-riscv64
          - runner: pqcp-x64
            name: 'ubuntu-latest (x86_64)'
+           arch: x86_64
+           mode: native
+         - runner: pqcp-x64
+           name: 'ubuntu-latest (x86_64)'
+           arch: aarch64
+           mode: cross-aarch64
         exclude:
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'ubuntu-latest (aarch64)',
+               arch: aarch64,
+               mode: native
+             }}
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'ubuntu-latest (aarch64)',
+               arch: x86_64,
+               mode: cross-x86_64
+             }}
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'ubuntu-latest (aarch64)',
+               arch: riscv64,
+               mode: cross-riscv64
              }}
           - {external: true,
              target: {
                runner: pqcp-x64,
                name: 'ubuntu-latest (x86_64)',
+               arch: x86_64,
+               mode: native
              }}
-    name: Functional tests (${{ matrix.target.name }})
+          - {external: true,
+             target: {
+               runner: pqcp-x64,
+               name: 'ubuntu-latest (x86_64)',
+               arch: aarch64,
+               mode: cross-aarch64
+             }}
+    name: Functional tests (${{ matrix.target.arch }}${{ matrix.target.mode != 'native' && ', cross' || ''}})
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: native build
+      - name: build + test
         uses: ./.github/actions/multi-functest
         with:
+          nix-shell: ${{ matrix.target.mode == 'native' && 'ci' || 'ci-cross' }}
+          nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: native
-      - name: native tests (+debug+memsan+ubsan)
+          compile_mode: ${{ matrix.target.mode }}
+          # There is no native code on R-V yet, so no point running opt tests
+          opt: ${{ matrix.target.arch != 'riscv64' && 'all' || 'no_opt' }}
+      - name: build + test (+debug+memsan+ubsan)
         uses: ./.github/actions/multi-functest
+        if: ${{ matrix.target.mode == 'native' }}
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
           cflags: "-DMLKEM_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-      - name: cross x86_64 tests (opt only)
-        uses: ./.github/actions/multi-functest
-        if: ${{ matrix.target.runner == 'pqcp-arm64' && (success() || failure()) }}
-        with:
-          nix-shell: ci-cross
-          nix-cache: true
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: cross-x86_64
-          opt: opt
-      - name: cross riscv64 tests (opt only)
-        uses: ./.github/actions/multi-functest
-        if: ${{ matrix.target.runner == 'pqcp-arm64' && (success() || failure()) }}
-        with:
-          nix-shell: ci-cross
-          nix-cache: true
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: cross-riscv64
-          opt: opt
   compiler_tests:
     name: Compiler tests (${{ matrix.target.name }})
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
       verbose: true
     secrets: inherit
   cbmc_k2:
+    name: CBMC (ML-KEM-512)
     needs: [quickcheck, quickcheck-windows]
     permissions:
       contents: 'read'
@@ -366,6 +367,7 @@ jobs:
       cbmc_mlkem_k: 2
     secrets: inherit
   cbmc_k3:
+    name: CBMC (ML-KEM-768)
     needs: [quickcheck, quickcheck-windows]
     permissions:
       contents: 'read'
@@ -389,6 +391,7 @@ jobs:
       cbmc_mlkem_k: 3
     secrets: inherit
   cbmc_k4:
+    name: CBMC (ML-KEM-1024)
     needs: [quickcheck, quickcheck-windows]
     permissions:
       contents: 'read'

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -66,7 +66,7 @@ env:
   AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
 jobs:
   start-ec2-runner:
-    name: Start ${{ inputs.name }} (${{ inputs.ec2_instance_type }})
+    name: Start instance (${{ inputs.ec2_instance_type }})
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -113,6 +113,7 @@ jobs:
           subnet-id: subnet-07b2729e5e065962f
           security-group-id: sg-0ab2e297196c8c381
   tests:
+    name: Run test
     needs: start-ec2-runner
     runs-on: ${{ needs.start-ec2-runner.outputs.label }}
     steps:
@@ -152,7 +153,7 @@ jobs:
           mlkem_k: ${{ inputs.cbmc_mlkem_k }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
   stop-ec2-runner:
-    name: Stop ${{ inputs.name }} (${{ inputs.ec2_instance_type }})
+    name: Stop instance (${{ inputs.ec2_instance_type }})
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/META.yml
+++ b/META.yml
@@ -10,7 +10,7 @@ implementations:
     length-ciphertext: 768
     length-secret-key: 1632
     length-shared-secret: 32
-    kat-sha256: 323d0e9aefe34819f10cdce1f0d9e5c8a55193cebe984fb1718e779ebfbc0da8
+    kat-sha256: d2839e390c89b91d06ac73a903ce140d7edc91536bfdcbea094f8c63eaf7a2da
     nistkat-sha256: a30184edee53b3b009356e1e31d7f9e93ce82550e3c622d7192e387b0cc84f2e
     nistkat-shake256-256: 8517b4bed03f8f97f464ccbebbb395e887530d3426f171d77dd3b3a0e5add7ce
   - name: ML-KEM-768
@@ -20,7 +20,7 @@ implementations:
     length-ciphertext: 1088
     length-secret-key: 2400
     length-shared-secret: 32
-    kat-sha256: 99b497dcddfe418f44d30c7376fda09ae7cca2e9141143032d842508b4a1f438
+    kat-sha256: 923f97741b0950cd0b6e6fc772994a0eb2abdce2eb43ddc12fb5e6abe0f66840
     nistkat-sha256: 729367b590637f4a93c68d5e4a4d2e2b4454842a52c9eec503e3a0d24cb66471
     nistkat-shake256-256: 1383531be7867e0eab6c914472abfaed2f3846e518e401195880f8d25239c93e
   - name: ML-KEM-1024
@@ -30,6 +30,6 @@ implementations:
     length-ciphertext: 1568
     length-secret-key: 3168
     length-shared-secret: 32
-    kat-sha256: 104058bab1fef70aa10606831faabef7053d44b1adac6b34d35e505c3085db78
+    kat-sha256: 8ad4b85a08c2ee9b06fb4d5f7f8bf915b984d0959bef3cf6c705441b91aea1d7
     nistkat-sha256: 3fba7327d0320cb6134badf2a1bcb963a5b3c0026c7dece8f00d6a6155e47b33
     nistkat-shake256-256: 2c567fe56c8a1f60b7757d7c5367ec57d9b41e7cae3f157fd24616f3ce952f17

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             let
               x86_64-gcc = wrap-gcc pkgs.pkgsCross.gnu64;
               aarch64-gcc = wrap-gcc pkgs.pkgsCross.aarch64-multiplatform;
+              riscv64-gcc = wrap-gcc pkgs.pkgsCross.riscv64;
             in
             # NOTE:
               # - native toolchain should be equipped in the shell via `mkShellWithCC` (see `mkShell`)
@@ -53,6 +54,7 @@
             pkgs.lib.optionals (cross && !pkgs.stdenv.isDarwin) [
               (pkgs.lib.optional (! pkgs.stdenv.hostPlatform.isx86_64) x86_64-gcc)
               (pkgs.lib.optional (! pkgs.stdenv.hostPlatform.isAarch64) aarch64-gcc)
+              (pkgs.lib.optional (! pkgs.stdenv.hostPlatform.isRiscV64) riscv64-gcc)
               native-gcc
             ]
             ++ builtins.attrValues {

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -143,6 +143,8 @@ class Base:
                 cmd = ["qemu-x86_64"] + cmd
             elif "aarch64" in self.cross_prefix:
                 cmd = ["qemu-aarch64"] + cmd
+            elif "riscv64" in self.cross_prefix:
+                cmd = ["qemu-riscv64"] + cmd
             else:
                 log.info(
                     f"Emulation for {self.cross_prefix} on {platform.system()} not supported",

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -299,9 +299,14 @@ class Tests:
                 elif "riscv64" in opts.cross_prefix:
                     self.cmd_prefix.append("qemu-riscv64")
                 else:
-                    log.info(
+                    logging.info(
                         f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
                     )
+            elif opts.cross_prefix:
+                logging.error(
+                    f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
+                )
+                sys.exit(1)
 
     def _run_func(self, opt: bool):
         """Underlying function for functional test"""

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -48,6 +48,8 @@ class Options(object):
         self.opt = "ALL"
         self.compile = True
         self.run = True
+        self.exec_wrapper = ""
+        self.run_as_root = ""
 
 
 class Base:
@@ -136,21 +138,7 @@ class Base:
             log.error(f"{bin} does not exists")
             sys.exit(1)
 
-        cmd = [f"{bin}"]
-        if self.cross_prefix and platform.system() != "Darwin":
-            log.info(f"Emulating {bin} with QEMU")
-            if "x86_64" in self.cross_prefix:
-                cmd = ["qemu-x86_64"] + cmd
-            elif "aarch64" in self.cross_prefix:
-                cmd = ["qemu-aarch64"] + cmd
-            elif "riscv64" in self.cross_prefix:
-                cmd = ["qemu-riscv64"] + cmd
-            else:
-                log.info(
-                    f"Emulation for {self.cross_prefix} on {platform.system()} not supported",
-                )
-
-        cmd = cmd_prefix + cmd + extra_args
+        cmd = cmd_prefix + [f"{bin}"] + extra_args
 
         log.debug(" ".join(cmd))
 
@@ -208,7 +196,7 @@ class Test_Implementations:
         scheme: SCHEME,
         actual_proc: Callable[[bytes], str] = None,
         expect_proc: Callable[[SCHEME, str], tuple[bool, str]] = None,
-        prefix: [str] = [],
+        cmd_prefix: [str] = [],
         extra_args: [str] = [],
     ) -> TypedDict:
         k = "opt" if opt else "no_opt"
@@ -216,7 +204,7 @@ class Test_Implementations:
         results = {}
         results[k] = {}
         results[k][scheme] = self.ts[k].run_scheme(
-            scheme, actual_proc, expect_proc, prefix, extra_args
+            scheme, actual_proc, expect_proc, cmd_prefix, extra_args
         )
 
         return results
@@ -290,6 +278,30 @@ class Tests:
         self.compile_mode = copts.compile_mode()
         self.compile = opts.compile
         self.run = opts.run
+        self.cmd_prefix = []
+
+        if self.run:
+            if opts.run_as_root:
+                logging.info(
+                    f"Running {bin} as root -- you may need to enter your root password.",
+                )
+                self.cmd_prefix.append("sudo")
+
+            if opts.exec_wrapper:
+                logging.info(f"Running with customized wrapper {opts.exec_wrapper}")
+                self.cmd_prefix = self.cmd_prefix + opts.exec_wrapper.split(" ")
+            elif opts.cross_prefix and platform.system() != "Darwin":
+                logging.info(f"Emulating with QEMU")
+                if "x86_64" in opts.cross_prefix:
+                    self.cmd_prefix.append("qemu-x86_64")
+                elif "aarch64" in opts.cross_prefix:
+                    self.cmd_prefix.append("qemu-aarch64")
+                elif "riscv64" in opts.cross_prefix:
+                    self.cmd_prefix.append("qemu-riscv64")
+                else:
+                    log.info(
+                        f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
+                    )
 
     def _run_func(self, opt: bool):
         """Underlying function for functional test"""
@@ -314,6 +326,7 @@ class Tests:
             opt,
             actual_proc=lambda result: str(result, encoding="utf-8"),
             expect_proc=expect,
+            cmd_prefix=self.cmd_prefix,
         )
 
     def func(self):
@@ -349,6 +362,7 @@ class Tests:
             opt,
             actual_proc=sha256sum,
             expect_proc=expect_proc,
+            cmd_prefix=self.cmd_prefix,
         )
 
     def nistkat(self):
@@ -383,6 +397,7 @@ class Tests:
             opt,
             actual_proc=sha256sum,
             expect_proc=expect_proc,
+            cmd_prefix=self.cmd_prefix,
         )
 
     def kat(self):
@@ -477,6 +492,7 @@ class Tests:
                     extra_args=extra_args,
                     actual_proc=actual_proc,
                     expect_proc=partial(_expect_proc, tc),
+                    cmd_prefix=self.cmd_prefix,
                 )
                 for k, r in rs.items():
                     results[k][scheme] = results[k][scheme] or r[scheme]
@@ -516,6 +532,7 @@ class Tests:
                     extra_args=extra_args,
                     actual_proc=actual_proc,
                     expect_proc=partial(_expect_proc, tc),
+                    cmd_prefix=self.cmd_prefix,
                 )
                 for k, r in rs.items():
                     results[k][scheme] = results[k][scheme] or r[scheme]
@@ -557,28 +574,16 @@ class Tests:
             exit(1)
 
     def _run_bench(
-        self, t: Test_Implementations, opt: bool, run_as_root: bool, exec_wrapper: str
+        self,
+        t: Test_Implementations,
+        opt: bool,
     ) -> TypedDict:
-        cmd_prefix = []
-        if run_as_root:
-            logging.info(
-                f"Running {bin} as root -- you may need to enter your root password.",
-            )
-            cmd_prefix.append("sudo")
-
-        if exec_wrapper:
-            logging.info(f"Running with customized wrapper.")
-            exec_wrapper = exec_wrapper.split(" ")
-            cmd_prefix = cmd_prefix + exec_wrapper
-
-        return t.run_schemes(opt, cmd_prefix=cmd_prefix)
+        return t.run_schemes(opt, cmd_prefix=self.cmd_prefix)
 
     def bench(
         self,
         cycles: str,
         output,
-        run_as_root: bool,
-        exec_wrapper: str,
         mac_taskpolicy,
         components,
     ):
@@ -602,11 +607,11 @@ class Tests:
             if self.compile:
                 t.compile(False, extra_make_args=[f"CYCLES={cycles}"])
             if self.run:
-                self._run_bench(t, False, run_as_root, exec_wrapper)
+                self._run_bench(t, False)
             if self.compile:
                 t.compile(True, extra_make_args=[f"CYCLES={cycles}"])
             if self.run:
-                resultss = self._run_bench(t, True, run_as_root, exec_wrapper)
+                resultss = self._run_bench(t, True)
         else:
             if self.compile:
                 t.compile(
@@ -617,8 +622,6 @@ class Tests:
                 resultss = self._run_bench(
                     t,
                     True if self.opt.lower() == "opt" else False,
-                    run_as_root,
-                    exec_wrapper,
                 )
 
         if resultss is None:

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -183,11 +183,12 @@ def github_summary(title: str, test_label: str, results: TypedDict):
             print("\n".join(summaries), file=f)
 
 
-def config_logger(verbose):
-    logging.basicConfig(
-        stream=sys.stdout, format="%(levelname)-5s > %(name)-40s %(message)s"
-    )
+logging.basicConfig(
+    stream=sys.stdout, format="%(levelname)-5s > %(name)-40s %(message)s"
+)
 
+
+def config_logger(verbose):
     logger = logging.getLogger()
 
     if verbose:

--- a/scripts/tests
+++ b/scripts/tests
@@ -104,6 +104,26 @@ _shared_options = [
         help="Determine to run the compiled binary or not",
         callback=__callback("run"),
     ),
+    click.option(
+        "-w",
+        "--exec-wrapper",
+        expose_value=False,
+        show_default=True,
+        default="",
+        help="Run the benchmark binary with the user-customized wrapper.",
+        callback=__callback("exec_wrapper"),
+    ),
+    click.option(
+        "-r",
+        "--run-as-root",
+        expose_value=False,
+        is_flag=True,
+        show_default=True,
+        default=False,
+        type=bool,
+        help="Benchmarking binary is run with sudo.",
+        callback=__callback("run_as_root"),
+    ),
 ]
 
 _bench_options = [
@@ -121,20 +141,6 @@ _bench_options = [
         "--output",
         nargs=1,
         help="Path to output file in json format",
-    ),
-    click.option(
-        "-r",
-        "--run-as-root",
-        is_flag=True,
-        show_default=True,
-        default=False,
-        type=bool,
-        help="Benchmarking binary is run with sudo.",
-    ),
-    click.option(
-        "-w",
-        "--exec-wrapper",
-        help="Run the benchmark binary with the user-customized wrapper.",
     ),
     click.option(
         "-t",
@@ -226,16 +232,12 @@ def bench(
     opts: Options,
     cycles: str,
     output,
-    run_as_root: bool,
-    exec_wrapper: str,
     mac_taskpolicy,
     components,
 ):
     Tests(opts).bench(
         cycles,
         output,
-        run_as_root,
-        exec_wrapper,
         mac_taskpolicy,
         components,
     )

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -7,7 +7,7 @@
 #include "kem.h"
 #include "params.h"
 
-#define NTESTS 10000
+#define NTESTS 1000
 
 static void print_hex(const char *label, const uint8_t *data, size_t size)
 {


### PR DESCRIPTION
- ~Based on #448~ 
- Add riscv64 toolchain in nix shell
- Add riscv64 qemu support in the tests script
- Fixed an issue where test scripts could incorrectly execute binaries using a custom exec wrapper in QEMU when a cross prefix differs from the native toolchain and a custom exec wrapper is provided.
- With the fix, we could now also run `tests func/kat/nistkat/all` with a provided custom wrapper