### PR TITLE
Test mlkem-native on AArch64_be

### DIFF
--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -90,6 +90,22 @@ runs:
           kat: ${{ inputs.kat }}
           nistkat: ${{ inputs.nistkat }}
           acvp: ${{ inputs.acvp }}
+      - name: Cross aarch64_be Tests
+        if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-aarch64_be') && (success() || failure()) }}
+        uses: ./.github/actions/functest
+        with:
+          nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
+          gh_token: ${{ inputs.gh_token }}
+          custom_shell: ${{ inputs.custom_shell }}
+          cflags: "${{ inputs.cflags }} -static"
+          cross_prefix: aarch64_be-none-linux-gnu-
+          opt: ${{ inputs.opt }}
+          func: ${{ inputs.func }}
+          kat: ${{ inputs.kat }}
+          nistkat: ${{ inputs.nistkat }}
+          acvp: ${{ inputs.acvp }}
       - name: Cross riscv64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
         uses: ./.github/actions/functest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,10 @@ jobs:
            name: 'ubuntu-latest (x86_64)'
            arch: aarch64
            mode: cross-aarch64
+         - runner: pqcp-x64
+           name: 'ubuntu-latest (x86_64)'
+           arch: aarch64_be
+           mode: cross-aarch64_be
         exclude:
           - {external: true,
              target: {
@@ -187,6 +191,13 @@ jobs:
                arch: aarch64,
                mode: cross-aarch64
              }}
+          - {external: true,
+             target: {
+               runner: pqcp-x64,
+               name: 'ubuntu-latest (x86_64)',
+               arch: aarch64_be,
+               mode: cross-aarch64_be
+             }}
     name: Functional tests (${{ matrix.target.arch }}${{ matrix.target.mode != 'native' && ', cross' || ''}})
     runs-on: ${{ matrix.target.runner }}
     steps:
