### PR TITLE
Add marker for non-public API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,3 +21,5 @@ Macros:
  # Make this artifically long to avoid function bodies after short contracts
  - __contract__(x)={ void a; void b; void c; void d; void e; void f; } void abcdefghijklmnopqrstuvw()
  - __loop__(x)={}
+ # Make this artifically long to force line break
+ - MLKEM_NATIVE_INTERNAL_API=void abcdefghijklmnopqrstuvwabcdefghijklmnopqrstuvwabcdefg();

--- a/examples/monolithic_build/Makefile
+++ b/examples/monolithic_build/Makefile
@@ -52,6 +52,8 @@ CFLAGS := \
 	-std=c90 \
 	-pedantic \
 	-MMD
+# Set this flag to give all non-global functions internal linkage
+CFLAGS += -DMLKEM_NATIVE_MONOBUILD
 
 BINARY_NAME_FULL=$(BUILD_DIR)/$(BIN)
 

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -235,6 +235,16 @@
 #endif
 
 /* mlkem/common.h */
+#if defined(MLKEM_NATIVE_INTERNAL_API)
+#undef MLKEM_NATIVE_INTERNAL_API
+#endif
+
+/* mlkem/common.h */
+#if defined(MLKEM_NATIVE_INTERNAL_API)
+#undef MLKEM_NATIVE_INTERNAL_API
+#endif
+
+/* mlkem/common.h */
 #if defined(MLKEM_ASM_NAMESPACE)
 #undef MLKEM_ASM_NAMESPACE
 #endif

--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -131,6 +131,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
 }
 #endif /* MLKEM_ETA1 == 3 */
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4])
 {
 #if MLKEM_ETA1 == 2
@@ -142,6 +143,7 @@ void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4])
 #endif
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4])
 {
 #if MLKEM_ETA2 == 2

--- a/mlkem/cbd.h
+++ b/mlkem/cbd.h
@@ -20,6 +20,7 @@
  * Arguments:   - poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4])
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -39,6 +40,7 @@ __contract__(
  * Arguments:   - poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4])
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -32,6 +32,14 @@
 #define MLKEM_NATIVE_FIPS202_BACKEND_NAME C
 #endif
 
