### PR TITLE
Makefile: Don't include HAL into libmlkem.a when building benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 all: quickcheck
 
 include mk/config.mk
--include mk/$(MAKECMDGOALS).mk
 include mk/crypto.mk
 include mk/schemes.mk
 include mk/rules.mk

--- a/mk/bench.mk
+++ b/mk/bench.mk
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-CFLAGS += -Itest/hal
-SOURCES += $(wildcard test/hal/*.c)

--- a/mk/bench_components.mk
+++ b/mk/bench_components.mk
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-include mk/bench.mk

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -39,6 +39,20 @@ $(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(BUILD
 $(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(BUILD_DIR)/lib$(1).a
 endef
 
+$(MLKEM512_DIR)/bin/bench_mlkem512: CFLAGS += -Itest/hal
+$(MLKEM768_DIR)/bin/bench_mlkem768: CFLAGS += -Itest/hal
+$(MLKEM1024_DIR)/bin/bench_mlkem1024: CFLAGS += -Itest/hal
+$(MLKEM512_DIR)/bin/bench_components_mlkem512: CFLAGS += -Itest/hal
+$(MLKEM768_DIR)/bin/bench_components_mlkem768: CFLAGS += -Itest/hal
+$(MLKEM1024_DIR)/bin/bench_components_mlkem1024: CFLAGS += -Itest/hal
+
+$(MLKEM512_DIR)/bin/bench_mlkem512: $(MLKEM512_DIR)/test/hal/hal.c.o
+$(MLKEM768_DIR)/bin/bench_mlkem768: $(MLKEM768_DIR)/test/hal/hal.c.o
+$(MLKEM1024_DIR)/bin/bench_mlkem1024: $(MLKEM1024_DIR)/test/hal/hal.c.o
+$(MLKEM512_DIR)/bin/bench_components_mlkem512: $(MLKEM512_DIR)/test/hal/hal.c.o
+$(MLKEM768_DIR)/bin/bench_components_mlkem768: $(MLKEM768_DIR)/test/hal/hal.c.o
+$(MLKEM1024_DIR)/bin/bench_components_mlkem1024: $(MLKEM1024_DIR)/test/hal/hal.c.o
+
 $(MLKEM512_DIR)/bin/%: CFLAGS += -DMLKEM_K=2
 $(MLKEM768_DIR)/bin/%: CFLAGS += -DMLKEM_K=3
 $(MLKEM1024_DIR)/bin/%: CFLAGS += -DMLKEM_K=4


### PR DESCRIPTION
Previously, `make bench` or `make bench_components` would add hal.c to SOURCES, which would make it part of the libmlkemXXX.a libraries. That should not be so, and the HAL implementation instead be compiled alongside the benchmarking source. This commit changes the Makefiles accordingly.

* Fixes #601 
* Fixes #515 