### PR TITLE
Fix macOS build of benchmark test with GCC 14

### DIFF
--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -246,6 +246,13 @@ static void init_rdtsc(void)
     printf("kperf = %p\n", kperf);
     return;
   }
+
+/* Temporarily disable -Wpedantic here to allow conversion
+ * from (void *) to function-pointer.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 #define F(ret, name, ...)                     \
   name = (name##proc *)(dlsym(kperf, #name)); \
   if (!name)                                  \
@@ -255,6 +262,8 @@ static void init_rdtsc(void)
   }
   KPERF_LIST
 #undef F
+
+#pragma GCC diagnostic pop
 
   g_config[0] = CPMU_CORE_CYCLE | CFGWORD_EL0A64EN_MASK;
 }


### PR DESCRIPTION
Fixes #552 

Disables -Wpedantic in hal/hal.c where the result of calling dlsym() needs to be converted from "void *" to the appropriate function-pointer type, which normally generates a warning or error with GCC 14.

All tests pass
"tests bench -r -c M1" now works on macOS with GCC 14.2.0
lint passes
No expected performance impact

