### PR TITLE
Tests/CI: Move QEMU choice logic from `tests` into workflow

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -25,6 +25,9 @@ inputs:
   cross_prefix:
     description: Binary prefix for cross compilation
     default: ""
+  exec_wrapper:
+    description: Binary wrapper for execution (e.g. QEMU)
+    default: ""
   opt:
     description: Whether to build opt/non-opt binaries or all (all | opt | no_opt)
     default: "all"
@@ -85,7 +88,7 @@ runs:
       - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          ./scripts/tests all  --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
+          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} -v
       - name: Check namespacing ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -69,6 +69,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: x86_64-unknown-linux-gnu-
+          exec_wrapper: qemu-x86_64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -85,6 +86,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: aarch64-unknown-linux-gnu-
+          exec_wrapper: qemu-aarch64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -101,6 +103,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: "${{ inputs.cflags }} -static"
           cross_prefix: aarch64_be-none-linux-gnu-
+          exec_wrapper: qemu-aarch64_be
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}
@@ -117,6 +120,7 @@ runs:
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           cross_prefix: riscv64-unknown-linux-gnu-
+          exec_wrapper: qemu-riscv64
           opt: ${{ inputs.opt }}
           func: ${{ inputs.func }}
           kat: ${{ inputs.kat }}

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,6 @@ kat: \
 	$(MLKEM768_DIR)/bin/gen_KAT768 \
 	$(MLKEM1024_DIR)/bin/gen_KAT1024
 
-# emulate ARM64 binary on x86_64 machine
-emulate:
-	$(Q)$(MAKE) --quiet CROSS_PREFIX=aarch64-none-linux-gnu- $(TARGET)
-	$(Q)$(QEMU) $(TARGET)
-
 clean:
 	-$(RM) -rf *.gcno *.gcda *.lcov *.o *.so
 	-$(RM) -rf $(BUILD_DIR)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -51,7 +51,6 @@ CFLAGS := \
 # Some Variables #
 ##################
 Q ?= @
-QEMU = qemu-aarch64
 
 HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)
 # linux x86_64

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -324,25 +324,6 @@ class Tests:
             if opts.exec_wrapper:
                 logging.info(f"Running with customized wrapper {opts.exec_wrapper}")
                 self.cmd_prefix = self.cmd_prefix + opts.exec_wrapper.split(" ")
-            elif opts.cross_prefix and platform.system() != "Darwin":
-                logging.info(f"Emulating with QEMU")
-                if "x86_64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-x86_64")
-                elif "aarch64_be" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-aarch64_be")
-                elif "aarch64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-aarch64")
-                elif "riscv64" in opts.cross_prefix:
-                    self.cmd_prefix.append("qemu-riscv64")
-                else:
-                    logging.info(
-                        f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
-                    )
-            elif opts.cross_prefix:
-                logging.error(
-                    f"Emulation for {opts.cross_prefix} on {platform.system()} not supported",
-                )
-                sys.exit(1)
 
     def _run_func(self, opt):
         """Underlying function for functional test"""


### PR DESCRIPTION
Previously, `tests` would automatically detect which QEMU binary to use for emulation. With this commit, this is instead made explicit in the logic of the workflow. This is a step towards simplifying the `tests` script and eventually replacing it by calls to `make`.