@@ -198,8 +209,8 @@ jobs:
           nix-cache: ${{ matrix.target.mode == 'native' && 'false' || 'true' }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: ${{ matrix.target.mode }}
-          # There is no native code on R-V yet, so no point running opt tests
-          opt: ${{ matrix.target.arch != 'riscv64' && 'all' || 'no_opt' }}
+          # There is no native code on R-V or AArch64_be yet, so no point running opt tests
+          opt: ${{ (matrix.target.arch != 'riscv64' && matrix.target.arch != 'aarch64_be') && 'all' || 'no_opt' }}
       - name: build + test (+debug+memsan+ubsan)
         uses: ./.github/actions/multi-functest
         if: ${{ matrix.target.mode == 'native' }}

--- a/aarch64_be-none-linux-gnu-gcc.nix
+++ b/aarch64_be-none-linux-gnu-gcc.nix
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+{ stdenvNoCC
+, fetchurl
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "aarch64_be-none-linux-gnu";
+  version = "10.3.2021.07";
+
+  platform = {
+    x86_64-linux = "x86_64";
+  }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+
+  platform_suffix = {
+    x86_64-linux = "linux-gnu";
+  }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64_be-none-linux-gnu.tar.xz";
+    sha256 = {
+      x86_64-linux = "sha256-Y8NMrAfOrddGIOqH8nrxqmpvVcIKW8EWryGlndtramo";
+    }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+}

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
               x86_64-gcc = wrap-gcc pkgs.pkgsCross.gnu64;
               aarch64-gcc = wrap-gcc pkgs.pkgsCross.aarch64-multiplatform;
               riscv64-gcc = wrap-gcc pkgs.pkgsCross.riscv64;
+              aarch64_be-gcc = (pkgs.callPackage ./aarch64_be-none-linux-gnu-gcc.nix { });
             in
             # NOTE:
               # - native toolchain should be equipped in the shell via `mkShellWithCC` (see `mkShell`)
@@ -55,6 +56,7 @@
               (pkgs.lib.optional (! pkgs.stdenv.hostPlatform.isx86_64) x86_64-gcc)
               (pkgs.lib.optional (! pkgs.stdenv.hostPlatform.isAarch64) aarch64-gcc)
               (pkgs.lib.optional (! pkgs.stdenv.hostPlatform.isRiscV64) riscv64-gcc)
+              (pkgs.lib.optional (pkgs.stdenv.hostPlatform.isx86_64) aarch64_be-gcc)
               native-gcc
             ]
             ++ builtins.attrValues {

--- a/mk/auto.mk
+++ b/mk/auto.mk
@@ -5,6 +5,8 @@ ifeq ($(HOST_PLATFORM),Linux-x86_64)
 ifeq ($(CROSS_PREFIX),)
 	ARCH_FLAGS += -mavx2 -mbmi2 -mpopcnt -maes
 	CFLAGS += -DFORCE_X86_64
+else ifneq ($(findstring aarch64_be, $(CROSS_PREFIX)),)
+	CFLAGS += -DFORCE_AARCH64_EB
 else ifneq ($(findstring aarch64, $(CROSS_PREFIX)),)
 	CFLAGS += -DFORCE_AARCH64
 else

--- a/mlkem/native/aarch64/README.md
+++ b/mlkem/native/aarch64/README.md
@@ -1,0 +1,19 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# AArch64 backend (little endian)
+
+This directory contains a native backend for little endian AArch64 systems. It is derived from the following research
+works:
+
+- _Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1_, Hanno Becker, Vincent Hwang, Matthias
+  J. Kannwischer, Bo-Yin Yang, and Shang-Yi Yang, [https://eprint.iacr.org/2021/986](https://eprint.iacr.org/2021/986)
+- _Fast and Clean: Auditable high-performance assembly via constraint solving_, Amin Abdulrahman, Hanno Becker, Matthias
+  J. Kannwischer, Fabien Klein, [https://eprint.iacr.org/2022/1303](https://eprint.iacr.org/2022/1303)
+
+## Profiles
+
+This backend comes with two profiles: "clean" and optimized. The "clean" backend is handwritten and meant to be easy to
+read and modify; for example, is heavily leverages register aliases and assembly macros. The optimized profile is
+automatically generated from the clean profile via [SLOTHY](https://github.com/slothy-optimizer/slothy). Currently, the
+target architecture is Cortex-A55, but you can easily re-optimize the code for a different microarchitecture supported
+by SLOTHY, by adjusting the parameters in [optimize.sh](optimize.sh).

--- a/mlkem/sys/cpucap.h
+++ b/mlkem/sys/cpucap.h
@@ -6,9 +6,15 @@
 #ifndef CPUCAP_H
 #define CPUCAP_H
 
-/* Check if we're running on an AArch64 system. _M_ARM64 is set by MSVC. */
+/* Check if we're running on an AArch64 little endian system. _M_ARM64 is set by
+ * MSVC. */
 #if defined(__AARCH64EL__) || defined(_M_ARM64)
 #define SYS_AARCH64
+#endif
+
+/* Check if we're running on an AArch64 big endian system. */
+#if defined(__AARCH64EB__)
+#define SYS_AARCH64_EB
 #endif
 
 #if defined(__x86_64__)
@@ -33,6 +39,12 @@
 /* If FORCE_AARCH64 is set, assert that we're indeed on an AArch64 system. */
 #if defined(FORCE_AARCH64) && !defined(SYS_AARCH64)
 #error "FORCE_AARCH64 is set, but we don't seem to be on an AArch64 system."
+#endif
+
+/* If FORCE_AARCH64_EB is set, assert that we're indeed on a big endian AArch64
+ * system. */
+#if defined(FORCE_AARCH64_EB) && !defined(SYS_AARCH64_EB)
+#error "FORCE_AARCH64_EB is set, but we don't seem to be on an AArch64 system."
 #endif
 
 /* If FORCE_X86_64 is set, assert that we're indeed on an X86_64 system. */

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -295,6 +295,8 @@ class Tests:
                 logging.info(f"Emulating with QEMU")
                 if "x86_64" in opts.cross_prefix:
                     self.cmd_prefix.append("qemu-x86_64")
+                elif "aarch64_be" in opts.cross_prefix:
+                    self.cmd_prefix.append("qemu-aarch64_be")
                 elif "aarch64" in opts.cross_prefix:
                     self.cmd_prefix.append("qemu-aarch64")
                 elif "riscv64" in opts.cross_prefix:


### PR DESCRIPTION
* Resolves #528 

This commit modifies the nix flake to install an AArch64 big endian compiler in the ci-cross shell.

It also modifies the CI to cross-(build+test) mlkem-native on aarch64_be.

This confirms that the C frontend and backend are working on big endian systems. This is important to check since we do have a few cases of endian-ness dependent code.

The AArch64 backend is currently _not_ compatible with big endian systems, and already disabled (this is because we use `__AARCH64_EL__` as a guarding architecture flag -- for big endian, it would be `__ARCH64_EB__`).
