### PR TITLE
Build static library for 3 parameter set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,18 @@ jobs:
           # print compiler version
           cl
           nmake /f ./Makefile.Microsoft_nmake quickcheck
+  quickcheck-lib:
+    name: Quickcheck lib
+    strategy:
+      matrix:
+        system: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: make lib
+        run: |
+          make lib
+
   build_kat:
     needs: [quickcheck, quickcheck-windows]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: make lib
         run: |
-          make lib
+          make test/build/tmp/libtmp_mlkem.a
 
   build_kat:
     needs: [quickcheck, quickcheck-windows]

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ quickcheck: buildall
 	./scripts/acvp
 	$(Q)echo "  Functionality and ACVP tests passed!"
 
-lib: $(BUILD_DIR)/libmlkem.a
-
 mlkem: \
   $(MLKEM512_DIR)/bin/test_mlkem512 \
   $(MLKEM768_DIR)/bin/test_mlkem768 \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ quickcheck: buildall
 	./scripts/acvp
 	$(Q)echo "  Functionality and ACVP tests passed!"
 
+lib: $(BUILD_DIR)/libmlkem.a
+
 mlkem: \
   $(MLKEM512_DIR)/bin/test_mlkem512 \
   $(MLKEM768_DIR)/bin/test_mlkem768 \

--- a/fips202/native/x86_64/xkcp/KeccakP-1600-times4-SIMD256.c
+++ b/fips202/native/x86_64/xkcp/KeccakP-1600-times4-SIMD256.c
@@ -445,8 +445,10 @@ void KeccakP1600times4_PermuteAll_24rounds(void *states)
 }
 
 #else
+#include "params.h"
 
 /* Dummy constant to keep compiler happy despite empty CU */
+#define empty_cu_avx2_keccakx4 MLKEM_NAMESPACE(empty_cu_avx2_keccakx4)
 int empty_cu_avx2_keccakx4;
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -89,6 +89,7 @@ include mk/auto.mk
 endif
 
 BUILD_DIR ?= test/build
+TMP_DIR ?= test/build/tmp
 
 MAKE_OBJS = $(2:%=$(1)/%.o)
 OBJS = $(call MAKE_OBJS,$(BUILD_DIR),$(1))

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -75,7 +75,7 @@ endif
 AUTO ?= 1
 CYCLES ?=
 OPT ?= 1
-RETAINED_VARS := CYCLES OPT AUTO
+RETAINED_VARS := CROSS_PREFIX CYCLES OPT AUTO
 
 ifeq ($(AUTO),1)
 include mk/auto.mk

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -12,10 +12,17 @@ CROSS_PREFIX ?=
 CC  ?= gcc
 CPP ?= cpp
 AR  ?= ar
+# NOTE: gcc-ar is a wrapper around ar that ensures proper integration with GCC plugins,
+# 		such as lto. Using gcc-ar is preferred when creating or linking static libraries
+# 		if the binary is compiled with -flto.
+# 		However, this doesn't apply to darwin as it is using clang instead, and there's no
+# 		gcc-ar wrapper as well.
+CC_AR ?= $(if $(findstring Darwin,$(shell uname -s)),ar,gcc-ar)
 
 CC  := $(CROSS_PREFIX)$(CC)
 CPP := $(CROSS_PREFIX)$(CPP)
 AR  := $(CROSS_PREFIX)$(AR)
+CC_AR  := $(CROSS_PREFIX)$(CC_AR)
 LD  := $(CC)
 OBJCOPY := $(CROSS_PREFIX)objcopy
 SIZE := $(CROSS_PREFIX)size

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -81,7 +81,7 @@ ifeq ($(AUTO),1)
 include mk/auto.mk
 endif
 
-BUILD_DIR := test/build
+BUILD_DIR ?= test/build
 
 MAKE_OBJS = $(2:%=$(1)/%.o)
 OBJS = $(call MAKE_OBJS,$(BUILD_DIR),$(1))

--- a/mk/crypto.mk
+++ b/mk/crypto.mk
@@ -5,16 +5,16 @@ ifeq ($(OPT),1)
 	FIPS202_SRCS += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
 endif
 
