### PR TITLE
Tests/CI: Move QEMU choice logic from `tests` into workflow

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -25,6 +25,9 @@ inputs:
   cross_prefix:
     description: Binary prefix for cross compilation
     default: ""
+  exec_wrapper:
+    description: Binary wrapper for execution (e.g. QEMU)
+    default: ""
   opt:
     description: Whether to build opt/non-opt binaries or all (all | opt | no_opt)
     default: "all"
@@ -85,7 +88,7 @@ runs:
       - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          ./scripts/tests all  --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
+          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
       - name: Check namespacing ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -85,6 +85,12 @@ runs:
             - $(python3 --version)
             - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
           EOF
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (no-opt, func)
+        if: ${{ inputs.func == 'true' && (inputs.opt == 'no-opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          make clean
+          make EXEC_WRAPPER="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" CFLAGS="${{ inputs.cflags }}" AUTO=1 OPT=0 check_func
       - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -69,6 +69,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: x86_64-unknown-linux-gnu-
+          exec_wrapper: qemu-x86_64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -85,6 +86,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: aarch64-unknown-linux-gnu-
+          exec_wrapper: qemu-aarch64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -101,6 +103,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -static"
           cross_prefix: aarch64_be-none-linux-gnu-
+          exec_wrapper: qemu-aarch64_be
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -117,6 +120,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: riscv64-unknown-linux-gnu-
+          exec_wrapper: qemu-riscv64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ include mk/crypto.mk
 include mk/schemes.mk
 include mk/rules.mk
 
+# Binary wrapper, e.g. qemu-aarch64/qemu-x86_64 for emulation.
+# Usually chosen consistently with CROSS_PREFIX for compilation.
+WRAP?=
+
 quickcheck: checkall
 
 buildall: mlkem nistkat kat acvp
@@ -19,19 +23,19 @@ checkall: buildall check_kat check_nistkat check_func check_acvp
 	$(Q)echo "  Everything checks fine!"
 
 check_kat: buildall
-	$(MLKEM512_DIR)/bin/gen_KAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
-	$(MLKEM768_DIR)/bin/gen_KAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
-	$(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 kat-sha256
+	$(WRAP) $(MLKEM512_DIR)/bin/gen_KAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
+	$(WRAP) $(MLKEM768_DIR)/bin/gen_KAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
+	$(WRAP) $(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 kat-sha256
 
 check_nistkat: buildall
-	$(MLKEM512_DIR)/bin/gen_NISTKAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
-	$(MLKEM768_DIR)/bin/gen_NISTKAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
-	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 nistkat-sha256
+	$(WRAP) $(MLKEM512_DIR)/bin/gen_NISTKAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
+	$(WRAP) $(MLKEM768_DIR)/bin/gen_NISTKAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
+	$(WRAP) $(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 nistkat-sha256
 
 check_func: buildall
-	$(MLKEM512_DIR)/bin/test_mlkem512
-	$(MLKEM768_DIR)/bin/test_mlkem768
-	$(MLKEM1024_DIR)/bin/test_mlkem1024
+	$(WRAP) $(MLKEM512_DIR)/bin/test_mlkem512
+	$(WRAP) $(MLKEM768_DIR)/bin/test_mlkem768
+	$(WRAP) $(MLKEM1024_DIR)/bin/test_mlkem1024
 
 check_acvp: buildall
 	python3 ./test/acvp_client.py

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -330,25 +330,6 @@ class Tests:
             if opts.exec_wrapper:
                 logging.info(f"Running with customized wrapper {opts.exec_wrapper}")
                 self.cmd_prefix = self.cmd_prefix + opts.exec_wrapper.split(" ")
-            elif opts.cross_prefix and platform.system() != "Darwin":
-                logging.info(f"Emulating with QEMU")
-                if "x86_64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-x86_64")
-                elif "aarch64_be" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-aarch64_be")
-                elif "aarch64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-aarch64")
-                elif "riscv64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-riscv64")
-                else:
-                    logging.info(
-                        f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
-                    )
-            elif opts.cross_prefix:
-                logging.error(
-                    f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
-                )
-                sys.exit(1)
 
     def _run_func(self, opt):
         """Underlying function for functional test"""


### PR DESCRIPTION
Previously, `tests` would automatically detect which QEMU binary to use for emulation. With this commit, this is instead made explicit in the logic of the workflow. This is a step towards simplifying the `tests` script and eventually replacing it by calls to `make`.