### PR TITLE
Test: Use `make` instead of `tests` in `functest` action

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -25,6 +25,9 @@ inputs:
   cross_prefix:
     description: Binary prefix for cross compilation
     default: ""
+  exec_wrapper:
+    description: Binary wrapper for execution (e.g. QEMU)
+    default: ""
   opt:
     description: Whether to build opt/non-opt binaries or all (all | opt | no_opt)
     default: "all"
@@ -85,7 +88,7 @@ runs:
       - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          ./scripts/tests all  --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
+          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
       - name: Check namespacing ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -85,10 +85,57 @@ runs:
             - $(python3 --version)
             - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
           EOF
-      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
+
+      - name: Cleanup
         shell: ${{ env.SHELL }}
         run: |
-          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
+          make clean
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (no_opt, func)
+        if: ${{ inputs.func == 'true' && (inputs.opt == 'no_opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=0 check_func
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (no_opt, nistkat)
+        if: ${{ inputs.nistkat == 'true' && (inputs.opt == 'no_opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=0 check_nistkat
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (no_opt, kat)
+        if: ${{ inputs.kat == 'true' && (inputs.opt == 'no_opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=0 check_kat
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (no_opt, acvp)
+        if: ${{ inputs.acvp == 'true' && (inputs.opt == 'no_opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=0 check_acvp
+
+      - name: Cleanup
+        shell: ${{ env.SHELL }}
+        run: |
+          make clean
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (opt, func)
+        if: ${{ inputs.func == 'true' && (inputs.opt == 'opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=1 check_func
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (opt, nistkat)
+        if: ${{ inputs.nistkat == 'true' && (inputs.opt == 'opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=1 check_nistkat
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (opt, kat)
+        if: ${{ inputs.kat == 'true' && (inputs.opt == 'opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=1 check_kat
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (opt, acvp)
+        if: ${{ inputs.acvp == 'true' && (inputs.opt == 'opt' || inputs.opt == 'all') }}
+        shell: ${{ env.SHELL }}
+        run: |
+          CFLAGS="${{ inputs.cflags }}" make EXEC_PREFIX="${{ inputs.exec_wrapper }}" CROSS_PREFIX="${{ inputs.cross_prefix }}" AUTO=1 OPT=1 check_acvp
+
       - name: Check namespacing ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -69,6 +69,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: x86_64-unknown-linux-gnu-
+          exec_wrapper: qemu-x86_64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -85,6 +86,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: aarch64-unknown-linux-gnu-
+          exec_wrapper: qemu-aarch64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -101,6 +103,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -static"
           cross_prefix: aarch64_be-none-linux-gnu-
+          exec_wrapper: qemu-aarch64_be
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -117,6 +120,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: riscv64-unknown-linux-gnu-
+          exec_wrapper: qemu-riscv64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ include mk/crypto.mk
 include mk/schemes.mk
 include mk/rules.mk
 
+# Binary wrapper, e.g. qemu-aarch64/qemu-x86_64 for emulation.
+# Usually chosen consistently with CROSS_PREFIX for compilation.
+EXEC_PREFIX?=
+
 quickcheck: checkall
 
 buildall: mlkem nistkat kat acvp
@@ -19,19 +23,19 @@ checkall: buildall check_kat check_nistkat check_func check_acvp
 	$(Q)echo "  Everything checks fine!"
 
 check_kat: buildall
-	$(MLKEM512_DIR)/bin/gen_KAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
-	$(MLKEM768_DIR)/bin/gen_KAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
-	$(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 kat-sha256
+	$(EXEC_PREFIX) $(MLKEM512_DIR)/bin/gen_KAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
+	$(EXEC_PREFIX) $(MLKEM768_DIR)/bin/gen_KAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
+	$(EXEC_PREFIX) $(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 kat-sha256
 
 check_nistkat: buildall
-	$(MLKEM512_DIR)/bin/gen_NISTKAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
-	$(MLKEM768_DIR)/bin/gen_NISTKAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
-	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 nistkat-sha256
+	$(EXEC_PREFIX) $(MLKEM512_DIR)/bin/gen_NISTKAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
+	$(EXEC_PREFIX) $(MLKEM768_DIR)/bin/gen_NISTKAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
+	$(EXEC_PREFIX) $(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 nistkat-sha256
 
 check_func: buildall
-	$(MLKEM512_DIR)/bin/test_mlkem512
-	$(MLKEM768_DIR)/bin/test_mlkem768
-	$(MLKEM1024_DIR)/bin/test_mlkem1024
+	$(EXEC_PREFIX) $(MLKEM512_DIR)/bin/test_mlkem512
+	$(EXEC_PREFIX) $(MLKEM768_DIR)/bin/test_mlkem768
+	$(EXEC_PREFIX) $(MLKEM1024_DIR)/bin/test_mlkem1024
 
 check_acvp: buildall
 	python3 ./test/acvp_client.py

--- a/README.md
+++ b/README.md
@@ -26,20 +26,12 @@ bounds accesses, nor integer overflows during optimized modular arithmetic.
 git clone https://github.com/pq-code-package/mlkem-native.git
 cd mlkem-native
 
-# Install base packages
+# Make sure to have `make`
 sudo apt-get update
-sudo apt-get install python3-venv python3-pip make
+sudo apt-get install make
 
-# Setup Python environment
-python3 -m venv venv
-source venv/bin/activate
-python3 -m pip install -r requirements.txt
-
-# Build and run base tests
-make quickcheck
-
-# Build and run all tests
-./scripts/tests all
+# Build & run tests
+make checkall
 ```
 
 See [BUILDING.md](BUILDING.md) for more information.

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -330,25 +330,6 @@ class Tests:
             if opts.exec_wrapper:
                 logging.info(f"Running with customized wrapper {opts.exec_wrapper}")
                 self.cmd_prefix = self.cmd_prefix + opts.exec_wrapper.split(" ")
-            elif opts.cross_prefix and platform.system() != "Darwin":
-                logging.info(f"Emulating with QEMU")
-                if "x86_64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-x86_64")
-                elif "aarch64_be" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-aarch64_be")
-                elif "aarch64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-aarch64")
-                elif "riscv64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-riscv64")
-                else:
-                    logging.info(
-                        f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
-                    )
-            elif opts.cross_prefix:
-                logging.error(
-                    f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
-                )
-                sys.exit(1)
 
     def _run_func(self, opt):
         """Underlying function for functional test"""

--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -9,11 +9,17 @@
 # Invokes `acvp_mlkem{lvl}` under the hood.
 
 import json
+import os
 import subprocess
 
 acvp_dir = "test/acvp_data"
 acvp_keygen_json = f"{acvp_dir}/acvp_keygen_internalProjection.json"
 acvp_encapDecap_json = f"{acvp_dir}/acvp_encapDecap_internalProjection.json"
+
+if os.environ.get("EXEC_PREFIX","").strip() != "":
+    exec_wrapper = [os.environ["EXEC_PREFIX"].strip()]
+else:
+    exec_wrapper = []
 
 with open(acvp_keygen_json, "r") as f:
     acvp_keygen_data = json.load(f)
@@ -39,7 +45,7 @@ def run_encapDecap_test(tg, tc):
     print(f"Running encapDecap test case {tc['tcId']} ({tg['function']}) ... ", end="")
     if tg["function"] == "encapsulation":
         acvp_bin = get_acvp_binary(tg)
-        acvp_call = [
+        acvp_call = exec_wrapper + [
             acvp_bin,
             "encapDecap",
             "AFT",
@@ -63,7 +69,7 @@ def run_encapDecap_test(tg, tc):
         print("OK")
     elif tg["function"] == "decapsulation":
         acvp_bin = get_acvp_binary(tg)
-        acvp_call = [
+        acvp_call = exec_wrapper + [
             acvp_bin,
             "encapDecap",
             "VAL",
@@ -90,7 +96,13 @@ def run_encapDecap_test(tg, tc):
 def run_keyGen_test(tg, tc):
     print(f"Running keyGen test case {tc['tcId']} ... ", end="")
     acvp_bin = get_acvp_binary(tg)
-    acvp_call = [acvp_bin, "keyGen", "AFT", f"z={tc['z']}", f"d={tc['d']}"]
+    acvp_call = exec_wrapper + [
+        acvp_bin,
+        "keyGen",
+        "AFT",
+        f"z={tc['z']}",
+        f"d={tc['d']}",
+    ]
     result = subprocess.run(acvp_call, encoding="utf-8", capture_output=True)
     if result.returncode != 0:
         print("FAIL!")

--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -16,7 +16,7 @@ acvp_dir = "test/acvp_data"
 acvp_keygen_json = f"{acvp_dir}/acvp_keygen_internalProjection.json"
 acvp_encapDecap_json = f"{acvp_dir}/acvp_encapDecap_internalProjection.json"
 
-if os.environ.get("EXEC_PREFIX","").strip() != "":
+if os.environ.get("EXEC_PREFIX", "").strip() != "":
     exec_wrapper = [os.environ["EXEC_PREFIX"].strip()]
 else:
     exec_wrapper = []


### PR DESCRIPTION
* Fix https://github.com/pq-code-package/mlkem-native/issues/567

This PR replaces calls to `tests` in the `functest` CI action by direct invocations of `make`. There is a bit of explicit repetition, which we may want to remove: IIRC, we always want to run all tests, so the splitting into `func/acvp/nistkat/kat` is redundant, and we could as well just call `make checkall`.

The PR does not yet remove the increasingly obsolete test-functionality of `tests`. Note that the benchmarking logic is more involved and may merit keeping `tests` (perhaps renamed to `bench`).