### PR TITLE
CI: Don't suppress output of `make quickcheck`

### DIFF
--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -147,9 +147,9 @@ jobs:
           sudo: ""
       - name: make quickcheck
         run: |
-          OPT=0 make quickcheck >/dev/null
+          OPT=0 make quickcheck
           make clean            >/dev/null
-          OPT=1 make quickcheck >/dev/null
+          OPT=1 make quickcheck
       - name: Functional Tests
         uses: ./.github/actions/multi-functest
         with:


### PR DESCRIPTION
bcef8f63034f1203abd22646e90182a776a47e39 already tried to do this, but one the ec2 container tests were missed.
