### PR TITLE
Fix linker warning when checking for duplicated symbols

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -24,15 +24,17 @@ $(BUILD_DIR)/%.a: $(CONFIG)
 # 	$AR doesn't care about duplicated symbols, one can only find it out via actually linking.
 # 	The easiest one to do this that one can think of is to create a dummy C file with empty main function on the fly, pipe it to $CC and link with the built library
 	$(eval _LIB := $(subst $(BUILD_DIR)/lib,,$(@:%.a=%)))
+	$(eval _CFLAGS := $(subst -static,,$(CFLAGS)))
+
 ifneq ($(findstring Darwin,$(HOST_PLATFORM)),) # if is on macOS
-	$(Q)echo "int main() {return 0;}" \
-		| $(CC) -x c - -L$(BUILD_DIR) \
+	$(Q)echo "int main(void) {return 0;}" \
+		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
 		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
 		 -Imlkem $(wildcard test/notrandombytes/*.c)
 	$(Q)rm -f a.out
 else                                           # if not on macOS
-	$(Q)echo "int main() {return 0;}" \
-		| $(CC) -x c - -L$(BUILD_DIR) \
+	$(Q)echo "int main(void) {return 0;}" \
+		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
 		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \
 		-Wl,--no-whole-archive \
 		-Imlkem $(wildcard test/notrandombytes/*.c)


### PR DESCRIPTION
When we build archive files for mlkem-native, we check for duplicated
symbols by linking the target library against a dummy .c file. The
ad-hoc compiler invocation used for this did not use and `-z noexecstack`
flag which led to linker warnings.

This commit addresses this by passing the same CFLAGS to the dummy compilation
as we use in the rest of the build, which in particular includes `-z noexecstack`. The 
only exception is `-static`, which is part of the CFLAGS for the library build, but dropped
for the dummy compilation.

* Fix #590 
