### PR TITLE
CBMC: Use exclusive upper bounds for `forall` primitive

### DIFF
--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -73,7 +73,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4])
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 8)
-    invariant(array_abs_bound(r->coeffs, 0, (8 * i - 1), 2)))
+    invariant(array_abs_bound(r->coeffs, 0, 8 * i, 2)))
   {
     int j;
     uint32_t t = load32_littleendian(buf + 4 * i);
@@ -83,7 +83,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4])
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_abs_bound(r->coeffs, 0, 8 * i + j - 1, 2)))
+      invariant(array_abs_bound(r->coeffs, 0, 8 * i + j, 2)))
     {
       const int16_t a = (d >> (4 * j + 0)) & 0x3;
       const int16_t b = (d >> (4 * j + 2)) & 0x3;
@@ -110,7 +110,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
   for (i = 0; i < MLKEM_N / 4; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 4)
-    invariant(array_abs_bound(r->coeffs, 0, (4 * i - 1), 3)))
+    invariant(array_abs_bound(r->coeffs, 0, 4 * i, 3)))
   {
     int j;
     const uint32_t t = load24_littleendian(buf + 3 * i);
@@ -121,7 +121,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
     for (j = 0; j < 4; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 4 && j >= 0 && j <= 4)
-      invariant(array_abs_bound(r->coeffs, 0, 4 * i + j - 1, 3)))
+      invariant(array_abs_bound(r->coeffs, 0, 4 * i + j, 3)))
     {
       const int16_t a = (d >> (6 * j + 0)) & 0x7;
       const int16_t b = (d >> (6 * j + 3)) & 0x7;

--- a/mlkem/cbd.h
+++ b/mlkem/cbd.h
@@ -26,7 +26,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(buf, MLKEM_ETA1 * MLKEM_N / 4))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, MLKEM_ETA1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA1))
 );
 
 #if MLKEM_K == 2 || MLKEM_K == 4
@@ -47,7 +47,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(buf, MLKEM_ETA2 * MLKEM_N / 4))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, MLKEM_ETA2))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA2))
 );
 #endif /* MLKEM_K == 2 || MLKEM_K == 4 */
 

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -69,7 +69,7 @@
 
 /*
  * Quantifiers
- * Note that the range on qvar is _inclusive_ between qvar_lb .. qvar_ub
+ * Note that the range on qvar is _exclusive_ between qvar_lb .. qvar_ub
  * https://diffblue.github.io/cbmc/contracts-quantifiers.html
  */
 
@@ -81,14 +81,14 @@
   __CPROVER_forall                                                \
   {                                                               \
     type qvar;                                                    \
-    ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) ==> (predicate)  \
+    ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==> (predicate)   \
   }
 
 #define EXISTS(type, qvar, qvar_lb, qvar_ub, predicate)         \
   __CPROVER_exists                                              \
   {                                                             \
     type qvar;                                                  \
-    ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) && (predicate) \
+    ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) && (predicate)  \
   }
 /* clang-format on */
 
@@ -100,7 +100,7 @@
  * Boolean-value predidate that asserts that "all values of array_var are in
  * range value_lb .. value_ub (inclusive)"
  * Example:
- *  array_bound(a->coeffs, 0, MLKEM_N-1, -(MLKEM_Q - 1), MLKEM_Q - 1)
+ *  array_bound(a->coeffs, 0, MLKEM_N, -(MLKEM_Q - 1), MLKEM_Q - 1)
  * expands to
  *  __CPROVER_forall { int k; (0 <= k && k <= MLKEM_N-1) ==> ( (-(MLKEM_Q -
  *  1) <= a->coeffs[k]) && (a->coeffs[k] <= (MLKEM_Q - 1))) }
