### PR TITLE
Build libraries for individual and all security levels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: make lib
         run: |
-          make test/build/tmp/libtmp_mlkem.a
+          make lib
 
   build_kat:
     needs: [quickcheck, quickcheck-windows]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ quickcheck: buildall
 	./scripts/acvp
 	$(Q)echo "  Functionality and ACVP tests passed!"
 
+lib: $(BUILD_DIR)/libmlkem.a
+
 mlkem: \
   $(MLKEM512_DIR)/bin/test_mlkem512 \
   $(MLKEM768_DIR)/bin/test_mlkem768 \

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -89,7 +89,6 @@ include mk/auto.mk
 endif
 
 BUILD_DIR ?= test/build
-TMP_DIR ?= test/build/tmp
 
 MAKE_OBJS = $(2:%=$(1)/%.o)
 OBJS = $(call MAKE_OBJS,$(BUILD_DIR),$(1))

--- a/mk/crypto.mk
+++ b/mk/crypto.mk
@@ -5,18 +5,7 @@ ifeq ($(OPT),1)
 	FIPS202_SRCS += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
 endif
 
-$(BUILD_DIR)/libfips202.a: $(call OBJS, $(FIPS202_SRCS))
 $(BUILD_DIR)/libmlkem.a: $(call OBJS, $(FIPS202_SRCS))
-
-# all lib<scheme>.a depends on libfips202.a
-define ADD_FIPS202
-$(BUILD_DIR)/lib$(1).a: LDLIBS += -lfips202
-# NOTE:
-# - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
-
-$(BUILD_DIR)/lib$(1).a: $(BUILD_DIR)/libfips202.a $(call OBJS, $(FIPS202_SRCS))
-endef
-
-$(foreach scheme,mlkem512 mlkem768 mlkem1024, \
-	$(eval $(call ADD_FIPS202,$(scheme))) \
-)
+$(BUILD_DIR)/libmlkem512.a: $(call OBJS, $(FIPS202_SRCS))
+$(BUILD_DIR)/libmlkem768.a: $(call OBJS, $(FIPS202_SRCS))
+$(BUILD_DIR)/libmlkem1024.a: $(call OBJS, $(FIPS202_SRCS))

