### PR TITLE
AVX2: Document bounds in NTT and invNTT

### DIFF
--- a/mlkem/native/x86_64/basemul.S
+++ b/mlkem/native/x86_64/basemul.S
@@ -13,6 +13,7 @@
 #include "consts.h"
 #include "params.h"
 
+// Polynomials to be multiplied are denoted a+bX (rsi arg) and c+dX (rdx arg)
 .macro schoolbook off
 vmovdqa		_16XQINV*2(%rcx),%ymm0
 vmovdqa		(64*\off+ 0)*2(%rsi),%ymm1		# a0
@@ -20,6 +21,7 @@ vmovdqa		(64*\off+16)*2(%rsi),%ymm2		# b0
 vmovdqa		(64*\off+32)*2(%rsi),%ymm3		# a1
 vmovdqa		(64*\off+48)*2(%rsi),%ymm4		# b1
 
+// Prepare Montgomery twists
 vpmullw		%ymm0,%ymm1,%ymm9			# a0.lo
 vpmullw		%ymm0,%ymm2,%ymm10			# b0.lo
 vpmullw		%ymm0,%ymm3,%ymm11			# a1.lo
@@ -28,6 +30,7 @@ vpmullw		%ymm0,%ymm4,%ymm12			# b1.lo
 vmovdqa		(64*\off+ 0)*2(%rdx),%ymm5		# c0
 vmovdqa		(64*\off+16)*2(%rdx),%ymm6		# d0
 
+// Compute high-parts of monomials in (a0+b0*X)*(c0+d0*X)
 vpmulhw		%ymm5,%ymm1,%ymm13			# a0c0.hi
 vpmulhw		%ymm6,%ymm1,%ymm1			# a0d0.hi
 vpmulhw		%ymm5,%ymm2,%ymm14			# b0c0.hi
@@ -36,6 +39,8 @@ vpmulhw		%ymm6,%ymm2,%ymm2			# b0d0.hi
 vmovdqa		(64*\off+32)*2(%rdx),%ymm7		# c1
 vmovdqa		(64*\off+48)*2(%rdx),%ymm8		# d1
 
+// Compute high-parts of monomials in (a1+b1*X)*(c1+d1*X)
+// Don't yet accumulate nor reduce X^2
 vpmulhw		%ymm7,%ymm3,%ymm15			# a1c1.hi
 vpmulhw		%ymm8,%ymm3,%ymm3			# a1d1.hi
 vpmulhw		%ymm7,%ymm4,%ymm0			# b1c1.hi
@@ -43,16 +48,21 @@ vpmulhw		%ymm8,%ymm4,%ymm4			# b1d1.hi
 
 vmovdqa		%ymm13,(%rsp)
 
+// Compute low-parts of monomials in (a0+b0*X)*(c0+d0*X),
+// using Montgomery twists calculated before
 vpmullw		%ymm5,%ymm9,%ymm13			# a0c0.lo
 vpmullw		%ymm6,%ymm9,%ymm9			# a0d0.lo
 vpmullw		%ymm5,%ymm10,%ymm5			# b0c0.lo
 vpmullw		%ymm6,%ymm10,%ymm10			# b0d0.lo
 
+// Compute low-parts of monomials in (a1+b1*X)*(c1+d1*X),
+// using Montgomery twists calculated before
 vpmullw		%ymm7,%ymm11,%ymm6			# a1c1.lo
 vpmullw		%ymm8,%ymm11,%ymm11			# a1d1.lo
 vpmullw		%ymm7,%ymm12,%ymm7			# b1c1.lo
 vpmullw		%ymm8,%ymm12,%ymm12			# b1d1.lo
 
+// Compute 2nd high multiplication in Montgomery multiplication
 vmovdqa		_16XQ*2(%rcx),%ymm8
 vpmulhw		%ymm8,%ymm13,%ymm13
 vpmulhw		%ymm8,%ymm9,%ymm9
@@ -63,6 +73,7 @@ vpmulhw		%ymm8,%ymm11,%ymm11
 vpmulhw		%ymm8,%ymm7,%ymm7
 vpmulhw		%ymm8,%ymm12,%ymm12
 
+// Finish Montgomery multiplications
 vpsubw		(%rsp),%ymm13,%ymm13			# -a0c0
 vpsubw		%ymm9,%ymm1,%ymm9			# a0d0
 vpsubw		%ymm5,%ymm14,%ymm5			# b0c0
@@ -73,6 +84,10 @@ vpsubw		%ymm11,%ymm3,%ymm11			# a1d1
 vpsubw		%ymm7,%ymm0,%ymm7			# b1c1
 vpsubw		%ymm12,%ymm4,%ymm12			# b1d1
 
+// b0*d0 and b1*d1 need twisting by a twiddle, accounting
+// for X^2=zeta in F_q[X]/(X^2-zeta).
+//
+// TODO: This could be precomputed in the mulcache
 vmovdqa		(%r9),%ymm0
 vmovdqa		32(%r9),%ymm1
 vpmullw		%ymm0,%ymm10,%ymm2
@@ -89,6 +104,12 @@ vpaddw		%ymm7,%ymm11,%ymm11
 vpsubw		%ymm13,%ymm10,%ymm13
 vpsubw		%ymm12,%ymm6,%ymm6
 
+// Bounds: Note that we assume that a+b*X is coefficient-wise bound by q in
+// in absolute value: This is coming from the contract for
+// polyvec_basemul_acc_montgomery_cached().
+//
+// Then, each Montgomery multiplication has absolute value < q,
+// and hence the coefficients of the output have absolute value < 2q.
 vmovdqa		%ymm13,(64*\off+ 0)*2(%rdi)
 vmovdqa		%ymm9,(64*\off+16)*2(%rdi)
 vmovdqa		%ymm6,(64*\off+32)*2(%rdi)

--- a/mlkem/native/x86_64/basemul.S
+++ b/mlkem/native/x86_64/basemul.S
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024 The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
- */ 
+ */
 
 // Implementation from Kyber reference repository
 // https://github.com/pq-crystals/kyber/blob/main/avx2
@@ -13,7 +13,7 @@
 #include "consts.h"
 #include "params.h"
 
-// Polynomials to be multiplied are denoted a+bX (rsi arg) and c+dX (rdx arg)
+/* Polynomials to be multiplied are denoted a+bX (rsi arg) and c+dX (rdx arg) */
 .macro schoolbook off
 vmovdqa		_16XQINV*2(%rcx),%ymm0
 vmovdqa		(64*\off+ 0)*2(%rsi),%ymm1		# a0
@@ -21,7 +21,7 @@ vmovdqa		(64*\off+16)*2(%rsi),%ymm2		# b0
 vmovdqa		(64*\off+32)*2(%rsi),%ymm3		# a1
 vmovdqa		(64*\off+48)*2(%rsi),%ymm4		# b1
 
-// Prepare Montgomery twists
+/* Prepare Montgomery twists */
 vpmullw		%ymm0,%ymm1,%ymm9			# a0.lo
 vpmullw		%ymm0,%ymm2,%ymm10			# b0.lo
 vpmullw		%ymm0,%ymm3,%ymm11			# a1.lo
@@ -30,7 +30,7 @@ vpmullw		%ymm0,%ymm4,%ymm12			# b1.lo
 vmovdqa		(64*\off+ 0)*2(%rdx),%ymm5		# c0
 vmovdqa		(64*\off+16)*2(%rdx),%ymm6		# d0
 
-// Compute high-parts of monomials in (a0+b0*X)*(c0+d0*X)
+/* Compute high-parts of monomials in (a0+b0*X)*(c0+d0*X) */
 vpmulhw		%ymm5,%ymm1,%ymm13			# a0c0.hi
 vpmulhw		%ymm6,%ymm1,%ymm1			# a0d0.hi
 vpmulhw		%ymm5,%ymm2,%ymm14			# b0c0.hi
@@ -39,8 +39,8 @@ vpmulhw		%ymm6,%ymm2,%ymm2			# b0d0.hi
 vmovdqa		(64*\off+32)*2(%rdx),%ymm7		# c1
 vmovdqa		(64*\off+48)*2(%rdx),%ymm8		# d1
 