@@ -118,7 +118,7 @@
   __CPROVER_forall                                                     \
   {                                                                    \
     indextype qvar;                                                    \
-    ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) ==>                   \
+    ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
         (((value_lb) <= (array_var[(qvar)])) &&                        \
         ((array_var[(qvar)]) <= (value_ub)))                           \
   }

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -163,10 +163,10 @@ __contract__(
   requires(memory_no_alias(seed[2], MLKEM_SYMBYTES + 2))
   requires(memory_no_alias(seed[3], MLKEM_SYMBYTES + 2))
   assigns(memory_slice(vec, sizeof(poly) * 4))
-  ensures(array_bound(vec[0].coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
-  ensures(array_bound(vec[1].coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
-  ensures(array_bound(vec[2].coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
-  ensures(array_bound(vec[3].coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1))))
+  ensures(array_bound(vec[0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(vec[1].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(vec[2].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(vec[3].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
 {
   /* Temporary buffers for XOF output before rejection sampling */
   uint8_t buf0[MLKEM_GEN_MATRIX_NBLOCKS * XOF_RATE];
@@ -207,10 +207,10 @@ __contract__(
        object_whole(buf1), object_whole(buf2), object_whole(buf3))
     invariant(ctr[0] <= MLKEM_N && ctr[1] <= MLKEM_N)
     invariant(ctr[2] <= MLKEM_N && ctr[3] <= MLKEM_N)
-    invariant(ctr[0] > 0 ==> array_bound(vec[0].coeffs, 0, ctr[0] - 1, 0, (MLKEM_Q - 1)))
-    invariant(ctr[1] > 0 ==> array_bound(vec[1].coeffs, 0, ctr[1] - 1, 0, (MLKEM_Q - 1)))
-    invariant(ctr[2] > 0 ==> array_bound(vec[2].coeffs, 0, ctr[2] - 1, 0, (MLKEM_Q - 1)))
-    invariant(ctr[3] > 0 ==> array_bound(vec[3].coeffs, 0, ctr[3] - 1, 0, (MLKEM_Q - 1))))
+    invariant(ctr[0] > 0 ==> array_bound(vec[0].coeffs, 0, ctr[0], 0, (MLKEM_Q - 1)))
+    invariant(ctr[1] > 0 ==> array_bound(vec[1].coeffs, 0, ctr[1], 0, (MLKEM_Q - 1)))
+    invariant(ctr[2] > 0 ==> array_bound(vec[2].coeffs, 0, ctr[2], 0, (MLKEM_Q - 1)))
+    invariant(ctr[3] > 0 ==> array_bound(vec[3].coeffs, 0, ctr[3], 0, (MLKEM_Q - 1))))
   {
     xof_x4_squeezeblocks(buf0, buf1, buf2, buf3, 1, &statex);
     ctr[0] = rej_uniform(vec[0].coeffs, MLKEM_N, ctr[0], buf0, buflen);
@@ -231,7 +231,7 @@ __contract__(
   requires(memory_no_alias(entry, sizeof(poly)))
   requires(memory_no_alias(seed, MLKEM_SYMBYTES + 2))
   assigns(memory_slice(entry, sizeof(poly)))
-  ensures(array_bound(entry->coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1))))
+  ensures(array_bound(entry->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
 {
   xof_ctx state;
   uint8_t buf[MLKEM_GEN_MATRIX_NBLOCKS * XOF_RATE];
@@ -252,7 +252,7 @@ __contract__(
   __loop__(
     assigns(ctr, state, memory_slice(entry, sizeof(poly)), object_whole(buf))
     invariant(0 <= ctr && ctr <= MLKEM_N)
-    invariant(ctr > 0 ==> array_bound(entry->coeffs, 0, ctr - 1,
+    invariant(ctr > 0 ==> array_bound(entry->coeffs, 0, ctr,
                                           0, (MLKEM_Q - 1))))
   {
     xof_squeezeblocks(buf, 1, &state);
@@ -273,9 +273,9 @@ __contract__(
   /* We don't specify that this should be a permutation, but only
    * that it does not change the bound established at the end of gen_matrix. */
   requires(memory_no_alias(data, sizeof(poly)))
-  requires(array_bound(data->coeffs, 0, MLKEM_N - 1, 0, MLKEM_Q - 1))
+  requires(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q - 1))
   assigns(memory_slice(data, sizeof(poly)))
-  ensures(array_bound(data->coeffs, 0, MLKEM_N - 1, 0, MLKEM_Q - 1))) { ((void)data); }
+  ensures(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q - 1))) { ((void)data); }
 #endif /* MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER */
 
 /* Not static for benchmarking */
@@ -391,9 +391,9 @@ __contract__(
   requires(memory_no_alias(a, sizeof(polyvec) * MLKEM_K))
   requires(memory_no_alias(v, sizeof(polyvec)))
   requires(memory_no_alias(vc, sizeof(polyvec_mulcache)))
-  requires(forall(int, k0, 0, MLKEM_K - 1,
-  forall(int, k1, 0, MLKEM_K - 1,
-    array_abs_bound(a[k0].vec[k1].coeffs, 0, MLKEM_N - 1, UINT12_MAX))))
+  requires(forall(int, k0, 0, MLKEM_K,
+    forall(int, k1, 0, MLKEM_K,
+      array_abs_bound(a[k0].vec[k1].coeffs, 0, MLKEM_N, UINT12_MAX))))
   assigns(object_whole(out)))
 {
   int i;

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -30,8 +30,8 @@ __contract__(
   requires(memory_no_alias(seed, MLKEM_SYMBYTES))
   requires(transposed == 0 || transposed == 1)
   assigns(object_whole(a))
-  ensures(forall(int, x, 0, MLKEM_K - 1, forall(int, y, 0, MLKEM_K - 1,
-  array_bound(a[x].vec[y].coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))));
+  ensures(forall(int, x, 0, MLKEM_K, forall(int, y, 0, MLKEM_K,
+  array_bound(a[x].vec[y].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))));
 );
 
 #define indcpa_keypair_derand MLKEM_NAMESPACE(indcpa_keypair_derand)

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -36,9 +36,9 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
-  requires(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, MLKEM_Q - 1))
+  requires(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_Q - 1))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, NTT_BOUND - 1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, NTT_BOUND - 1))
 );
 
 #define poly_invntt_tomont MLKEM_NAMESPACE(poly_invntt_tomont)
@@ -63,7 +63,7 @@ void poly_invntt_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, INVNTT_BOUND - 1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, INVNTT_BOUND - 1))
 );
 
 #define basemul_cached MLKEM_NAMESPACE(basemul_cached)
@@ -94,9 +94,9 @@ __contract__(
   requires(memory_no_alias(r, 2 * sizeof(int16_t)))
   requires(memory_no_alias(a, 2 * sizeof(int16_t)))
   requires(memory_no_alias(b, 2 * sizeof(int16_t)))
-  requires(array_abs_bound(a, 0, 1, UINT12_MAX))
+  requires(array_abs_bound(a, 0, 2, UINT12_MAX))
   assigns(memory_slice(r, 2 * sizeof(int16_t)))
-  ensures(array_abs_bound(r, 0, 1, 2 * MLKEM_Q - 1))
+  ensures(array_abs_bound(r, 0, 2, 2 * MLKEM_Q - 1))
 );
 
 

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -29,7 +29,7 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
     for (k = 0; k < 8; k++)
     __loop__(
       invariant(k >= 0 && k <= 8)
-      invariant(forall(int, r, 0, k - 1, t[r] < (1u << 11))))
+      invariant(forall(int, r, 0, k, t[r] < (1u << 11))))
     {
       t[k] = scalar_compress_d11(a->coeffs[8 * j + k]);
     }
@@ -60,7 +60,7 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
     for (k = 0; k < 4; k++)
     __loop__(
       invariant(k >= 0 && k <= 4)
-      invariant(forall(int, r, 0, k - 1, t[r] < (1u << 10))))
+      invariant(forall(int, r, 0, k, t[r] < (1u << 10))))
     {
       t[k] = scalar_compress_d10(a->coeffs[4 * j + k]);
     }
@@ -89,7 +89,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
   for (j = 0; j < MLKEM_N / 8; j++)
   __loop__(
     invariant(0 <= j && j <= MLKEM_N / 8)
-    invariant(array_bound(r->coeffs, 0, 8 * j - 1, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 8 * j, 0, (MLKEM_Q - 1))))
   {
     int k;
     uint16_t t[8];
@@ -108,7 +108,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
     for (k = 0; k < 8; k++)
     __loop__(
       invariant(0 <= k && k <= 8)
-      invariant(array_bound(r->coeffs, 0, 8 * j + k - 1, 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 8 * j + k, 0, (MLKEM_Q - 1))))
     {
       r->coeffs[8 * j + k] = scalar_decompress_d11(t[k]);
     }
@@ -117,7 +117,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
   for (j = 0; j < MLKEM_N / 4; j++)
   __loop__(
     invariant(0 <= j && j <= MLKEM_N / 4)
-    invariant(array_bound(r->coeffs, 0, 4 * j - 1, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 4 * j, 0, (MLKEM_Q - 1))))
   {
     int k;
     uint16_t t[4];
@@ -131,7 +131,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
     for (k = 0; k < 4; k++)
     __loop__(
       invariant(0 <= k && k <= 4)
-      invariant(array_bound(r->coeffs, 0, 4 * j + k - 1, 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 4 * j + k, 0, (MLKEM_Q - 1))))
     {
       r->coeffs[4 * j + k] = scalar_decompress_d10(t[k]);
     }
@@ -156,7 +156,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_bound(t, 0, (j-1), 0, 15)))
+      invariant(array_bound(t, 0, j, 0, 15)))
     {
       t[j] = scalar_compress_d4(a->coeffs[8 * i + j]);
     }
@@ -175,7 +175,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_bound(t, 0, (j-1), 0, 31)))
+      invariant(array_bound(t, 0, j, 0, 31)))
     {
       t[j] = scalar_compress_d5(a->coeffs[8 * i + j]);
     }
@@ -204,7 +204,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 2)
-    invariant(array_bound(r->coeffs, 0, (2 * i - 1), 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 2 * i, 0, (MLKEM_Q - 1))))
   {
     r->coeffs[2 * i + 0] = scalar_decompress_d4((a[i] >> 0) & 0xF);
     r->coeffs[2 * i + 1] = scalar_decompress_d4((a[i] >> 4) & 0xF);
@@ -213,7 +213,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 8)
-    invariant(array_bound(r->coeffs, 0, (8 * i - 1), 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 8 * i, 0, (MLKEM_Q - 1))))
   {
     int j;
     uint8_t t[8];
@@ -241,7 +241,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(j >= 0 && j <= 8 && i >= 0 && i <= MLKEM_N / 8)
-      invariant(array_bound(r->coeffs, 0, (8 * i + j - 1), 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, (MLKEM_Q - 1))))
     {
       r->coeffs[8 * i + j] = scalar_decompress_d5(t[j]);
     }
