### PR TITLE
Format: Ignore symlinks

### DIFF
--- a/scripts/format
+++ b/scripts/format
@@ -46,7 +46,7 @@ if ! command -v clang-format 2>&1 >/dev/null; then
   echo "clang-format not found. Are you running in a nix shell? See BUILDING.md."
   exit 1
 fi
-clang-format -i $(git ls-files ":/*.c" ":/*.h")
+clang-format -i $(git ls-files ":/*.c" ":/*.h" | xargs -I {} sh -c "[ ! -L {} ] && echo '{}'")
 
 info "Checking for eol"
 check-eol()


### PR DESCRIPTION
* Fix #614 

The examples in `examples/` contain many symlinks to the mlkem-native source files. Previously, `format`, and specifically `clang-format` invoked by it, would follow those symlinks and replace them by a copy of the modified file if the linked file needed re-formatting. This is not desirable: _only_ the file behind the symlink should be changed.

This commit fixes `format` by not running `clang-format` on symlinks.
