### PR TITLE
Remove double-namespacing for assembly symbols

### DIFF
--- a/examples/custom_backend/mlkem_native/custom_config.h
+++ b/examples/custom_backend/mlkem_native/custom_config.h
@@ -44,7 +44,6 @@
 #define CONC(a, b) __CONC(a, b)
 
 #define MLKEM_NAMESPACE(sym) CONC(CUSTOM_TINY_SHA3_, sym)
-#define _MLKEM_NAMESPACE(sym) CONC(_CUSTOM_TINY_SHA3_, sym)
 
 /******************************************************************************
  * Name:        FIPS202_NAMESPACE
@@ -54,7 +53,6 @@
  *              from mlkem/fips202/.
  *****************************************************************************/
 #define FIPS202_NAMESPACE(sym) CONC(CUSTOM_TINY_SHA3_, sym)
-#define _FIPS202_NAMESPACE(sym) CONC(_CUSTOM_TINY_SHA3_, sym)
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -26,4 +26,17 @@
  * since the backend choice may be part of the namespace. */
 #include "namespace.h"
 
+/* On Apple platforms, we need to emit leading underscore
+ * in front of assembly symbols. We thus introducee a separate
+ * namespace wrapper for ASM symbols. */
+#if !defined(__APPLE__)
+#define MLKEM_ASM_NAMESPACE(sym) MLKEM_NAMESPACE(sym)
+#define FIPS202_ASM_NAMESPACE(sym) FIPS202_NAMESPACE(sym)
+#else
+#define _PREFIX_UNDERSCORE(sym) _##sym
+#define PREFIX_UNDERSCORE(sym) _PREFIX_UNDERSCORE(sym)
+#define MLKEM_ASM_NAMESPACE(sym) PREFIX_UNDERSCORE(MLKEM_NAMESPACE(sym))
+#define FIPS202_ASM_NAMESPACE(sym) PREFIX_UNDERSCORE(FIPS202_NAMESPACE(sym))
+#endif
+
 #endif /* MLKEM_NATIVE_COMMON_H */

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -39,23 +39,19 @@
 
 /******************************************************************************
  * Name:        MLKEM_NAMESPACE
- *              _MLKEM_NAMESPACE
  *
  * Description: The macros to use to namespace global symbols
  *              from mlkem/.
  *****************************************************************************/
 #define MLKEM_NAMESPACE(sym) MLKEM_DEFAULT_NAMESPACE(sym)
-#define _MLKEM_NAMESPACE(sym) _MLKEM_DEFAULT_NAMESPACE(sym)
 
 /******************************************************************************
  * Name:        FIPS202_NAMESPACE
- *              _FIPS202_NAMESPACE
  *
  * Description: The macros to use to namespace global symbols
  *              from mlkem/fips202/.
  *****************************************************************************/
 #define FIPS202_NAMESPACE(sym) FIPS202_DEFAULT_NAMESPACE(sym)
-#define _FIPS202_NAMESPACE(sym) _FIPS202_DEFAULT_NAMESPACE(sym)
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
@@ -164,11 +164,9 @@
 
 .text
 .balign 16
-.global FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
-.global _FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
 
-FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
-_FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
     alloc_stack
     save_gprs
 

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -310,11 +310,9 @@
 
 .text
 .align 4
-.global FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
-.global _FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
 
-FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
-_FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
     alloc_stack
     save_vregs
     mov const_addr, input_rc

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm_clean.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm_clean.S
@@ -338,11 +338,9 @@
 
 .text
 .align 4
-.global FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
-.global _FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
 
-FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
-_FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
     alloc_stack
     save_vregs
     mov const_addr, input_rc

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
@@ -379,11 +379,9 @@
 
 .text
 .align 4
-.global FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
-.global _FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
 
-FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
-_FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
     alloc_stack
     save_gprs
     save_vregs

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
@@ -875,13 +875,11 @@
     ror sAsu, sAsu,#(64-55)
 .endm
 