@@ -303,7 +303,7 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 2)
-    invariant(array_bound(r->coeffs, 0, (2 * i - 1), 0, UINT12_MAX)))
+    invariant(array_bound(r->coeffs, 0, 2 * i, 0, UINT12_MAX)))
   {
     const uint8_t t0 = a[3 * i + 0];
     const uint8_t t1 = a[3 * i + 1];
@@ -334,13 +334,13 @@ void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 8)
-    invariant(array_bound(r->coeffs, 0, (8 * i - 1), 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 8 * i, 0, (MLKEM_Q - 1))))
   {
     int j;
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <  MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_bound(r->coeffs, 0, (8 * i + j - 1), 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, (MLKEM_Q - 1))))
     {
       /* Prevent the compiler from recognizing this as a bit selection */
       uint8_t mask = value_barrier_u8(1u << j);
@@ -469,7 +469,7 @@ void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
   __loop__(
     assigns(i, object_whole(r))
     invariant(i >= 0 && i <= MLKEM_N / 4)
-    invariant(array_abs_bound(r->coeffs, 0, (4 * i - 1), 2 * MLKEM_Q - 1)))
+    invariant(array_abs_bound(r->coeffs, 0, 4 * i, 2 * MLKEM_Q - 1)))
   {
     basemul_cached(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
                    b_cache->coeffs[2 * i]);
@@ -487,7 +487,7 @@ void poly_tomont(poly *r)
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N)
-    invariant(array_abs_bound(r->coeffs ,0, (i - 1), (MLKEM_Q - 1))))
+    invariant(array_abs_bound(r->coeffs ,0, i, (MLKEM_Q - 1))))
   {
     r->coeffs[i] = fqmul(r->coeffs[i], f);
   }