--- a/mk/crypto.mk
+++ b/mk/crypto.mk
@@ -5,16 +5,16 @@ ifeq ($(OPT),1)
 	FIPS202_SRCS += $(wildcard fips202/native/aarch64/*.S) $(wildcard fips202/native/x86_64/xkcp/*.c)
 endif
 
-$(TMP_DIR)/libtmp_fips202.a: $(call OBJS, $(FIPS202_SRCS))
-$(TMP_DIR)/libtmp_mlkem.a: $(call OBJS, $(FIPS202_SRCS))
+$(BUILD_DIR)/libfips202.a: $(call OBJS, $(FIPS202_SRCS))
+$(BUILD_DIR)/libmlkem.a: $(call OBJS, $(FIPS202_SRCS))
 
 # all lib<scheme>.a depends on libfips202.a
 define ADD_FIPS202
-$(TMP_DIR)/libtmp_$(1).a: LDLIBS += -ltmp_fips202
+$(BUILD_DIR)/lib$(1).a: LDLIBS += -lfips202
 # NOTE:
 # - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
 
-$(TMP_DIR)/libtmp_$(1).a: $(TMP_DIR)/libtmp_fips202.a $(call OBJS, $(FIPS202_SRCS))
+$(BUILD_DIR)/lib$(1).a: $(BUILD_DIR)/libfips202.a $(call OBJS, $(FIPS202_SRCS))
 endef
 
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -23,16 +23,16 @@ $(BUILD_DIR)/%.a: $(CONFIG)
 # NOTE:
 # 	$AR doesn't care about duplicated symbols, one can only find it out via actually linking.
 # 	The easiest one to do this that one can think of is to create a dummy C file with empty main function on the fly, pipe it to $CC and link with the built library
-	$(eval _LIB := $(subst $(shell dirname $@)/lib,,$(@:%.a=%)))
+	$(eval _LIB := $(subst $(BUILD_DIR)/lib,,$(@:%.a=%)))
 ifneq ($(findstring clang,$(shell $(CC) --version)),) # if CC is clang
 	$(Q)echo "int main() {return 0;}" \
-		| $(CC) -x c - -L$(shell dirname $@) \
+		| $(CC) -x c - -L$(BUILD_DIR) \
 		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
 		 -Imlkem $(wildcard test/notrandombytes/*.c)
 	$(Q)rm -f a.out
 else                                                  # if CC is not clang
 	$(Q)echo "int main() {return 0;}" \
-		| $(CC) -x c - -L$(shell dirname $@) \
+		| $(CC) -x c - -L$(BUILD_DIR) \
 		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \
 		-Wl,--no-whole-archive \
 		-Imlkem $(wildcard test/notrandombytes/*.c)

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -19,8 +19,9 @@ $(BUILD_DIR)/lib$(1).a: CFLAGS += -static
 $(BUILD_DIR)/lib$(1).a: $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
 
 # NOTE:
-# - The order matters, or else the `MLKEM_K` preprocessor won't be properly set
-# - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
+# libmlkem.a does not link against libmlkem{512,768,1024}.a, but the underlying object files.
+# Still, we currently need a dependency on libmlkem{512,768,1024}.a here as otherwise there is
+# a hiccup with the setting of MLKEM_K (TODO: look at this more closely)
 $(BUILD_DIR)/libmlkem.a: $(BUILD_DIR)/lib$(1).a $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
 endef
 

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -15,18 +15,18 @@ MLKEM1024_DIR = $(BUILD_DIR)/mlkem1024
 
 # build lib<scheme>.a
 define BUILD_LIB
-$(TMP_DIR)/libtmp_$(1).a: CFLAGS += -static
-$(TMP_DIR)/libtmp_$(1).a: $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
+$(BUILD_DIR)/lib$(1).a: CFLAGS += -static
+$(BUILD_DIR)/lib$(1).a: $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
 
 # NOTE:
 # - The order matters, or else the `MLKEM_K` preprocessor won't be properly set
 # - Merging multiple .a files with ar is more complex than building a single library directly from all the object files (.o). Hence, all .o files are added as dependencies here.
-$(TMP_DIR)/libtmp_mlkem.a: $(TMP_DIR)/libtmp_$(1).a $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
+$(BUILD_DIR)/libmlkem.a: $(BUILD_DIR)/lib$(1).a $(call MAKE_OBJS,$(BUILD_DIR)/$(1),$(SOURCES))
 endef
 
-$(TMP_DIR)/libtmp_mlkem512.a: CPPFLAGS += -DMLKEM_K=2
-$(TMP_DIR)/libtmp_mlkem768.a: CPPFLAGS += -DMLKEM_K=3
-$(TMP_DIR)/libtmp_mlkem1024.a: CPPFLAGS += -DMLKEM_K=4
+$(BUILD_DIR)/libmlkem512.a: CPPFLAGS += -DMLKEM_K=2
+$(BUILD_DIR)/libmlkem768.a: CPPFLAGS += -DMLKEM_K=3
+$(BUILD_DIR)/libmlkem1024.a: CPPFLAGS += -DMLKEM_K=4
 
 # build libmlkem512.a libmlkem768.a libmlkem1024.a
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
@@ -34,8 +34,8 @@ $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
 
 # rules for compilation for all tests: mainly linking with mlkem static link library
 define ADD_SOURCE
-$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(TMP_DIR) -ltmp_$(1)
-$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(TMP_DIR)/libtmp_$(1).a
+$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(BUILD_DIR) -l$(1)
+$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(BUILD_DIR)/lib$(1).a
 endef
 
 $(MLKEM512_DIR)/bin/%: CPPFLAGS += -DMLKEM_K=2


### PR DESCRIPTION
This PR changes the build so that we generate four libraries:
* `libmlkem.a`
* `libmlkem{512,768,1024}.a`

All of those libraries include the FIPS functionality, which is no longer built as a separate `.a` file.