### PR TITLE
CI: Spread work across multiple AWS regions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -107,6 +107,7 @@ jobs:
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes
             cflags: "-flto -DFORCE_X86_64"
+            aws_region: "eu-west-2" # Use separate region for metal instance to avoid exceeding vCPU quota
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
             ec2_instance_type: c6a.large

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,9 +385,10 @@ jobs:
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     with:
       name: CBMC (MLKEM-512)
+      aws_region: "us-west-1"
       ec2_instance_type: c7g.2xlarge
       ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
+      ec2_ami_id: ami-09458fc989530d66f
       compile_mode: native
       opt: no_opt
       lint: false
@@ -410,8 +411,9 @@ jobs:
     with:
       name: CBMC (MLKEM-768)
       ec2_instance_type: c7g.2xlarge
+      aws_region: "us-west-1"
       ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
+      ec2_ami_id: ami-09458fc989530d66f
       compile_mode: native
       opt: no_opt
       lint: false
@@ -434,8 +436,9 @@ jobs:
     with:
       name: CBMC (MLKEM-1024)
       ec2_instance_type: c7g.2xlarge
+      aws_region: "us-west-1"
       ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
+      ec2_ami_id: ami-09458fc989530d66f
       compile_mode: native
       opt: no_opt
       lint: false

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -59,9 +59,11 @@ on:
       cbmc_mlkem_k:
         type: string
         default: 2
+      aws_region:
+        type: string
+        default: "us-east-1"
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
-  AWS_REGION: us-east-1
   AMI_UBUNTU_LATEST_X86_64: ami-0e86e20dae9224db8
   AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
 jobs:
@@ -101,7 +103,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ inputs.aws_region }}
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: mkannwischer/ec2-github-runner@d15c8804522523d2bac7119a01ffff83b7795d87
@@ -167,7 +169,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ inputs.aws_region }}
       - name: Stop EC2 runner
         uses: mkannwischer/ec2-github-runner@d15c8804522523d2bac7119a01ffff83b7795d87
         with:


### PR DESCRIPTION
We benchmark c7i on a metal instance with 96 vCPUs, a few of which can get us past the vCPU quota for our CI accounts.

This commit changes the AWS region in which to run the c7i metal benchmark, to spread the load and reduce the likelihood of exceeding the vCPU quota.