@@ -511,7 +511,7 @@ void poly_reduce(poly *r)
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N)
-    invariant(array_bound(r->coeffs, 0, (i - 1), 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, i, 0, (MLKEM_Q - 1))))
   {
     /* Barrett reduction, giving signed canonical representative */
     int16_t t = barrett_reduce(r->coeffs[i]);
@@ -537,8 +537,8 @@ void poly_add(poly *r, const poly *b)
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N)
-    invariant(forall(int, k0, i, MLKEM_N - 1, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
-    invariant(forall(int, k1, 0, i - 1, r->coeffs[k1] == loop_entry(*r).coeffs[k1] + b->coeffs[k1])))
+    invariant(forall(int, k0, i, MLKEM_N, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
+    invariant(forall(int, k1, 0, i, r->coeffs[k1] == loop_entry(*r).coeffs[k1] + b->coeffs[k1])))
   {
     r->coeffs[i] = r->coeffs[i] + b->coeffs[i];
   }
@@ -551,8 +551,8 @@ void poly_sub(poly *r, const poly *b)
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N)
-    invariant(forall(int, k0, i, MLKEM_N - 1, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
-    invariant(forall(int, k1, 0, i - 1, r->coeffs[k1] == loop_entry(*r).coeffs[k1] - b->coeffs[k1])))
+    invariant(forall(int, k0, i, MLKEM_N, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
+    invariant(forall(int, k1, 0, i, r->coeffs[k1] == loop_entry(*r).coeffs[k1] - b->coeffs[k1])))
   {
     r->coeffs[i] = r->coeffs[i] - b->coeffs[i];
   }

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -339,7 +339,7 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(array_bound(a->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
   assigns(memory_slice(r, MLKEM_POLYCOMPRESSEDBYTES_DU))
 );
 
@@ -364,7 +364,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_bound(r->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
 );
 
 #define poly_compress_dv MLKEM_NAMESPACE(poly_compress_dv)
@@ -385,7 +385,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYCOMPRESSEDBYTES_DV))
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(array_bound(a->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
   assigns(object_whole(r))
 );
 
@@ -411,7 +411,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYCOMPRESSEDBYTES_DV))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(object_whole(r))
-  ensures(array_bound(r->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
 );
 
 #define poly_tobytes MLKEM_NAMESPACE(poly_tobytes)
@@ -434,7 +434,7 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYBYTES))
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(array_bound(a->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
   assigns(object_whole(r))
 );
 
@@ -459,7 +459,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYBYTES))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_bound(r->coeffs, 0, (MLKEM_N - 1), 0, UINT12_MAX))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, UINT12_MAX))
 );
 
 
