### PR TITLE
[TEST] Run nix setup in compatibility tests

### DIFF
--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -153,7 +153,6 @@ jobs:
       - name: Functional Tests
         uses: ./.github/actions/multi-functest
         with:
-          nix-shell: ""
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
           cflags: ${{ inputs.cflags }}
           compile_mode: ${{ inputs.compile_mode }}


### PR DESCRIPTION
This is a test-only PR to check if the Docker based compatibility tests pass when a nix shell is used instead of the built-in shell. In particular, this tests the nix setup in those containers.