### PR TITLE
FIPS202: Remove redundant zeroization in shake128_absorb_once()

### DIFF
--- a/fips202/fips202.c
+++ b/fips202/fips202.c
@@ -133,11 +133,6 @@ static void keccak_squeeze_once(uint8_t *h, size_t outlen, uint64_t *s,
 void shake128_absorb_once(shake128ctx *state, const uint8_t *input,
                           size_t inlen)
 {
-  int i;
-  for (i = 0; i < 25; i++)
-  {
-    state->ctx[i] = 0;
-  }
   keccak_absorb_once(state->ctx, SHAKE128_RATE, input, inlen, 0x1F);
 }
 


### PR DESCRIPTION
`shake128_absorb_once()` calls `keccak_absorb_once()`, which already includes zeroization of the state. The zeroization can therefore be dropped from `shake128_absorb_once()`.