@@ -478,7 +478,7 @@ __contract__(
   requires(memory_no_alias(msg, MLKEM_INDCPA_MSGBYTES))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(object_whole(r))
-  ensures(array_bound(r->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
 );
 
 #define poly_tomsg MLKEM_NAMESPACE(poly_tomsg)
@@ -496,7 +496,7 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *r)
 __contract__(
   requires(memory_no_alias(msg, MLKEM_INDCPA_MSGBYTES))
   requires(memory_no_alias(r, sizeof(poly)))
-  requires(array_bound(r->coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1)))
+  requires(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
   assigns(object_whole(msg))
 );
 
@@ -534,10 +534,10 @@ __contract__(
   assigns(memory_slice(r2, sizeof(poly)))
   assigns(memory_slice(r3, sizeof(poly)))
   ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N - 1, MLKEM_ETA1));
+    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1));
 );
 #elif MLKEM_K == 4
 __contract__(
@@ -549,10 +549,10 @@ __contract__(
   assigns(memory_slice(r2, sizeof(poly)))
   assigns(memory_slice(r3, sizeof(poly)))
   ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N - 1, MLKEM_ETA1));
+    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1));
 );
 #elif MLKEM_K == 3
 __contract__(
@@ -565,10 +565,10 @@ __contract__(
   assigns(memory_slice(r2, sizeof(poly)))
   assigns(memory_slice(r3, sizeof(poly)))
   ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N - 1, MLKEM_ETA1));
+    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1)
+    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1));
 );
 #endif /* MLKEM_K */
 
@@ -602,7 +602,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(seed, MLKEM_SYMBYTES))
   assigns(object_whole(r))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, MLKEM_ETA2))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA2))
 );
 #endif /* MLKEM_K == 2 || MLKEM_K == 4 */
 
@@ -631,10 +631,10 @@ __contract__(
    r1 == r0 + 1 && r3 == r2 + 1 && !same_object(r0, r2)))
   requires(memory_no_alias(seed, MLKEM_SYMBYTES))
   assigns(object_whole(r0), object_whole(r1), object_whole(r2), object_whole(r3))
-  ensures(array_abs_bound(r0->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-     && array_abs_bound(r1->coeffs,0, MLKEM_N - 1, MLKEM_ETA1)
-     && array_abs_bound(r2->coeffs,0, MLKEM_N - 1, MLKEM_ETA2)
-     && array_abs_bound(r3->coeffs,0, MLKEM_N - 1, MLKEM_ETA2));
+  ensures(array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
+     && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
+     && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA2)
+     && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA2));
 );
 #endif /* MLKEM_K == 2 */
 
@@ -667,9 +667,9 @@ __contract__(
   requires(memory_no_alias(a, sizeof(poly)))
   requires(memory_no_alias(b, sizeof(poly)))
   requires(memory_no_alias(b_cache, sizeof(poly_mulcache)))
-  requires(array_abs_bound(a->coeffs, 0, MLKEM_N - 1, UINT12_MAX))
+  requires(array_abs_bound(a->coeffs, 0, MLKEM_N, UINT12_MAX))
   assigns(object_whole(r))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, 2 * MLKEM_Q - 1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, 2 * MLKEM_Q - 1))
 );
 
 #define poly_tomont MLKEM_NAMESPACE(poly_tomont)
