### PR TITLE
CBMC: Big-endian proofs for KeccakF1600_State{Extract,XOR}Bytes

### DIFF
--- a/cbmc/KeccakF1600_StateExtractBytes_BE/KeccakF1600_StateExtractBytes_be_harness.c
+++ b/cbmc/KeccakF1600_StateExtractBytes_BE/KeccakF1600_StateExtractBytes_be_harness.c
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <keccakf1600.h>
+
+void harness(void)
+{
+  uint64_t *state;
+  unsigned char *data;
+  unsigned int offset;
+  unsigned int length;
+  KeccakF1600_StateExtractBytes(state, data, offset, length);
+}

--- a/cbmc/KeccakF1600_StateExtractBytes_BE/Makefile
+++ b/cbmc/KeccakF1600_StateExtractBytes_BE/Makefile
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = KeccakF1600_StateExtractBytes_be_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = KeccakF1600_StateExtractBytes (big endian)
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/keccakf1600.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)KeccakF1600_StateExtractBytes
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla --big-endian
+DEFINES += -DSYS_BIG_ENDIAN=1
+
+FUNCTION_NAME = $(FIPS202_NAMESPACE)KeccakF1600_StateExtractBytes
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/KeccakF1600_StateExtractBytes_BE/cbmc-proof.txt
+++ b/cbmc/KeccakF1600_StateExtractBytes_BE/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/KeccakF1600_StateXORBytes_BE/KeccakF1600_StateXORBytes_be_harness.c
+++ b/cbmc/KeccakF1600_StateXORBytes_BE/KeccakF1600_StateXORBytes_be_harness.c
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <keccakf1600.h>
+
+void harness(void)
+{
+  uint64_t *state;
+  const unsigned char *data;
+  unsigned int offset;
+  unsigned int length;
+  KeccakF1600_StateXORBytes(state, data, offset, length);
+}

--- a/cbmc/KeccakF1600_StateXORBytes_BE/Makefile
+++ b/cbmc/KeccakF1600_StateXORBytes_BE/Makefile
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = KeccakF1600_StateXORBytes_be_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = KeccakF1600_StateXORBytes (big endian)
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/keccakf1600.c
+
+CHECK_FUNCTION_CONTRACTS=$(FIPS202_NAMESPACE)KeccakF1600_StateXORBytes
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla --big-endian
+
+DEFINES += -DSYS_BIG_ENDIAN
+
+FUNCTION_NAME = $(FIPS202_NAMESPACE)KeccakF1600_StateXORBytes
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/KeccakF1600_StateXORBytes_BE/cbmc-proof.txt
+++ b/cbmc/KeccakF1600_StateXORBytes_BE/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/run-cbmc-proofs.py
+++ b/cbmc/run-cbmc-proofs.py
@@ -298,11 +298,12 @@ def get_litani_capabilities(litani_path):
 def check_uid_uniqueness(proof_dir, proof_uids):
     with (pathlib.Path(proof_dir) / "Makefile").open() as handle:
         for line in handle:
-            match = re.match(r"^PROOF_UID\s*=\s*(?P<uid>\w+)", line)
+            match = re.match(r"^PROOF_UID\s*=(?P<uid>[^#]+)", line)
             if not match:
                 continue
-            if match["uid"] not in proof_uids:
-                proof_uids[match["uid"]] = proof_dir
+            uid = match["uid"].strip()
+            if uid not in proof_uids:
+                proof_uids[uid] = proof_dir
                 return
 
             logging.critical(

--- a/mlkem/fips202/keccakf1600.c
+++ b/mlkem/fips202/keccakf1600.c
@@ -41,8 +41,9 @@ void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data,
 #else  /* SYS_LITTLE_ENDIAN */
   /* Portable version */
   for (i = 0; i < length; i++)
+  __loop__(invariant(0 <= i && i <= length))
   {
-    data[i] = state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07));
+    data[i] = (state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07))) & 0xFF;
   }
 #endif /* SYS_LITTLE_ENDIAN */
 }
@@ -61,6 +62,7 @@ void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data,
 #else  /* SYS_LITTLE_ENDIAN */
   /* Portable version */
   for (i = 0; i < length; i++)
+  __loop__(invariant(i <= length))
   {
     state[(offset + i) >> 3] ^= (uint64_t)data[i]
                                 << (8 * ((offset + i) & 0x07));

--- a/mlkem/sys.h
+++ b/mlkem/sys.h
@@ -23,9 +23,9 @@
 #endif
 #endif /* __x86_64__ */
 
-/* Check endianness */
+/* Try to find endianness, if not forced through CFLAGS already */
+#if !defined(SYS_LITTLE_ENDIAN) && !defined(SYS_BIG_ENDIAN)
 #if defined(__BYTE_ORDER__)
-
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define SYS_LITTLE_ENDIAN
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
@@ -34,6 +34,7 @@
 #error "__BYTE_ORDER__ defined, but don't recognize value."
 #endif /* __BYTE_ORER__ */
 #endif /* !defined(__BYTE_ORER__) */
+#endif /* defined(SYS_LITTLE_ENDIAN) || defined(SYS_BIG_ENDIAN) */
 
 /* If FORCE_AARCH64 is set, assert that we're indeed on an AArch64 system. */
 #if defined(FORCE_AARCH64) && !defined(SYS_AARCH64)


### PR DESCRIPTION
Those functions have an explicit distinction between little and big endian systems and therefore need a proof for either case.

Care has to be taken to allow overwriting the directives in the host system's preprocessor; we disable the auto-detection of endianness if SYS_LITTLE_ENDIAN or SYS_BIG_ENDIAN have been set manually.