-// Compute high-parts of monomials in (a1+b1*X)*(c1+d1*X)
-// Don't yet accumulate nor reduce X^2
+/* Compute high-parts of monomials in (a1+b1*X)*(c1+d1*X) */
+/* Don't yet accumulate nor reduce X^2 */
 vpmulhw		%ymm7,%ymm3,%ymm15			# a1c1.hi
 vpmulhw		%ymm8,%ymm3,%ymm3			# a1d1.hi
 vpmulhw		%ymm7,%ymm4,%ymm0			# b1c1.hi
@@ -48,21 +48,21 @@ vpmulhw		%ymm8,%ymm4,%ymm4			# b1d1.hi
 
 vmovdqa		%ymm13,(%rsp)
 
-// Compute low-parts of monomials in (a0+b0*X)*(c0+d0*X),
-// using Montgomery twists calculated before
+/* Compute low-parts of monomials in (a0+b0*X)*(c0+d0*X), */
+/* using Montgomery twists calculated before */
 vpmullw		%ymm5,%ymm9,%ymm13			# a0c0.lo
 vpmullw		%ymm6,%ymm9,%ymm9			# a0d0.lo
 vpmullw		%ymm5,%ymm10,%ymm5			# b0c0.lo
 vpmullw		%ymm6,%ymm10,%ymm10			# b0d0.lo
 
-// Compute low-parts of monomials in (a1+b1*X)*(c1+d1*X),
-// using Montgomery twists calculated before
+/* Compute low-parts of monomials in (a1+b1*X)*(c1+d1*X), */
+/* using Montgomery twists calculated before */
 vpmullw		%ymm7,%ymm11,%ymm6			# a1c1.lo
 vpmullw		%ymm8,%ymm11,%ymm11			# a1d1.lo
 vpmullw		%ymm7,%ymm12,%ymm7			# b1c1.lo
 vpmullw		%ymm8,%ymm12,%ymm12			# b1d1.lo
 
-// Compute 2nd high multiplication in Montgomery multiplication
+/* Compute 2nd high multiplication in Montgomery multiplication */
 vmovdqa		_16XQ*2(%rcx),%ymm8
 vpmulhw		%ymm8,%ymm13,%ymm13
 vpmulhw		%ymm8,%ymm9,%ymm9
@@ -73,7 +73,7 @@ vpmulhw		%ymm8,%ymm11,%ymm11
 vpmulhw		%ymm8,%ymm7,%ymm7
 vpmulhw		%ymm8,%ymm12,%ymm12
 
-// Finish Montgomery multiplications
+/* Finish Montgomery multiplications */
 vpsubw		(%rsp),%ymm13,%ymm13			# -a0c0
 vpsubw		%ymm9,%ymm1,%ymm9			# a0d0
 vpsubw		%ymm5,%ymm14,%ymm5			# b0c0
@@ -84,10 +84,10 @@ vpsubw		%ymm11,%ymm3,%ymm11			# a1d1
 vpsubw		%ymm7,%ymm0,%ymm7			# b1c1
 vpsubw		%ymm12,%ymm4,%ymm12			# b1d1
 
-// b0*d0 and b1*d1 need twisting by a twiddle, accounting
-// for X^2=zeta in F_q[X]/(X^2-zeta).
-//
-// TODO: This could be precomputed in the mulcache
+/* b0*d0 and b1*d1 need twisting by a twiddle, accounting
+ * for X^2=zeta in F_q[X]/(X^2-zeta).
+ *
+ * TODO: This could be precomputed in the mulcache */
 vmovdqa		(%r9),%ymm0
 vmovdqa		32(%r9),%ymm1
 vpmullw		%ymm0,%ymm10,%ymm2
@@ -104,12 +104,12 @@ vpaddw		%ymm7,%ymm11,%ymm11
 vpsubw		%ymm13,%ymm10,%ymm13
 vpsubw		%ymm12,%ymm6,%ymm6
 
-// Bounds: Note that we assume that a+b*X is coefficient-wise bound by q in
-// in absolute value: This is coming from the contract for
-// polyvec_basemul_acc_montgomery_cached().
-//
-// Then, each Montgomery multiplication has absolute value < q,
-// and hence the coefficients of the output have absolute value < 2q.
+/* Bounds: Note that we assume that a+b*X is coefficient-wise bound by q in
+ * in absolute value: This is coming from the contract for
+ * polyvec_basemul_acc_montgomery_cached().
+ *
+ * Then, each Montgomery multiplication has absolute value < q,
+ * and hence the coefficients of the output have absolute value < 2q. */
 vmovdqa		%ymm13,(64*\off+ 0)*2(%rdi)
 vmovdqa		%ymm9,(64*\off+16)*2(%rdi)
 vmovdqa		%ymm6,(64*\off+32)*2(%rdi)

--- a/mlkem/native/x86_64/basemul.c
+++ b/mlkem/native/x86_64/basemul.c
@@ -43,10 +43,12 @@ void polyvec_basemul_acc_montgomery_cached_avx2(poly *r, const polyvec *a,
   unsigned int i;
   poly t;
 
-  ((void)b_cache); /* cache unused */
+  /* TODO: Use mulcache for AVX2. So far, it is unused. */
+  ((void)b_cache);
 
-  /* TODO! Think through bounds */
-
+  /* Coefficient-wise bound of each basemul is 2q.
+   * Since we are accumulating at most 4 times, the
+   * overall bound is 8q < INT16_MAX. */
   poly_basemul_montgomery_avx2(r, &a->vec[0], &b->vec[0]);
   for (i = 1; i < MLKEM_K; i++)
   {

--- a/mlkem/native/x86_64/fq.inc
+++ b/mlkem/native/x86_64/fq.inc
@@ -32,6 +32,8 @@ vpand		%ymm0,%ymm\x,%ymm\x
 vpaddw		%ymm\x,%ymm\r,%ymm\r
 .endm
 
+// Montgomery multiplication between b and ah,
+// with Montgomery twist of ah in al.
 .macro fqmulprecomp al,ah,b,x=12
 vpmullw		%ymm\al,%ymm\b,%ymm\x
 vpmulhw		%ymm\ah,%ymm\b,%ymm\b

--- a/mlkem/native/x86_64/fq.inc
+++ b/mlkem/native/x86_64/fq.inc
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2024 The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
- */ 
+ */
 
-/* 
+/*
  * Implementation from Kyber reference repository
  * https://github.com/pq-crystals/kyber/blob/main/avx2
  */
@@ -32,8 +32,8 @@ vpand		%ymm0,%ymm\x,%ymm\x
 vpaddw		%ymm\x,%ymm\r,%ymm\r
 .endm
 
-// Montgomery multiplication between b and ah,
-// with Montgomery twist of ah in al.
+/* Montgomery multiplication between b and ah,
+ * with Montgomery twist of ah in al. */
 .macro fqmulprecomp al,ah,b,x=12
 vpmullw		%ymm\al,%ymm\b,%ymm\x
 vpmulhw		%ymm\ah,%ymm\b,%ymm\b

--- a/mlkem/native/x86_64/intt.S
+++ b/mlkem/native/x86_64/intt.S
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */ 
 
-// Implementation from Kyber reference repository
+// Implementation based on Kyber repository
 // https://github.com/pq-crystals/kyber/blob/main/avx2
-
+//
+// Changes to placement of modular reductions have
+// been made to simplify reasoning of non-overflow
 #include "config.h"
 
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
@@ -93,13 +95,12 @@ vpshufb		%ymm12,%ymm3,%ymm3
 
 butterfly	4,5,8,9,6,7,10,11,15,1,2,3
 
-// Montgomery multiplication of a value <C*q with a signed canonical
-// twiddle has absolute value < q*(0.0254 * C + 1/2) (see reduce.c).
-// In the above butterfly, the values multiplied with twiddles have
-// absolute value <2q, so we get an absolute bound < q*(1/2 + 2 * 0.0254),
-// which is < INT16_MAX/16.
+// Montgmoery multiplication with a signed canonical twiddle
+// always has absolute value < q. This is used henceforth to
+// normalize the absolute bounds on the second half inputs
+// to the current butterfly
 //
-// 4,5,8,9 abs bound < 2q; 6,7,10,11 abs bound < INT16_MAX/16
+// 4,5,8,9 abs bound < 2q; 6,7,10,11 abs bound < q
 
 /* level 1 */
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+144)*2(%rsi),%ymm2
@@ -113,7 +114,7 @@ butterfly	4,5,6,7,8,9,10,11,2,2,3,3
 // For 8,9,10,11, it is sufficient to use the bound <q (much weaker
 // than what we used above) for the absolute value of the Montgomery
 // multiplication with a twiddle.
-// 4,5 abs bound < 4q; 6,7 abs bound < INT16_MAX/8; 8,9,10,11 abs bound <q.
+// 4,5 abs bound < 4q; 6,7 abs bound < 2q; 8,9,10,11 abs bound <q.
 
 shuffle1	4,5,3,5      // 3,5  abs bound < 4q
 shuffle1	6,7,4,7      // 4,7  abs bound < INT16_MAX/8
@@ -126,15 +127,13 @@ vpermd		(_ZETAS_EXP+(1-\off)*224+112)*2(%rsi),%ymm12,%ymm2
 vpermd		(_ZETAS_EXP+(1-\off)*224+128)*2(%rsi),%ymm12,%ymm10
 
 butterfly	3,4,6,8,5,7,9,11,2,2,10,10
-// 3 abs bound < 8q, 4 abs bound < INT16_MAX/4, 6,8 abs bound < 2q, 5,7,9,11 abs bound < q
+// 3 abs bound < 8q, 4 abs bound < 4q, 6,8 abs bound < 2q, 5,7,9,11 abs bound < q
 
 vmovdqa		_16XV*2(%rsi),%ymm1
 red16		3
-// 4 abs bound < INT16_MAX/4, 6,8 abs bound < 2q, 3,5,7,9,11 abs bound < q
+// 4 abs bound < 4q, 6,8 abs bound < 2q, 3,5,7,9,11 abs bound < q
 
-shuffle2	3,4,10,4   // see comment for shuffle2;
-                           // 10,4: even 16-bit pairs from 3, so abs bound <q
-                           // 10,4: odd  16-bit pairs from 4, so abs bound <INT16_MAX/4
+shuffle2	3,4,10,4   // 4,10 abs bound < 4q
 shuffle2	6,8,3,8    // 3,8 abs bound < 2q
 shuffle2	5,7,6,7    // 6,7 abs bound < q
 shuffle2	9,11,5,11  // 5,11 abs bound < q
@@ -144,11 +143,23 @@ vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+80)*2(%rsi),%ymm2
 vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+96)*2(%rsi),%ymm9
 
 butterfly	10,3,6,5,4,8,7,11,2,2,9,9