-$(BUILD_DIR)/libfips202.a: $(call OBJS, $(FIPS202_SRCS))
-$(BUILD_DIR)/libmlkem.a: $(call OBJS, $(FIPS202_SRCS))
+$(TMP_DIR)/libtmp_fips202.a: $(call OBJS, $(FIPS202_SRCS))
+$(TMP_DIR)/libtmp_mlkem.a: $(call OBJS, $(FIPS202_SRCS))
 
 # all lib<scheme>.a depends on libfips202.a
 define ADD_FIPS202
-$(BUILD_DIR)/lib$(1).a: LDLIBS += -lfips202
+$(TMP_DIR)/libtmp_$(1).a: LDLIBS += -ltmp_fips202
 # NOTE:
 # - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
 
-$(BUILD_DIR)/lib$(1).a: $(BUILD_DIR)/libfips202.a $(call OBJS, $(FIPS202_SRCS))
+$(TMP_DIR)/libtmp_$(1).a: $(TMP_DIR)/libtmp_fips202.a $(call OBJS, $(FIPS202_SRCS))
 endef
 
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \

--- a/mk/crypto.mk
+++ b/mk/crypto.mk
@@ -1,7 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 CPPFLAGS += -Ifips202 -Ifips202/native
-
-SOURCES += $(wildcard fips202/*.c)
+FIPS202_SRCS = $(wildcard fips202/*.c)
 ifeq ($(OPT),1)
-	SOURCES += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
+	FIPS202_SRCS += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
 endif
+
+$(BUILD_DIR)/libfips202.a: $(call OBJS, $(FIPS202_SRCS))
+$(BUILD_DIR)/libmlkem.a: $(call OBJS, $(FIPS202_SRCS))
+
+# all lib<scheme>.a depends on libfips202.a
+define ADD_FIPS202
+$(BUILD_DIR)/lib$(1).a: LDLIBS += -lfips202
+# NOTE:
+# - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
+
+$(BUILD_DIR)/lib$(1).a: $(BUILD_DIR)/libfips202.a $(call OBJS, $(FIPS202_SRCS))
+endef
+
+$(foreach scheme,mlkem512 mlkem768 mlkem1024, \
+	$(eval $(call ADD_FIPS202,$(scheme))) \
+)

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -20,6 +20,26 @@ $(BUILD_DIR)/%.a: $(CONFIG)
 	$(Q)rm -f $@
 	$(Q)$(CC_AR) rcs $@ $(filter %.o,$^)
 
+# NOTE:
+# 	$AR doesn't care about duplicated symbols, one can only find it out via actually linking.
+# 	The easiest one to do this that one can think of is to create a dummy C file with empty main function on the fly, pipe it to $CC and link with the built library
+	$(eval _LIB := $(subst $(BUILD_DIR)/lib,,$(@:%.a=%)))
+ifneq ($(findstring clang,$(shell $(CC) --version)),) # if CC is clang
+	$(Q)echo "int main() {return 0;}" \
+		| $(CC) -x c - -L$(BUILD_DIR) \
+		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
+		 -Imlkem $(wildcard test/notrandombytes/*.c)
+	$(Q)rm -f a.out
+else                                                  # if CC is not clang
+	$(Q)echo "int main() {return 0;}" \
+		| $(CC) -x c - -L$(BUILD_DIR) \
+		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \
+		-Wl,--no-whole-archive \
+		-Imlkem $(wildcard test/notrandombytes/*.c)
+	$(Q)rm -f a.out
+endif
+	$(Q)echo "  AR         Checked for duplicated symbols"
+
 $(BUILD_DIR)/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"
 	$(Q)echo "  $(CC) -c -o $@ $(CFLAGS) $<"

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -2,17 +2,23 @@
 $(BUILD_DIR)/mlkem512/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/mlkem768/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/mlkem1024/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+
+$(BUILD_DIR)/%.a: $(CONFIG)
+	$(Q)echo "  AR      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)rm -f $@
+	$(Q)$(CC_AR) rcs $@ $(filter %.o,$^)
 
 $(BUILD_DIR)/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -23,16 +23,16 @@ $(BUILD_DIR)/%.a: $(CONFIG)
 # NOTE:
 # 	$AR doesn't care about duplicated symbols, one can only find it out via actually linking.
 # 	The easiest one to do this that one can think of is to create a dummy C file with empty main function on the fly, pipe it to $CC and link with the built library
-	$(eval _LIB := $(subst $(BUILD_DIR)/lib,,$(@:%.a=%)))
+	$(eval _LIB := $(subst $(shell dirname $@)/lib,,$(@:%.a=%)))
 ifneq ($(findstring clang,$(shell $(CC) --version)),) # if CC is clang
 	$(Q)echo "int main() {return 0;}" \
-		| $(CC) -x c - -L$(BUILD_DIR) \
+		| $(CC) -x c - -L$(shell dirname $@) \
 		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
 		 -Imlkem $(wildcard test/notrandombytes/*.c)
 	$(Q)rm -f a.out
 else                                                  # if CC is not clang
 	$(Q)echo "int main() {return 0;}" \
-		| $(CC) -x c - -L$(BUILD_DIR) \
+		| $(CC) -x c - -L$(shell dirname $@) \
 		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \
 		-Wl,--no-whole-archive \
 		-Imlkem $(wildcard test/notrandombytes/*.c)

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -15,18 +15,18 @@ MLKEM1024_DIR = $(BUILD_DIR)/mlkem1024
 
 # build lib<scheme>.a
 define BUILD_LIB
-$(BUILD_DIR)/lib$(1).a: CFLAGS += -static
-$(BUILD_DIR)/lib$(1).a: $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
+$(TMP_DIR)/libtmp_$(1).a: CFLAGS += -static
+$(TMP_DIR)/libtmp_$(1).a: $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
 
 # NOTE:
 # - The order matters, or else the `MLKEM_K` preprocessor won't be properly set
 # - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
-$(BUILD_DIR)/libmlkem.a: $(BUILD_DIR)/lib$(1).a $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
+$(TMP_DIR)/libtmp_mlkem.a: $(TMP_DIR)/libtmp_$(1).a $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
 endef
 
-$(BUILD_DIR)/libmlkem512.a: CPPFLAGS += -DMLKEM_K=2
-$(BUILD_DIR)/libmlkem768.a: CPPFLAGS += -DMLKEM_K=3
-$(BUILD_DIR)/libmlkem1024.a: CPPFLAGS += -DMLKEM_K=4
+$(TMP_DIR)/libtmp_mlkem512.a: CPPFLAGS += -DMLKEM_K=2
+$(TMP_DIR)/libtmp_mlkem768.a: CPPFLAGS += -DMLKEM_K=3
+$(TMP_DIR)/libtmp_mlkem1024.a: CPPFLAGS += -DMLKEM_K=4
 
 # build libmlkem512.a libmlkem768.a libmlkem1024.a
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
@@ -34,8 +34,8 @@ $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
 
 # rules for compilation for all tests: mainly linking with mlkem static link library
 define ADD_SOURCE
-$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(BUILD_DIR) -l$(1)
-$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(BUILD_DIR)/lib$(1).a
+$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(TMP_DIR) -ltmp_$(1)
+$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(TMP_DIR)/libtmp_$(1).a
 endef
 
 $(MLKEM512_DIR)/bin/%: CPPFLAGS += -DMLKEM_K=2

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -32,14 +32,21 @@ $(BUILD_DIR)/libmlkem1024.a: CPPFLAGS += -DMLKEM_K=4
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
 	$(eval $(call BUILD_LIB,$(scheme))))
 
+# rules for compilation for all tests: mainly linking with mlkem static link library
+define ADD_SOURCE
+$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(BUILD_DIR) -l$(1)
+$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(BUILD_DIR)/lib$(1).a
+endef
+
 $(MLKEM512_DIR)/bin/%: CPPFLAGS += -DMLKEM_K=2
-$(ALL_TESTS:%=$(MLKEM512_DIR)/bin/%512):$(MLKEM512_DIR)/bin/%512: $(MLKEM512_DIR)/test/%.c.o $(call MAKE_OBJS,$(MLKEM512_DIR), $(SOURCES))
-
 $(MLKEM768_DIR)/bin/%: CPPFLAGS += -DMLKEM_K=3
-$(ALL_TESTS:%=$(MLKEM768_DIR)/bin/%768):$(MLKEM768_DIR)/bin/%768: $(MLKEM768_DIR)/test/%.c.o $(call MAKE_OBJS,$(MLKEM768_DIR), $(SOURCES))
-
 $(MLKEM1024_DIR)/bin/%: CPPFLAGS += -DMLKEM_K=4
-$(ALL_TESTS:%=$(MLKEM1024_DIR)/bin/%1024):$(MLKEM1024_DIR)/bin/%1024: $(MLKEM1024_DIR)/test/%.c.o $(call MAKE_OBJS,$(MLKEM1024_DIR), $(SOURCES))
+
+$(foreach scheme,mlkem512 mlkem768 mlkem1024, \
+	$(foreach test,$(ALL_TESTS), \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test))) \
+	) \
+)
 
 # nistkat tests require special RNG
 $(MLKEM512_DIR)/bin/gen_NISTKAT512: CPPFLAGS += -Itest/nistrng

--- a/mlkem/debug/debug.c
+++ b/mlkem/debug/debug.c
@@ -52,7 +52,9 @@ void mlkem_debug_print_error(const char *file, int line, const char *msg)
 }
 
 #else /* MLKEM_DEBUG */
+#include "params.h"
 
+#define empty_cu_debug MLKEM_NAMESPACE(empty_cu_debug)
 int empty_cu_debug;
 
 #endif /* MLKEM_DEBUG */

--- a/mlkem/native/aarch64/aarch64_zetas.c
+++ b/mlkem/native/aarch64/aarch64_zetas.c
@@ -163,7 +163,10 @@ const int16_t aarch64_zetas_mulcache_twisted_native[] = {
     -11566, 11566,
 };
 
-#else  /* MLKEM_USE_NATIVE_AARCH64 */
+#else /* MLKEM_USE_NATIVE_AARCH64 */
+#include "params.h"
+
 /* Dummy declaration for compilers disliking empty compilation units */
+#define empty_cu_aarch64_zetas MLKEM_NAMESPACE(empty_cu_aarch64_zetas)
 int empty_cu_aarch64_zetas;
 #endif /* MLKEM_USE_NATIVE_AARCH64 */

--- a/mlkem/native/x86_64/basemul.c
+++ b/mlkem/native/x86_64/basemul.c
@@ -58,8 +58,11 @@ void polyvec_basemul_acc_montgomery_cached_avx2(poly *r, const polyvec *a,
 }
 
 #else
+#include "params.h"
 
 /* Dummy constant to keep compiler happy despite empty CU */
+
+#define empty_cu_avx2_basemul MLKEM_NAMESPACE(empty_cu_avx2_basemul)
 int empty_cu_avx2_basemul;
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/consts.c
+++ b/mlkem/native/x86_64/consts.c
@@ -86,7 +86,10 @@ const qdata_t qdata = {{
     SHIFT,    SHIFT,    SHIFT,    SHIFT,    SHIFT,    SHIFT,
     SHIFT,    SHIFT,    SHIFT,    SHIFT}};
 
-#else  /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
+#else /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
+#include "params.h"
+
 /* Dummy declaration for compilers disliking empty compilation units */
+#define empty_cu_consts MLKEM_NAMESPACE(empty_cu_consts)
 int empty_cu_consts;
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/rej_uniform_avx2.c
+++ b/mlkem/native/x86_64/rej_uniform_avx2.c
@@ -290,7 +290,10 @@ unsigned int rej_uniform_avx2(int16_t *RESTRICT r, const uint8_t *buf)
   return ctr;
 }
 
