### PR TITLE
Add poly_getnoise_eta2_4x alias for poly_getnoise_eta1_4x

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -468,12 +468,12 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
   poly_getnoise_eta1_4x(sp.vec + 0, sp.vec + 1, sp.vec + 2, &b.vec[0], coins, 0,
                         1, 2, 0xFF);
   // The fourth output buffer in this call _is_ used.
-  poly_getnoise_eta1_4x(ep.vec + 0, ep.vec + 1, ep.vec + 2, &epp, coins, 3, 4,
+  poly_getnoise_eta2_4x(ep.vec + 0, ep.vec + 1, ep.vec + 2, &epp, coins, 3, 4,
                         5, 6);
 #elif MLKEM_K == 4
   poly_getnoise_eta1_4x(sp.vec + 0, sp.vec + 1, sp.vec + 2, sp.vec + 3, coins,
                         0, 1, 2, 3);
-  poly_getnoise_eta1_4x(ep.vec + 0, ep.vec + 1, ep.vec + 2, ep.vec + 3, coins,
+  poly_getnoise_eta2_4x(ep.vec + 0, ep.vec + 1, ep.vec + 2, ep.vec + 3, coins,
                         4, 5, 6, 7);
   poly_getnoise_eta2(&epp, coins, 8);
 #endif

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -528,6 +528,13 @@ ENSURES(
  && ARRAY_ABS_BOUND(r3->coeffs,0, MLKEM_N - 1, MLKEM_ETA1));
 // clang-format on
 
+#if MLKEM_ETA1 == MLKEM_ETA2
+// We only require poly_getnoise_eta2_4x for ml-kem-768 and ml-kem-1024
+// where MLKEM_ETA2 = MLKEM_ETA1 = 2.
+// For ml-kem-512, poly_getnoise_eta1122_4x is used instead.
+#define poly_getnoise_eta2_4x poly_getnoise_eta1_4x
+#endif /* MLKEM_ETA1 == MLKEM_ETA2 */
+
 #define poly_getnoise_eta2 MLKEM_NAMESPACE(poly_getnoise_eta2)
 /*************************************************
  * Name:        poly_getnoise_eta2


### PR DESCRIPTION
In encapsulation of ml-kem-768 and ml-kem-1024, we are using poly_getnoise_eta1_4x to sample both the secret and the error. This works because ETA1 = ETA2 = 2.
However, this is somewhat confusing when reading the code.

This commit uses poly_getnoise_eta2_4x instead and defines it as an alias for poly_getnoise_eta1_4x in case ETA1=ETA2. I think this the cleaner solution.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
