### PR TITLE
Add -march=native -mtune=native for benchmarking

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -67,43 +67,43 @@ jobs:
           - name: Graviton2
             ec2_instance_type: t4g.small
             ec2_ami: ubuntu-latest (aarch64)
-            archflags: -mcpu=cortex-a76 -march=armv8.2-a
+            archflags: -mcpu=cortex-a76 -march=armv8.2-a -mtune=native
             cflags: "-flto -DFORCE_AARCH64"
             perf: PERF
           - name: Graviton3
             ec2_instance_type: c7g.medium
             ec2_ami: ubuntu-latest (aarch64)
-            archflags: -march=armv8.4-a+sha3
+            archflags: -march=armv8.4-a+sha3 -mtune=native
             cflags: "-flto -DFORCE_AARCH64"
             perf: PERF
           - name: Graviton4
             ec2_instance_type: c8g.medium
             ec2_ami: ubuntu-latest (aarch64)
-            archflags: -march=armv9-a+sha3
+            archflags: -march=armv9-a+sha3 -mtune=native
             cflags: "-flto -DFORCE_AARCH64"
             perf: PERF
           - name: AMD EPYC 4th gen (c7a)
             ec2_instance_type: c7a.medium
             ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -maes
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=native -mtune=native
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 4th gen (c7i)
             ec2_instance_type: c7i.metal-24xl
             ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -maes
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=native -mtune=native
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
             ec2_instance_type: c6a.large
             ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -maes
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=native -mtune=native
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 3rd gen (c6i)
             ec2_instance_type: c6i.large
             ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -maes
+            archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=native -mtune=native
             cflags: "-flto -DFORCE_X86_64"
             perf: PMU
     uses: ./.github/workflows/bench_ec2_reusable.yml


### PR DESCRIPTION
On my machine adding `-march=native -mtune=native` improves performance. 
Since we know have a bot telling us performance changes, let's just try in CI as well. 