-// 10 abs bound < INT16_MAX/2
-// 3 abs bound < 4q, 5,6 abs bound < 2q
+// 10 abs bound < 8q
+// 3 abs bound < 4q
+// 5,6 abs bound < 2q
 // 4,8,7,11 abs bound < q
 
-shuffle4	10,3,9,3   // 3,9  abs bound < INT16_MAX/2
+// REF-CHANGE: The official AVX2 implementation from
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+// does not have this reduction. We add it here to simplify reasoning of
+// non-overflow. Without it, one has to work with more precise bounds for
+// the output of a Montgomery multiplication; with this reduction,
+// in turn, the generic bound by q is sufficient.
+red16 10
+// 3 abs bound < 4q
+// 5,6 abs bound < 2q
+// 4,8,7,10,11 abs bound < q
+
+shuffle4	10,3,9,3   // 3,9  abs bound < 4q
 shuffle4	6,5,10,5   // 5,10 abs bound < 2q
 shuffle4	4,8,6,8    // 6,8  abs bound < q
 shuffle4	7,11,4,11  // 4,11 abs bound < q
@@ -158,11 +169,13 @@ vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+48)*2(%rsi),%ymm2
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+64)*2(%rsi),%ymm7
 
 butterfly	9,10,6,4,3,5,8,11,2,2,7,7
-// 9 abs bound < INT16_MAX
-// 10 abs bound < 4q, 4,6 abs bound <2q
+// 9 abs bound < 8q
+// 10 abs bound < 4q
+// 4,6 abs bound <2q
 // 3,5,8,11 abs bound < q
-red16		9
-// 10 abs bound < 4q, 4,6 abs bound <2q
+red16 9
+// 10 abs bound < 4q
+// 4,6 abs bound <2q
 // 3,5,8,9,11 abs bound < q
 
 shuffle8	9,10,7,10  // 7,10 abs bound < 4q

--- a/mlkem/native/x86_64/intt.S
+++ b/mlkem/native/x86_64/intt.S
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2024 The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
- */ 
+ */
 
-// Implementation based on Kyber repository
-// https://github.com/pq-crystals/kyber/blob/main/avx2
-//
-// Changes to placement of modular reductions have
-// been made to simplify reasoning of non-overflow
+/* Implementation based on Kyber repository
+ * https://github.com/pq-crystals/kyber/blob/main/avx2
+ *
+ * Changes to placement of modular reductions have
+ * been made to simplify reasoning of non-overflow */
 #include "config.h"
 
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
@@ -17,42 +17,42 @@
 .include "shuffle.inc"
 .include "fq.inc"
 
-// Compute four GS butterflies between rh{0,1,2,3} and rl{0,1,2,3}.
-// Butterflies 0,1 use root zh0 and twisted root zl0, and butterflies
-// 2,3 use root zh1 and twisted root zl1
-// Results are again in rl{0-3} and rh{0-3}
+/* Compute four GS butterflies between rh{0,1,2,3} and rl{0,1,2,3}.
+ * Butterflies 0,1 use root zh0 and twisted root zl0, and butterflies
+ * 2,3 use root zh1 and twisted root zl1
+ * Results are again in rl{0-3} and rh{0-3} */
 .macro butterfly rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3,zl0=2,zl1=2,zh0=3,zh1=3
-vpsubw		%ymm\rl0,%ymm\rh0,%ymm12    // ymm12 = rh0 - rl0
-vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rl0  // rl0   = rh0 + rl0
-vpsubw		%ymm\rl1,%ymm\rh1,%ymm13    // ymm13 = rh1 - rl1
+vpsubw		%ymm\rl0,%ymm\rh0,%ymm12    /* ymm12 = rh0 - rl0 */
+vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rl0  /* rl0   = rh0 + rl0 */
+vpsubw		%ymm\rl1,%ymm\rh1,%ymm13    /* ymm13 = rh1 - rl1 */
 
-vpmullw		%ymm\zl0,%ymm12,%ymm\rh0    // rh0   = (rh0 - rl0) * root0_twisted
-vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl1  // rl1   = rh1 + rh1
-vpsubw		%ymm\rl2,%ymm\rh2,%ymm14    // ymm14 = rh2 - rl2
+vpmullw		%ymm\zl0,%ymm12,%ymm\rh0    /* rh0   = (rh0 - rl0) * root0_twisted */
+vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl1  /* rl1   = rh1 + rh1 */
+vpsubw		%ymm\rl2,%ymm\rh2,%ymm14    /* ymm14 = rh2 - rl2 */
 
-vpmullw		%ymm\zl0,%ymm13,%ymm\rh1    // rh1   = (rh1 - rl1) * root0_twisted
-vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl2  // rl2   = rh2 + rl2
-vpsubw		%ymm\rl3,%ymm\rh3,%ymm15    // ymm15 = rh3 - rl3
+vpmullw		%ymm\zl0,%ymm13,%ymm\rh1    /* rh1   = (rh1 - rl1) * root0_twisted */
+vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl2  /* rl2   = rh2 + rl2 */
+vpsubw		%ymm\rl3,%ymm\rh3,%ymm15    /* ymm15 = rh3 - rl3 */
 
-vpmullw		%ymm\zl1,%ymm14,%ymm\rh2    // rh2   = (rh2 - rl2) * root1_twisted
-vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl3  // rl3   = rh3 + rl3
-vpmullw		%ymm\zl1,%ymm15,%ymm\rh3    // rh3   = (rh3 - rl3) * root1_twisted
+vpmullw		%ymm\zl1,%ymm14,%ymm\rh2    /* rh2   = (rh2 - rl2) * root1_twisted */
+vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl3  /* rl3   = rh3 + rl3 */
+vpmullw		%ymm\zl1,%ymm15,%ymm\rh3    /* rh3   = (rh3 - rl3) * root1_twisted */
 
-vpmulhw		%ymm\zh0,%ymm12,%ymm12      // ymm12 = (rh0 - rl0) * root0
-vpmulhw		%ymm\zh0,%ymm13,%ymm13      // ymm13 = (rh1 - rl1) * root0
+vpmulhw		%ymm\zh0,%ymm12,%ymm12      /* ymm12 = (rh0 - rl0) * root0 */
+vpmulhw		%ymm\zh0,%ymm13,%ymm13      /* ymm13 = (rh1 - rl1) * root0 */
 
