### PR TITLE
Fixes unused buflen in gen_matrix_entry

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -243,7 +243,7 @@ __contract__(
                                           0, (MLKEM_Q - 1))))
   {
     xof_squeezeblocks(buf, 1, &state);
-    ctr = rej_uniform(entry->coeffs, MLKEM_N, ctr, buf, XOF_RATE);
+    ctr = rej_uniform(entry->coeffs, MLKEM_N, ctr, buf, buflen);
   }
 
   xof_release(&state);


### PR DESCRIPTION
<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
Fixes unused buflen variable in gen_matrix_entry. Detected when importing the code to liboqs and running a build with `scan_build`.

**Performed local tests**:
 - [ ] `lint` passing (not sure how to run this locally.)
 - [x] `tests all` passing
 - [x] `tests bench` passing
 - [ ] `tests cbmc` passing (I might be missing some dependencies to run this.)

**Do you expect this change to impact performance**: No

If yes, please provide local benchmarking results.
