### PR TITLE
Move all function signature documentation to header files

### DIFF
--- a/fips202/fips202.c
+++ b/fips202/fips202.c
@@ -241,18 +241,7 @@ void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
 
 void shake256_inc_ctx_release(shake256incctx *state) { (void)state; }
 
-/*************************************************
- * Name:        shake128_absorb
- *
- * Description: Absorb step of the SHAKE128 XOF.
- *              non-incremental, starts by zeroeing the state.
- *
- * Arguments:   - uint64_t *state:      pointer to (uninitialized) output Keccak
- *state
- *              - const uint8_t *input: pointer to input to be absorbed into
- *state
- *              - size_t inlen:         length of input in bytes
- **************************************************/
+
 void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen)
 {
   int i;
@@ -264,18 +253,6 @@ void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen)
   keccak_absorb(state->ctx, SHAKE128_RATE, input, inlen, 0x1F);
 }
 
-/*************************************************
- * Name:        shake128_squeezeblocks
- *
- * Description: Squeeze step of SHAKE128 XOF. Squeezes full blocks of
- *SHAKE128_RATE bytes each. Modifies the state. Can be called multiple times to
- *keep squeezing, i.e., is incremental.
- *
- * Arguments:   - uint8_t *output:     pointer to output blocks
- *              - size_t nblocks:      number of blocks to be squeezed (written
- *to output)
- *              - shake128ctx *state:  pointer to in/output Keccak state
- **************************************************/
 void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
 {
   keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE128_RATE);
@@ -284,16 +261,6 @@ void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
 
 void shake128_ctx_release(shake128ctx *state) { (void)state; }
 