-vpmulhw		%ymm\zh1,%ymm14,%ymm14      // ymm14 = (rh2 - rl2) * root1
-vpmulhw		%ymm\zh1,%ymm15,%ymm15      // ymm15 = (rh3 - rl3) * root1
+vpmulhw		%ymm\zh1,%ymm14,%ymm14      /* ymm14 = (rh2 - rl2) * root1 */
+vpmulhw		%ymm\zh1,%ymm15,%ymm15      /* ymm15 = (rh3 - rl3) * root1 */
 
-vpmulhw		%ymm0,%ymm\rh0,%ymm\rh0     // rh0 = Q * [(rh0 - rl0) * root0_twisted]
-vpmulhw		%ymm0,%ymm\rh1,%ymm\rh1     // rh1 = Q * [(rh1 - rl1) * root0_twisted]
-vpmulhw		%ymm0,%ymm\rh2,%ymm\rh2     // rh2 = Q * [(rh2 - rl2) * root0_twisted]
-vpmulhw		%ymm0,%ymm\rh3,%ymm\rh3     // rh3 = Q * [(rh3 - rl3) * root0_twisted]
+vpmulhw		%ymm0,%ymm\rh0,%ymm\rh0     /* rh0 = Q * [(rh0 - rl0) * root0_twisted] */
+vpmulhw		%ymm0,%ymm\rh1,%ymm\rh1     /* rh1 = Q * [(rh1 - rl1) * root0_twisted] */
+vpmulhw		%ymm0,%ymm\rh2,%ymm\rh2     /* rh2 = Q * [(rh2 - rl2) * root0_twisted] */
+vpmulhw		%ymm0,%ymm\rh3,%ymm\rh3     /* rh3 = Q * [(rh3 - rl3) * root0_twisted] */
 
-vpsubw		%ymm\rh0,%ymm12,%ymm\rh0    // rh0 = montmul(rh0-rl0, root0)
-vpsubw		%ymm\rh1,%ymm13,%ymm\rh1    // rh1 = montmul(rh1-rl1, root0)
-vpsubw		%ymm\rh2,%ymm14,%ymm\rh2    // rh2 = montmul(rh2-rl2, root0)
-vpsubw		%ymm\rh3,%ymm15,%ymm\rh3    // rh3 = montmul(rh3-rl3, root0)
+vpsubw		%ymm\rh0,%ymm12,%ymm\rh0    /* rh0 = montmul(rh0-rl0, root0) */
+vpsubw		%ymm\rh1,%ymm13,%ymm\rh1    /* rh1 = montmul(rh1-rl1, root0) */
+vpsubw		%ymm\rh2,%ymm14,%ymm\rh2    /* rh2 = montmul(rh2-rl2, root0) */
+vpsubw		%ymm\rh3,%ymm15,%ymm\rh3    /* rh3 = montmul(rh3-rl3, root0) */
 .endm
 
 .macro intt_levels0t5 off
@@ -95,12 +95,12 @@ vpshufb		%ymm12,%ymm3,%ymm3
 
 butterfly	4,5,8,9,6,7,10,11,15,1,2,3
 
-// Montgmoery multiplication with a signed canonical twiddle
-// always has absolute value < q. This is used henceforth to
-// normalize the absolute bounds on the second half inputs
-// to the current butterfly
-//
-// 4,5,8,9 abs bound < 2q; 6,7,10,11 abs bound < q
+/* Montgmoery multiplication with a signed canonical twiddle
+ * always has absolute value < q. This is used henceforth to
+ * normalize the absolute bounds on the second half inputs
+ * to the current butterfly
+ *
+ * 4,5,8,9 abs bound < 2q; 6,7,10,11 abs bound < q */
 
 /* level 1 */
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+144)*2(%rsi),%ymm2
@@ -111,10 +111,10 @@ vpshufb		%ymm1,%ymm3,%ymm3
 
 butterfly	4,5,6,7,8,9,10,11,2,2,3,3
 
-// For 8,9,10,11, it is sufficient to use the bound <q (much weaker
-// than what we used above) for the absolute value of the Montgomery
-// multiplication with a twiddle.
-// 4,5 abs bound < 4q; 6,7 abs bound < 2q; 8,9,10,11 abs bound <q.
+/* For 8,9,10,11, it is sufficient to use the bound <q (much weaker
+ * than what we used above) for the absolute value of the Montgomery
+ * multiplication with a twiddle.
+ * 4,5 abs bound < 4q; 6,7 abs bound < 2q; 8,9,10,11 abs bound <q. */
 
 shuffle1	4,5,3,5      // 3,5  abs bound < 4q
 shuffle1	6,7,4,7      // 4,7  abs bound < INT16_MAX/8
@@ -127,11 +127,11 @@ vpermd		(_ZETAS_EXP+(1-\off)*224+112)*2(%rsi),%ymm12,%ymm2
 vpermd		(_ZETAS_EXP+(1-\off)*224+128)*2(%rsi),%ymm12,%ymm10
 
 butterfly	3,4,6,8,5,7,9,11,2,2,10,10
-// 3 abs bound < 8q, 4 abs bound < 4q, 6,8 abs bound < 2q, 5,7,9,11 abs bound < q
+/* 3 abs bound < 8q, 4 abs bound < 4q, 6,8 abs bound < 2q, 5,7,9,11 abs bound < q */
 
 vmovdqa		_16XV*2(%rsi),%ymm1
 red16		3
-// 4 abs bound < 4q, 6,8 abs bound < 2q, 3,5,7,9,11 abs bound < q
+/*  4 abs bound < 4q, 6,8 abs bound < 2q, 3,5,7,9,11 abs bound < q */
 
 shuffle2	3,4,10,4   // 4,10 abs bound < 4q
 shuffle2	6,8,3,8    // 3,8 abs bound < 2q
@@ -143,62 +143,62 @@ vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+80)*2(%rsi),%ymm2
 vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+96)*2(%rsi),%ymm9
 
 butterfly	10,3,6,5,4,8,7,11,2,2,9,9
-// 10 abs bound < 8q
-// 3 abs bound < 4q
-// 5,6 abs bound < 2q
-// 4,8,7,11 abs bound < q
+/* 10 abs bound < 8q
+ * 3 abs bound < 4q
+ * 5,6 abs bound < 2q
+ * 4,8,7,11 abs bound < q */
 
-// REF-CHANGE: The official AVX2 implementation from
-// https://github.com/pq-crystals/kyber/blob/main/avx2
-// does not have this reduction. We add it here to simplify reasoning of
-// non-overflow. Without it, one has to work with more precise bounds for
-// the output of a Montgomery multiplication; with this reduction,
-// in turn, the generic bound by q is sufficient.
+/* REF-CHANGE: The official AVX2 implementation from
+ * https://github.com/pq-crystals/kyber/blob/main/avx2
+ * does not have this reduction. We add it here to simplify reasoning of
+ * non-overflow. Without it, one has to work with more precise bounds for
+ * the output of a Montgomery multiplication; with this reduction,
+ * in turn, the generic bound by q is sufficient. */
 red16 10
-// 3 abs bound < 4q
-// 5,6 abs bound < 2q
-// 4,8,7,10,11 abs bound < q
+/* 3 abs bound < 4q
+ * 5,6 abs bound < 2q
+ * 4,8,7,10,11 abs bound < q */
 
-shuffle4	10,3,9,3   // 3,9  abs bound < 4q
-shuffle4	6,5,10,5   // 5,10 abs bound < 2q
-shuffle4	4,8,6,8    // 6,8  abs bound < q
-shuffle4	7,11,4,11  // 4,11 abs bound < q
+shuffle4	10,3,9,3   /* 3,9  abs bound < 4q */
+shuffle4	6,5,10,5   /* 5,10 abs bound < 2q */
+shuffle4	4,8,6,8    /* 6,8  abs bound < q */
+shuffle4	7,11,4,11  /* 4,11 abs bound < q */
 
 /* level 4 */
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+48)*2(%rsi),%ymm2
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+64)*2(%rsi),%ymm7
 
 butterfly	9,10,6,4,3,5,8,11,2,2,7,7
-// 9 abs bound < 8q
-// 10 abs bound < 4q
-// 4,6 abs bound <2q
-// 3,5,8,11 abs bound < q
+/* 9 abs bound < 8q
+ * 10 abs bound < 4q
+ * 4,6 abs bound <2q
+ * 3,5,8,11 abs bound < q */
 red16 9