-.global FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
-.global _FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
 .text
 .align 4
 
-FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
-_FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
     alloc_stack
     save_gprs
     save_vregs

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
@@ -857,13 +857,11 @@
     ror sAsu, sAsu,#(64-55)
 .endm
 
-.global FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
-.global _FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
 .text
 .align 4
 
-FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
-_FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
     alloc_stack
     save_gprs
     save_vregs

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
@@ -875,13 +875,11 @@
     ror sAsu, sAsu,#(64-55)
 .endm
 
-.global FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
-.global _FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
+.global FIPS202_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
 .text
 .align 4
 
-FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
-_FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
+FIPS202_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
     alloc_stack
     save_gprs
     save_vregs

--- a/mlkem/native/aarch64/src/intt_clean.S
+++ b/mlkem/native/aarch64/src/intt_clean.S
@@ -141,8 +141,7 @@
 
 .text
 
-        .global MLKEM_NAMESPACE(intt_asm_clean)
-        .global _MLKEM_NAMESPACE(intt_asm_clean)
+        .global MLKEM_ASM_NAMESPACE(intt_asm_clean)
 
         in         .req x0
         r01234_ptr .req x1
@@ -222,8 +221,7 @@ c_consts:         .short 3329
 c_ninv:           dup8h 512
 c_ninv_tw:        dup8h 5040
 
-MLKEM_NAMESPACE(intt_asm_clean):
-_MLKEM_NAMESPACE(intt_asm_clean):
+MLKEM_ASM_NAMESPACE(intt_asm_clean):
         push_stack
 
         ldr q_consts,  c_consts

--- a/mlkem/native/aarch64/src/intt_opt.S
+++ b/mlkem/native/aarch64/src/intt_opt.S
@@ -141,8 +141,7 @@
 
 .text
 
-        .global MLKEM_NAMESPACE(intt_asm_opt)
-        .global _MLKEM_NAMESPACE(intt_asm_opt)
+        .global MLKEM_ASM_NAMESPACE(intt_asm_opt)
 
         in         .req x0
         r01234_ptr .req x1
@@ -222,8 +221,7 @@ c_consts:         .short 3329
 c_ninv:           dup8h 512
 c_ninv_tw:        dup8h 5040
 
-MLKEM_NAMESPACE(intt_asm_opt):
-_MLKEM_NAMESPACE(intt_asm_opt):
+MLKEM_ASM_NAMESPACE(intt_asm_opt):
         push_stack
 
         ldr q_consts,  c_consts

--- a/mlkem/native/aarch64/src/ntt_clean.S
+++ b/mlkem/native/aarch64/src/ntt_clean.S
@@ -165,8 +165,7 @@
         t3  .req v28
 
         .text
-        .global MLKEM_NAMESPACE(ntt_asm_clean)
-        .global _MLKEM_NAMESPACE(ntt_asm_clean)
+        .global MLKEM_ASM_NAMESPACE(ntt_asm_clean)
 
 /* Literal pool */
 .p2align 4
@@ -180,8 +179,7 @@ c_consts:
         .short 0
         .short 0
 
-MLKEM_NAMESPACE(ntt_asm_clean):
-_MLKEM_NAMESPACE(ntt_asm_clean):
+MLKEM_ASM_NAMESPACE(ntt_asm_clean):
         push_stack
         ldr q_consts, c_consts
 

--- a/mlkem/native/aarch64/src/ntt_opt.S
+++ b/mlkem/native/aarch64/src/ntt_opt.S
@@ -165,8 +165,7 @@
         t3  .req v28
 
         .text
-        .global MLKEM_NAMESPACE(ntt_asm_opt)
-        .global _MLKEM_NAMESPACE(ntt_asm_opt)
+        .global MLKEM_ASM_NAMESPACE(ntt_asm_opt)
 
 /* Literal pool */
 .p2align 4