-/*************************************************
- * Name:        shake256
- *
- * Description: SHAKE256 XOF with non-incremental API
- *
- * Arguments:   - uint8_t *output:      pointer to output
- *              - size_t outlen:        requested output length in bytes
- *              - const uint8_t *input: pointer to input
- *              - size_t inlen:         length of input in bytes
- **************************************************/
 void shake256(uint8_t *output, size_t outlen, const uint8_t *input,
               size_t inlen)
 {
@@ -309,15 +276,6 @@ void shake256(uint8_t *output, size_t outlen, const uint8_t *input,
   keccak_inc_squeeze(output, outlen, state.ctx, SHAKE256_RATE);
 }
 
-/*************************************************
- * Name:        sha3_256
- *
- * Description: SHA3-256 with non-incremental API
- *
- * Arguments:   - uint8_t *output:      pointer to output
- *              - const uint8_t *input: pointer to input
- *              - size_t inlen:         length of input in bytes
- **************************************************/
 void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
 {
   uint64_t ctx[26];
@@ -331,15 +289,6 @@ void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
   keccak_inc_squeeze(output, 32, ctx, SHA3_256_RATE);
 }
 
-/*************************************************
- * Name:        sha3_512
- *
- * Description: SHA3-512 with non-incremental API
- *
- * Arguments:   - uint8_t *output:      pointer to output
- *              - const uint8_t *input: pointer to input
- *              - size_t inlen:         length of input in bytes
- **************************************************/
 void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen)
 {
   uint64_t ctx[26];

--- a/fips202/fips202.h
+++ b/fips202/fips202.h
@@ -36,6 +36,18 @@ typedef struct
  * with the same state.
  */
 #define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
+/*************************************************
+ * Name:        shake128_absorb
+ *
+ * Description: Absorb step of the SHAKE128 XOF.
+ *              non-incremental, starts by zeroeing the state.
+ *
+ * Arguments:   - uint64_t *state:      pointer to (uninitialized) output Keccak
+ *state
+ *              - const uint8_t *input: pointer to input to be absorbed into
+ *state
+ *              - size_t inlen:         length of input in bytes
+ **************************************************/
 void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen)
 __contract__(
   requires(memory_no_alias(state, sizeof(shake128ctx)))
@@ -48,6 +60,18 @@ __contract__(
  * Supports being called multiple times
  */
 #define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
+/*************************************************
+ * Name:        shake128_squeezeblocks
+ *
+ * Description: Squeeze step of SHAKE128 XOF. Squeezes full blocks of
+ *SHAKE128_RATE bytes each. Modifies the state. Can be called multiple times to
+ *keep squeezing, i.e., is incremental.
+ *
+ * Arguments:   - uint8_t *output:     pointer to output blocks
+ *              - size_t nblocks:      number of blocks to be squeezed (written
+ *to output)
+ *              - shake128ctx *state:  pointer to in/output Keccak state
+ **************************************************/
 void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
 __contract__(
   requires(memory_no_alias(state, sizeof(shake128ctx)))
@@ -106,6 +130,16 @@ void shake256_inc_ctx_release(shake256incctx *state);
 /* One-stop SHAKE256 call. Aliasing between input and
  * output is not permitted */
 #define shake256 FIPS202_NAMESPACE(shake256)
+/*************************************************
+ * Name:        shake256
+ *
+ * Description: SHAKE256 XOF with non-incremental API
+ *
+ * Arguments:   - uint8_t *output:      pointer to output
+ *              - size_t outlen:        requested output length in bytes
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen:         length of input in bytes
+ **************************************************/
 void shake256(uint8_t *output, size_t outlen, const uint8_t *input,
               size_t inlen)
 __contract__(
@@ -118,6 +152,15 @@ __contract__(
  * output is not permitted */
 #define SHA3_256_HASHBYTES 32
 #define sha3_256 FIPS202_NAMESPACE(sha3_256)
+/*************************************************
+ * Name:        sha3_256
+ *
+ * Description: SHA3-256 with non-incremental API
+ *
+ * Arguments:   - uint8_t *output:      pointer to output
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen:         length of input in bytes
+ **************************************************/
 void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
 __contract__(
   requires(memory_no_alias(input, inlen))
@@ -129,6 +172,15 @@ __contract__(
  * output is not permitted */
 #define SHA3_512_HASHBYTES 64
 #define sha3_512 FIPS202_NAMESPACE(sha3_512)
+/*************************************************
+ * Name:        sha3_512
+ *
+ * Description: SHA3-512 with non-incremental API
+ *
+ * Arguments:   - uint8_t *output:      pointer to output
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen:         length of input in bytes
+ **************************************************/
 void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen)
 __contract__(
   requires(memory_no_alias(input, inlen))

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -255,18 +255,7 @@ __contract__(
   shake128_ctx_release(&state);
 }
 
-/*************************************************
- * Name:        gen_matrix
- *
- * Description: Deterministically generate matrix A (or the transpose of A)
- *              from a seed. Entries of the matrix are polynomials that look
- *              uniformly random. Performs rejection sampling on output of
- *              a XOF
- *
- * Arguments:   - polyvec *a: pointer to ouptput matrix A
- *              - const uint8_t *seed: pointer to input seed
- *              - int transposed: boolean deciding whether A or A^T is generated
- **************************************************/
+
 /* Not static for benchmarking */
 void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
 {
@@ -397,19 +386,7 @@ __contract__(
   }
 }
 
-/*************************************************
- * Name:        indcpa_keypair_derand
- *
- * Description: Generates public and private key for the CPA-secure
- *              public-key encryption scheme underlying ML-KEM
- *
- * Arguments:   - uint8_t *pk: pointer to output public key
- *                             (of length MLKEM_INDCPA_PUBLICKEYBYTES bytes)
- *              - uint8_t *sk: pointer to output private key
- *                             (of length MLKEM_INDCPA_SECRETKEYBYTES bytes)
- *              - const uint8_t *coins: pointer to input randomness
- *                             (of length MLKEM_SYMBYTES bytes)
- **************************************************/
+
 
 STATIC_ASSERT(NTT_BOUND + MLKEM_Q < INT16_MAX, indcpa_enc_bound_0)
 
@@ -470,21 +447,6 @@ void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
   pack_pk(pk, &pkpv, publicseed);
 }
 
-/*************************************************
- * Name:        indcpa_enc
- *
- * Description: Encryption function of the CPA-secure
- *              public-key encryption scheme underlying Kyber.
- *
- * Arguments:   - uint8_t *c: pointer to output ciphertext
- *                            (of length MLKEM_INDCPA_BYTES bytes)
- *              - const uint8_t *m: pointer to input message
- *                                  (of length MLKEM_INDCPA_MSGBYTES bytes)
- *              - const uint8_t *pk: pointer to input public key
- *                                   (of length MLKEM_INDCPA_PUBLICKEYBYTES)
- *              - const uint8_t *coins: pointer to input random coins used as
- *seed (of length MLKEM_SYMBYTES) to deterministically generate all randomness
- **************************************************/
 
 /* Check that the arithmetic in indcpa_enc() does not overflow */
 STATIC_ASSERT(INVNTT_BOUND + MLKEM_ETA1 < INT16_MAX, indcpa_enc_bound_0)

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -12,7 +12,18 @@
 
 
 #define gen_matrix MLKEM_NAMESPACE(gen_matrix)
-
+/*************************************************
+ * Name:        gen_matrix
+ *
+ * Description: Deterministically generate matrix A (or the transpose of A)
+ *              from a seed. Entries of the matrix are polynomials that look
+ *              uniformly random. Performs rejection sampling on output of
+ *              a XOF
+ *
+ * Arguments:   - polyvec *a: pointer to ouptput matrix A
+ *              - const uint8_t *seed: pointer to input seed
+ *              - int transposed: boolean deciding whether A or A^T is generated
+ **************************************************/
 void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
 __contract__(
   requires(memory_no_alias(a, sizeof(polyvec) * MLKEM_K))
@@ -24,6 +35,19 @@ __contract__(
 );
 
 #define indcpa_keypair_derand MLKEM_NAMESPACE(indcpa_keypair_derand)
+/*************************************************
+ * Name:        indcpa_keypair_derand
+ *
+ * Description: Generates public and private key for the CPA-secure
+ *              public-key encryption scheme underlying ML-KEM
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                             (of length MLKEM_INDCPA_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                             (of length MLKEM_INDCPA_SECRETKEYBYTES bytes)
+ *              - const uint8_t *coins: pointer to input randomness
+ *                             (of length MLKEM_SYMBYTES bytes)
+ **************************************************/
 void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
                            const uint8_t coins[MLKEM_SYMBYTES])
@@ -37,17 +61,19 @@ __contract__(
 
 #define indcpa_enc MLKEM_NAMESPACE(indcpa_enc)
 /*************************************************
- * Name:        indcpa_dec
+ * Name:        indcpa_enc
  *
- * Description: Decryption function of the CPA-secure
+ * Description: Encryption function of the CPA-secure
  *              public-key encryption scheme underlying Kyber.
  *
- * Arguments:   - uint8_t *m: pointer to output decrypted message
- *                            (of length MLKEM_INDCPA_MSGBYTES)
- *              - const uint8_t *c: pointer to input ciphertext
- *                                  (of length MLKEM_INDCPA_BYTES)
- *              - const uint8_t *sk: pointer to input secret key
- *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
+ * Arguments:   - uint8_t *c: pointer to output ciphertext
+ *                            (of length MLKEM_INDCPA_BYTES bytes)
+ *              - const uint8_t *m: pointer to input message
+ *                                  (of length MLKEM_INDCPA_MSGBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                                   (of length MLKEM_INDCPA_PUBLICKEYBYTES)
+ *              - const uint8_t *coins: pointer to input random coins used as
+ *seed (of length MLKEM_SYMBYTES) to deterministically generate all randomness
  **************************************************/
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
@@ -62,6 +88,19 @@ __contract__(
 );
 
 #define indcpa_dec MLKEM_NAMESPACE(indcpa_dec)
+/*************************************************
+ * Name:        indcpa_dec
+ *
+ * Description: Decryption function of the CPA-secure
+ *              public-key encryption scheme underlying Kyber.
+ *
+ * Arguments:   - uint8_t *m: pointer to output decrypted message
+ *                            (of length MLKEM_INDCPA_MSGBYTES)
+ *              - const uint8_t *c: pointer to input ciphertext
+ *                                  (of length MLKEM_INDCPA_BYTES)
+ *              - const uint8_t *sk: pointer to input secret key
+ *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
+ **************************************************/
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES])

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -78,22 +78,6 @@ static int check_sk(const uint8_t sk[MLKEM_SECRETKEYBYTES])
   return 0;
 }
 
-/*************************************************
- * Name:        crypto_kem_keypair_derand
- *
- * Description: Generates public and private key
- *              for CCA-secure ML-KEM key encapsulation mechanism
- *
- * Arguments:   - uint8_t *pk: pointer to output public key
- *                (an already allocated array of MLKEM_PUBLICKEYBYTES bytes)
- *              - uint8_t *sk: pointer to output private key
- *                (an already allocated array of MLKEM_SECRETKEYBYTES bytes)
- *              - uint8_t *coins: pointer to input randomness
- *                (an already allocated array filled with 2*MLKEM_SYMBYTES
- *random bytes)
- **
- * Returns 0 (success)
- **************************************************/
 int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins)
 {
   indcpa_keypair_derand(pk, sk, coins);

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -23,6 +23,22 @@
 #endif
 
 #define crypto_kem_keypair_derand MLKEM_NAMESPACE(keypair_derand)
+/*************************************************
+ * Name:        crypto_kem_keypair_derand
+ *
+ * Description: Generates public and private key
+ *              for CCA-secure ML-KEM key encapsulation mechanism
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                (an already allocated array of MLKEM_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                (an already allocated array of MLKEM_SECRETKEYBYTES bytes)
+ *              - uint8_t *coins: pointer to input randomness
+ *                (an already allocated array filled with 2*MLKEM_SYMBYTES
+ *random bytes)
+ **
+ * Returns 0 (success)
+ **************************************************/
 int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins)
 __contract__(
   requires(memory_no_alias(pk, MLKEM_PUBLICKEYBYTES))

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -242,21 +242,6 @@ void poly_invntt_tomont(poly *p)
 }
 #endif /* MLKEM_USE_NATIVE_INTT */
 
-/*************************************************
- * Name:        basemul_cached
- *
- * Description: Multiplication of polynomials in Zq[X]/(X^2-zeta)
- *              used for multiplication of elements in Rq in NTT domain
- *
- *              Bounds:
- *              - a is assumed to be < q in absolute value.
- *              - Return value < 3/2 q in absolute value
- *
- * Arguments:   - int16_t r[2]: pointer to the output polynomial
- *              - const int16_t a[2]: pointer to the first factor
- *              - const int16_t b[2]: pointer to the second factor
- *              - int16_t b_cached: Cached precomputation of b[1] * zeta
- **************************************************/
 void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
                     int16_t b_cached)
 {

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -15,6 +15,7 @@
 #define zetas MLKEM_NAMESPACE(zetas)
 extern const int16_t zetas[128];
 
+#define poly_ntt MLKEM_NAMESPACE(poly_ntt)
 /*************************************************
  * Name:        poly_ntt
  *
@@ -32,8 +33,6 @@ extern const int16_t zetas[128];
  *
  * Arguments:   - poly *p: pointer to in/output polynomial
  **************************************************/
-
-#define poly_ntt MLKEM_NAMESPACE(poly_ntt)
 void poly_ntt(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -42,6 +41,7 @@ __contract__(
   ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, NTT_BOUND - 1))
 );
 
+#define poly_invntt_tomont MLKEM_NAMESPACE(poly_invntt_tomont)
 /*************************************************
  * Name:        poly_invntt_tomont
  *
@@ -58,7 +58,6 @@ __contract__(
  *
  * Arguments:   - uint16_t *a: pointer to in/output polynomial
  **************************************************/
-#define poly_invntt_tomont MLKEM_NAMESPACE(poly_invntt_tomont)
 void poly_invntt_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -71,24 +71,6 @@ void polyvec_invntt_tomont(polyvec *r)
   }
 }
 