-// 10 abs bound < 4q
-// 4,6 abs bound <2q
-// 3,5,8,9,11 abs bound < q
+/* 10 abs bound < 4q
+ * 4,6 abs bound <2q
+ * 3,5,8,9,11 abs bound < q */
 
-shuffle8	9,10,7,10  // 7,10 abs bound < 4q
-shuffle8	6,4,9,4    // 4,9  abs bound < 2q
-shuffle8	3,5,6,5    // 5,6  abs bound < q
-shuffle8	8,11,3,11  // 3,11 abs bound < q
+shuffle8	9,10,7,10  /* 7,10 abs bound < 4q */
+shuffle8	6,4,9,4    /* 4,9  abs bound < 2q */
+shuffle8	3,5,6,5    /* 5,6  abs bound < q */
+shuffle8	8,11,3,11  /* 3,11 abs bound < q */
 
 /* level 5 */
 vmovdqa		(_ZETAS_EXP+(1-\off)*224+16)*2(%rsi),%ymm2
 vmovdqa		(_ZETAS_EXP+(1-\off)*224+32)*2(%rsi),%ymm8
 
 butterfly	7,9,6,3,10,4,5,11,2,2,8,8
-// 7         abs bound <8q
-// 9         abs bound <4q
-// 6,3       abs bound < 2q
-// 4,5,10,11 abs bound < q
+/* 7         abs bound <8q
+ * 9         abs bound <4q
+ * 6,3       abs bound < 2q
+ * 4,5,10,11 abs bound < q */
 
-// REF-CHANGE: The official AVX2 implementation does not
-// have this reduction, but it is not readily clear how
-// to improve the 8q bound on ymm7 to guarantee that
-// layer 6 won't overflow (16q > INT16_MAX).
+/* REF-CHANGE: The official AVX2 implementation does not
+ * have this reduction, but it is not readily clear how
+ * to improve the 8q bound on ymm7 to guarantee that
+ * layer 6 won't overflow (16q > INT16_MAX). */
 red16 7
-// global abs bound < 4q
+/* global abs bound < 4q */
 
 vmovdqa         %ymm7,(128*\off+  0)*2(%rdi)
 vmovdqa         %ymm9,(128*\off+ 16)*2(%rdi)
@@ -225,10 +225,10 @@ vmovdqa         (64*\off+176)*2(%rdi),%ymm11
 vpbroadcastq	(_ZETAS_EXP+4)*2(%rsi),%ymm3
 
 butterfly	4,5,6,7,8,9,10,11
-// global abs bound < 8q
+/* global abs bound < 8q */
 
-// REF-CHANGE: The official AVX2 implementation has a `red16 4` for `off=0`.
-// We don't need this because of the earlier red16 which ensures an 8q bound
+/* REF-CHANGE: The official AVX2 implementation has a `red16 4` for `off=0`.
+ * We don't need this because of the earlier red16 which ensures an 8q bound */
 
 vmovdqa		%ymm4,(64*\off+  0)*2(%rdi)
 vmovdqa		%ymm5,(64*\off+ 16)*2(%rdi)

--- a/mlkem/native/x86_64/intt.S
+++ b/mlkem/native/x86_64/intt.S
@@ -15,50 +15,47 @@
 .include "shuffle.inc"
 .include "fq.inc"
 
+// Compute four GS butterflies between rh{0,1,2,3} and rl{0,1,2,3}.
+// Butterflies 0,1 use root zh0 and twisted root zl0, and butterflies
+// 2,3 use root zh1 and twisted root zl1
+// Results are again in rl{0-3} and rh{0-3}
 .macro butterfly rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3,zl0=2,zl1=2,zh0=3,zh1=3
-vpsubw		%ymm\rl0,%ymm\rh0,%ymm12
-vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rl0
-vpsubw		%ymm\rl1,%ymm\rh1,%ymm13
+vpsubw		%ymm\rl0,%ymm\rh0,%ymm12    // ymm12 = rh0 - rl0
+vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rl0  // rl0   = rh0 + rl0
+vpsubw		%ymm\rl1,%ymm\rh1,%ymm13    // ymm13 = rh1 - rl1
 
-vpmullw		%ymm\zl0,%ymm12,%ymm\rh0
-vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl1
-vpsubw		%ymm\rl2,%ymm\rh2,%ymm14
+vpmullw		%ymm\zl0,%ymm12,%ymm\rh0    // rh0   = (rh0 - rl0) * root0_twisted
+vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl1  // rl1   = rh1 + rh1
+vpsubw		%ymm\rl2,%ymm\rh2,%ymm14    // ymm14 = rh2 - rl2
 
-vpmullw		%ymm\zl0,%ymm13,%ymm\rh1
-vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl2
-vpsubw		%ymm\rl3,%ymm\rh3,%ymm15
+vpmullw		%ymm\zl0,%ymm13,%ymm\rh1    // rh1   = (rh1 - rl1) * root0_twisted
+vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl2  // rl2   = rh2 + rl2
+vpsubw		%ymm\rl3,%ymm\rh3,%ymm15    // ymm15 = rh3 - rl3
 
-vpmullw		%ymm\zl1,%ymm14,%ymm\rh2
-vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl3
-vpmullw		%ymm\zl1,%ymm15,%ymm\rh3
+vpmullw		%ymm\zl1,%ymm14,%ymm\rh2    // rh2   = (rh2 - rl2) * root1_twisted
+vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl3  // rl3   = rh3 + rl3
+vpmullw		%ymm\zl1,%ymm15,%ymm\rh3    // rh3   = (rh3 - rl3) * root1_twisted
 
-vpmulhw		%ymm\zh0,%ymm12,%ymm12
-vpmulhw		%ymm\zh0,%ymm13,%ymm13
+vpmulhw		%ymm\zh0,%ymm12,%ymm12      // ymm12 = (rh0 - rl0) * root0
+vpmulhw		%ymm\zh0,%ymm13,%ymm13      // ymm13 = (rh1 - rl1) * root0
 
-vpmulhw		%ymm\zh1,%ymm14,%ymm14
-vpmulhw		%ymm\zh1,%ymm15,%ymm15
+vpmulhw		%ymm\zh1,%ymm14,%ymm14      // ymm14 = (rh2 - rl2) * root1
+vpmulhw		%ymm\zh1,%ymm15,%ymm15      // ymm15 = (rh3 - rl3) * root1
 
-vpmulhw		%ymm0,%ymm\rh0,%ymm\rh0
+vpmulhw		%ymm0,%ymm\rh0,%ymm\rh0     // rh0 = Q * [(rh0 - rl0) * root0_twisted]
+vpmulhw		%ymm0,%ymm\rh1,%ymm\rh1     // rh1 = Q * [(rh1 - rl1) * root0_twisted]
+vpmulhw		%ymm0,%ymm\rh2,%ymm\rh2     // rh2 = Q * [(rh2 - rl2) * root0_twisted]
+vpmulhw		%ymm0,%ymm\rh3,%ymm\rh3     // rh3 = Q * [(rh3 - rl3) * root0_twisted]
 
-vpmulhw		%ymm0,%ymm\rh1,%ymm\rh1
-
-vpmulhw		%ymm0,%ymm\rh2,%ymm\rh2
-vpmulhw		%ymm0,%ymm\rh3,%ymm\rh3
-
-#
-
-#
-
-vpsubw		%ymm\rh0,%ymm12,%ymm\rh0
-
-vpsubw		%ymm\rh1,%ymm13,%ymm\rh1
-
-vpsubw		%ymm\rh2,%ymm14,%ymm\rh2
-vpsubw		%ymm\rh3,%ymm15,%ymm\rh3
+vpsubw		%ymm\rh0,%ymm12,%ymm\rh0    // rh0 = montmul(rh0-rl0, root0)
+vpsubw		%ymm\rh1,%ymm13,%ymm\rh1    // rh1 = montmul(rh1-rl1, root0)
+vpsubw		%ymm\rh2,%ymm14,%ymm\rh2    // rh2 = montmul(rh2-rl2, root0)
+vpsubw		%ymm\rh3,%ymm15,%ymm\rh3    // rh3 = montmul(rh3-rl3, root0)
 .endm
 
 .macro intt_levels0t5 off
 /* level 0 */
+/* no bounds assumptions */
 vmovdqa		_16XFLO*2(%rsi),%ymm2
 vmovdqa		_16XFHI*2(%rsi),%ymm3
 