@@ -180,8 +179,7 @@ c_consts:
         .short 0
         .short 0
 
-MLKEM_NAMESPACE(ntt_asm_opt):
-_MLKEM_NAMESPACE(ntt_asm_opt):
+MLKEM_ASM_NAMESPACE(ntt_asm_opt):
         push_stack
         ldr q_consts, c_consts
 

--- a/mlkem/native/aarch64/src/poly_clean.S
+++ b/mlkem/native/aarch64/src/poly_clean.S
@@ -66,8 +66,7 @@ c_barrett_twist:   dup8h -10276 // Barrett twist of -1044 (wrt 2^16)
  *          poly_reduce()         *
  **********************************/
 
-.global MLKEM_NAMESPACE(poly_reduce_asm_clean)
-.global _MLKEM_NAMESPACE(poly_reduce_asm_clean)
+.global MLKEM_ASM_NAMESPACE(poly_reduce_asm_clean)
 
         ptr               .req x0
         count             .req x1
@@ -82,8 +81,7 @@ c_barrett_twist:   dup8h -10276 // Barrett twist of -1044 (wrt 2^16)
         modulus_twisted   .req v4
         q_modulus_twisted .req q4
 
-MLKEM_NAMESPACE(poly_reduce_asm_clean):
-_MLKEM_NAMESPACE(poly_reduce_asm_clean):
+MLKEM_ASM_NAMESPACE(poly_reduce_asm_clean):
 
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
@@ -132,8 +130,7 @@ loop_start:
  *          poly_mulcache_compute()         *
  ********************************************/
 
-.global MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean)
-.global _MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean)
+.global MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_clean)
 
         cache_ptr         .req x0
         data_ptr          .req x1
@@ -159,8 +156,7 @@ loop_start:
         modulus_twisted   .req v7
         q_modulus_twisted .req q7
 
-MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean):
-_MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean):
+MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_clean):
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
 
@@ -211,8 +207,7 @@ mulcache_compute_loop_start:
 /********************************************
  *             poly_tobytes()               *
  ********************************************/
-.global MLKEM_NAMESPACE(poly_tobytes_asm_clean)
-.global _MLKEM_NAMESPACE(poly_tobytes_asm_clean)
+.global MLKEM_ASM_NAMESPACE(poly_tobytes_asm_clean)
 
         data0 .req v0
         data1 .req v1
@@ -225,8 +220,7 @@ mulcache_compute_loop_start:
         src   .req x1
         count .req x2
 
-MLKEM_NAMESPACE(poly_tobytes_asm_clean):
-_MLKEM_NAMESPACE(poly_tobytes_asm_clean):
+MLKEM_ASM_NAMESPACE(poly_tobytes_asm_clean):
 
         mov count, #16
 poly_tobytes_asm_clean_asm_loop_start:
@@ -263,8 +257,7 @@ poly_tobytes_asm_clean_asm_loop_start:
 /**********************************
  *          poly_tomont()         *
  **********************************/
-.global MLKEM_NAMESPACE(poly_tomont_asm_clean)
-.global _MLKEM_NAMESPACE(poly_tomont_asm_clean)
+.global MLKEM_ASM_NAMESPACE(poly_tomont_asm_clean)
 
         src               .req x0
         count             .req x1
@@ -285,8 +278,7 @@ poly_tobytes_asm_clean_asm_loop_start:
 
         tmp0              .req v6
 
-MLKEM_NAMESPACE(poly_tomont_asm_clean):
-_MLKEM_NAMESPACE(poly_tomont_asm_clean):
+MLKEM_ASM_NAMESPACE(poly_tomont_asm_clean):
 
         ldr q_modulus,         c_modulus
         ldr q_modulus_twisted, c_modulus_twisted

