### PR TITLE
Remove REF-CHANGE annotations

### DIFF
--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -120,10 +120,7 @@ __contract__(
  * but this is not needed in the calling code. Should we change the
  * base multiplication strategy to require smaller NTT output bounds,
  * the proof may need strengthening.
- * REF-CHANGE: Removed indirection poly_ntt -> ntt()
- * and integrated polynomial reduction into the NTT.
  */
-
 
 void poly_ntt(poly *p)
 {

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -35,8 +35,6 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
     }
 
     /*
-     * REF-CHANGE: Use array indexing into
-     * r rather than pointer-arithmetic to simplify verification
      * Make all implicit truncation explicit. No data is being
      * truncated for the LHS's since each t[i] is 11-bit in size.
      */
@@ -68,8 +66,6 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
     }
 
     /*
-     * REF-CHANGE: Use array indexing into
-     * r rather than pointer-arithmetic to simplify verification
      * Make all implicit truncation explicit. No data is being
      * truncated for the LHS's since each t[i] is 10-bit in size.
      */
@@ -160,14 +156,9 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
       invariant(array_bound(t, 0, (j-1), 0, 15)))
     {
-      /* REF-CHANGE: Precondition change, we assume unsigned canonical data */
       t[j] = scalar_compress_d4(a->coeffs[8 * i + j]);
     }
 
-    /*
-     * REF-CHANGE: Use array indexing into
-     * r rather than pointer-arithmetic to simplify verification
-     */
     r[i * 4] = t[0] | (t[1] << 4);
     r[i * 4 + 1] = t[2] | (t[3] << 4);
     r[i * 4 + 2] = t[4] | (t[5] << 4);
@@ -184,12 +175,11 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
       invariant(array_bound(t, 0, (j-1), 0, 31)))
     {
-      /* REF-CHANGE: Precondition change, we assume unsigned canonical data */
       t[j] = scalar_compress_d5(a->coeffs[8 * i + j]);
     }
 
     /*
-     * REF-CHANGE: Explicitly truncate to avoid warning about
+     * Explicitly truncate to avoid warning about
      * implicit truncation in CBMC, and use array indexing into
      * r rather than pointer-arithmetic to simplify verification
      */
@@ -213,7 +203,6 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
     invariant(i >= 0 && i <= MLKEM_N / 2)
     invariant(array_bound(r->coeffs, 0, (2 * i - 1), 0, (MLKEM_Q - 1))))
   {
-    /* REF-CHANGE: Hoist scalar decompression into separate function */
     r->coeffs[2 * i + 0] = scalar_decompress_d4((a[i] >> 0) & 0xF);
     r->coeffs[2 * i + 1] = scalar_decompress_d4((a[i] >> 4) & 0xF);
   }
@@ -227,7 +216,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
     uint8_t t[8];
     const int offset = i * 5;
     /*
-     * REF-CHANGE: Explicitly truncate to avoid warning about
+     * Explicitly truncate to avoid warning about
      * implicit truncation in CBMC and unwind loop for ease
      * of proof.
      */
@@ -251,7 +240,6 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
       invariant(j >= 0 && j <= 8 && i >= 0 && i <= MLKEM_N / 8)
       invariant(array_bound(r->coeffs, 0, (8 * i + j - 1), 0, (MLKEM_Q - 1))))
     {
-      /* REF-CHANGE: Hoist scalar decompression into separate function */
       r->coeffs[8 * i + j] = scalar_decompress_d5(t[j]);
     }
   }
@@ -274,8 +262,6 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
   {
     const uint16_t t0 = a->coeffs[2 * i];
     const uint16_t t1 = a->coeffs[2 * i + 1];
-    /* REF-CHANGE: Precondition change, we assume unsigned canonical data */
-
     /*
      * t0 and t1 are both < MLKEM_Q, so contain at most 12 bits each of
      * significant data, so these can be packed into 24 bits or exactly
@@ -313,7 +299,6 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
     invariant(i >= 0 && i <= MLKEM_N / 2)
     invariant(array_bound(r->coeffs, 0, (2 * i - 1), 0, UINT12_MAX)))
   {
-    /* REF-CHANGE: Introduce some locals for better readability */
     const uint8_t t0 = a[3 * i + 0];
     const uint8_t t1 = a[3 * i + 1];
     const uint8_t t2 = a[3 * i + 2];

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -31,10 +31,6 @@ typedef struct
  * INTERNAL presentation of precomputed data speeding up
  * the base multiplication of two polynomials in NTT domain.
  */
-/*
- * REF-CHANGE: This structure does not exist in the reference
- * implementation.
- */
 typedef struct
 {
   int16_t coeffs[MLKEM_N >> 1];
@@ -660,7 +656,6 @@ __contract__(
   ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, (MLKEM_Q - 1)))
 );
 