@@ -82,6 +79,8 @@ fqmulprecomp	2,3,10
 fqmulprecomp	2,3,9
 fqmulprecomp	2,3,11
 
+/* bounds: coefficients < q */
+
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+208)*2(%rsi),%ymm15
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+176)*2(%rsi),%ymm1
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+224)*2(%rsi),%ymm2
@@ -94,6 +93,14 @@ vpshufb		%ymm12,%ymm3,%ymm3
 
 butterfly	4,5,8,9,6,7,10,11,15,1,2,3
 
+// Montgomery multiplication of a value <C*q with a signed canonical
+// twiddle has absolute value < q*(0.0254 * C + 1/2) (see reduce.c).
+// In the above butterfly, the values multiplied with twiddles have
+// absolute value <2q, so we get an absolute bound < q*(1/2 + 2 * 0.0254),
+// which is < INT16_MAX/16.
+//
+// 4,5,8,9 abs bound < 2q; 6,7,10,11 abs bound < INT16_MAX/16
+
 /* level 1 */
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+144)*2(%rsi),%ymm2
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+160)*2(%rsi),%ymm3
@@ -103,10 +110,15 @@ vpshufb		%ymm1,%ymm3,%ymm3
 
 butterfly	4,5,6,7,8,9,10,11,2,2,3,3
 
-shuffle1	4,5,3,5
-shuffle1	6,7,4,7
-shuffle1	8,9,6,9
-shuffle1	10,11,8,11
+// For 8,9,10,11, it is sufficient to use the bound <q (much weaker
+// than what we used above) for the absolute value of the Montgomery
+// multiplication with a twiddle.
+// 4,5 abs bound < 4q; 6,7 abs bound < INT16_MAX/8; 8,9,10,11 abs bound <q.
+
+shuffle1	4,5,3,5      // 3,5  abs bound < 4q
+shuffle1	6,7,4,7      // 4,7  abs bound < INT16_MAX/8
+shuffle1	8,9,6,9      // 6,9  abs bound < q
+shuffle1	10,11,8,11   // 8,11 abs bound < q
 
 /* level 2 */
 vmovdqa		_REVIDXD*2(%rsi),%ymm12
@@ -114,44 +126,66 @@ vpermd		(_ZETAS_EXP+(1-\off)*224+112)*2(%rsi),%ymm12,%ymm2
 vpermd		(_ZETAS_EXP+(1-\off)*224+128)*2(%rsi),%ymm12,%ymm10
 
 butterfly	3,4,6,8,5,7,9,11,2,2,10,10
+// 3 abs bound < 8q, 4 abs bound < INT16_MAX/4, 6,8 abs bound < 2q, 5,7,9,11 abs bound < q
 
 vmovdqa		_16XV*2(%rsi),%ymm1
 red16		3
+// 4 abs bound < INT16_MAX/4, 6,8 abs bound < 2q, 3,5,7,9,11 abs bound < q
 
-shuffle2	3,4,10,4
-shuffle2	6,8,3,8
-shuffle2	5,7,6,7
-shuffle2	9,11,5,11
+shuffle2	3,4,10,4   // see comment for shuffle2;
+                           // 10,4: even 16-bit pairs from 3, so abs bound <q
+                           // 10,4: odd  16-bit pairs from 4, so abs bound <INT16_MAX/4
+shuffle2	6,8,3,8    // 3,8 abs bound < 2q
+shuffle2	5,7,6,7    // 6,7 abs bound < q
+shuffle2	9,11,5,11  // 5,11 abs bound < q
 
 /* level 3 */
 vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+80)*2(%rsi),%ymm2
 vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+96)*2(%rsi),%ymm9
 
 butterfly	10,3,6,5,4,8,7,11,2,2,9,9
+// 10 abs bound < INT16_MAX/2
+// 3 abs bound < 4q, 5,6 abs bound < 2q
+// 4,8,7,11 abs bound < q
 
-shuffle4	10,3,9,3
-shuffle4	6,5,10,5
-shuffle4	4,8,6,8
-shuffle4	7,11,4,11
+shuffle4	10,3,9,3   // 3,9  abs bound < INT16_MAX/2
+shuffle4	6,5,10,5   // 5,10 abs bound < 2q
+shuffle4	4,8,6,8    // 6,8  abs bound < q
+shuffle4	7,11,4,11  // 4,11 abs bound < q
 
 /* level 4 */
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+48)*2(%rsi),%ymm2
 vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+64)*2(%rsi),%ymm7
 
 butterfly	9,10,6,4,3,5,8,11,2,2,7,7
-
+// 9 abs bound < INT16_MAX
+// 10 abs bound < 4q, 4,6 abs bound <2q
+// 3,5,8,11 abs bound < q
 red16		9
+// 10 abs bound < 4q, 4,6 abs bound <2q
+// 3,5,8,9,11 abs bound < q
 
-shuffle8	9,10,7,10
-shuffle8	6,4,9,4
-shuffle8	3,5,6,5
-shuffle8	8,11,3,11
+shuffle8	9,10,7,10  // 7,10 abs bound < 4q
+shuffle8	6,4,9,4    // 4,9  abs bound < 2q
+shuffle8	3,5,6,5    // 5,6  abs bound < q
+shuffle8	8,11,3,11  // 3,11 abs bound < q
 
 /* level 5 */
 vmovdqa		(_ZETAS_EXP+(1-\off)*224+16)*2(%rsi),%ymm2
 vmovdqa		(_ZETAS_EXP+(1-\off)*224+32)*2(%rsi),%ymm8
 
 butterfly	7,9,6,3,10,4,5,11,2,2,8,8
+// 7         abs bound <8q
+// 9         abs bound <4q
+// 6,3       abs bound < 2q
+// 4,5,10,11 abs bound < q
+
+// REF-CHANGE: The official AVX2 implementation does not
+// have this reduction, but it is not readily clear how
+// to improve the 8q bound on ymm7 to guarantee that
+// layer 6 won't overflow (16q > INT16_MAX).
+red16 7
+// global abs bound < 4q
 
 vmovdqa         %ymm7,(128*\off+  0)*2(%rdi)
 vmovdqa         %ymm9,(128*\off+ 16)*2(%rdi)
@@ -178,10 +212,10 @@ vmovdqa         (64*\off+176)*2(%rdi),%ymm11
 vpbroadcastq	(_ZETAS_EXP+4)*2(%rsi),%ymm3
 
 butterfly	4,5,6,7,8,9,10,11
+// global abs bound < 8q
 
-.if \off == 0
-red16		4
-.endif
+// REF-CHANGE: The official AVX2 implementation has a `red16 4` for `off=0`.
+// We don't need this because of the earlier red16 which ensures an 8q bound
 
 vmovdqa		%ymm4,(64*\off+  0)*2(%rdi)
 vmovdqa		%ymm5,(64*\off+ 16)*2(%rdi)

--- a/mlkem/native/x86_64/ntt.S
+++ b/mlkem/native/x86_64/ntt.S
@@ -15,6 +15,7 @@
 
 .include "shuffle.inc"
 
+// Compute steps 1,2 / 3 of Montgomery multiplication
 .macro mul rh0,rh1,rh2,rh3,zl0=15,zl1=15,zh0=2,zh1=2
 vpmullw		%ymm\zl0,%ymm\rh0,%ymm12
 vpmullw		%ymm\zl0,%ymm\rh1,%ymm13
@@ -29,6 +30,8 @@ vpmulhw		%ymm\zh1,%ymm\rh2,%ymm\rh2
 vpmulhw		%ymm\zh1,%ymm\rh3,%ymm\rh3
 .endm
 
+// Compute step 3 / 3 of Montgomery multiplication
+// Multiply-high is signed; outputs are bound by 2^15 * q in abs value
 .macro reduce
 vpmulhw		%ymm0,%ymm12,%ymm12
 vpmulhw		%ymm0,%ymm13,%ymm13
@@ -37,28 +40,42 @@ vpmulhw		%ymm0,%ymm14,%ymm14
 vpmulhw		%ymm0,%ymm15,%ymm15
 .endm
 