-#else  /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
+#else /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
+#include "params.h"
+
 /* Dummy declaration for compilers disliking empty compilation units */
+#define empty_cu_rej_uniform_avx2 MLKEM_NAMESPACE(empty_cu_rej_uniform_avx2)
 int empty_cu_rej_uniform_avx2;
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -13,7 +13,9 @@
 volatile uint64_t ct_opt_blocker_u64 = 0;
 
 #else /* MLKEM_USE_ASM_VALUE_BARRIER */
+#include "params.h"
 
+#define empty_cu_verify MLKEM_NAMESPACE(empty_cu_verify)
 int empty_cu_verify;
 
 #endif /* MLKEM_USE_ASM_VALUE_BARRIER */

--- a/scripts/autogenerate_files.py
+++ b/scripts/autogenerate_files.py
@@ -328,7 +328,10 @@ def gen_aarch64_fwd_ntt_zeta_file(dry_run=False):
         yield "};"
         yield ""
         yield "#else /* MLKEM_USE_NATIVE_AARCH64 */"
+        yield '#include "params.h"'
+        yield ""
         yield "/* Dummy declaration for compilers disliking empty compilation units */"
+        yield "#define empty_cu_aarch64_zetas MLKEM_NAMESPACE(empty_cu_aarch64_zetas)"
         yield "int empty_cu_aarch64_zetas;"
         yield "#endif /* MLKEM_USE_NATIVE_AARCH64 */"
         yield ""

