### PR TITLE
Remove ARCH_FLAGS from test script and Makefile

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -74,12 +74,12 @@ runs:
       shell: ${{ env.SHELL }}
       run: |
         ./scripts/tests bench -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
-              --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" \
+              --cflags="${{ inputs.cflags }} ${{ inputs.archflags }}" \
               --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v --output=output.json ${{ inputs.bench_extra_args }}
 
         ./scripts/tests bench --components -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" \
-              --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" \
+              --cflags="${{ inputs.cflags }} ${{ inputs.archflags }}" \
               --opt=$([[ ${{ inputs.opt }} == "false" ]] && echo "no_opt" || echo "opt")  \
               -v --output=output.json ${{ inputs.bench_extra_args }}
     - name: Check namespace

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -30,7 +30,6 @@ CC_AR  := $(CROSS_PREFIX)$(CC_AR)
 # Common config #
 #################
 CFLAGS := \
-	$(ARCH_FLAGS) \
 	-Wall \
 	-Wextra \
 	-Wpedantic \

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -24,10 +24,9 @@ gh_env = os.environ.get("GITHUB_ENV")
 
 class CompileOptions(object):
 
-    def __init__(self, cross_prefix, cflags, arch_flags, auto, verbose):
+    def __init__(self, cross_prefix, cflags, auto, verbose):
         self.cross_prefix = cross_prefix
         self.cflags = cflags
-        self.arch_flags = arch_flags
         self.auto = auto
         self.verbose = verbose
 
@@ -39,7 +38,6 @@ class Options(object):
     def __init__(self):
         self.cross_prefix = ""
         self.cflags = ""
-        self.arch_flags = ""
         self.auto = True
         self.verbose = False
         self.opt = "ALL"
@@ -56,7 +54,6 @@ class Base:
         self.test_type = test_type
         self.cross_prefix = copts.cross_prefix
         self.cflags = copts.cflags
-        self.arch_flags = copts.arch_flags
         self.auto = copts.auto
         self.verbose = copts.verbose
         self.opt = opt
@@ -102,8 +99,6 @@ class Base:
         env = os.environ.copy()
         if self.cflags is not None:
             env["CFLAGS"] = self.cflags
-        if self.arch_flags is not None:
-            env["ARCH_FLAGS"] = self.arch_flags
 
         env.update(extra_make_envs)
 
@@ -299,7 +294,6 @@ class Tests:
         copts = CompileOptions(
             opts.cross_prefix,
             opts.cflags,
-            opts.arch_flags,
             opts.auto,
             opts.verbose,
         )

--- a/scripts/tests
+++ b/scripts/tests
@@ -26,9 +26,6 @@ def cli():
     common_parser.add_argument(
         "--cflags", help="Extra cflags to passed in (e.g. '-mcpu=cortex-a72')"
     )
-    common_parser.add_argument(
-        "--arch-flags", help="Extra arch flags to passed in (e.g. '-march=armv8')"
-    )
 
     # --auto / --no-auto
     auto_group = common_parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Previously, we distinguished between CFLAGS and ARCH_FLAGS in the `Makefile` and the `tests` script. Ultimately, however, they are both just flags passed to the compiler, and the semantic difference is not worth highlighting at the level of the Makefile and tests script. This commit thus removes ARCH_FLAGS and uses CFLAGS instead.

The CI workflows so far retain their `archflags` parameter, but it is passed as `--cflags` to the `tests` script.