-/*************************************************
- * Name:        polyvec_basemul_acc_montgomery
- *
- * Description: Multiply elements of a and b in NTT domain, accumulate into r,
- *              and multiply by 2^-16.
- *
- *              Bounds:
- *              - a is assumed to be coefficient-wise < q in absolute value.
- *              - b is assumed to be the output of a forward NTT and
- *                thus coefficient-wise bound by NTT_BOUND
- *              - b_cache is assumed to be coefficient-wise bound by
- *                MLKEM_Q.
- *
- * Arguments: - poly *r: pointer to output polynomial
- *            - const polyvec *a: pointer to first input vector of polynomials
- *            - const polyvec *b: pointer to second input vector of polynomials
- *            - const polyvec_mulcache *b_cache: mulcache for b
- **************************************************/
 #if !defined(MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED)
 void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
                                            const polyvec *b,
@@ -135,16 +117,6 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
 }
 #endif /* MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
 
-/*************************************************
- * Name:        polyvec_basemul_acc_montgomery
- *
- * Description: Multiply elements of a and b in NTT domain, accumulate into r,
- *              and multiply by 2^-16.
- *
- * Arguments: - poly *r: pointer to output polynomial
- *            - const polyvec *a: pointer to first input vector of polynomials
- *            - const polyvec *b: pointer to second input vector of polynomials
- **************************************************/
 void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
 {
   polyvec_mulcache b_cache;
@@ -152,16 +124,6 @@ void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
   polyvec_basemul_acc_montgomery_cached(r, a, b, &b_cache);
 }
 