--- a/mlkem/native/aarch64/src/poly_opt.S
+++ b/mlkem/native/aarch64/src/poly_opt.S
@@ -66,8 +66,7 @@ c_barrett_twist:   dup8h -10276 // Barrett twist of -1044 (wrt 2^16)
  *          poly_reduce()         *
  **********************************/
 
-.global MLKEM_NAMESPACE(poly_reduce_asm_opt)
-.global _MLKEM_NAMESPACE(poly_reduce_asm_opt)
+.global MLKEM_ASM_NAMESPACE(poly_reduce_asm_opt)
 
         ptr               .req x0
         count             .req x1
@@ -82,8 +81,7 @@ c_barrett_twist:   dup8h -10276 // Barrett twist of -1044 (wrt 2^16)
         modulus_twisted   .req v4
         q_modulus_twisted .req q4
 
-MLKEM_NAMESPACE(poly_reduce_asm_opt):
-_MLKEM_NAMESPACE(poly_reduce_asm_opt):
+MLKEM_ASM_NAMESPACE(poly_reduce_asm_opt):
 
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
@@ -295,8 +293,7 @@ _MLKEM_NAMESPACE(poly_reduce_asm_opt):
  *          poly_mulcache_compute()         *
  ********************************************/
 
-.global MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt)
-.global _MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt)
+.global MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_opt)
 
         cache_ptr         .req x0
         data_ptr          .req x1
@@ -322,8 +319,7 @@ _MLKEM_NAMESPACE(poly_reduce_asm_opt):
         modulus_twisted   .req v7
         q_modulus_twisted .req q7
 
-MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt):
-_MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt):
+MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_opt):
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
 
@@ -452,8 +448,7 @@ _MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt):
 /********************************************
  *             poly_tobytes()               *
  ********************************************/
-.global MLKEM_NAMESPACE(poly_tobytes_asm_opt)
-.global _MLKEM_NAMESPACE(poly_tobytes_asm_opt)
+.global MLKEM_ASM_NAMESPACE(poly_tobytes_asm_opt)
 
         data0 .req v0
         data1 .req v1
@@ -466,8 +461,7 @@ _MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt):
         src   .req x1
         count .req x2
 
-MLKEM_NAMESPACE(poly_tobytes_asm_opt):
-_MLKEM_NAMESPACE(poly_tobytes_asm_opt):
+MLKEM_ASM_NAMESPACE(poly_tobytes_asm_opt):
 
         mov count, #16
 poly_tobytes_asm_opt_asm_loop_start:
@@ -504,8 +498,7 @@ poly_tobytes_asm_opt_asm_loop_start:
 /**********************************
  *          poly_tomont()         *
  **********************************/
-.global MLKEM_NAMESPACE(poly_tomont_asm_opt)
-.global _MLKEM_NAMESPACE(poly_tomont_asm_opt)
+.global MLKEM_ASM_NAMESPACE(poly_tomont_asm_opt)
 
         src               .req x0
         count             .req x1
@@ -526,8 +519,7 @@ poly_tobytes_asm_opt_asm_loop_start:
 
         tmp0              .req v6
 
-MLKEM_NAMESPACE(poly_tomont_asm_opt):
-_MLKEM_NAMESPACE(poly_tomont_asm_opt):
+MLKEM_ASM_NAMESPACE(poly_tomont_asm_opt):
 
         ldr q_modulus,         c_modulus
         ldr q_modulus_twisted, c_modulus_twisted

--- a/mlkem/native/aarch64/src/polyvec_clean.S
+++ b/mlkem/native/aarch64/src/polyvec_clean.S
@@ -164,11 +164,9 @@ c_modulus_twisted: dup8h 3327
         t0   .req v28
 
 #if MLKEM_K == 2
-.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
-.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
+.global MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
 
-MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
-_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
+MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
         push_stack
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
@@ -200,11 +198,9 @@ k2_loop_start:
 #endif /* MLKEM_K == 2 */
 
 #if MLKEM_K == 3
-.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
-.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
+.global MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
 
-MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
-_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
+MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
         push_stack
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
@@ -241,11 +237,9 @@ k3_loop_start:
 #endif /* MLKEM_K == 3 */
 
 #if MLKEM_K == 4
-.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
-.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
+.global MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean)
 
-MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
-_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
+MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_clean):
         push_stack
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted

--- a/mlkem/native/aarch64/src/polyvec_opt.S
+++ b/mlkem/native/aarch64/src/polyvec_opt.S
@@ -164,11 +164,9 @@ c_modulus_twisted: dup8h 3327
         t0   .req v28
 
 #if MLKEM_K == 2
-.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
-.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
+.global MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
 
-MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
-_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
+MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
         push_stack
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
@@ -532,11 +530,9 @@ _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
 #endif /* MLKEM_K == 2 */
 
 #if MLKEM_K == 3
-.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
-.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
+.global MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
 
-MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
-_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
+MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
         push_stack
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted
@@ -1005,11 +1001,9 @@ _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
 #endif /* MLKEM_K == 3 */
 
 #if MLKEM_K == 4
-.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
-.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
+.global MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt)
 
-MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
-_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
+MLKEM_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_opt):
         push_stack
         ldr q_modulus, c_modulus
         ldr q_modulus_twisted, c_modulus_twisted

--- a/mlkem/native/aarch64/src/rej_uniform_asm_clean.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm_clean.S
@@ -119,10 +119,8 @@ c_bit_table:
     .short 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80
 
 .align 4
-.global MLKEM_NAMESPACE(rej_uniform_asm_clean)
-.global _MLKEM_NAMESPACE(rej_uniform_asm_clean)
-MLKEM_NAMESPACE(rej_uniform_asm_clean):
-_MLKEM_NAMESPACE(rej_uniform_asm_clean):
+.global MLKEM_ASM_NAMESPACE(rej_uniform_asm_clean)
+MLKEM_ASM_NAMESPACE(rej_uniform_asm_clean):
     push_stack
 
     ldr  bits_q, c_bit_table

--- a/mlkem/native/x86_64/src/basemul.S
+++ b/mlkem/native/x86_64/src/basemul.S
@@ -113,8 +113,8 @@ vmovdqa		%ymm11,(64*\off+48)*2(%rdi)
 .endm
 
 .text
-.global MLKEM_NAMESPACE(basemul_avx2)
-MLKEM_NAMESPACE(basemul_avx2):
+.global MLKEM_ASM_NAMESPACE(basemul_avx2)
+MLKEM_ASM_NAMESPACE(basemul_avx2):
 mov		%rsp,%r8
 and		$-32,%rsp
 sub		$32,%rsp

--- a/mlkem/native/x86_64/src/fq.S
+++ b/mlkem/native/x86_64/src/fq.S
@@ -60,8 +60,8 @@ vmovdqa		%ymm9,224(%rdi)
 
 ret
 
-.global MLKEM_NAMESPACE(reduce_avx2)
-MLKEM_NAMESPACE(reduce_avx2):
+.global MLKEM_ASM_NAMESPACE(reduce_avx2)
+MLKEM_ASM_NAMESPACE(reduce_avx2):
 #consts
 vmovdqa		_16XQ*2(%rsi),%ymm0
 vmovdqa		_16XV*2(%rsi),%ymm1
@@ -103,8 +103,8 @@ vmovdqa		%ymm10,224(%rdi)
 
 ret
 
-.global MLKEM_NAMESPACE(tomont_avx2)
-MLKEM_NAMESPACE(tomont_avx2):
+.global MLKEM_ASM_NAMESPACE(tomont_avx2)
+MLKEM_ASM_NAMESPACE(tomont_avx2):
 #consts
 vmovdqa		_16XQ*2(%rsi),%ymm0
 vmovdqa		_16XMONTSQLO*2(%rsi),%ymm1