--- a/scripts/ci/check-namespace
+++ b/scripts/ci/check-namespace
@@ -16,19 +16,17 @@
 import subprocess
 import os
 
+
 def check_file(file_path, namespaces):
     if file_path.endswith("debug.c.o"):
         print("skipping namespacing: {}".format(file_path))
         return
     print("checking namespacing: {}".format(file_path))
-    command = ['nm', '-g', file_path]
+    command = ["nm", "-g", file_path]
 
-    result = subprocess.run(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    result = result.stdout.decode('utf-8')
+    result = result.stdout.decode("utf-8")
     lines = result.strip().split("\n")
     symbols = []
     for line in lines:
@@ -37,15 +35,14 @@ def check_file(file_path, namespaces):
 
     def is_namespaced(symbol):
         for namespace in namespaces:
-            if (symbol.startswith(namespace) or
-                symbol.startswith('_' + namespace)):
+            if symbol.startswith(namespace) or symbol.startswith("_" + namespace):
                 return True
         return False
 
     non_namespaced = []
     for symbolstr in symbols:
         *_, symtype, symbol = symbolstr.split()
-        if symtype in 'TDRS':
+        if symtype in "TDRS":
             if is_namespaced(symbol) is False:
                 non_namespaced.append(symbol)
 
@@ -67,23 +64,29 @@ def check_folder(folder, namespace):
     print("Checked {} files".format(checked))
     assert checked > 0
 
+
 def list_mlkem_namespaces(lvl):
-    return [ f"PQCP_MLKEM_NATIVE_MLKEM{lvl}_C",
-             f"PQCP_MLKEM_NATIVE_MLKEM{lvl}_AARCH64",
-             f"PQCP_MLKEM_NATIVE_MLKEM{lvl}_X86_64" ]
+    return [
+        f"PQCP_MLKEM_NATIVE_MLKEM{lvl}_C",
+        f"PQCP_MLKEM_NATIVE_MLKEM{lvl}_AARCH64",
+        f"PQCP_MLKEM_NATIVE_MLKEM{lvl}_X86_64",
+    ]
+
 
 def list_fips202_namespaces():
-    return [ f"PQCP_MLKEM_NATIVE_FIPS202_C",
-             f"PQCP_MLKEM_NATIVE_FIPS202_AARCH64",
-             f"PQCP_MLKEM_NATIVE_FIPS202_X86_64" ]
+    return [
+        f"PQCP_MLKEM_NATIVE_FIPS202_C",
+        f"PQCP_MLKEM_NATIVE_FIPS202_AARCH64",
+        f"PQCP_MLKEM_NATIVE_FIPS202_X86_64",
+    ]
+
 
 def run():
     check_folder("test/build/mlkem512/mlkem", list_mlkem_namespaces(512))
     check_folder("test/build/mlkem768/mlkem", list_mlkem_namespaces(768))
     check_folder("test/build/mlkem1024/mlkem", list_mlkem_namespaces(1024))
-    check_folder("test/build/mlkem512/fips202", list_fips202_namespaces())
-    check_folder("test/build/mlkem768/fips202", list_fips202_namespaces())
-    check_folder("test/build/mlkem1024/fips202", list_fips202_namespaces())
+    check_folder("test/build/fips202", list_fips202_namespaces())
+
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
- Resovles #457 

**Steps**:
- Since `$AR` doesn't care about duplicated symbols, the build system now links the static library after it is built for chekcing any duplicates. Additionally, a quick check for this has been added to CI.

- The build system is adjusted to build test binaries by linking with static library instead of directly with object files, since we'll need to test the built static library anyway. Therefore the build system would be simpler and easier to maintain if we do it this way.

- However, seems like `gcc` and `ar` are not happy with linking with static library if `-flto` is provided. `--plugin` would need to be properly set to the lto plugin location. Using `gcc-ar` as default instead of `ar` should resolve the issue, as the wrapper is already properly set with the configuration. 
  - Note that this is not the case for `ar` shipped with `apple clang` - 
  - Haven't checked with `llvm clang` yet, but there's also `llvm-ar` wrapper, which should make fixing any issues straightforward if they arise.

**Performed local tests**:
 - [x] `lint` passing
 - [x] `tests all` passing
 - [x] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