-/*************************************************
- * Name:        polyvec_mulcache_compute
- *
- * Description: Precompute values speeding up
- *              base multiplications of polynomials
- *              in NTT domain.
- *
- * Arguments: - polyvec_mulcache *x: pointer to output cache.
- *            - const poly *a: pointer to input polynomial
- **************************************************/
 void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)
 {
   unsigned int i;
@@ -171,16 +133,6 @@ void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)
   }
 }
 
-
-/*************************************************
- * Name:        polyvec_reduce
- *
- * Description: Applies Barrett reduction to each coefficient
- *              of each element of a vector of polynomials;
- *              for details of the Barrett reduction see comments in reduce.c
- *
- * Arguments:   - polyvec *r: pointer to input/output polynomial
- **************************************************/
 void polyvec_reduce(polyvec *r)
 {
   unsigned int i;

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -156,6 +156,16 @@ __contract__(
 
 #define polyvec_basemul_acc_montgomery \
   MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery)
+/*************************************************
+ * Name:        polyvec_basemul_acc_montgomery
+ *
+ * Description: Multiply elements of a and b in NTT domain, accumulate into r,
+ *              and multiply by 2^-16.
+ *
+ * Arguments: - poly *r: pointer to output polynomial
+ *            - const polyvec *a: pointer to first input vector of polynomials
+ *            - const polyvec *b: pointer to second input vector of polynomials
+ **************************************************/
 void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a,
                                     const polyvec *b);
 

