### PR TITLE
Makefile: Fix race condition during duplicated symbol checking

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -30,15 +30,15 @@ ifneq ($(findstring Darwin,$(HOST_PLATFORM)),) # if is on macOS
 	$(Q)echo "int main(void) {return 0;}" \
 		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
 		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
-		 -Imlkem $(wildcard test/notrandombytes/*.c)
-	$(Q)rm -f a.out
+		 -Imlkem $(wildcard test/notrandombytes/*.c) -o $(@:%.a=%_tmp.a.out)
+	$(Q)rm -f $(@:%.a=%_tmp.a.out)
 else                                           # if not on macOS
 	$(Q)echo "int main(void) {return 0;}" \
 		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
 		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \
 		-Wl,--no-whole-archive \
-		-Imlkem $(wildcard test/notrandombytes/*.c)
-	$(Q)rm -f a.out
+		-Imlkem $(wildcard test/notrandombytes/*.c) -o $(@:%.a=%_tmp.a.out)
+	$(Q)rm -f $(@:%.a=%_tmp.a.out)
 endif
 	$(Q)echo "  AR         Checked for duplicated symbols"
 


### PR DESCRIPTION
* Fixes #607 

When checking for duplicated symbols, we build a temporary `a.out` binary by linking a dummy C file against libmlkem{512,768,1024}.a. Afterwards, `a.out` is removed.

When running multiple `make` jobs in parallel, this can lead to a race condition where multiple jobs create and destroy `a.out` at the same time.

This commit fixes this by using a temporary filename derived from the library target, hence avoiding the nameclash and race condition.