+// Finish Montgomery multiplication and compute add/sub steps in NTT butterfly
+//
+// At this point, the two high-products of 4 ongoing Montgomery multiplications
+// are in %ymm{12,13,14,15} and %ymm{rh{0,1,2,3}}, respectively.
+// The NTT coefficients that the results of the Montgomery multiplications should
+// be add/sub-ed with, are in %ymm{rl{0,1,2,3}}.
+//
+// What's interesting, here, is that rather than completing the Montgomery
+// multiplications by computing `%ymm{12+i} + %ymm{rh{i}}`, and then add/sub'ing
+// the result into %ymm{rl{0,1,2,3}}, we add/sub both `%ymm{12+i}` and
+// %ymm{rh{i}} to %ymm{rl{0,1,2,3}}, and then add the results.
+//
+// Functionally, though, this is still a signed Montgomery multiplication
+// followed by an add/sub.
+//
+// Since the result of the Montgomery multiplication is bounded
+// by q in absolute value, the coefficients overall grow by not
+// more than q in absolute value per layer.
 .macro update rln,rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3
-vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rln
-vpsubw		%ymm\rh0,%ymm\rl0,%ymm\rh0
-vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl0
+vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rln // rln = rl0 + rh0
+vpsubw		%ymm\rh0,%ymm\rl0,%ymm\rh0 // rh0 = rl0 - rh0
+vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl0 // rl0 = rl1 + rh1
+vpsubw		%ymm\rh1,%ymm\rl1,%ymm\rh1 // rh1 = rl1 - rh1
+vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl1 // rl1 = rl2 + rh2
+vpsubw		%ymm\rh2,%ymm\rl2,%ymm\rh2 // rh2 = rl2 - rh2
+vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl2 // rl2 = rl3 + rh3
+vpsubw		%ymm\rh3,%ymm\rl3,%ymm\rh3 // rh3 = rl3 - rh3
 
-vpsubw		%ymm\rh1,%ymm\rl1,%ymm\rh1
-vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl1
-vpsubw		%ymm\rh2,%ymm\rl2,%ymm\rh2
-
-vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl2
-vpsubw		%ymm\rh3,%ymm\rl3,%ymm\rh3
-
-vpsubw		%ymm12,%ymm\rln,%ymm\rln
-vpaddw		%ymm12,%ymm\rh0,%ymm\rh0
-vpsubw		%ymm13,%ymm\rl0,%ymm\rl0
-
-vpaddw		%ymm13,%ymm\rh1,%ymm\rh1
-vpsubw		%ymm14,%ymm\rl1,%ymm\rl1
-vpaddw		%ymm14,%ymm\rh2,%ymm\rh2
-
-vpsubw		%ymm15,%ymm\rl2,%ymm\rl2
-vpaddw		%ymm15,%ymm\rh3,%ymm\rh3
+vpsubw		%ymm12,%ymm\rln,%ymm\rln // rln = rh0 + rl0 - ymm12 = rl0 + (rh0 - ymm12)
+vpaddw		%ymm12,%ymm\rh0,%ymm\rh0 // rh0 = rl0 - rh0 + ymm12 = rl0 - (rh0 - ymm12)
+vpsubw		%ymm13,%ymm\rl0,%ymm\rl0 // rl0 = rl1 + rh1 - ymm13 = rl1 + (rh1 - ymm13)
+vpaddw		%ymm13,%ymm\rh1,%ymm\rh1 // rh1 = rl1 - rh1 + ymm13 = rl1 - (rh1 - ymm13)
+vpsubw		%ymm14,%ymm\rl1,%ymm\rl1 // rl1 = rh2 + rl2 - ymm14 = rl2 + (rh2 - ymm14)
+vpaddw		%ymm14,%ymm\rh2,%ymm\rh2 // rh2 = rl2 - rh2 + ymm14 = rl2 - (rh2 - ymm14)
+vpsubw		%ymm15,%ymm\rl2,%ymm\rl2 // rl2 = rh3 + rl3 - ymm15 = rl3 + (rh3 - ymm15)
+vpaddw		%ymm15,%ymm\rh3,%ymm\rh3 // rh3 = rl3 - rh3 + ymm15 = rl3 - (rh3 - ymm15)
 .endm
 
 .macro level0 off

--- a/mlkem/native/x86_64/ntt.S
+++ b/mlkem/native/x86_64/ntt.S
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024 The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
- */ 
+ */
 
 // Implementation from Kyber reference repository
 // https://github.com/pq-crystals/kyber/blob/main/avx2
@@ -15,7 +15,7 @@
 
 .include "shuffle.inc"
 
-// Compute steps 1,2 / 3 of Montgomery multiplication
+/* Compute steps 1,2 / 3 of Montgomery multiplication */
 .macro mul rh0,rh1,rh2,rh3,zl0=15,zl1=15,zh0=2,zh1=2
 vpmullw		%ymm\zl0,%ymm\rh0,%ymm12
 vpmullw		%ymm\zl0,%ymm\rh1,%ymm13
@@ -30,8 +30,8 @@ vpmulhw		%ymm\zh1,%ymm\rh2,%ymm\rh2
 vpmulhw		%ymm\zh1,%ymm\rh3,%ymm\rh3
 .endm
 
-// Compute step 3 / 3 of Montgomery multiplication
-// Multiply-high is signed; outputs are bound by 2^15 * q in abs value
+/* Compute step 3 / 3 of Montgomery multiplication */
+/* Multiply-high is signed; outputs are bound by 2^15 * q in abs value */
 .macro reduce
 vpmulhw		%ymm0,%ymm12,%ymm12
 vpmulhw		%ymm0,%ymm13,%ymm13
@@ -40,42 +40,42 @@ vpmulhw		%ymm0,%ymm14,%ymm14
 vpmulhw		%ymm0,%ymm15,%ymm15
 .endm
 
-// Finish Montgomery multiplication and compute add/sub steps in NTT butterfly
-//
-// At this point, the two high-products of 4 ongoing Montgomery multiplications
-// are in %ymm{12,13,14,15} and %ymm{rh{0,1,2,3}}, respectively.
-// The NTT coefficients that the results of the Montgomery multiplications should
-// be add/sub-ed with, are in %ymm{rl{0,1,2,3}}.
-//
-// What's interesting, here, is that rather than completing the Montgomery
-// multiplications by computing `%ymm{12+i} + %ymm{rh{i}}`, and then add/sub'ing
-// the result into %ymm{rl{0,1,2,3}}, we add/sub both `%ymm{12+i}` and
-// %ymm{rh{i}} to %ymm{rl{0,1,2,3}}, and then add the results.
-//
-// Functionally, though, this is still a signed Montgomery multiplication
-// followed by an add/sub.
-//
-// Since the result of the Montgomery multiplication is bounded
-// by q in absolute value, the coefficients overall grow by not
-// more than q in absolute value per layer.
+/* Finish Montgomery multiplication and compute add/sub steps in NTT butterfly
+ *
+ * At this point, the two high-products of 4 ongoing Montgomery multiplications
+ * are in %ymm{12,13,14,15} and %ymm{rh{0,1,2,3}}, respectively.
+ * The NTT coefficients that the results of the Montgomery multiplications should
+ * be add/sub-ed with, are in %ymm{rl{0,1,2,3}}.
+ *
+ * What's interesting, here, is that rather than completing the Montgomery
+ * multiplications by computing `%ymm{12+i} + %ymm{rh{i}}`, and then add/sub'ing
+ * the result into %ymm{rl{0,1,2,3}}, we add/sub both `%ymm{12+i}` and
+ * %ymm{rh{i}} to %ymm{rl{0,1,2,3}}, and then add the results.
+ *
+ * Functionally, though, this is still a signed Montgomery multiplication
+ * followed by an add/sub.
+ *
+ * Since the result of the Montgomery multiplication is bounded
+ * by q in absolute value, the coefficients overall grow by not
+ * more than q in absolute value per layer. */
 .macro update rln,rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3
-vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rln // rln = rl0 + rh0
-vpsubw		%ymm\rh0,%ymm\rl0,%ymm\rh0 // rh0 = rl0 - rh0
-vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl0 // rl0 = rl1 + rh1
-vpsubw		%ymm\rh1,%ymm\rl1,%ymm\rh1 // rh1 = rl1 - rh1
-vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl1 // rl1 = rl2 + rh2
-vpsubw		%ymm\rh2,%ymm\rl2,%ymm\rh2 // rh2 = rl2 - rh2
-vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl2 // rl2 = rl3 + rh3
-vpsubw		%ymm\rh3,%ymm\rl3,%ymm\rh3 // rh3 = rl3 - rh3
+vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rln /* rln = rl0 + rh0 */
+vpsubw		%ymm\rh0,%ymm\rl0,%ymm\rh0 /* rh0 = rl0 - rh0 */
+vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl0 /* rl0 = rl1 + rh1 */
+vpsubw		%ymm\rh1,%ymm\rl1,%ymm\rh1 /* rh1 = rl1 - rh1 */
+vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl1 /* rl1 = rl2 + rh2 */
+vpsubw		%ymm\rh2,%ymm\rl2,%ymm\rh2 /* rh2 = rl2 - rh2 */
+vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl2 /* rl2 = rl3 + rh3 */
+vpsubw		%ymm\rh3,%ymm\rl3,%ymm\rh3 /* rh3 = rl3 - rh3 */
 