-/* REF-CHANGE: This function does not exist in the reference implementation */
 #define poly_mulcache_compute MLKEM_NAMESPACE(poly_mulcache_compute)
 /************************************************************
  * Name: poly_mulcache_compute
@@ -703,7 +698,7 @@ __contract__(
  * Arguments:   - poly *r: pointer to input/output polynomial
  **************************************************/
 /*
- * REF-CHANGE: The semantics of poly_reduce() is different in
+ * NOTE: The semantics of poly_reduce() is different in
  * the reference implementation, which requires
  * signed canonical output data. Unsigned canonical
  * outputs are better suited to the only remaining
@@ -731,8 +726,7 @@ __contract__(
  *
  ************************************************************/
 /*
- * REF-CHANGE:
- * The reference implementation uses a 3-argument poly_add.
+ * NOTE: The reference implementation uses a 3-argument poly_add.
  * We specialize to the accumulator form to avoid reasoning about aliasing.
  */
 void poly_add(poly *r, const poly *b)
@@ -756,8 +750,7 @@ __contract__(
  *            - const poly *b: Pointer to second input polynomial
  **************************************************/
 /*
- * REF-CHANGE:
- * The reference implementation uses a 3-argument poly_sub.
+ * NOTE: The reference implementation uses a 3-argument poly_sub.
  * We specialize to the accumulator form to avoid reasoning about aliasing.
  */
 void poly_sub(poly *r, const poly *b)

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -14,7 +14,6 @@ typedef struct
   poly vec[MLKEM_K];
 } ALIGN polyvec;
 
-/* REF-CHANGE: This struct does not exist in the reference implementation */
 typedef struct
 {
   poly_mulcache vec[MLKEM_K];
@@ -177,7 +176,6 @@ __contract__(
 );
 
 
-/* REF-CHANGE: This function does not exist in the reference implementation */
 #define polyvec_basemul_acc_montgomery_cached \
   MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached)
 /*************************************************
@@ -210,7 +208,6 @@ __contract__(
   assigns(memory_slice(r, sizeof(poly)))
 );
 
-/* REF-CHANGE: This function does not exist in the reference implementation */
 #define polyvec_mulcache_compute MLKEM_NAMESPACE(polyvec_mulcache_compute)
 /************************************************************
  * Name: polyvec_mulcache_compute
@@ -255,11 +252,11 @@ __contract__(
  * Arguments:   - polyvec *r: pointer to input/output polynomial
  **************************************************/
 /*
- * REF-CHANGE: The semantics of polyvec_reduce() is different in
- *             the reference implementation, which requires
- *             signed canonical output data. Unsigned canonical
- *             outputs are better suited to the only remaining
- *             use of poly_reduce() in the context of (de)serialization.
+ * NOTE: The semantics of polyvec_reduce() is different in
+ *       the reference implementation, which requires
+ *       signed canonical output data. Unsigned canonical
+ *       outputs are better suited to the only remaining
+ *       use of poly_reduce() in the context of (de)serialization.
  */
 void polyvec_reduce(polyvec *r)
 __contract__(

--- a/mlkem/rej_uniform.h
+++ b/mlkem/rej_uniform.h
@@ -42,7 +42,7 @@
  **************************************************/
 
 /*
- * REF-CHANGE: The signature differs from the Kyber reference implementation
+ * NOTE: The signature differs from the Kyber reference implementation
  * in that it adds the offset and always expects the base of the target
  * buffer. This avoids shifting the buffer base in the caller, which appears
  * tricky to reason about.


### PR DESCRIPTION
Those annotations were previously meant to completely enumerate all changes from the reference implementation, but we have not been diligent adding them, so that now numerous changes are not annotated.

This commit gives up on the idea of annotating every change from the reference implementation, and removes REF-CHANGE annotations accordingly.