@@ -688,7 +688,7 @@ void poly_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N - 1, (MLKEM_Q - 1)))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, (MLKEM_Q - 1)))
 );
 
 #define poly_mulcache_compute MLKEM_NAMESPACE(poly_mulcache_compute)
@@ -745,7 +745,7 @@ void poly_reduce(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_bound(r->coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
 );
 
 #define poly_add MLKEM_NAMESPACE(poly_add)
@@ -771,9 +771,9 @@ void poly_add(poly *r, const poly *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(b, sizeof(poly)))
-  requires(forall(int, k0, 0, MLKEM_N - 1, (int32_t) r->coeffs[k0] + b->coeffs[k0] <= INT16_MAX))
-  requires(forall(int, k1, 0, MLKEM_N - 1, (int32_t) r->coeffs[k1] + b->coeffs[k1] >= INT16_MIN))
-  ensures(forall(int, k, 0, MLKEM_N - 1, r->coeffs[k] == old(*r).coeffs[k] + b->coeffs[k]))
+  requires(forall(int, k0, 0, MLKEM_N, (int32_t) r->coeffs[k0] + b->coeffs[k0] <= INT16_MAX))
+  requires(forall(int, k1, 0, MLKEM_N, (int32_t) r->coeffs[k1] + b->coeffs[k1] >= INT16_MIN))
+  ensures(forall(int, k, 0, MLKEM_N, r->coeffs[k] == old(*r).coeffs[k] + b->coeffs[k]))
   assigns(memory_slice(r, sizeof(poly)))
 );
 
@@ -796,9 +796,9 @@ void poly_sub(poly *r, const poly *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(b, sizeof(poly)))
-  requires(forall(int, k0, 0, MLKEM_N - 1, (int32_t) r->coeffs[k0] - b->coeffs[k0] <= INT16_MAX))
-  requires(forall(int, k1, 0, MLKEM_N - 1, (int32_t) r->coeffs[k1] - b->coeffs[k1] >= INT16_MIN))
-  ensures(forall(int, k, 0, MLKEM_N - 1, r->coeffs[k] == old(*r).coeffs[k] - b->coeffs[k]))
+  requires(forall(int, k0, 0, MLKEM_N, (int32_t) r->coeffs[k0] - b->coeffs[k0] <= INT16_MAX))
+  requires(forall(int, k1, 0, MLKEM_N, (int32_t) r->coeffs[k1] - b->coeffs[k1] >= INT16_MIN))
+  ensures(forall(int, k, 0, MLKEM_N, r->coeffs[k] == old(*r).coeffs[k] - b->coeffs[k]))
   assigns(object_whole(r))
 );
 

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -103,9 +103,8 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
    * in the higher level bounds reasoning. It is thus best to omit
    * them from the spec to not unnecessarily constraint native implementations.
    */
-  cassert(
-      array_abs_bound(r->coeffs, 0, MLKEM_N - 1, MLKEM_K * (2 * MLKEM_Q - 1)),
-      "polyvec_basemul_acc_montgomery_cached output bounds");
+  cassert(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_K * (2 * MLKEM_Q - 1)),
+          "polyvec_basemul_acc_montgomery_cached output bounds");
   /* TODO: Integrate CBMC assertion into POLY_BOUND if CBMC is set */
   POLY_BOUND(r, MLKEM_K * 2 * MLKEM_Q);
 }

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -39,8 +39,8 @@ void polyvec_compress_du(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES_DU],
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYVECCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(a, sizeof(polyvec)))
-  requires(forall(int, k0, 0, MLKEM_K - 1,
-         array_bound(a->vec[k0].coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1))))
+  requires(forall(int, k0, 0, MLKEM_K,
+         array_bound(a->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
   assigns(object_whole(r))
 );
 
@@ -63,8 +63,8 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYVECCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(object_whole(r))
-  ensures(forall(int, k0, 0, MLKEM_K - 1,
-         array_bound(r->vec[k0].coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1))))
+  ensures(forall(int, k0, 0, MLKEM_K,
+         array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
 );
 
 #define polyvec_tobytes MLKEM_NAMESPACE(polyvec_tobytes)
@@ -83,8 +83,8 @@ void polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const polyvec *a)
 __contract__(
   requires(memory_no_alias(a, sizeof(polyvec)))
   requires(memory_no_alias(r, MLKEM_POLYVECBYTES))
-  requires(forall(int, k0, 0, MLKEM_K - 1,
-         array_bound(a->vec[k0].coeffs, 0, (MLKEM_N - 1), 0, (MLKEM_Q - 1))))
+  requires(forall(int, k0, 0, MLKEM_K,
+         array_bound(a->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
   assigns(object_whole(r))
 );
 
@@ -106,8 +106,8 @@ __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   requires(memory_no_alias(a, MLKEM_POLYVECBYTES))
   assigns(object_whole(r))
-  ensures(forall(int, k0, 0, MLKEM_K - 1,
-        array_bound(r->vec[k0].coeffs, 0, (MLKEM_N - 1), 0, UINT12_MAX)))
+  ensures(forall(int, k0, 0, MLKEM_K,
+        array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, UINT12_MAX)))
 );
 
 #define polyvec_ntt MLKEM_NAMESPACE(polyvec_ntt)
@@ -129,11 +129,11 @@ MLKEM_NATIVE_INTERNAL_API
 void polyvec_ntt(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
-  requires(forall(int, j, 0, MLKEM_K - 1,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N - 1, (MLKEM_Q - 1))))
+  requires(forall(int, j, 0, MLKEM_K,
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (MLKEM_Q - 1))))
   assigns(object_whole(r))
-  ensures(forall(int, j, 0, MLKEM_K - 1,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N - 1, (NTT_BOUND - 1))))
+  ensures(forall(int, j, 0, MLKEM_K,
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (NTT_BOUND - 1))))
 );
 
 #define polyvec_invntt_tomont MLKEM_NAMESPACE(polyvec_invntt_tomont)
