### PR TITLE
CBMC: Add separate proof for rej_uniform_scalar

### DIFF
--- a/cbmc/rej_uniform_scalar/Makefile
+++ b/cbmc/rej_uniform_scalar/Makefile
@@ -3,11 +3,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = rej_uniform_harness
+HARNESS_FILE = rej_uniform_scalar_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = rej_uniform
+PROOF_UID = rej_uniform_scalar
 
 DEFINES +=
 INCLUDES +=
@@ -18,8 +18,8 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/rej_uniform.c
 
-CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)rej_uniform
-USE_FUNCTION_CONTRACTS=rej_uniform_scalar
+CHECK_FUNCTION_CONTRACTS=rej_uniform_scalar
+USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--bitwuzla
 
-FUNCTION_NAME = $(MLKEM_NAMESPACE)rej_uniform
+FUNCTION_NAME = rej_uniform_scalar
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/rej_uniform_scalar/cbmc-proof.txt
+++ b/cbmc/rej_uniform_scalar/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/rej_uniform_scalar/rej_uniform_scalar_harness.c
+++ b/cbmc/rej_uniform_scalar/rej_uniform_scalar_harness.c
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include "cbmc.h"
+#include "rej_uniform.h"
+
+unsigned int rej_uniform_scalar(int16_t *r, unsigned int target,
+                                unsigned int offset, const uint8_t *buf,
+                                unsigned int buflen);
+
+void harness(void)
+{
+  unsigned int target, offset, inlen;
+  int16_t *r;
+  uint8_t *buf;
+
+  rej_uniform_scalar(r, target, offset, buf, inlen);
+}

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -35,9 +35,19 @@
  * is guaranteed to have been consumed. If it is equal to len, no information
  * is provided on how many bytes of the input buffer have been consumed.
  **************************************************/
-static unsigned int rej_uniform_scalar(int16_t *r, unsigned int target,
-                                       unsigned int offset, const uint8_t *buf,
-                                       unsigned int buflen)
+STATIC_TESTABLE
+unsigned int rej_uniform_scalar(int16_t *r, unsigned int target,
+                                unsigned int offset, const uint8_t *buf,
+                                unsigned int buflen)
+__contract__(
+  requires(offset <= target && target <= 4096 && buflen <= 4096 && buflen % 3 == 0)
+  requires(memory_no_alias(r, sizeof(int16_t) * target))
+  requires(memory_no_alias(buf, buflen))
+  requires(offset > 0 ==> array_bound(r, 0, offset - 1, 0, (MLKEM_Q - 1)))
+  assigns(memory_slice(r, sizeof(int16_t) * target))
+  ensures(offset <= return_value && return_value <= target)
+  ensures(return_value > 0 ==> array_bound(r, 0, return_value - 1, 0, (MLKEM_Q - 1)))
+)
 {
   unsigned int ctr, pos;
   uint16_t val0, val1;


### PR DESCRIPTION
Currently, rej_uniform_scalar and rej_uniform are basically the same if no native backend is used (as is the case with CBMC proofs). However, once we include the axiomatized call to native backend in the scope of CBMC, the proof will be simpler if we hoist out the contract for the scalar fallback.
