### PR TITLE
Further simplification of `tests` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: mlkem kat nistkat clean quickcheck buildall checkall all check-defined-CYCLES
+.PHONY: build_func build_kat build_nistkat build_acvp \
+	check_func check_kat check_nistkat check_acvp \
+	buildall checkall all 			      \
+	clean quickcheck check-defined-CYCLES
+
 .DEFAULT_GOAL := buildall
 all: quickcheck
 
@@ -12,33 +16,33 @@ include mk/rules.mk
 
 quickcheck: checkall
 
-buildall: mlkem nistkat kat acvp
+buildall: build_func build_nistkat build_kat build_acvp
 	$(Q)echo "  Everything builds fine!"
 
 checkall: check_kat check_nistkat check_func check_acvp
 	$(Q)echo "  Everything checks fine!"
 
-check_kat: kat
+check_kat: build_kat
 	$(MLKEM512_DIR)/bin/gen_KAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
 	$(MLKEM768_DIR)/bin/gen_KAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
 	$(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 kat-sha256
 
-check_nistkat: nistkat
+check_nistkat: build_nistkat
 	$(MLKEM512_DIR)/bin/gen_NISTKAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
 	$(MLKEM768_DIR)/bin/gen_NISTKAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
 	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 nistkat-sha256
 
-check_func: mlkem
+check_func: build_func
 	$(MLKEM512_DIR)/bin/test_mlkem512
 	$(MLKEM768_DIR)/bin/test_mlkem768
 	$(MLKEM1024_DIR)/bin/test_mlkem1024
 
-check_acvp: acvp
+check_acvp: build_acvp
 	python3 ./test/acvp_client.py
 
 lib: $(BUILD_DIR)/libmlkem.a
 
-mlkem: \
+build_func: \
   $(MLKEM512_DIR)/bin/test_mlkem512 \
   $(MLKEM768_DIR)/bin/test_mlkem768 \
   $(MLKEM1024_DIR)/bin/test_mlkem1024
@@ -54,7 +58,7 @@ bench: check-defined-CYCLES \
 	$(MLKEM768_DIR)/bin/bench_mlkem768 \
 	$(MLKEM1024_DIR)/bin/bench_mlkem1024
 
-acvp: \
+build_acvp: \
 	$(MLKEM512_DIR)/bin/acvp_mlkem512 \
 	$(MLKEM768_DIR)/bin/acvp_mlkem768 \
 	$(MLKEM1024_DIR)/bin/acvp_mlkem1024
@@ -64,12 +68,12 @@ bench_components: check-defined-CYCLES \
 	$(MLKEM768_DIR)/bin/bench_components_mlkem768 \
 	$(MLKEM1024_DIR)/bin/bench_components_mlkem1024
 
-nistkat: \
+build_nistkat: \
 	$(MLKEM512_DIR)/bin/gen_NISTKAT512 \
 	$(MLKEM768_DIR)/bin/gen_NISTKAT768 \
 	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024
 
-kat: \
+build_kat: \
 	$(MLKEM512_DIR)/bin/gen_KAT512 \
 	$(MLKEM768_DIR)/bin/gen_KAT768 \
 	$(MLKEM1024_DIR)/bin/gen_KAT1024

--- a/Makefile
+++ b/Makefile
@@ -22,30 +22,54 @@ buildall: build_func build_nistkat build_kat build_acvp
 checkall: check_kat check_nistkat check_func check_acvp
 	$(Q)echo "  Everything checks fine!"
 
-check_kat: build_kat
-	$(MLKEM512_DIR)/bin/gen_KAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
-	$(MLKEM768_DIR)/bin/gen_KAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
-	$(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 kat-sha256
+check_kat_512: build_kat_512
+	$(MLKEM512_DIR)/bin/gen_KAT512 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  kat-sha256
+check_kat_768: build_kat_768
+	$(MLKEM768_DIR)/bin/gen_KAT768 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  kat-sha256
+check_kat_1024: build_kat_1024
+	$(MLKEM1024_DIR)/bin/gen_KAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024  kat-sha256
+check_kat: check_kat_512 check_kat_768 check_kat_1024
 
-check_nistkat: build_nistkat
-	$(MLKEM512_DIR)/bin/gen_NISTKAT512   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
-	$(MLKEM768_DIR)/bin/gen_NISTKAT768   | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
-	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024 nistkat-sha256
+check_nistkat_512: build_nistkat_512
+	$(MLKEM512_DIR)/bin/gen_NISTKAT512 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-512  nistkat-sha256
+check_nistkat_768: build_nistkat_768
+	$(MLKEM768_DIR)/bin/gen_NISTKAT768 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-768  nistkat-sha256
+check_nistkat_1024: build_nistkat_1024
+	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024 | sha256sum | cut -d " " -f 1 | xargs ./META.sh ML-KEM-1024  nistkat-sha256
+check_nistkat: check_nistkat_512 check_nistkat_768 check_nistkat_1024
 
-check_func: build_func
+check_func_512: build_func_512
 	$(MLKEM512_DIR)/bin/test_mlkem512
+check_func_768: build_func_768
 	$(MLKEM768_DIR)/bin/test_mlkem768
+check_func_1024: build_func_1024
 	$(MLKEM1024_DIR)/bin/test_mlkem1024
+check_func: check_func_512 check_func_768 check_func_1024
 
 check_acvp: build_acvp
 	python3 ./test/acvp_client.py
 
-lib: $(BUILD_DIR)/libmlkem.a
+build_func_512:  $(MLKEM512_DIR)/bin/test_mlkem512
+build_func_768:  $(MLKEM768_DIR)/bin/test_mlkem768
+build_func_1024: $(MLKEM1024_DIR)/bin/test_mlkem1024
+build_func: build_func_512 build_func_768 build_func_1024
 
-build_func: \
-  $(MLKEM512_DIR)/bin/test_mlkem512 \
-  $(MLKEM768_DIR)/bin/test_mlkem768 \
-  $(MLKEM1024_DIR)/bin/test_mlkem1024
+build_nistkat_512: $(MLKEM512_DIR)/bin/gen_NISTKAT512
+build_nistkat_768: $(MLKEM768_DIR)/bin/gen_NISTKAT768
+build_nistkat_1024: $(MLKEM1024_DIR)/bin/gen_NISTKAT1024
+build_nistkat: build_nistkat_512 build_nistkat_768 build_nistkat_1024
+
+build_kat_512: $(MLKEM512_DIR)/bin/gen_KAT512
+build_kat_768: $(MLKEM768_DIR)/bin/gen_KAT768
+build_kat_1024: $(MLKEM1024_DIR)/bin/gen_KAT1024
+build_kat: build_kat_512 build_kat_768 build_kat_1024
+
+build_acvp_512:  $(MLKEM512_DIR)/bin/acvp_mlkem512
+build_acvp_768:  $(MLKEM768_DIR)/bin/acvp_mlkem768
+build_acvp_1024: $(MLKEM1024_DIR)/bin/acvp_mlkem1024
+build_acvp: build_acvp_512 build_acvp_768 build_acvp_1024
+
+lib: $(BUILD_DIR)/libmlkem.a
 
 # Enforce setting CYCLES make variable when
 # building benchmarking binaries
@@ -58,25 +82,10 @@ bench: check-defined-CYCLES \
 	$(MLKEM768_DIR)/bin/bench_mlkem768 \
 	$(MLKEM1024_DIR)/bin/bench_mlkem1024
 
-build_acvp: \
-	$(MLKEM512_DIR)/bin/acvp_mlkem512 \
-	$(MLKEM768_DIR)/bin/acvp_mlkem768 \
-	$(MLKEM1024_DIR)/bin/acvp_mlkem1024
-
 bench_components: check-defined-CYCLES \
 	$(MLKEM512_DIR)/bin/bench_components_mlkem512 \
 	$(MLKEM768_DIR)/bin/bench_components_mlkem768 \
 	$(MLKEM1024_DIR)/bin/bench_components_mlkem1024
-
-build_nistkat: \
-	$(MLKEM512_DIR)/bin/gen_NISTKAT512 \
-	$(MLKEM768_DIR)/bin/gen_NISTKAT768 \
-	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024
-
-build_kat: \
-	$(MLKEM512_DIR)/bin/gen_KAT512 \
-	$(MLKEM768_DIR)/bin/gen_KAT768 \
-	$(MLKEM1024_DIR)/bin/gen_KAT1024
 
 clean:
 	-$(RM) -rf *.gcno *.gcda *.lcov *.o *.so

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -34,20 +34,6 @@ class CompileOptions(object):
         return "Cross" if self.cross_prefix else "Native"
 
 
-class Options(object):
-    def __init__(self):
-        self.cross_prefix = ""
-        self.cflags = ""
-        self.auto = True
-        self.verbose = False
-        self.opt = "ALL"
-        self.compile = True
-        self.run = True
-        self.exec_wrapper = ""
-        self.run_as_root = ""
-        self.k = "ALL"
-
-
 class Base:
 
     def __init__(self, test_type: TEST_TYPES, copts: CompileOptions, opt):

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -124,7 +124,6 @@ class Base:
         scheme,
         check_proc=None,
         cmd_prefix=None,
-        extra_args=None,
     ):
         """Run the binary in all different ways
 
@@ -134,12 +133,9 @@ class Base:
         - check_proc: Callable to process and check the raw byte-output
             of the test run with.
         - cmd_prefix: Command prefix; array of strings, or None
-        - extra_args: Extra arguments; array of strings, or None
         """
         if cmd_prefix is None:
             cmd_prefix = []
-        if extra_args is None:
-            extra_args = []
 
         log = logger(self.test_type, scheme, self.cross_prefix, self.opt, self.i)
         self.i += 1
@@ -149,7 +145,7 @@ class Base:
             log.error(f"{bin} does not exists")
             sys.exit(1)
 
-        cmd = cmd_prefix + [f"{bin}"] + extra_args
+        cmd = cmd_prefix + [f"{bin}"]
 
         log.debug(" ".join(cmd))
 
@@ -206,7 +202,6 @@ class Test_Implementations:
         scheme,
         check_proc=None,
         cmd_prefix=None,
-        extra_args=None,
     ):
         """Arguments:
 
@@ -215,37 +210,29 @@ class Test_Implementations:
         - check_proc: Callable to process and check the
             raw byte-output of the test run with.
         - cmd_prefix: Command prefix; array of strings, or None
-        - extra_args: Extra arguments; array of strings, or None
         """
         if cmd_prefix is None:
             cmd_prefix = []