@@ -157,8 +157,8 @@ void polyvec_invntt_tomont(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(object_whole(r))
-  ensures(forall(int, j, 0, MLKEM_K - 1,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N - 1, (INVNTT_BOUND - 1))))
+  ensures(forall(int, j, 0, MLKEM_K,
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (INVNTT_BOUND - 1))))
 );
 
 #define polyvec_basemul_acc_montgomery \
@@ -179,8 +179,8 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(a, sizeof(polyvec)))
   requires(memory_no_alias(b, sizeof(polyvec)))
-  requires(forall(int, k1, 0, MLKEM_K - 1,
-    array_abs_bound(a->vec[k1].coeffs, 0, MLKEM_N - 1, UINT12_MAX)))
+  requires(forall(int, k1, 0, MLKEM_K,
+    array_abs_bound(a->vec[k1].coeffs, 0, MLKEM_N, UINT12_MAX)))
   assigns(memory_slice(r, sizeof(poly)))
 );
 
@@ -213,8 +213,8 @@ __contract__(
   requires(memory_no_alias(a, sizeof(polyvec)))
   requires(memory_no_alias(b, sizeof(polyvec)))
   requires(memory_no_alias(b_cache, sizeof(polyvec_mulcache)))
-  requires(forall(int, k1, 0, MLKEM_K - 1,
-    array_abs_bound(a->vec[k1].coeffs, 0, MLKEM_N - 1, UINT12_MAX)))
+  requires(forall(int, k1, 0, MLKEM_K,
+    array_abs_bound(a->vec[k1].coeffs, 0, MLKEM_N, UINT12_MAX)))
   assigns(memory_slice(r, sizeof(poly)))
 );
 