--- a/mlkem/native/x86_64/src/intt.S
+++ b/mlkem/native/x86_64/src/intt.S
@@ -242,8 +242,8 @@ vmovdqa		%ymm11,(64*\off+176)*2(%rdi)
 .endm
 
 .text
-.global MLKEM_NAMESPACE(invntt_avx2)
-MLKEM_NAMESPACE(invntt_avx2):
+.global MLKEM_ASM_NAMESPACE(invntt_avx2)
+MLKEM_ASM_NAMESPACE(invntt_avx2):
 vmovdqa         _16XQ*2(%rsi),%ymm0
 
 intt_levels0t5	0

--- a/mlkem/native/x86_64/src/ntt.S
+++ b/mlkem/native/x86_64/src/ntt.S
@@ -206,8 +206,8 @@ vmovdqa		%ymm11,(128*\off+112)*2(%rdi)
 .endm
 
 .text
-.global MLKEM_NAMESPACE(ntt_avx2)
-MLKEM_NAMESPACE(ntt_avx2):
+.global MLKEM_ASM_NAMESPACE(ntt_avx2)
+MLKEM_ASM_NAMESPACE(ntt_avx2):
 vmovdqa		_16XQ*2(%rsi),%ymm0
 
 level0		0

--- a/mlkem/native/x86_64/src/shuffle.S
+++ b/mlkem/native/x86_64/src/shuffle.S
@@ -15,8 +15,8 @@
 #include "fq.inc"
 #include "shuffle.inc"
 
-.global MLKEM_NAMESPACE(nttpack_avx2)
-MLKEM_NAMESPACE(nttpack_avx2):
+.global MLKEM_ASM_NAMESPACE(nttpack_avx2)
+MLKEM_ASM_NAMESPACE(nttpack_avx2):
 #load
 vmovdqa		(%rdi),%ymm4
 vmovdqa		32(%rdi),%ymm5
@@ -102,8 +102,8 @@ vmovdqa		%ymm11,224(%rdi)
 
 ret
 
-.global MLKEM_NAMESPACE(nttunpack_avx2)
-MLKEM_NAMESPACE(nttunpack_avx2):
+.global MLKEM_ASM_NAMESPACE(nttunpack_avx2)
+MLKEM_ASM_NAMESPACE(nttunpack_avx2):
 call		nttunpack128_avx2
 add		$256,%rdi
 call		nttunpack128_avx2
@@ -169,8 +169,8 @@ vmovdqu		%ymm9,160(%rdi)
 
 ret
 
-.global MLKEM_NAMESPACE(ntttobytes_avx2)
-MLKEM_NAMESPACE(ntttobytes_avx2):
+.global MLKEM_ASM_NAMESPACE(ntttobytes_avx2)
+MLKEM_ASM_NAMESPACE(ntttobytes_avx2):
 #consts
 vmovdqa		_16XQ*2(%rdx),%ymm0
 call		ntttobytes128_avx
@@ -245,8 +245,8 @@ vmovdqa		%ymm1,224(%rdi)
 
 ret
 
-.global MLKEM_NAMESPACE(nttfrombytes_avx2)
-MLKEM_NAMESPACE(nttfrombytes_avx2):
+.global MLKEM_ASM_NAMESPACE(nttfrombytes_avx2)
+MLKEM_ASM_NAMESPACE(nttfrombytes_avx2):
 #consts
 vmovdqa		_16XMASK*2(%rdx),%ymm0
 call		nttfrombytes128_avx


### PR DESCRIPTION
* Resolves #545 

We previously exported two versions of every assembly symbol, one prefixed with a leading underscore, one not. This was to accommodate both Apple and non-Apple platforms.

This commit removes duplicated assembly symbols by introducing separate namespace wrappers
- MLKEM_ASM_NAMESPACE, and
- FIPS202_ASM_NAMESPACE which wrap around the configurable {MLKEM,FIPS202}_NAMESPACE by adding a leading underscore for Apple systems (only).