-vpsubw		%ymm12,%ymm\rln,%ymm\rln // rln = rh0 + rl0 - ymm12 = rl0 + (rh0 - ymm12)
-vpaddw		%ymm12,%ymm\rh0,%ymm\rh0 // rh0 = rl0 - rh0 + ymm12 = rl0 - (rh0 - ymm12)
-vpsubw		%ymm13,%ymm\rl0,%ymm\rl0 // rl0 = rl1 + rh1 - ymm13 = rl1 + (rh1 - ymm13)
-vpaddw		%ymm13,%ymm\rh1,%ymm\rh1 // rh1 = rl1 - rh1 + ymm13 = rl1 - (rh1 - ymm13)
-vpsubw		%ymm14,%ymm\rl1,%ymm\rl1 // rl1 = rh2 + rl2 - ymm14 = rl2 + (rh2 - ymm14)
-vpaddw		%ymm14,%ymm\rh2,%ymm\rh2 // rh2 = rl2 - rh2 + ymm14 = rl2 - (rh2 - ymm14)
-vpsubw		%ymm15,%ymm\rl2,%ymm\rl2 // rl2 = rh3 + rl3 - ymm15 = rl3 + (rh3 - ymm15)
-vpaddw		%ymm15,%ymm\rh3,%ymm\rh3 // rh3 = rl3 - rh3 + ymm15 = rl3 - (rh3 - ymm15)
+vpsubw		%ymm12,%ymm\rln,%ymm\rln /* rln = rh0 + rl0 - ymm12 = rl0 + (rh0 - ymm12) */
+vpaddw		%ymm12,%ymm\rh0,%ymm\rh0 /* rh0 = rl0 - rh0 + ymm12 = rl0 - (rh0 - ymm12) */
+vpsubw		%ymm13,%ymm\rl0,%ymm\rl0 /* rl0 = rl1 + rh1 - ymm13 = rl1 + (rh1 - ymm13) */
+vpaddw		%ymm13,%ymm\rh1,%ymm\rh1 /* rh1 = rl1 - rh1 + ymm13 = rl1 - (rh1 - ymm13) */
+vpsubw		%ymm14,%ymm\rl1,%ymm\rl1 /* rl1 = rh2 + rl2 - ymm14 = rl2 + (rh2 - ymm14) */
+vpaddw		%ymm14,%ymm\rh2,%ymm\rh2 /* rh2 = rl2 - rh2 + ymm14 = rl2 - (rh2 - ymm14) */
+vpsubw		%ymm15,%ymm\rl2,%ymm\rl2 /* rl2 = rh3 + rl3 - ymm15 = rl3 + (rh3 - ymm15) */
+vpaddw		%ymm15,%ymm\rh3,%ymm\rh3 /* rh3 = rl3 - rh3 + ymm15 = rl3 - (rh3 - ymm15) */
 .endm
 
 .macro level0 off

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -30,10 +30,8 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_POLY_FROMBYTES
 
-/*  Bound from the official Kyber repository */
-#define INVNTT_BOUND_NATIVE (14870 + 1)
-/*  Bound from the official Kyber repository */
-#define NTT_BOUND_NATIVE (16118 + 1)
+#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
+#define NTT_BOUND_NATIVE (8 * MLKEM_Q)
 
 static INLINE void poly_permute_bitrev_to_custom(poly *data)
 {

--- a/mlkem/native/x86_64/shuffle.inc
+++ b/mlkem/native/x86_64/shuffle.inc
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024 The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
- */ 
+ */
 
 .macro shuffle8 r0,r1,r2,r3
 vperm2i128	$0x20,%ymm\r1,%ymm\r0,%ymm\r2
@@ -13,19 +13,19 @@ vpunpcklqdq	%ymm\r1,%ymm\r0,%ymm\r2
 vpunpckhqdq	%ymm\r1,%ymm\r0,%ymm\r3
 .endm
 
-// Shuffle r0=(a0,b0,c0,d0,...), r1=(a1,b1,c1,d1,...) into
-// r2 = (a0,b0,a1,b1,e0,f0,e1,f1,...)
-// r3 = (c0,d0,c1,d1,g0,h0,g1,h1,...)
+/* Shuffle r0=(a0,b0,c0,d0,...), r1=(a1,b1,c1,d1,...) into */
+/* r2 = (a0,b0,a1,b1,e0,f0,e1,f1,...) */
+/* r3 = (c0,d0,c1,d1,g0,h0,g1,h1,...) */
 .macro shuffle2 r0,r1,r2,r3
-// r2=(a1,b1,a1,b1,e1,f1,e1,f1,...)
+/* r2=(a1,b1,a1,b1,e1,f1,e1,f1,...) */
 vmovsldup	%ymm\r1,%ymm\r2
-// Conditional move
-// 0xAA = 0b10101010
-// r2=(a0,b0,a1,b1,e0,f0,e1,f1,...)
+/* Conditional move */
+/* 0xAA = 0b10101010 */
+/* r2=(a0,b0,a1,b1,e0,f0,e1,f1,...) */
 vpblendd	$0xAA,%ymm\r2,%ymm\r0,%ymm\r2
-// r0=(c0,d0,0,0,g0,h0,0,0,...)
+/* r0=(c0,d0,0,0,g0,h0,0,0,...) */
 vpsrlq		$32,%ymm\r0,%ymm\r0
-// r3=(c0,d0,c1,d1,g0,h0,g1,h1,...)
+/* r3=(c0,d0,c1,d1,g0,h0,g1,h1,...) */
 vpblendd	$0xAA,%ymm\r1,%ymm\r0,%ymm\r3
 .endm
 

--- a/mlkem/native/x86_64/shuffle.inc
+++ b/mlkem/native/x86_64/shuffle.inc
@@ -13,12 +13,19 @@ vpunpcklqdq	%ymm\r1,%ymm\r0,%ymm\r2
 vpunpckhqdq	%ymm\r1,%ymm\r0,%ymm\r3
 .endm
 
+// Shuffle r0=(a0,b0,c0,d0,...), r1=(a1,b1,c1,d1,...) into
+// r2 = (a0,b0,a1,b1,e0,f0,e1,f1,...)
+// r3 = (c0,d0,c1,d1,g0,h0,g1,h1,...)
 .macro shuffle2 r0,r1,r2,r3
-#vpsllq		$32,%ymm\r1,%ymm\r2
+// r2=(a1,b1,a1,b1,e1,f1,e1,f1,...)
 vmovsldup	%ymm\r1,%ymm\r2
+// Conditional move
+// 0xAA = 0b10101010
+// r2=(a0,b0,a1,b1,e0,f0,e1,f1,...)
 vpblendd	$0xAA,%ymm\r2,%ymm\r0,%ymm\r2
+// r0=(c0,d0,0,0,g0,h0,0,0,...)
 vpsrlq		$32,%ymm\r0,%ymm\r0
-#vmovshdup	%ymm\r0,%ymm\r0
+// r3=(c0,d0,c1,d1,g0,h0,g1,h1,...)
 vpblendd	$0xAA,%ymm\r1,%ymm\r0,%ymm\r3
 .endm
 


### PR DESCRIPTION
Resolves #222

This commit documents the AVX2 assembly for the [inv]NTT in the x86_64 native backend. In particular, it tracks the bounds of data through the various layers.

The invNTT implementation is highly aggressive in terms of minimizing the number of modular reductions, which makes a pen-and-paper analysis rather difficult.

At the last invNTT layer, the bounds reasoning applied is not enough to show absence of overflow. To remedy, an additional reduction is added.

The analysis for the forward NTT is straightforward.

Ultimately, we confirm the absolute bound of 8*MLKEM_Q for the output of forward and inverse NTT; this is the contractual bound that the higher-level C-code is working with.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