+/* For a monobuild (where all compilation units are merged into one), mark
+ * all non-public API as static since they don't need external linkage. */
+#if !defined(MLKEM_NATIVE_MONOBUILD)
+#define MLKEM_NATIVE_INTERNAL_API
+#else
+#define MLKEM_NATIVE_INTERNAL_API static
+#endif
+
 /* On Apple platforms, we need to emit leading underscore
  * in front of assembly symbols. We thus introducee a separate
  * namespace wrapper for ASM symbols. */

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -279,6 +279,7 @@ __contract__(
 #endif /* MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER */
 
 /* Not static for benchmarking */
+MLKEM_NATIVE_INTERNAL_API
 void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
 {
   int i;
@@ -409,6 +410,7 @@ __contract__(
 
 STATIC_ASSERT(NTT_BOUND + MLKEM_Q < INT16_MAX, indcpa_enc_bound_0)
 
+MLKEM_NATIVE_INTERNAL_API
 void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
                            const uint8_t coins[MLKEM_SYMBYTES])
@@ -472,6 +474,7 @@ STATIC_ASSERT(INVNTT_BOUND + MLKEM_ETA1 < INT16_MAX, indcpa_enc_bound_0)
 STATIC_ASSERT(INVNTT_BOUND + MLKEM_ETA2 + MLKEM_Q < INT16_MAX,
               indcpa_enc_bound_1)
 
+MLKEM_NATIVE_INTERNAL_API
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
@@ -531,6 +534,7 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
 /* Check that the arithmetic in indcpa_dec() does not overflow */
 STATIC_ASSERT(INVNTT_BOUND + MLKEM_Q < INT16_MAX, indcpa_dec_bound_0)
 
+MLKEM_NATIVE_INTERNAL_API
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES])

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -23,6 +23,7 @@
  *              - const uint8_t *seed: pointer to input seed
  *              - int transposed: boolean deciding whether A or A^T is generated
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
 __contract__(
   requires(memory_no_alias(a, sizeof(polyvec) * MLKEM_K))
@@ -47,6 +48,7 @@ __contract__(
  *              - const uint8_t *coins: pointer to input randomness
  *                             (of length MLKEM_SYMBYTES bytes)
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
                            const uint8_t coins[MLKEM_SYMBYTES])
@@ -74,6 +76,7 @@ __contract__(
  *              - const uint8_t *coins: pointer to input random coins used as
  *seed (of length MLKEM_SYMBYTES) to deterministically generate all randomness
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
@@ -100,6 +103,7 @@ __contract__(
  *              - const uint8_t *sk: pointer to input secret key
  *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES])

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -127,6 +127,7 @@ __contract__(
  * the proof may need strengthening.
  */
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *p)
 {
   int len, layer;
@@ -150,6 +151,7 @@ void poly_ntt(poly *p)
 /* Check that bound for native NTT implies contractual bound */
 STATIC_ASSERT(NTT_BOUND_NATIVE <= NTT_BOUND, invntt_bound)
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *p)
 {
   POLY_BOUND_MSG(p, MLKEM_Q, "native ntt input");
@@ -201,6 +203,7 @@ __contract__(
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *p)
 {
   /*
@@ -236,6 +239,7 @@ void poly_invntt_tomont(poly *p)
 /* Check that bound for native invNTT implies contractual bound */
 STATIC_ASSERT(INVNTT_BOUND_NATIVE <= INVNTT_BOUND, invntt_bound)
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *p)
 {
   intt_native(p);
@@ -243,6 +247,7 @@ void poly_invntt_tomont(poly *p)
 }
 #endif /* MLKEM_USE_NATIVE_INTT */
 
+MLKEM_NATIVE_INTERNAL_API
 void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
                     int16_t b_cached)
 {

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -32,6 +32,7 @@ extern const int16_t zetas[128];
  *
  * Arguments:   - poly *p: pointer to in/output polynomial
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -57,6 +58,7 @@ __contract__(
  *
  * Arguments:   - uint16_t *a: pointer to in/output polynomial
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -85,6 +87,7 @@ __contract__(
  *            - b_cached: Some precomputed value, typically derived from
  *                   b1 and a twiddle factor. Can be an arbitary int16_t.
  ************************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
                     int16_t b_cached)
 __contract__(

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -16,6 +16,7 @@
 #include "symmetric.h"
 #include "verify.h"
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
 {
   int j;
@@ -80,6 +81,7 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
 }
 
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 {
   int j;
@@ -139,6 +141,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 #endif
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 {
   int i;
@@ -193,6 +196,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 #endif
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
 {
   int i;
@@ -250,6 +254,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
 }
 
 #if !defined(MLKEM_USE_NATIVE_POLY_TOBYTES)
+MLKEM_NATIVE_INTERNAL_API
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 {
   unsigned int i;
@@ -282,6 +287,7 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
   }
 }
 #else  /* MLKEM_USE_NATIVE_POLY_TOBYTES */
+MLKEM_NATIVE_INTERNAL_API
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 {
   POLY_UBOUND(a, MLKEM_Q);
@@ -290,6 +296,7 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 #endif /* MLKEM_USE_NATIVE_POLY_TOBYTES */
 
 #if !defined(MLKEM_USE_NATIVE_POLY_FROMBYTES)
+MLKEM_NATIVE_INTERNAL_API
 void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
   int i;
@@ -309,12 +316,14 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
   POLY_UBOUND(r, 4096);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
+MLKEM_NATIVE_INTERNAL_API
 void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
   poly_frombytes_native(r, a);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
 {
   int i;
@@ -341,6 +350,7 @@ void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
   POLY_BOUND_MSG(r, MLKEM_Q, "poly_frommsg output");
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *a)
 {
   int i;
@@ -361,6 +371,7 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *a)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                            const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce0,
                            uint8_t nonce1, uint8_t nonce2, uint8_t nonce3)
@@ -388,6 +399,7 @@ void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
   POLY_BOUND_MSG(r3, MLKEM_ETA1 + 1, "poly_getnoise_eta1_4x output 3");
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES],
                         uint8_t nonce)
 {
@@ -403,6 +415,7 @@ void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES],
   POLY_BOUND_MSG(r, MLKEM_ETA1 + 1, "poly_getnoise_eta2 output");
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                               const uint8_t seed[MLKEM_SYMBYTES],
                               uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
@@ -441,6 +454,7 @@ void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
   POLY_BOUND_MSG(r3, MLKEM_ETA2 + 1, "poly_getnoise_eta1122_4x output 3");
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
                                     const poly_mulcache *b_cache)
 {
@@ -461,6 +475,7 @@ void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
 }
 
 #if !defined(MLKEM_USE_NATIVE_POLY_TOMONT)
+MLKEM_NATIVE_INTERNAL_API
 void poly_tomont(poly *r)
 {
   int i;
@@ -476,6 +491,7 @@ void poly_tomont(poly *r)
   POLY_BOUND(r, MLKEM_Q);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_TOMONT */
+MLKEM_NATIVE_INTERNAL_API
 void poly_tomont(poly *r)
 {
   poly_tomont_native(r);
@@ -484,6 +500,7 @@ void poly_tomont(poly *r)
 #endif /* MLKEM_USE_NATIVE_POLY_TOMONT */
 
 #if !defined(MLKEM_USE_NATIVE_POLY_REDUCE)
+MLKEM_NATIVE_INTERNAL_API
 void poly_reduce(poly *r)
 {
   int i;
@@ -501,6 +518,7 @@ void poly_reduce(poly *r)
   POLY_UBOUND(r, MLKEM_Q);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_REDUCE */
+MLKEM_NATIVE_INTERNAL_API
 void poly_reduce(poly *r)
 {
   poly_reduce_native(r);
@@ -508,6 +526,7 @@ void poly_reduce(poly *r)
 }
 #endif /* MLKEM_USE_NATIVE_POLY_REDUCE */
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_add(poly *r, const poly *b)
 {
   int i;
@@ -521,6 +540,7 @@ void poly_add(poly *r, const poly *b)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void poly_sub(poly *r, const poly *b)
 {
   int i;
@@ -535,6 +555,7 @@ void poly_sub(poly *r, const poly *b)
 }
 
 #if !defined(MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE)
+MLKEM_NATIVE_INTERNAL_API
 void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 {
   int i;
@@ -547,6 +568,7 @@ void poly_mulcache_compute(poly_mulcache *x, const poly *a)
   POLY_BOUND(x, MLKEM_Q);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE */
+MLKEM_NATIVE_INTERNAL_API
 void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 {
   poly_mulcache_compute_native(x, a);

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -334,6 +334,7 @@ __contract__(
  *                  Coefficients must be unsigned canonical,
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYCOMPRESSEDBYTES_DU))
@@ -357,6 +358,7 @@ __contract__(
  * (non-negative and smaller than MLKEM_Q).
  *
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 __contract__(
   requires(memory_no_alias(a, MLKEM_POLYCOMPRESSEDBYTES_DU))
@@ -378,6 +380,7 @@ __contract__(
  *                  Coefficients must be unsigned canonical,
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYCOMPRESSEDBYTES_DV))
@@ -402,6 +405,7 @@ __contract__(
  * (non-negative and smaller than MLKEM_Q).
  *
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
 __contract__(
   requires(memory_no_alias(a, MLKEM_POLYCOMPRESSEDBYTES_DV))
@@ -425,6 +429,7 @@ __contract__(
  *              - r: pointer to output byte array
  *                   (of MLKEM_POLYBYTES bytes)
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYBYTES))
@@ -448,6 +453,7 @@ __contract__(
  *                   each coefficient unsigned and in the range
  *                   0 .. 4095
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
 __contract__(
   requires(memory_no_alias(a, MLKEM_POLYBYTES))
@@ -466,6 +472,7 @@ __contract__(
  * Arguments:   - poly *r: pointer to output polynomial
  *              - const uint8_t *msg: pointer to input message
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
 __contract__(
   requires(memory_no_alias(msg, MLKEM_INDCPA_MSGBYTES))
@@ -484,6 +491,7 @@ __contract__(
  *              - const poly *r: pointer to input polynomial
  *                Coefficients must be unsigned canonical
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *r)
 __contract__(
   requires(memory_no_alias(msg, MLKEM_INDCPA_MSGBYTES))
@@ -505,6 +513,7 @@ __contract__(
  *                                     (of length MLKEM_SYMBYTES bytes)
  *              - uint8_t nonce{0,1,2,3}: one-byte input nonce
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                            const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce0,
                            uint8_t nonce1, uint8_t nonce2, uint8_t nonce3)
@@ -585,6 +594,7 @@ __contract__(
  *                                     (of length MLKEM_SYMBYTES bytes)
  *              - uint8_t nonce: one-byte input nonce
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES],
                         uint8_t nonce)
 __contract__(
@@ -607,6 +617,7 @@ __contract__(
  *                                     (of length MLKEM_SYMBYTES bytes)
  *              - uint8_t nonce{0,1,2,3}: one-byte input nonce
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                               const uint8_t seed[MLKEM_SYMBYTES],
                               uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
@@ -644,6 +655,7 @@ __contract__(
  *                  for second input polynomial. Can be computed
  *                  via poly_mulcache_compute().
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
                                     const poly_mulcache *b_cache)
 __contract__(
@@ -667,6 +679,7 @@ __contract__(
  *
  * Arguments:   - poly *r: pointer to input/output polynomial
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void poly_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -697,6 +710,7 @@ __contract__(
  * the mulcache with values in (-q,q), but this is not needed for the
  * higher level safety proofs, and thus not part of the spec.
  */
+MLKEM_NATIVE_INTERNAL_API
 void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 __contract__(
   requires(memory_no_alias(x, sizeof(poly_mulcache)))
@@ -722,6 +736,7 @@ __contract__(
  * outputs are better suited to the only remaining
  * use of poly_reduce() in the context of (de)serialization.
  */
+MLKEM_NATIVE_INTERNAL_API
 void poly_reduce(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -747,6 +762,7 @@ __contract__(
  * NOTE: The reference implementation uses a 3-argument poly_add.
  * We specialize to the accumulator form to avoid reasoning about aliasing.
  */
+MLKEM_NATIVE_INTERNAL_API
 void poly_add(poly *r, const poly *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -771,6 +787,7 @@ __contract__(
  * NOTE: The reference implementation uses a 3-argument poly_sub.
  * We specialize to the accumulator form to avoid reasoning about aliasing.
  */
+MLKEM_NATIVE_INTERNAL_API
 void poly_sub(poly *r, const poly *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -9,6 +9,8 @@
 #include "poly.h"
 
 #include "debug/debug.h"
+
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_compress_du(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES_DU],
                          const polyvec *a)
 {
@@ -21,6 +23,7 @@ void polyvec_compress_du(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES_DU],
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_decompress_du(polyvec *r,
                            const uint8_t a[MLKEM_POLYVECCOMPRESSEDBYTES_DU])
 {
@@ -33,6 +36,7 @@ void polyvec_decompress_du(polyvec *r,
   POLYVEC_UBOUND(r, MLKEM_Q);
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const polyvec *a)
 {
   unsigned int i;
@@ -42,6 +46,7 @@ void polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const polyvec *a)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_frombytes(polyvec *r, const uint8_t a[MLKEM_POLYVECBYTES])
 {
   int i;
@@ -51,6 +56,7 @@ void polyvec_frombytes(polyvec *r, const uint8_t a[MLKEM_POLYVECBYTES])
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_ntt(polyvec *r)
 {
   unsigned int i;
@@ -60,6 +66,7 @@ void polyvec_ntt(polyvec *r)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_invntt_tomont(polyvec *r)
 {
   unsigned int i;
@@ -70,6 +77,7 @@ void polyvec_invntt_tomont(polyvec *r)
 }
 
 #if !defined(MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED)
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
                                            const polyvec *b,
                                            const polyvec_mulcache *b_cache)
@@ -102,6 +110,7 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
   POLY_BOUND(r, MLKEM_K * 2 * MLKEM_Q);
 }
 #else  /* !MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
                                            const polyvec *b,
                                            const polyvec_mulcache *b_cache)
@@ -115,6 +124,7 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
 }
 #endif /* MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
 {
   polyvec_mulcache b_cache;
@@ -122,6 +132,7 @@ void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
   polyvec_basemul_acc_montgomery_cached(r, a, b, &b_cache);
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)
 {
   unsigned int i;
@@ -131,6 +142,7 @@ void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_reduce(polyvec *r)
 {
   unsigned int i;
@@ -140,6 +152,7 @@ void polyvec_reduce(polyvec *r)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_add(polyvec *r, const polyvec *b)
 {
   int i;
@@ -149,6 +162,7 @@ void polyvec_add(polyvec *r, const polyvec *b)
   }
 }
 
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_tomont(polyvec *r)
 {
   unsigned int i;

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -33,6 +33,7 @@ typedef struct
  *                                  Coefficients must be unsigned canonical,
  *                                  i.e. in [0,1,..,MLKEM_Q-1].
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_compress_du(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES_DU],
                          const polyvec *a)
 __contract__(
@@ -55,6 +56,7 @@ __contract__(
  *              - const uint8_t *a: pointer to input byte array
  *                                  (of length MLKEM_POLYVECCOMPRESSEDBYTES_DU)
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_decompress_du(polyvec *r,
                            const uint8_t a[MLKEM_POLYVECCOMPRESSEDBYTES_DU])
 __contract__(
@@ -76,6 +78,7 @@ __contract__(
  *              - const polyvec *a: pointer to input vector of polynomials
  *                  Each polynomial must have coefficients in [0,..,q-1].
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const polyvec *a)
 __contract__(
   requires(memory_no_alias(a, sizeof(polyvec)))
@@ -97,6 +100,7 @@ __contract__(
  *                 normalized in [0..4095].
  *              - uint8_t *r: pointer to input byte array
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_frombytes(polyvec *r, const uint8_t a[MLKEM_POLYVECBYTES])
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
@@ -121,6 +125,7 @@ __contract__(
  * Arguments:   - polyvec *r: pointer to in/output vector of polynomials
  *
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_ntt(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
@@ -147,6 +152,7 @@ __contract__(
  *
  * Arguments:   - polyvec *r: pointer to in/output vector of polynomials
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_invntt_tomont(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
@@ -167,6 +173,7 @@ __contract__(
  *            - const polyvec *a: pointer to first input vector of polynomials
  *            - const polyvec *b: pointer to second input vector of polynomials
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
@@ -197,6 +204,7 @@ __contract__(
  *                  for second input polynomial vector. Can be computed
  *                  via polyvec_mulcache_compute().
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
                                            const polyvec *b,
                                            const polyvec_mulcache *b_cache)
@@ -236,6 +244,7 @@ __contract__(
  * the mulcache with values in (-q,q), but this is not needed for the
  * higher level safety proofs, and thus not part of the spec.
  */
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)
 __contract__(
   requires(memory_no_alias(x, sizeof(polyvec_mulcache)))
@@ -260,6 +269,7 @@ __contract__(
  *       outputs are better suited to the only remaining
  *       use of poly_reduce() in the context of (de)serialization.
  */
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_reduce(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
@@ -285,6 +295,7 @@ __contract__(
  * to prove type-safety of calling units. Therefore, no stronger
  * ensures clause is required on this function.
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_add(polyvec *r, const polyvec *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
@@ -308,6 +319,7 @@ __contract__(
  *              Bounds: Output < q in absolute value.
  *
  **************************************************/
+MLKEM_NATIVE_INTERNAL_API
 void polyvec_tomont(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -90,6 +90,7 @@ unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
 }
 #else  /* MLKEM_USE_NATIVE_REJ_UNIFORM */
 
+MLKEM_NATIVE_INTERNAL_API
 unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
                          const uint8_t *buf, unsigned int buflen)
 {

--- a/mlkem/rej_uniform.h
+++ b/mlkem/rej_uniform.h
@@ -47,6 +47,7 @@
  * buffer. This avoids shifting the buffer base in the caller, which appears
  * tricky to reason about.
  */
+MLKEM_NATIVE_INTERNAL_API
 unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
                          const uint8_t *buf, unsigned int buflen)
 __contract__(


### PR DESCRIPTION
This commit introduces the marker MLKEM_NATIVE_INTERNAL_API. This marker is used in front of every declaration and implementation of an API that has external linkage for the standard build process of mlkem-native, but is not part of mlkem-native's public API.

Beyond being an explicit reminder to consumers that they can not rely on the stability of an API so marked as internal, the marker can be unfolded to the `static` keyword for monolithic builds, thereby giving internal linkage to all internal functions. This enables further compiler optimizations, and also removes the corresponding symbols from the resulting monolithic object file.
