### PR TITLE
Make `tests` a shallow wrapper around `make`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,38 +11,50 @@ To build **mlkem-native**, you need `make` and a C90 compiler. To use the test s
 You can build and test **mlkem-native** as follows:
 
 ```bash
-make quickcheck       # With native code backend (if available)
-make OPT=0 quickcheck # With C backend
+make test       # With native code backend (if available)
+make OPT=0 test # With C backend
 ```
 
-To merely build test and benchmarking components, use the following `make` targets:
+To merely build test components, use the following `make` targets:
 
 ```bash
-make mlkem
+make func
 make nistkat
 make kat
+make acvp
 ```
 
-For benchmarking, specify the cycle counting method. Currently, **mlkem-native** is supporting PERF, PMU (AArch64 and x86 only), M1 (Apple Silicon only):
+To run them, add `run_`:
+
+```bash
+make run_func
+make run_nistkat
+make run_kat
+make run_acvp
+```
+
+The resulting binaries can be found in `test/build` (their full path is printed by `make`).
+
+For benchmarking, specify the cycle counting method. Currently, **mlkem-native** is supporting PERF, PMU (AArch64 and
+x86 only), M1 (Apple Silicon only):
+
 ```
 # CYCLES has to be on of PERF, PMU, M1, NO
-make bench CYCLES=PERF
-make bench_components CYCLES=PERF
+make run_bench CYCLES=PERF
+make run_bench_components CYCLES=PERF
 ```
-
-The resulting binaries can then be found in `test/build`.
 
 ### Using `tests` script
 
-We recommend compiling and running tests and benchmarks using the [`./scripts/tests`](scripts/tests) script. For
+For convenience, you can also use the [`./scripts/tests`](scripts/tests) script as a wrapper around `make`. For
 example,
 
 ```bash
 ./scripts/tests func
 ```
 
-will compile and run functionality tests. For detailed information on how to use the script, please refer to the
-`--help` option.
+will compile and run functionality tests. For detailed information on how to use the script, please refer to
+`./scripts/tests --help`.
 
 ### Windows
 
@@ -59,7 +71,7 @@ There are further scripts used for development of mlkem-native, such as `format`
 
 ### nix setup
 