--- a/mlkem/reduce.c
+++ b/mlkem/reduce.c
@@ -124,17 +124,6 @@ int16_t fqmul(int16_t a, int16_t b)
 static const int32_t barrett_multiplier =
     ((1 << BPOWER) + MLKEM_Q / 2) / MLKEM_Q;
 
-/*************************************************
- * Name:        barrett_reduce
- *
- * Description: Barrett reduction; given a 16-bit integer a, computes
- *              centered representative congruent to a mod q in
- *              {-(q-1)/2,...,(q-1)/2}
- *
- * Arguments:   - int16_t a: input integer to be reduced
- *
- * Returns:     integer in {-(q-1)/2,...,(q-1)/2} congruent to a modulo q.
- **************************************************/
 int16_t barrett_reduce(int16_t a)
 {
   /*

--- a/mlkem/reduce.h
+++ b/mlkem/reduce.h
@@ -13,6 +13,7 @@
 #define MONT -1044                 /* 2^16 mod q */
 #define HALF_Q ((MLKEM_Q + 1) / 2) /* 1665 */
 
+#define montgomery_reduce MLKEM_NAMESPACE(montgomery_reduce)
 /*************************************************
  * Name:        montgomery_reduce
  *
@@ -24,7 +25,6 @@
  * Returns:     integer congruent to a * R^-1 modulo q,
  *              smaller than 3/2 q in absolute value.
  **************************************************/
-#define montgomery_reduce MLKEM_NAMESPACE(montgomery_reduce)
 int16_t montgomery_reduce(int32_t a)
 __contract__(
   requires(a > -(2 * MLKEM_Q * 32768))
@@ -33,6 +33,17 @@ __contract__(
 );
 
 #define barrett_reduce MLKEM_NAMESPACE(barrett_reduce)
+/*************************************************
+ * Name:        barrett_reduce
+ *
+ * Description: Barrett reduction; given a 16-bit integer a, computes
+ *              centered representative congruent to a mod q in
+ *              {-(q-1)/2,...,(q-1)/2}
+ *
+ * Arguments:   - int16_t a: input integer to be reduced
+ *
+ * Returns:     integer in {-(q-1)/2,...,(q-1)/2} congruent to a modulo q.
+ **************************************************/
 int16_t barrett_reduce(int16_t a)
 __contract__(
   ensures(return_value > -HALF_Q && return_value < HALF_Q)


### PR DESCRIPTION
We have partially moved documentations describing function sigantures to header files while writing CBMC proofs. However, it's currently not consistent and there is still come documentation left in C sources.

This commit moves all those comments to the header files.

Resolves https://github.com/pq-code-package/mlkem-native/issues/434 Resolves https://github.com/pq-code-package/mlkem-native/issues/211

I also cleaned up the placement of the namespacing.