-        if extra_args is None:
-            extra_args = []
 
         # Returns TypedDict
         k = "opt" if opt else "no_opt"
 
         results = {}
         results[k] = {}
-        results[k][scheme] = self.ts[k].run_scheme(
-            scheme, check_proc, cmd_prefix, extra_args
-        )
+        results[k][scheme] = self.ts[k].run_scheme(scheme, check_proc, cmd_prefix)
 
         return results
 
-    def run_schemes(self, opt, check_proc=None, cmd_prefix=None, extra_args=None):
+    def run_schemes(self, opt, check_proc=None, cmd_prefix=None):
         """Arguments:
 
         - opt: Whether native backends should be enabled
         - check_proc: Functionto process and check the raw byte-output
                       of the test run with.
         - cmd_prefix: Command prefix; array of strings
-        - extra_args: Extra arguments; array of strings
         """
         if cmd_prefix is None:
             cmd_prefix = []
-        if extra_args is None:
-            extra_args = []
 
         # Returns
         results = {}
@@ -261,7 +248,6 @@ class Test_Implementations:
                 scheme,
                 check_proc,
                 cmd_prefix,
-                extra_args,
             )
 
             results[k][scheme] = result

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -102,17 +102,17 @@ class TEST_TYPES(IntEnum):
 
     def make_target(self):
         if self == TEST_TYPES.MLKEM:
-            return "mlkem"
+            return "build_func"
         if self == TEST_TYPES.BENCH:
             return "bench"
         if self == TEST_TYPES.BENCH_COMPONENTS:
             return "bench_components"
         if self == TEST_TYPES.NISTKAT:
-            return "nistkat"
+            return "build_nistkat"
         if self == TEST_TYPES.KAT:
-            return "kat"
+            return "build_kat"
         if self == TEST_TYPES.ACVP:
-            return "acvp"
+            return "build_acvp"
 
     def bin_path(self, scheme):
         return path(

--- a/scripts/tests
+++ b/scripts/tests
@@ -210,19 +210,17 @@ def cli():
     )
 
     args = main_parser.parse_args()
+    if not hasattr(args, "mac_taskpolicy"):
+        args.mac_taskpolicy = None
 
     if args.cmd == "all":
-        Tests(args).all(args.func, args.kat, args.nistkat, args.acvp)
+        Tests(args).all()
     elif args.cmd == "acvp":
-        Tests(args).acvp(args.acvp_dir)
+        Tests(args).acvp()
     elif args.cmd == "bench":
-        if not hasattr(args, "mac_taskpolicy"):
-            args.mac_taskpolicy = None
-        Tests(args).bench(
-            args.cycles, args.output, args.mac_taskpolicy, args.components
-        )
+        Tests(args).bench()
     elif args.cmd == "cbmc":
-        Tests(args).cbmc(args.k)
+        Tests(args).cbmc()
     elif args.cmd == "func":
         Tests(args).func()
     elif args.cmd == "kat":


### PR DESCRIPTION
* Based on: #599 

The `tests` script previously stored aspects of the command line
arguments in various places. For example, aspects pertaining
to compilation would be stored in a `CompileOptions` class, and other
aspects, such as the `auto` or `opt` settings, would be copied in the
respective test class.

This commit simplifies the `tests` script by directly working with the
command line parameters as returned by `argparse`. To access derived data,
static functions in a newly introduced helper class `Args` are used.