-We specify the development environment for mlkem-native using nix. If you want to help develop mlkem-native, please setup nix using the [nix installer script](https://nixos.org/download/), not your package manager. 
+We specify the development environment for mlkem-native using nix. If you want to help develop mlkem-native, please setup nix using the [nix installer script](https://nixos.org/download/), not your package manager.
 
 All the development and build dependencies are specified in [flake.nix](flake.nix). To execute a bash shell, run
 ```bash
@@ -67,3 +79,7 @@ nix develop --experimental-features 'nix-command flakes'
 ```
 
 To confirm that everything worked, try `lint` or `tests cbmc`.
+
+# Checking the proofs
+
+To check the CBMC proofs, enter the `nix` development environment and use `tests cbmc`.

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@
 	run_bench_512 run_bench_768 run_bench_1024 run_bench \
 	bench_components_512 bench_components_768 bench_components_1024 bench_components \
 	run_bench_components_512 run_bench_components_768 run_bench_components_1024 run_bench_components \
-	buildall checkall all \
+	build test all \
 	clean quickcheck check-defined-CYCLES
 
-.DEFAULT_GOAL := buildall
-all: quickcheck
+.DEFAULT_GOAL := build
+all: build
 
 W := $(EXEC_WRAPPER)
 
@@ -24,12 +24,12 @@ include mk/config.mk
 include mk/components.mk
 include mk/rules.mk
 
-quickcheck: checkall
+quickcheck: test
 
-buildall: func nistkat kat acvp
+build: func nistkat kat acvp
 	$(Q)echo "  Everything builds fine!"
 
-checkall: run_kat run_nistkat run_func run_acvp
+test: run_kat run_nistkat run_func run_acvp
 	$(Q)echo "  Everything checks fine!"
 
 run_kat_512: kat_512

--- a/Makefile
+++ b/Makefile
@@ -60,23 +60,35 @@ run_acvp: acvp
 	python3 ./test/acvp_client.py
 
 func_512:  $(MLKEM512_DIR)/bin/test_mlkem512
+	$(Q)echo "  FUNC       ML-MEM-512:   $^"
 func_768:  $(MLKEM768_DIR)/bin/test_mlkem768
+	$(Q)echo "  FUNC       ML-MEM-768:   $^"
 func_1024: $(MLKEM1024_DIR)/bin/test_mlkem1024
+	$(Q)echo "  FUNC       ML-MEM-1024:  $^"
 func: func_512 func_768 func_1024
 
 nistkat_512: $(MLKEM512_DIR)/bin/gen_NISTKAT512
+	$(Q)echo "  NISTKAT    ML-MEM-512:   $^"
 nistkat_768: $(MLKEM768_DIR)/bin/gen_NISTKAT768
+	$(Q)echo "  NISTKAT    ML-MEM-768:   $^"
 nistkat_1024: $(MLKEM1024_DIR)/bin/gen_NISTKAT1024
+	$(Q)echo "  NISTKAT    ML-MEM-1024:  $^"
 nistkat: nistkat_512 nistkat_768 nistkat_1024
 
 kat_512: $(MLKEM512_DIR)/bin/gen_KAT512
+	$(Q)echo "  KAT        ML-MEM-512:   $^"
 kat_768: $(MLKEM768_DIR)/bin/gen_KAT768
+	$(Q)echo "  KAT        ML-MEM-768:   $^"
 kat_1024: $(MLKEM1024_DIR)/bin/gen_KAT1024
+	$(Q)echo "  KAT        ML-MEM-1024:  $^"
 kat: kat_512 kat_768 kat_1024
 
 acvp_512:  $(MLKEM512_DIR)/bin/acvp_mlkem512
+	$(Q)echo "  ACVP       ML-MEM-512:   $^"
 acvp_768:  $(MLKEM768_DIR)/bin/acvp_mlkem768
+	$(Q)echo "  ACVP       ML-MEM-768:   $^"
 acvp_1024: $(MLKEM1024_DIR)/bin/acvp_mlkem1024
+	$(Q)echo "  ACVP       ML-MEM-1024:  $^"
 acvp: acvp_512 acvp_768 acvp_1024
 
 lib: $(BUILD_DIR)/libmlkem.a

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ sudo apt-get install make gcc python3 git
 git clone https://github.com/pq-code-package/mlkem-native.git
 cd mlkem-native
 
-# Build and run base tests
-make quickcheck
+# Build and run tests
+make build
+make test
 
-# Build and run all tests
+# The same using `tests`, a convenience wrapper around `make`
 ./scripts/tests all
+# Show all options
+./scripts/tests --help
 ```
 
 See [BUILDING.md](BUILDING.md) for more information.

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -2,17 +2,17 @@
 $(BUILD_DIR)/mlkem512/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(Q)$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/mlkem768/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(Q)$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/mlkem1024/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+	$(Q)$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
 
 $(BUILD_DIR)/%.a: $(CONFIG)
 	$(Q)echo "  AR      $@"
@@ -44,7 +44,6 @@ endif
 
 $(BUILD_DIR)/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"
-	$(Q)echo "  $(CC) -c -o $@ $(CFLAGS) $<"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -60,7 +60,6 @@ class Base:
         self.test_type = test_type
         self.opt = opt
         self.opt_label = "opt" if self.opt else "no_opt"
-        self.i = 0
 
     def compile_schemes(
         self,
@@ -123,8 +122,7 @@ class Base:
         - suppress_output: Indicate whether to suppress or print-and-return the output
         """
 
-        log = logger(self.test_type, scheme, self.args.cross_prefix, self.opt, self.i)
-        self.i += 1
+        log = logger(self.test_type, scheme, self.args.cross_prefix, self.opt)
 
         args = ["make", self.test_type.make_run_target(scheme)]
 

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -262,8 +262,7 @@ class Tests:
         config_logger(self.args.verbose)
 
         def _func(opt):
-            if self.args.compile:
-                self._func.compile(opt)
+            self._func.compile(opt)
             if self.args.run:
                 return self._func.run_schemes(opt)
 
@@ -280,8 +279,7 @@ class Tests:
         config_logger(self.args.verbose)
 
         def _nistkat(opt):
-            if self.args.compile:
-                self._nistkat.compile(opt)
+            self._nistkat.compile(opt)
             if self.args.run:
                 return self._nistkat.run_schemes(opt)
 
@@ -298,8 +296,7 @@ class Tests:
         config_logger(self.args.verbose)
 
         def _kat(opt):
-            if self.args.compile:
-                self._kat.compile(opt)
+            self._kat.compile(opt)
             if self.args.run:
                 return self._kat.run_schemes(opt)
 
@@ -317,8 +314,7 @@ class Tests:
         config_logger(self.args.verbose)
 
         def _acvp(opt):
-            if self.args.compile:
-                self._acvp.compile(opt)
+            self._acvp.compile(opt)
             if self.args.run:
                 return self._acvp.run_scheme(opt, None)
 
@@ -354,20 +350,17 @@ class Tests:
 
         # NOTE: We haven't yet decided how to output both opt/no-opt benchmark results
         if Args.do_opt_all(self.args):
-            if self.args.compile:
-                t.compile(False, extra_make_args=[f"CYCLES={cycles}"])
+            t.compile(False, extra_make_args=[f"CYCLES={cycles}"])
             if self.args.run:
                 self._run_bench(t, False)
-            if self.args.compile:
-                t.compile(True, extra_make_args=[f"CYCLES={cycles}"])
+            t.compile(True, extra_make_args=[f"CYCLES={cycles}"])
             if self.args.run:
                 resultss = self._run_bench(t, True)
         else:
-            if self.args.compile:
-                t.compile(
-                    Args.do_opt(self.args),
-                    extra_make_args=[f"CYCLES={cycles}"],
-                )
+            t.compile(
+                Args.do_opt(self.args),
+                extra_make_args=[f"CYCLES={cycles}"],
+            )
             if self.args.run:
                 resultss = self._run_bench(
                     t,
@@ -418,21 +411,20 @@ class Tests:
 
         def all(opt):
             code = 0
-            if self.args.compile:
-                compiles = [
-                    *([self._func.compile] if func else []),
-                    *([self._nistkat.compile] if nistkat else []),
-                    *([self._kat.compile] if kat else []),
-                    *([self._acvp.compile] if acvp else []),
-                ]
+            compiles = [
+                *([self._func.compile] if func else []),
+                *([self._nistkat.compile] if nistkat else []),
+                *([self._kat.compile] if kat else []),
+                *([self._acvp.compile] if acvp else []),
+            ]
 
-                for f in compiles:
-                    try:
-                        f(opt)
-                    except SystemExit as e:
-                        code = code or e
+            for f in compiles:
+                try:
+                    f(opt)
+                except SystemExit as e:
+                    code = code or e
 
-                    sys.stdout.flush()
+                sys.stdout.flush()
 
             if self.args.run:
                 runs = [

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -10,12 +10,11 @@ from .util import (
     SCHEME,
     config_logger,
     github_summary,
+    github_log,
     logger,
     dict2str,
 )
 import json
-
-gh_env = os.environ.get("GITHUB_ENV")
 
 
 class Args:
@@ -67,10 +66,9 @@ class Base:
     def compile_schemes(self):
         """compile or cross compile with some extra environment variables and makefile arguments"""
 
-        if gh_env is not None:
-            print(
-                f"::group::compile {Args.compile_mode(self.args)} {self.opt_label} {self.test_type.desc()}"
-            )
+        github_log(
+            f"::group::compile {Args.compile_mode(self.args)} {self.opt_label} {self.test_type.desc()}"
+        )
 
         log = logger(self.test_type, "Compile", self.args.cross_prefix, self.opt)
 
@@ -101,8 +99,7 @@ class Base:
         if p.returncode != 0:
             log.error(f"make failed: {p.returncode}")
 
-        if gh_env is not None:
-            print(f"::endgroup::")
+        github_log("::endgroup::")
 
         if p.returncode != 0:
             sys.exit(1)
@@ -206,10 +203,9 @@ class Test_Implementations:
 
         k = "opt" if opt else "no_opt"
 
-        if gh_env is not None:
-            print(
-                f"::group::run {Args.compile_mode(self.args)} {k} {self.test_type.desc()}"
-            )
+        github_log(
+            f"::group::run {Args.compile_mode(self.args)} {k} {self.test_type.desc()}"
+        )
 
         results[k] = {}
         for scheme in SCHEME:
@@ -225,8 +221,7 @@ class Test_Implementations:
         )
         github_summary(title, self.test_type.desc(), results[k])
 
-        if gh_env is not None:
-            print(f"::endgroup::")
+        github_log("::endgroup::")
 
         ## TODO What is happening here?
         if suppress_output is True:

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -277,34 +277,33 @@ class Tests:
 
         # NOTE: There will only be one items in resultss, as we haven't yet decided how to write both opt/no-opt benchmark results
         for k, results in resultss.items():
-            if results is not None and output is not None and components is False:
-                import json
+            if not (results is not None and output is not None and components is False):
+                continue
 
-                with open(output, "w") as f:
-                    v = []
-                    for scheme in results:
-                        schemeStr = str(scheme)
-                        r = results[scheme]
+            v = []
+            for scheme in results:
+                schemeStr = str(scheme)
+                r = results[scheme]
 
-                        # The first 3 lines of the output are expected to be
-                        # keypair cycles=X
-                        # encaps cycles=X
-                        # decaps cycles=X
+                # The first 3 lines of the output are expected to be
+                # keypair cycles=X
+                # encaps cycles=X
+                # decaps cycles=X
 
-                        lines = [line for line in r.splitlines() if "=" in line]
+                lines = [line for line in r.splitlines() if "=" in line]
 
-                        d = {
-                            k.strip(): int(v) for k, v in (l.split("=") for l in lines)
+                d = {k.strip(): int(v) for k, v in (l.split("=") for l in lines)}
+                for primitive in ["keypair", "encaps", "decaps"]:
+                    v.append(
+                        {
+                            "name": f"{schemeStr} {primitive}",
+                            "unit": "cycles",
+                            "value": d[f"{primitive} cycles"],
                         }
-                        for primitive in ["keypair", "encaps", "decaps"]:
-                            v.append(
-                                {
-                                    "name": f"{schemeStr} {primitive}",
-                                    "unit": "cycles",
-                                    "value": d[f"{primitive} cycles"],
-                                }
-                            )
-                    f.write(json.dumps(v))
+                    )
+
+            with open(output, "w") as f:
+                f.write(json.dumps(v))
 
     def all(self):
         func = self.args.func

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -34,7 +34,7 @@ class Tests:
         return res
 
     def make_j(self):
-        if self.args.j is None:
+        if self.args.j is None or int(self.args.j) == 1:
             return []
         return [f"-j{self.args.j}"]
 
@@ -115,7 +115,9 @@ class Tests:
 
         log = logger(test_type, scheme_str, self.args.cross_prefix, opt)
 
-        args = ["make", test_type.make_run_target(scheme)] + self.make_j()
+        args = ["make", test_type.make_run_target(scheme)]
+        if test_type.is_benchmark() is False:
+            args += self.make_j()
 
         env_update = {}
         if len(self.cmd_prefix()) > 0:

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -242,6 +242,7 @@ Underlying functional tests
 
 class Tests:
     def __init__(self, args):
+        config_logger(args.verbose)
         self.args = args
 
         self._func = Test_Implementations(TEST_TYPES.MLKEM, args)
@@ -252,8 +253,6 @@ class Tests:
         self._bench_components = Test_Implementations(TEST_TYPES.BENCH_COMPONENTS, args)
 
     def func(self):
-        config_logger(self.args.verbose)
-
         def _func(opt):
             self._func.compile(opt)
             if self.args.run:
@@ -269,8 +268,6 @@ class Tests:
             exit(1)
 
     def nistkat(self):
-        config_logger(self.args.verbose)
-
         def _nistkat(opt):
             self._nistkat.compile(opt)
             if self.args.run:
@@ -286,8 +283,6 @@ class Tests:
             exit(1)
 
     def kat(self):
-        config_logger(self.args.verbose)
-
         def _kat(opt):
             self._kat.compile(opt)
             if self.args.run:
@@ -304,8 +299,6 @@ class Tests:
             exit(1)
 
     def acvp(self):
-        config_logger(self.args.verbose)
-
         def _acvp(opt):
             self._acvp.compile(opt)
             if self.args.run:
@@ -332,8 +325,6 @@ class Tests:
         cycles = self.args.cycles
         output = self.args.output
         components = self.args.components
-
-        config_logger(self.args.verbose)
 
         if components is False:
             t = self._bench
@@ -399,10 +390,9 @@ class Tests:
         nistkat = self.args.nistkat
         acvp = self.args.acvp
 
-        config_logger(self.args.verbose)
-
         def all(opt):
             code = 0
+
             compiles = [
                 *([self._func.compile] if func else []),
                 *([self._nistkat.compile] if nistkat else []),
@@ -445,8 +435,6 @@ class Tests:
         exit(exit_code)
 
     def cbmc(self):
-        config_logger(self.args.verbose)
-
         def run_cbmc(mlkem_k):
             envvars = {"MLKEM_K": mlkem_k}
             p = subprocess.Popen(

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -65,12 +65,9 @@ class Base:
 
     def compile_schemes(
         self,
-        extra_make_envs=None,
         extra_make_args=None,
     ):
         """compile or cross compile with some extra environment variables and makefile arguments"""
-        if extra_make_envs is None:
-            extra_make_envs = {}
         if extra_make_args is None:
             extra_make_args = []
 
@@ -102,9 +99,7 @@ class Base:
         if self.args.cflags is not None:
             env["CFLAGS"] = self.args.cflags
 
-        env.update(extra_make_envs)
-
-        log.info(dict2str(extra_make_envs) + " ".join(args))
+        log.info(" ".join(args))
 
         p = subprocess.run(
             args,
@@ -186,11 +181,9 @@ class Test_Implementations:
     def compile(
         self,
         opt,
-        extra_make_envs=None,
         extra_make_args=None,
     ):
         self.ts["opt" if opt else "no_opt"].compile_schemes(
-            extra_make_envs,
             extra_make_args,
         )
 

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -148,9 +148,11 @@ class Tests:
             log.error(f"'{cmd_str}' failed with with {p.returncode}")
             log.error(p.stderr.decode())
             self.fail(f"{test_type.desc()} ({opt_label}, {scheme_str})")
+            return True  # Failure
         elif suppress_output is True:
             if self.args.verbose is True:
                 log.info(p.stdout.decode())
+            return False  # No failure
         else:
             result = p.stdout.decode()
             log.info(result)
@@ -185,8 +187,8 @@ class Tests:
 
         github_log("::endgroup::")
 
-        ## TODO What is happening here?
         if suppress_output is True:
+            # In this case, we only gather success/failure booleans
             return reduce(
                 lambda acc, c: acc or c,
                 [r for rs in results.values() for r in rs.values()],
@@ -199,7 +201,7 @@ class Tests:
         def _func(opt):
             self._compile_schemes(TEST_TYPES.FUNC, opt)
             if self.args.run:
-                return self._run_schemes(TEST_TYPES.FUNC, opt)
+                self._run_schemes(TEST_TYPES.FUNC, opt)
 
         if self.do_no_opt():
             _func(False)
@@ -212,7 +214,7 @@ class Tests:
         def _nistkat(opt):
             self._compile_schemes(TEST_TYPES.NISTKAT, opt)
             if self.args.run:
-                return self._run_schemes(TEST_TYPES.NISTKAT, opt)
+                self._run_schemes(TEST_TYPES.NISTKAT, opt)
 
         if self.do_no_opt():
             _nistkat(False)
@@ -225,7 +227,7 @@ class Tests:
         def _kat(opt):
             self._compile_schemes(TEST_TYPES.KAT, opt)
             if self.args.run:
-                return self._run_schemes(TEST_TYPES.KAT, opt)
+                self._run_schemes(TEST_TYPES.KAT, opt)
 
         if self.do_no_opt():
             _kat(False)
@@ -238,7 +240,7 @@ class Tests:
         def _acvp(opt):
             self._compile_schemes(TEST_TYPES.ACVP, opt)
             if self.args.run:
-                return self._run_scheme(TEST_TYPES.ACVP, opt, None)
+                self._run_scheme(TEST_TYPES.ACVP, opt, None)
 
         if self.do_no_opt():
             _acvp(False)

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -1,14 +1,11 @@
 # Copyright (c) 2024 The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0
 
-import platform
 import os
 import sys
-import io
-import logging
 import subprocess
-from functools import reduce, partial
-from util import (
+from functools import reduce
+from .util import (
     TEST_TYPES,
     SCHEME,
     config_logger,

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -197,9 +197,9 @@ class Tests:
 
     def func(self):
         def _func(opt):
-            self._compile_schemes(TEST_TYPES.MLKEM, opt)
+            self._compile_schemes(TEST_TYPES.FUNC, opt)
             if self.args.run:
-                return self._run_schemes(TEST_TYPES.MLKEM, opt)
+                return self._run_schemes(TEST_TYPES.FUNC, opt)
 
         if self.do_no_opt():
             _func(False)
@@ -313,7 +313,7 @@ class Tests:
 
         def _all(opt):
             if func is True:
-                self._compile_schemes(TEST_TYPES.MLKEM, opt)
+                self._compile_schemes(TEST_TYPES.FUNC, opt)
             if kat is True:
                 self._compile_schemes(TEST_TYPES.KAT, opt)
             if nistkat is True:
@@ -325,7 +325,7 @@ class Tests:
                 return
 
             if func is True:
-                self._run_schemes(TEST_TYPES.MLKEM, opt)
+                self._run_schemes(TEST_TYPES.FUNC, opt)
             if kat is True:
                 self._run_schemes(TEST_TYPES.KAT, opt)
             if nistkat is True:

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -112,7 +112,7 @@ class Base:
     def run_scheme(
         self,
         scheme,
-        suppress_output=False,
+        suppress_output=True,
     ):
         """Run the binary in all different ways
 
@@ -183,7 +183,7 @@ class Test_Implementations:
         self,
         opt,
         scheme,
-        suppress_output=False,
+        suppress_output=True,
     ):
         """Arguments:
 
@@ -200,7 +200,7 @@ class Test_Implementations:
 
         return results
 
-    def run_schemes(self, opt, suppress_output=False):
+    def run_schemes(self, opt, suppress_output=True):
         """Arguments:
 
         - opt: Whether native backends should be enabled
@@ -268,7 +268,7 @@ class Tests:
             if self.args.compile:
                 self._func.compile(opt)
             if self.args.run:
-                return self._func.run_schemes(opt, suppress_output=True)
+                return self._func.run_schemes(opt)
 
         fail = False
         if Args.do_no_opt(self.args):
@@ -286,7 +286,7 @@ class Tests:
             if self.args.compile:
                 self._nistkat.compile(opt)
             if self.args.run:
-                return self._nistkat.run_schemes(opt, suppress_output=True)
+                return self._nistkat.run_schemes(opt)
 
         fail = False
         if Args.do_no_opt(self.args):
@@ -304,7 +304,7 @@ class Tests:
             if self.args.compile:
                 self._kat.compile(opt)
             if self.args.run:
-                return self._kat.run_schemes(opt, suppress_output=True)
+                return self._kat.run_schemes(opt)
 
         fail = False
 
@@ -323,7 +323,7 @@ class Tests:
             if self.args.compile:
                 self._acvp.compile(opt)
             if self.args.run:
-                return self._acvp.run_scheme(opt, None, suppress_output=True)
+                return self._acvp.run_scheme(opt, None)
 
         fail = False
 
@@ -340,7 +340,7 @@ class Tests:
         t,  # Testmplementations
         opt,
     ):
-        return t.run_schemes(opt)
+        return t.run_schemes(opt, suppress_output=False)
 
     def bench(self):
         cycles = self.args.cycles
@@ -439,26 +439,10 @@ class Tests:
 
             if self.args.run:
                 runs = [
-                    *(
-                        [lambda o: self._func.run_schemes(o, suppress_output=True)]
-                        if func
-                        else []
-                    ),
-                    *(
-                        [lambda o: self._nistkat.run_schemes(o, suppress_output=True)]
-                        if nistkat
-                        else []
-                    ),
-                    *(
-                        [lambda o: self._kat.run_schemes(o, suppress_output=True)]
-                        if kat
-                        else []
-                    ),
-                    *(
-                        [lambda o: self._acvp.run_schemes(o, suppress_output=True)]
-                        if acvp
-                        else []
-                    ),
+                    *([self._func.run_schemes] if func else []),
+                    *([self._nistkat.run_schemes] if nistkat else []),
+                    *([self._kat.run_schemes] if kat else []),
+                    *([self._acvp.run_schemes] if acvp else []),
                 ]
 
                 for f in runs:

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -22,28 +22,44 @@ import json
 gh_env = os.environ.get("GITHUB_ENV")
 
 
-class CompileOptions(object):
+class Args:
+    """Helper functions for working with command line parameters"""
 
-    def __init__(self, cross_prefix, cflags, auto, verbose):
-        self.cross_prefix = cross_prefix
-        self.cflags = cflags
-        self.auto = auto
-        self.verbose = verbose
+    @staticmethod
+    def cmd_prefix(args):
+        res = []
+        if args.run_as_root is True:
+            res += ["sudo"]
+        if args.exec_wrapper is not None:
+            res += args.exec_wrapper.split(" ")
+        if args.mac_taskpolicy is not None:
+            res += ["taskpolicy", "-c", f"{mac_taskpolicy}"]
 
-    def compile_mode(self):
-        return "Cross" if self.cross_prefix else "Native"
+        return res
+
+    @staticmethod
+    def do_opt_all(args):
+        return args.opt.lower() == ["all"]
+
+    @staticmethod
+    def do_opt(args):
+        return args.opt.lower() in ["all", "opt"]
+
+    @staticmethod
+    def do_no_opt(args):
+        return args.opt.lower() in ["all", "no_opt"]
+
+    @staticmethod
+    def compile_mode(args):
+        return "Cross" if args.cross_prefix is not None else "Native"
 
 
 class Base:
 
-    def __init__(self, test_type: TEST_TYPES, copts: CompileOptions, opt):
+    def __init__(self, test_type: TEST_TYPES, args, opt):
+        self.args = args
         self.test_type = test_type
-        self.cross_prefix = copts.cross_prefix
-        self.cflags = copts.cflags
-        self.auto = copts.auto
-        self.verbose = copts.verbose
         self.opt = opt
-        self.compile_mode = copts.compile_mode()
         self.opt_label = "opt" if self.opt else "no_opt"
         self.i = 0
 
@@ -60,10 +76,10 @@ class Base:
 
         if gh_env is not None:
             print(
-                f"::group::compile {self.compile_mode} {self.opt_label} {self.test_type.desc()}"
+                f"::group::compile {Args.compile_mode(self.args)} {self.opt_label} {self.test_type.desc()}"
             )
 
-        log = logger(self.test_type, "Compile", self.cross_prefix, self.opt)
+        log = logger(self.test_type, "Compile", self.args.cross_prefix, self.opt)
 
         def dict2str(dict):
             s = ""
@@ -72,19 +88,19 @@ class Base:
             return s
 
         extra_make_args = extra_make_args + list(
-            set([f"OPT={int(self.opt)}", f"AUTO={int(self.auto)}"])
+            set([f"OPT={int(self.opt)}", f"AUTO={int(self.args.auto)}"])
             - set(extra_make_args)
         )
 
         args = [
             "make",
-            f"CROSS_PREFIX={self.cross_prefix}",
+            f"CROSS_PREFIX={self.args.cross_prefix}",
             f"{self.test_type.make_target()}",
         ] + extra_make_args
 
         env = os.environ.copy()
-        if self.cflags is not None:
-            env["CFLAGS"] = self.cflags
+        if self.args.cflags is not None:
+            env["CFLAGS"] = self.args.cflags
 
         env.update(extra_make_envs)
 
@@ -92,7 +108,7 @@ class Base:
 
         p = subprocess.run(
             args,
-            stdout=subprocess.DEVNULL if not self.verbose else None,
+            stdout=subprocess.DEVNULL if not self.args.verbose else None,
             env=env,
         )
 
@@ -109,7 +125,6 @@ class Base:
         self,
         scheme,
         check_proc=None,
-        cmd_prefix=None,
     ):
         """Run the binary in all different ways
 
@@ -118,12 +133,9 @@ class Base:
         - scheme: Scheme to test
         - check_proc: Callable to process and check the raw byte-output
             of the test run with.
-        - cmd_prefix: Command prefix; array of strings, or None
         """
-        if cmd_prefix is None:
-            cmd_prefix = []
 
-        log = logger(self.test_type, scheme, self.cross_prefix, self.opt, self.i)
+        log = logger(self.test_type, scheme, self.args.cross_prefix, self.opt, self.i)
         self.i += 1
 
         bin = self.test_type.bin_path(scheme)
@@ -131,7 +143,7 @@ class Base:
             log.error(f"{bin} does not exists")
             sys.exit(1)
 
-        cmd = cmd_prefix + [f"{bin}"]
+        cmd = Args.cmd_prefix(self.args) + [f"{bin}"]
 
         log.debug(" ".join(cmd))
 
@@ -164,12 +176,12 @@ class Base:
 
 
 class Test_Implementations:
-    def __init__(self, test_type: TEST_TYPES, copts: CompileOptions):
+    def __init__(self, test_type: TEST_TYPES, args):
+        self.args = args
         self.test_type = test_type
-        self.compile_mode = copts.compile_mode()
         self.ts = {}
-        self.ts["opt"] = Base(test_type, copts, True)
-        self.ts["no_opt"] = Base(test_type, copts, False)
+        self.ts["opt"] = Base(test_type, args, True)
+        self.ts["no_opt"] = Base(test_type, args, False)
 
     def compile(
         self,
@@ -187,7 +199,6 @@ class Test_Implementations:
         opt,
         scheme,
         check_proc=None,
-        cmd_prefix=None,
     ):
         """Arguments:
 
@@ -195,30 +206,24 @@ class Test_Implementations:
         - scheme: Scheme to run
         - check_proc: Callable to process and check the
             raw byte-output of the test run with.
-        - cmd_prefix: Command prefix; array of strings, or None
         """
-        if cmd_prefix is None:
-            cmd_prefix = []
 
         # Returns TypedDict
         k = "opt" if opt else "no_opt"
 
         results = {}
         results[k] = {}
-        results[k][scheme] = self.ts[k].run_scheme(scheme, check_proc, cmd_prefix)
+        results[k][scheme] = self.ts[k].run_scheme(scheme, check_proc)
 
         return results
 
-    def run_schemes(self, opt, check_proc=None, cmd_prefix=None):
+    def run_schemes(self, opt, check_proc=None):
         """Arguments:
 
         - opt: Whether native backends should be enabled
         - check_proc: Functionto process and check the raw byte-output
                       of the test run with.
-        - cmd_prefix: Command prefix; array of strings
         """
-        if cmd_prefix is None:
-            cmd_prefix = []
 
         # Returns
         results = {}
@@ -226,19 +231,22 @@ class Test_Implementations:
         k = "opt" if opt else "no_opt"
 
         if gh_env is not None:
-            print(f"::group::run {self.compile_mode} {k} {self.test_type.desc()}")
+            print(
+                f"::group::run {Args.compile_mode(self.args)} {k} {self.test_type.desc()}"
+            )
 
         results[k] = {}
         for scheme in SCHEME:
             result = self.ts[k].run_scheme(
                 scheme,
                 check_proc,
-                cmd_prefix,
             )
 
             results[k][scheme] = result
 
-        title = "## " + (self.compile_mode) + " " + (k.capitalize()) + " Tests"
+        title = (
+            "## " + (Args.compile_mode(self.args)) + " " + (k.capitalize()) + " Tests"
+        )
         github_summary(title, self.test_type.desc(), results[k])
 
         if gh_env is not None:
@@ -262,40 +270,15 @@ Underlying functional tests
 
 
 class Tests:
-    def __init__(self, opts):
-        copts = CompileOptions(
-            opts.cross_prefix,
-            opts.cflags,
-            opts.auto,
-            opts.verbose,
-        )
-        self.opt = opts.opt
+    def __init__(self, args):
+        self.args = args
 
-        self.verbose = opts.verbose
-        self._func = Test_Implementations(TEST_TYPES.MLKEM, copts)
-        self._nistkat = Test_Implementations(TEST_TYPES.NISTKAT, copts)
-        self._kat = Test_Implementations(TEST_TYPES.KAT, copts)
-        self._acvp = Test_Implementations(TEST_TYPES.ACVP, copts)
-        self._bench = Test_Implementations(TEST_TYPES.BENCH, copts)
-        self._bench_components = Test_Implementations(
-            TEST_TYPES.BENCH_COMPONENTS, copts
-        )
-
-        self.compile_mode = copts.compile_mode()
-        self.compile = opts.compile
-        self.run = opts.run
-        self.cmd_prefix = []
-
-        if self.run:
-            if opts.run_as_root:
-                logging.info(
-                    f"Running {bin} as root -- you may need to enter your root password.",
-                )
-                self.cmd_prefix.append("sudo")
-
-            if opts.exec_wrapper:
-                logging.info(f"Running with customized wrapper {opts.exec_wrapper}")
-                self.cmd_prefix = self.cmd_prefix + opts.exec_wrapper.split(" ")
+        self._func = Test_Implementations(TEST_TYPES.MLKEM, args)
+        self._nistkat = Test_Implementations(TEST_TYPES.NISTKAT, args)
+        self._kat = Test_Implementations(TEST_TYPES.KAT, args)
+        self._acvp = Test_Implementations(TEST_TYPES.ACVP, args)
+        self._bench = Test_Implementations(TEST_TYPES.BENCH, args)
+        self._bench_components = Test_Implementations(TEST_TYPES.BENCH_COMPONENTS, args)
 
     def _run_func(self, opt):
         """Underlying function for functional test"""
@@ -323,23 +306,22 @@ class Tests:
         return self._func.run_schemes(
             opt,
             check_proc=expect,
-            cmd_prefix=self.cmd_prefix,
         )
 
     def func(self):
-        config_logger(self.verbose)
+        config_logger(self.args.verbose)
 
         def _func(opt):
 
-            if self.compile:
+            if self.args.compile:
                 self._func.compile(opt)
-            if self.run:
+            if self.args.run:
                 return self._run_func(opt)
 
         fail = False
-        if self.opt.lower() == "all" or self.opt.lower() == "no_opt":
+        if Args.do_no_opt(self.args):
             fail = fail or _func(False)
-        if self.opt.lower() == "all" or self.opt.lower() == "opt":
+        if Args.do_opt(self.args):
             fail = fail or _func(True)
 
         if fail:
@@ -361,22 +343,21 @@ class Tests:
         return self._nistkat.run_schemes(
             opt,
             check_proc=check_proc,
-            cmd_prefix=self.cmd_prefix,
         )
 
     def nistkat(self):
-        config_logger(self.verbose)
+        config_logger(self.args.verbose)
 
         def _nistkat(opt):
-            if self.compile:
+            if self.args.compile:
                 self._nistkat.compile(opt)
-            if self.run:
+            if self.args.run:
                 return self._run_nistkat(opt)
 
         fail = False
-        if self.opt.lower() == "all" or self.opt.lower() == "no_opt":
+        if Args.do_no_opt(self.args):
             fail = fail or _nistkat(False)
-        if self.opt.lower() == "all" or self.opt.lower() == "opt":
+        if Args.do_opt(self.args):
             fail = fail or _nistkat(True)
 
         if fail:
@@ -397,23 +378,22 @@ class Tests:
         return self._kat.run_schemes(
             opt,
             check_proc=check_proc,
-            cmd_prefix=self.cmd_prefix,
         )
 
     def kat(self):
-        config_logger(self.verbose)
+        config_logger(self.args.verbose)
 
         def _kat(opt):
-            if self.compile:
+            if self.args.compile:
                 self._kat.compile(opt)
-            if self.run:
+            if self.args.run:
                 return self._run_kat(opt)
 
         fail = False
 
-        if self.opt.lower() == "all" or self.opt.lower() == "no_opt":
+        if Args.do_no_opt(self.args):
             fail = fail or _kat(False)
-        if self.opt.lower() == "all" or self.opt.lower() == "opt":
+        if Args.do_opt(self.args):
             fail = fail or _kat(True)
 
         if fail:
@@ -422,14 +402,16 @@ class Tests:
     def _run_acvp(self, opt):
 
         opt_label = "opt" if opt else "no_opt"
-        log = logger(TEST_TYPES.ACVP, "Run", self._acvp.ts[opt_label].cross_prefix, opt)
+        log = logger(
+            TEST_TYPES.ACVP, "Run", self._acvp.ts[opt_label].args.cross_prefix, opt
+        )
 
         if gh_env is not None:
             print(
-                f"::group::run {self.compile_mode} {opt_label} {TEST_TYPES.ACVP.desc()}"
+                f"::group::run {Args.compile_mode(self.args)} {opt_label} {TEST_TYPES.ACVP.desc()}"
             )
 
-        env_update = {"EXEC_WRAPPER": " ".join(self.cmd_prefix)}
+        env_update = {"EXEC_WRAPPER": " ".join(Args.cmd_prefix(self.args))}
         env = os.environ.copy()
         env.update(env_update)
 
@@ -463,26 +445,31 @@ class Tests:
 
         for k, result in results.items():
             title = (
-                "## " + (self._acvp.compile_mode) + " " + (k.capitalize()) + " Tests"
+                "## "
+                + (Args.compile_mode(self.args))
+                + " "
+                + (k.capitalize())
+                + " Tests"
             )
             github_summary(title, f"{TEST_TYPES.ACVP.desc()}", result)
 
         return fail
 
-    def acvp(self, acvp_dir):
-        config_logger(self.verbose)
+    def acvp(self):
+        acvp_dir = self.args.acvp_dir
+        config_logger(self.args.verbose)
 
         def _acvp(opt):
-            if self.compile:
+            if self.args.compile:
                 self._acvp.compile(opt)
-            if self.run:
+            if self.args.run:
                 return self._run_acvp(opt)
 
         fail = False
 
-        if self.opt.lower() == "all" or self.opt.lower() == "no_opt":
+        if Args.do_no_opt(self.args):
             fail = fail or _acvp(False)
-        if self.opt.lower() == "all" or self.opt.lower() == "opt":
+        if Args.do_opt(self.args):
             fail = fail or _acvp(True)
 
         if fail:
@@ -493,16 +480,14 @@ class Tests:
         t,  # Testmplementations
         opt,
     ):
-        return t.run_schemes(opt, cmd_prefix=self.cmd_prefix)
+        return t.run_schemes(opt)
 
-    def bench(
-        self,
-        cycles,
-        output,
-        mac_taskpolicy,
-        components,
-    ):
-        config_logger(self.verbose)
+    def bench(self):
+        cycles = self.args.cycles
+        output = self.args.output
+        components = self.args.components
+
+        config_logger(self.args.verbose)
 
         if components is False:
             t = self._bench
@@ -510,29 +495,26 @@ class Tests:
             t = self._bench_components
             output = False
 
-        if mac_taskpolicy:
-            self.cmd_prefix.extend(["taskpolicy", "-c", f"{mac_taskpolicy}"])
-
         # NOTE: We haven't yet decided how to output both opt/no-opt benchmark results
-        if self.opt.lower() == "all":
-            if self.compile:
+        if Args.do_opt_all(self.args):
+            if self.args.compile:
                 t.compile(False, extra_make_args=[f"CYCLES={cycles}"])
-            if self.run:
+            if self.args.run:
                 self._run_bench(t, False)
-            if self.compile:
+            if self.args.compile:
                 t.compile(True, extra_make_args=[f"CYCLES={cycles}"])
-            if self.run:
+            if self.args.run:
                 resultss = self._run_bench(t, True)
         else:
-            if self.compile:
+            if self.args.compile:
                 t.compile(
-                    True if self.opt.lower() == "opt" else False,
+                    Args.do_opt(self.args),
                     extra_make_args=[f"CYCLES={cycles}"],
                 )
-            if self.run:
+            if self.args.run:
                 resultss = self._run_bench(
                     t,
-                    True if self.opt.lower() == "opt" else False,
+                    Args.do_opt(self.args),
                 )
 
         if resultss is None:
@@ -569,12 +551,17 @@ class Tests:
                             )
                     f.write(json.dumps(v))
 
-    def all(self, func, kat, nistkat, acvp):
-        config_logger(self.verbose)
+    def all(self):
+        func = self.args.func
+        kat = self.args.kat
+        nistkat = self.args.nistkat
+        acvp = self.args.acvp
+
+        config_logger(self.args.verbose)
 
         def all(opt):
             code = 0
-            if self.compile:
+            if self.args.compile:
                 compiles = [
                     *([self._func.compile] if func else []),
                     *([self._nistkat.compile] if nistkat else []),
@@ -590,7 +577,7 @@ class Tests:
 
                     sys.stdout.flush()
 
-            if self.run:
+            if self.args.run:
                 runs = [
                     *([self._run_func] if func else []),
                     *([self._run_nistkat] if nistkat else []),
@@ -609,15 +596,15 @@ class Tests:
 
         exit_code = 0
 
-        if self.opt.lower() == "all" or self.opt.lower() == "no_opt":
+        if Args.do_no_opt(self.args):
             exit_code = exit_code or all(False)
-        if self.opt.lower() == "all" or self.opt.lower() == "opt":
+        if Args.do_opt(self.args):
             exit_code = exit_code or all(True)
 
         exit(exit_code)
 
-    def cbmc(self, k):
-        config_logger(self.verbose)
+    def cbmc(self):
+        config_logger(self.args.verbose)
 
         def run_cbmc(mlkem_k):
             envvars = {"MLKEM_K": mlkem_k}
@@ -636,6 +623,7 @@ class Tests:
             p.communicate()
             assert p.returncode == 0
 
+        k = self.args.k
         if k == "ALL":
             run_cbmc("2")
             run_cbmc("3")

--- a/scripts/lib/mlkem_test.py
+++ b/scripts/lib/mlkem_test.py
@@ -314,13 +314,6 @@ class Tests:
         if fail:
             exit(1)
 
-    def _run_bench(
-        self,
-        t,  # Testmplementations
-        opt,
-    ):
-        return t.run_schemes(opt, suppress_output=False)
-
     def bench(self):
         cycles = self.args.cycles
         output = self.args.output
@@ -336,19 +329,16 @@ class Tests:
         if Args.do_opt_all(self.args):
             t.compile(False)
             if self.args.run:
-                self._run_bench(t, False)
+                t.run_schemes(False, suppress_output=False)
             t.compile(True)
             if self.args.run:
-                resultss = self._run_bench(t, True)
+                resultss = t.run_schemes(True, suppress_output=False)
         else:
             t.compile(
                 Args.do_opt(self.args),
             )
             if self.args.run:
-                resultss = self._run_bench(
-                    t,
-                    Args.do_opt(self.args),
-                )
+                resultss = t.run_schemes(Args.do_opt(self.args), suppress_output=False)
 
         if resultss is None:
             exit(0)

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -83,6 +83,12 @@ def dict2str(dict):
     return s
 
 
+def github_log(msg):
+    if os.environ.get("GITHUB_ENV") is None:
+        return
+    print(msg)
+
+
 def github_summary(title, test_label, results):
     """Generate summary for GitHub CI"""
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -3,14 +3,12 @@
 
 import os
 import sys
-import hashlib
 import logging
-from enum import IntEnum
+from enum import Enum
 from functools import reduce
-import json
 
 
-class SCHEME(IntEnum):
+class SCHEME(Enum):
     MLKEM512 = 1
     MLKEM768 = 2
     MLKEM1024 = 3
@@ -23,12 +21,6 @@ class SCHEME(IntEnum):
         if self == SCHEME.MLKEM1024:
             return "ML-KEM-1024"
 
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return self + 1
-
     def suffix(self):
         if self == SCHEME.MLKEM512:
             return "512"
@@ -38,16 +30,13 @@ class SCHEME(IntEnum):
             return "1024"
 
 
-class TEST_TYPES(IntEnum):
+class TEST_TYPES(Enum):
     MLKEM = 1
     BENCH = 2
     NISTKAT = 3
     KAT = 4
     BENCH_COMPONENTS = 5
     ACVP = 6
-
-    def __str__(self):
-        return self.name.lower()
 
     def desc(self):
         if self == TEST_TYPES.MLKEM:

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -31,7 +31,7 @@ class SCHEME(Enum):
 
 
 class TEST_TYPES(Enum):
-    MLKEM = 1
+    FUNC = 1
     BENCH = 2
     NISTKAT = 3
     KAT = 4
@@ -42,7 +42,7 @@ class TEST_TYPES(Enum):
         return self in [TEST_TYPES.BENCH, TEST_TYPES.BENCH_COMPONENTS]
 
     def desc(self):
-        if self == TEST_TYPES.MLKEM:
+        if self == TEST_TYPES.FUNC:
             return "Functional Test"
         if self == TEST_TYPES.BENCH:
             return "Benchmark"
@@ -56,7 +56,7 @@ class TEST_TYPES(Enum):
             return "ACVP Test"
 
     def make_target(self):
-        if self == TEST_TYPES.MLKEM:
+        if self == TEST_TYPES.FUNC:
             return "func"
         if self == TEST_TYPES.BENCH:
             return "bench"

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -9,14 +9,6 @@ from enum import IntEnum
 from functools import reduce
 import json
 
-CWD = os.getcwd()
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-
-
-def path(p):
-    return os.path.relpath(os.path.join(ROOT, p), CWD)
-
-
 class SCHEME(IntEnum):
     MLKEM512 = 1
     MLKEM768 = 2
@@ -43,17 +35,6 @@ class SCHEME(IntEnum):
             return "768"
         if self == SCHEME.MLKEM1024:
             return "1024"
-
-    @classmethod
-    def from_str(cls, s):
-        # Iterate through all enum members to find a match for the given string
-        for m in cls:
-            if str(m) == s:
-                return m
-        raise ValueError(
-            f"'{s}' is not a valid string representation for {cls.__name__}"
-        )
-
 
 class TEST_TYPES(IntEnum):
     MLKEM = 1

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -17,12 +17,6 @@ def path(p):
     return os.path.relpath(os.path.join(ROOT, p), CWD)
 
 
-def sha256sum(result):
-    m = hashlib.sha256()
-    m.update(result)
-    return m.hexdigest()
-
-
 class SCHEME(IntEnum):
     MLKEM512 = 1
     MLKEM768 = 2
@@ -86,20 +80,6 @@ class TEST_TYPES(IntEnum):
         if self == TEST_TYPES.ACVP:
             return "ACVP Test"
 
-    def bin(self):
-        if self == TEST_TYPES.MLKEM:
-            return "test_mlkem"
-        if self == TEST_TYPES.BENCH:
-            return "bench_mlkem"
-        if self == TEST_TYPES.BENCH_COMPONENTS:
-            return "bench_components_mlkem"
-        if self == TEST_TYPES.NISTKAT:
-            return "gen_NISTKAT"
-        if self == TEST_TYPES.KAT:
-            return "gen_KAT"
-        if self == TEST_TYPES.ACVP:
-            return "acvp_mlkem"
-
     def make_target(self):
         if self == TEST_TYPES.MLKEM:
             return "func"
@@ -114,16 +94,15 @@ class TEST_TYPES(IntEnum):
         if self == TEST_TYPES.ACVP:
             return "acvp"
 
-    def bin_path(self, scheme):
-        return path(
-            f"test/build/{scheme.name.lower()}/bin/{self.bin()}{scheme.suffix()}"
-        )
+    def make_run_target(self, scheme):
+        return f"run_{self.make_target()}_{scheme.suffix()}"
 
 
-def parse_meta(scheme, field):
-    with open("META.json", "r") as f:
-        meta = json.load(f)
-    return meta["implementations"][int(scheme) - 1][field]
+def dict2str(dict):
+    s = ""
+    for k, v in dict.items():
+        s += f"{k}={v} "
+    return s
 
 
 def github_summary(title, test_label, results):

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -192,20 +192,15 @@ def config_logger(verbose):
         logger.setLevel(logging.INFO)
 
 
-def logger(test_type, scheme, cross_prefix, opt, i=None):
+def logger(test_type, scheme, cross_prefix, opt):
     """Emit line indicating the processing of the given test"""
     compile_mode = "cross" if cross_prefix else "native"
     implementation = "opt" if opt else "no_opt"
 
     return logging.getLogger(
-        "{:<18} {:<11} ({:<6}, {:>6})".format(
-            (
-                test_type.desc()
-                if (i is None or test_type is not TEST_TYPES.ACVP)
-                else f"{test_type.desc():<15} {i}"
-            ),
+        "{:<18} {:<11} {:<17}".format(
+            (test_type.desc()),
             str(scheme),
-            compile_mode,
-            implementation,
+            "({}, {}):".format(compile_mode, implementation),
         )
     )

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -9,6 +9,7 @@ from enum import IntEnum
 from functools import reduce
 import json
 
+
 class SCHEME(IntEnum):
     MLKEM512 = 1
     MLKEM768 = 2
@@ -35,6 +36,7 @@ class SCHEME(IntEnum):
             return "768"
         if self == SCHEME.MLKEM1024:
             return "1024"
+
 
 class TEST_TYPES(IntEnum):
     MLKEM = 1
@@ -76,7 +78,10 @@ class TEST_TYPES(IntEnum):
             return "acvp"
 
     def make_run_target(self, scheme):
-        return f"run_{self.make_target()}_{scheme.suffix()}"
+        if scheme is not None:
+            return f"run_{self.make_target()}_{scheme.suffix()}"
+        else:
+            return f"run_{self.make_target()}"
 
 
 def dict2str(dict):

--- a/scripts/lib/util.py
+++ b/scripts/lib/util.py
@@ -38,6 +38,9 @@ class TEST_TYPES(Enum):
     BENCH_COMPONENTS = 5
     ACVP = 6
 
+    def is_benchmark(self):
+        return self in [TEST_TYPES.BENCH, TEST_TYPES.BENCH_COMPONENTS]
+
     def desc(self):
         if self == TEST_TYPES.MLKEM:
             return "Functional Test"

--- a/scripts/tests
+++ b/scripts/tests
@@ -210,19 +210,17 @@ def cli():
     )
 
     args = main_parser.parse_args()
+    if not hasattr(args, "mac_taskpolicy"):
+        args.mac_taskpolicy = None
 
     if args.cmd == "all":
-        Tests(args).all(args.func, args.kat, args.nistkat, args.acvp)
+        Tests(args).all()
     elif args.cmd == "acvp":
-        Tests(args).acvp(args.acvp_dir)
+        Tests(args).acvp()
     elif args.cmd == "bench":
-        if not hasattr(args, "mac_taskpolicy"):
-            args.mac_taskpolicy = None
-        Tests(args).bench(
-            args.cycles, args.output, args.mac_taskpolicy, args.components
-        )
+        Tests(args).bench()
     elif args.cmd == "cbmc":
-        Tests(args).cbmc(args.k)
+        Tests(args).cbmc()
     elif args.cmd == "func":
         Tests(args).func()
     elif args.cmd == "kat":

--- a/scripts/tests
+++ b/scripts/tests
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import platform
-import os
-import sys
 import argparse
-from functools import reduce
 
-sys.path.append(f"{os.path.join(os.path.dirname(__file__), 'lib')}")
-from mlkem_test import *
+from lib.mlkem_test import *
 
 
 def cli():

--- a/scripts/tests
+++ b/scripts/tests
@@ -134,14 +134,6 @@ def cli():
         "acvp", help="Run ACVP client", parents=[common_parser]
     )
 
-    acvp_parser.add_argument(
-        "-d",
-        "--acvp_dir",
-        dest="acvp_dir",
-        default=path("test/acvp_data"),
-        help="Path to acvp directory",
-    )
-
     # bench arguments
     bench_parser = cmd_subparsers.add_parser(
         "bench",

--- a/scripts/tests
+++ b/scripts/tests
@@ -46,22 +46,6 @@ def cli():
         default="ALL",
     )
 
-    # --compile / --no-compile
-    compile_group = common_parser.add_mutually_exclusive_group()
-    compile_group.add_argument(
-        "--compile",
-        action="store_true",
-        dest="compile",
-        help="Compile the binaries",
-        default=True,
-    )
-    compile_group.add_argument(
-        "--no-compile",
-        action="store_false",
-        dest="compile",
-        help="Do not compile the binaries",
-    )
-
     # --run / --no-run
     run_group = common_parser.add_mutually_exclusive_group()
     run_group.add_argument(

--- a/scripts/tests
+++ b/scripts/tests
@@ -78,7 +78,13 @@ def cli():
     common_parser.add_argument(
         "-w", "--exec-wrapper", help="Run the binary with the user-customized wrapper"
     )
-    common_parser.add_argument("-r", "--run-as-root", help="Run the binary as root")
+    common_parser.add_argument(
+        "-r",
+        "--run-as-root",
+        default=False,
+        action="store_true",
+        help="Run the binary as root",
+    )
 
     main_parser = argparse.ArgumentParser()
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -4,6 +4,7 @@
 
 import platform
 import argparse
+import os
 
 from lib.mlkem_test import *
 
@@ -20,6 +21,11 @@ def cli():
     )
     common_parser.add_argument(
         "--cflags", help="Extra cflags to passed in (e.g. '-mcpu=cortex-a72')"
+    )
+    common_parser.add_argument(
+        "-j",
+        help="Number of jobs to be used for `make` invocations",
+        default=os.cpu_count(),
     )
 
     # --auto / --no-auto

--- a/scripts/tests
+++ b/scripts/tests
@@ -10,7 +10,6 @@ from functools import reduce
 
 sys.path.append(f"{os.path.join(os.path.dirname(__file__), 'lib')}")
 from mlkem_test import *
-from util import path
 
 
 def cli():


### PR DESCRIPTION
* Based on #602 
* Based on #599 
* Based on #608 

This PR simplifies `tests` to merely become a wrapper around various `make` invocations, which are printed. The only exceptions are:
* Benchmarking: Here, `tests` additionally does some postprocessing
* GH summary generation