### PR TITLE
Force explcit CYCLES make variable for benchmarking

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,10 +19,15 @@ To merely build test and benchmarking components, use the following `make` targe
 
 ```bash
 make mlkem
-make bench
-make bench_components
 make nistkat
 make kat
+```
+
+For benchmarking, specify the cycle counting method. Currently, **mlkem-native** is supporting PERF, PMU (AArch64 and x86 only), M1 (Apple Silicon only):
+```
+# CYCLES has to be on of PERF, PMU, M1, NO
+make bench CYCLES=PERF
+make bench_components CYCLES=PERF
 ```
 
 The resulting binaries can then be found in `test/build`.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: mlkem kat nistkat clean quickcheck buildall checkall all
+.PHONY: mlkem kat nistkat clean quickcheck buildall checkall all check-defined-CYCLES
 .DEFAULT_GOAL := buildall
 all: quickcheck
 
@@ -43,7 +43,13 @@ mlkem: \
   $(MLKEM768_DIR)/bin/test_mlkem768 \
   $(MLKEM1024_DIR)/bin/test_mlkem1024
 
-bench: \
+# Enforce setting CYCLES make variable when 
+# building benchmarking binaries
+check_defined = $(if $(value $1),, $(error $2))
+check-defined-CYCLES:
+	@:$(call check_defined,CYCLES,CYCLES undefined. Benchmarking requires setting one of NO PMU PERF M1)
+
+bench: check-defined-CYCLES \
 	$(MLKEM512_DIR)/bin/bench_mlkem512 \
 	$(MLKEM768_DIR)/bin/bench_mlkem768 \
 	$(MLKEM1024_DIR)/bin/bench_mlkem1024
@@ -53,7 +59,7 @@ acvp: \
 	$(MLKEM768_DIR)/bin/acvp_mlkem768 \
 	$(MLKEM1024_DIR)/bin/acvp_mlkem1024
 
-bench_components: \
+bench_components: check-defined-CYCLES \
 	$(MLKEM512_DIR)/bin/bench_components_mlkem512 \
 	$(MLKEM768_DIR)/bin/bench_components_mlkem768 \
 	$(MLKEM1024_DIR)/bin/bench_components_mlkem1024

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -60,8 +60,6 @@ ifeq ($(HOST_PLATFORM),Linux-x86_64)
 	CFLAGS += -z noexecstack
 endif
 
-CYCLES ?= NO
-
 ifeq ($(CYCLES),PMU)
 	CFLAGS += -DPMU_CYCLES
 endif

--- a/scripts/tests
+++ b/scripts/tests
@@ -158,7 +158,7 @@ def cli():
         help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silicon.",
         choices=["NO", "PMU", "PERF", "M1"],
         type=str.upper,
-        default="NO",
+        required=True,
     )
     bench_parser.add_argument(
         "-o", "--output", help="Path to output file in json format"


### PR DESCRIPTION
Currently, when CYCLES is not set explicitly when
building the benchmarking binaries, we default to
NO which results in all 0 cycle counts which is
confusing.
This commit changes the buidl so that it fails
with a error when attempting to build the benchmarking binaries without explicitly setting CYCLES.