@@ -274,8 +274,8 @@ void polyvec_reduce(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(object_whole(r))
-  ensures(forall(int, k0, 0, MLKEM_K - 1,
-    array_bound(r->vec[k0].coeffs, 0, MLKEM_N - 1, 0, (MLKEM_Q - 1))))
+  ensures(forall(int, k0, 0, MLKEM_K,
+    array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
 );
 
 #define polyvec_add MLKEM_NAMESPACE(polyvec_add)
@@ -300,11 +300,11 @@ void polyvec_add(polyvec *r, const polyvec *b)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   requires(memory_no_alias(b, sizeof(polyvec)))
-  requires(forall(int, j0, 0, MLKEM_K - 1,
-          forall(int, k0, 0, MLKEM_N - 1,
+  requires(forall(int, j0, 0, MLKEM_K,
+          forall(int, k0, 0, MLKEM_N,
             (int32_t)r->vec[j0].coeffs[k0] + b->vec[j0].coeffs[k0] <= INT16_MAX)))
-  requires(forall(int, j1, 0, MLKEM_K - 1,
-          forall(int, k1, 0, MLKEM_N - 1,
+  requires(forall(int, j1, 0, MLKEM_K,
+          forall(int, k1, 0, MLKEM_N,
             (int32_t)r->vec[j1].coeffs[k1] + b->vec[j1].coeffs[k1] >= INT16_MIN)))
   assigns(object_whole(r))
 );
@@ -325,8 +325,8 @@ __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(memory_slice(r, sizeof(polyvec)))
   assigns(object_whole(r))
-  ensures(forall(int, j, 0, MLKEM_K - 1,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N - 1, (MLKEM_Q - 1))))
+  ensures(forall(int, j, 0, MLKEM_K,
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (MLKEM_Q - 1))))
 );
 
 #endif

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -49,10 +49,10 @@ __contract__(
   requires(offset <= target && target <= 4096 && buflen <= 4096 && buflen % 3 == 0)
   requires(memory_no_alias(r, sizeof(int16_t) * target))
   requires(memory_no_alias(buf, buflen))
-  requires(offset > 0 ==> array_bound(r, 0, offset - 1, 0, (MLKEM_Q - 1)))
+  requires(offset > 0 ==> array_bound(r, 0, offset, 0, (MLKEM_Q - 1)))
   assigns(memory_slice(r, sizeof(int16_t) * target))
   ensures(offset <= return_value && return_value <= target)
-  ensures(return_value > 0 ==> array_bound(r, 0, return_value - 1, 0, (MLKEM_Q - 1)))
+  ensures(return_value > 0 ==> array_bound(r, 0, return_value, 0, (MLKEM_Q - 1)))
 )
 {
   unsigned int ctr, pos;
@@ -64,7 +64,7 @@ __contract__(
   while (ctr < target && pos + 3 <= buflen)
   __loop__(
     invariant(offset <= ctr && ctr <= target && pos <= buflen)
-    invariant(ctr > 0 ==> array_bound(r, 0, ctr - 1, 0, (MLKEM_Q - 1))))
+    invariant(ctr > 0 ==> array_bound(r, 0, ctr, 0, (MLKEM_Q - 1))))
   {
     val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
     val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;

--- a/mlkem/rej_uniform.h
+++ b/mlkem/rej_uniform.h
@@ -54,9 +54,9 @@ __contract__(
   requires(offset <= target && target <= 4096 && buflen <= 4096 && buflen % 3 == 0)
   requires(memory_no_alias(r, sizeof(int16_t) * target))
   requires(memory_no_alias(buf, buflen))
-  requires(offset > 0 ==> array_bound(r, 0, offset - 1, 0, (MLKEM_Q - 1)))
+  requires(offset > 0 ==> array_bound(r, 0, offset, 0, (MLKEM_Q - 1)))
   assigns(memory_slice(r, sizeof(int16_t) * target))
   ensures(offset <= return_value && return_value <= target)
-  ensures(return_value > 0 ==> array_bound(r, 0, return_value - 1, 0, (MLKEM_Q - 1)))
+  ensures(return_value > 0 ==> array_bound(r, 0, return_value, 0, (MLKEM_Q - 1)))
 );
 #endif

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -261,7 +261,7 @@ __contract__(
   requires(memory_no_alias(a, len))
   requires(memory_no_alias(b, len))
   requires(len <= INT_MAX)
-  ensures((return_value == 0) == forall(int, i, 0, ((int)len - 1), (a[i] == b[i]))))
+  ensures((return_value == 0) == forall(int, i, 0, (int)len, (a[i] == b[i]))))
 {
   uint8_t r = 0, s = 0;
 
@@ -276,7 +276,7 @@ __contract__(
   for (i = 0; i < ilen; i++)
   __loop__(
     invariant(i >= 0 && i <= ilen)
-    invariant((r == 0) == (forall(int, k, 0, (i - 1), (a[k] == b[k])))))
+    invariant((r == 0) == (forall(int, k, 0, i, (a[k] == b[k])))))
   {
     r |= a[i] ^ b[i];
     /* s is useless, but prevents the loop from being aborted once r=0xff. */


### PR DESCRIPTION
This PR modifies the CBMC predicates `forall(...)`,
`array_bound(...)` and `array_abs_bound` to use exclusive
upper bounds for the indices.

This simplifies all call sites which previously manually issued
a `-1` to get from an array length to a maximal index.

It will also enable switching to unsigned loop indices everywhere;
the previous versions of `forall(...)`, `array_bound(...)` and
`array_abs_bound(...)` prevented this because they did not work
with the exclusive unsigned upper bound `0`.

Note that the _coefficient_ bounds are not changed and remain inclusive.