### PR TITLE
Fix x86 default flags

### DIFF
--- a/mk/auto.mk
+++ b/mk/auto.mk
@@ -3,7 +3,7 @@
 # Automatically detect system architecture and set preprocessor etc accordingly
 ifeq ($(HOST_PLATFORM),Linux-x86_64)
 ifeq ($(CROSS_PREFIX),)
-	ARCH_FLAGS += -mavx2 -mbmi2 -mpopcnt -maes
+	CFLAGS += -mavx2 -mbmi2 -mpopcnt -maes
 	CFLAGS += -DFORCE_X86_64
 else ifneq ($(findstring aarch64_be, $(CROSS_PREFIX)),)
 	CFLAGS += -DFORCE_AARCH64_EB
@@ -18,7 +18,7 @@ else ifeq ($(HOST_PLATFORM),Linux-aarch64)
 ifeq ($(CROSS_PREFIX),)
 	CFLAGS += -DFORCE_AARCH64
 else ifneq ($(findstring x86_64, $(CROSS_PREFIX)),)
-	ARCH_FLAGS += -mavx2 -mbmi2 -mpopcnt -maes
+	CFLAGS += -mavx2 -mbmi2 -mpopcnt -maes
 	CFLAGS += -DFORCE_X86_64
 else
 endif


### PR DESCRIPTION
https://github.com/pq-code-package/mlkem-native/commit/b94f8ce2e47e26ae93a54f0c6a04e83ebbec6360 broke the automatic detection of x86 systems and lead to the native x86 backend not being used unless `-mavx2` is passed specifically. The issue is lazy vs. eager evaluation of ARCH_FLAGS within CFLAGS: with := the variable is eagerly evaluated at time of definition, while with += it is lazily evaluated. This matters since auto.mk sets default ARCH_FLAGS only later based on your system. Setting the ARCH_FLAGS in auto.mk thus had no effect. 

This commit changes `auto.mk` to directly modify the CFLAGS instead of the ARCH_FLAGS. This resolves the issue of the x86 backend not being used by default. We may want to eliminate ARCH_FLAGS altogether in a follow up PR.

Fixes #577