### PR TITLE
Configure namespace prefix instead of namespace macro

### DIFF
--- a/examples/custom_backend/mlkem_native/custom_config.h
+++ b/examples/custom_backend/mlkem_native/custom_config.h
@@ -34,25 +34,20 @@
 /* #define MLKEM_NATIVE_CONFIG_FILE "config.h" */
 
 /******************************************************************************
- * Name:        MLKEM_NAMESPACE
- *              _MLKEM_NAMESPACE
+ * Name:        MLKEM_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/.
  *****************************************************************************/
-#define __CONC(a, b) a##b
-#define CONC(a, b) __CONC(a, b)
-
-#define MLKEM_NAMESPACE(sym) CONC(CUSTOM_TINY_SHA3_, sym)
+#define MLKEM_NAMESPACE_PREFIX CUSTOM_TINY_SHA3
 
 /******************************************************************************
- * Name:        FIPS202_NAMESPACE
- *              _FIPS202_NAMESPACE
+ * Name:        FIPS202_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/fips202/.
  *****************************************************************************/
-#define FIPS202_NAMESPACE(sym) CONC(CUSTOM_TINY_SHA3_, sym)
+#define FIPS202_NAMESPACE_PREFIX CUSTOM_TINY_SHA3
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE

--- a/examples/monolithic_build/config_1024.h
+++ b/examples/monolithic_build/config_1024.h
@@ -38,21 +38,26 @@
 /* #define MLKEM_NATIVE_CONFIG_FILE "config.h" */
 
 /******************************************************************************
- * Name:        MLKEM_NAMESPACE
+ * Name:        MLKEM_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define CONCAT(a, b) a##b
-#define MLKEM_NAMESPACE(sym) CONCAT(mlkem1024_, sym)
+#define MLKEM_NAMESPACE_PREFIX mlkem1024
 
 /******************************************************************************
- * Name:        FIPS202_NAMESPACE
+ * Name:        FIPS202_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/fips202/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define FIPS202_NAMESPACE(sym) CONCAT(fips202_, sym)
+#define FIPS202_NAMESPACE_PREFIX fips202
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE

--- a/examples/monolithic_build/config_512.h
+++ b/examples/monolithic_build/config_512.h
@@ -38,21 +38,26 @@
 /* #define MLKEM_NATIVE_CONFIG_FILE "config.h" */
 
 /******************************************************************************
- * Name:        MLKEM_NAMESPACE
+ * Name:        MLKEM_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define CONCAT(a, b) a##b
-#define MLKEM_NAMESPACE(sym) CONCAT(mlkem512_, sym)
+#define MLKEM_NAMESPACE_PREFIX mlkem512
 
 /******************************************************************************
- * Name:        FIPS202_NAMESPACE
+ * Name:        FIPS202_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/fips202/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define FIPS202_NAMESPACE(sym) CONCAT(fips202_, sym)
+#define FIPS202_NAMESPACE_PREFIX fips202
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE

--- a/examples/monolithic_build/config_768.h
+++ b/examples/monolithic_build/config_768.h
@@ -38,21 +38,26 @@
 /* #define MLKEM_NATIVE_CONFIG_FILE "config.h" */
 
 /******************************************************************************
- * Name:        MLKEM_NAMESPACE
+ * Name:        MLKEM_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define CONCAT(a, b) a##b
-#define MLKEM_NAMESPACE(sym) CONCAT(mlkem768_, sym)
+#define MLKEM_NAMESPACE_PREFIX mlkem768
 
 /******************************************************************************
- * Name:        FIPS202_NAMESPACE
+ * Name:        FIPS202_NAMESPACE_PREFIX
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/fips202/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define FIPS202_NAMESPACE(sym) CONCAT(fips202_, sym)
+#define FIPS202_NAMESPACE_PREFIX fips202
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -249,6 +249,26 @@
 #endif
 
 /* mlkem/common.h */
+#if defined(MLKEM_NATIVE_MAKE_NAMESPACE_)
+#undef MLKEM_NATIVE_MAKE_NAMESPACE_
+#endif
+
+/* mlkem/common.h */
+#if defined(MLKEM_NATIVE_MAKE_NAMESPACE)
+#undef MLKEM_NATIVE_MAKE_NAMESPACE
+#endif
+
+/* mlkem/common.h */
+#if defined(FIPS202_NAMESPACE)
+#undef FIPS202_NAMESPACE
+#endif
+
+/* mlkem/common.h */
+#if defined(MLKEM_NAMESPACE)
+#undef MLKEM_NAMESPACE
+#endif
+
+/* mlkem/common.h */
 #if defined(MLKEM_ASM_NAMESPACE)
 #undef MLKEM_ASM_NAMESPACE
 #endif
@@ -289,13 +309,13 @@
 #endif
 
 /* mlkem/config.h */
-#if defined(MLKEM_NAMESPACE)
-#undef MLKEM_NAMESPACE
+#if defined(MLKEM_NAMESPACE_PREFIX)
+#undef MLKEM_NAMESPACE_PREFIX
 #endif
 
 /* mlkem/config.h */
-#if defined(FIPS202_NAMESPACE)
-#undef FIPS202_NAMESPACE
+#if defined(FIPS202_NAMESPACE_PREFIX)
+#undef FIPS202_NAMESPACE_PREFIX
 #endif
 
 /* mlkem/config.h */
@@ -309,43 +329,23 @@
 #endif
 
 /* mlkem/config.h */
-#if defined(FIPS202_DEFAULT_NAMESPACE___)
-#undef FIPS202_DEFAULT_NAMESPACE___
+#if defined(FIPS202_DEFAULT_NAMESPACE_PREFIX)
+#undef FIPS202_DEFAULT_NAMESPACE_PREFIX
 #endif
 
 /* mlkem/config.h */
-#if defined(FIPS202_DEFAULT_NAMESPACE__)
-#undef FIPS202_DEFAULT_NAMESPACE__
+#if defined(MLKEM_DEFAULT_NAMESPACE_PREFIX)
+#undef MLKEM_DEFAULT_NAMESPACE_PREFIX
 #endif
 
 /* mlkem/config.h */
-#if defined(FIPS202_DEFAULT_NAMESPACE)
-#undef FIPS202_DEFAULT_NAMESPACE
+#if defined(MLKEM_DEFAULT_NAMESPACE_PREFIX)
+#undef MLKEM_DEFAULT_NAMESPACE_PREFIX
 #endif
 
 /* mlkem/config.h */
-#if defined(MLKEM_DEFAULT_NAMESPACE___)
-#undef MLKEM_DEFAULT_NAMESPACE___
-#endif
-
-/* mlkem/config.h */
-#if defined(MLKEM_DEFAULT_NAMESPACE__)
-#undef MLKEM_DEFAULT_NAMESPACE__
-#endif
-
-/* mlkem/config.h */
-#if defined(MLKEM_DEFAULT_NAMESPACE)
-#undef MLKEM_DEFAULT_NAMESPACE
-#endif
-
-/* mlkem/config.h */
-#if defined(MLKEM_DEFAULT_NAMESPACE)
-#undef MLKEM_DEFAULT_NAMESPACE
-#endif
-
-/* mlkem/config.h */
-#if defined(MLKEM_DEFAULT_NAMESPACE)
-#undef MLKEM_DEFAULT_NAMESPACE
+#if defined(MLKEM_DEFAULT_NAMESPACE_PREFIX)
+#undef MLKEM_DEFAULT_NAMESPACE_PREFIX
 #endif
 
 /* mlkem/debug/debug.c */
@@ -636,6 +636,16 @@
 /* mlkem/mlkem_native.h */
 #if defined(BUILD_INFO_LVL)
 #undef BUILD_INFO_LVL
+#endif
+
+/* mlkem/mlkem_native.h */
+#if defined(BUILD_INFO_CONCAT_)
+#undef BUILD_INFO_CONCAT_
+#endif
+
+/* mlkem/mlkem_native.h */
+#if defined(BUILD_INFO_CONCAT)
+#undef BUILD_INFO_CONCAT
 #endif
 
 /* mlkem/mlkem_native.h */

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -40,6 +40,15 @@
 #define MLKEM_NATIVE_INTERNAL_API static
 #endif
 
+#define MLKEM_NATIVE_MAKE_NAMESPACE_(x1, x2) x1##_##x2
+#define MLKEM_NATIVE_MAKE_NAMESPACE(x1, x2) MLKEM_NATIVE_MAKE_NAMESPACE_(x1, x2)
+
+#define FIPS202_NAMESPACE(s) \
+  MLKEM_NATIVE_MAKE_NAMESPACE(FIPS202_NAMESPACE_PREFIX, s)
+
+#define MLKEM_NAMESPACE(s) \
+  MLKEM_NATIVE_MAKE_NAMESPACE(MLKEM_NAMESPACE_PREFIX, s)
+
 /* On Apple platforms, we need to emit leading underscore
  * in front of assembly symbols. We thus introducee a separate
  * namespace wrapper for ASM symbols. */

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -42,18 +42,28 @@
 /******************************************************************************
  * Name:        MLKEM_NAMESPACE
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define MLKEM_NAMESPACE(sym) MLKEM_DEFAULT_NAMESPACE(sym)
+#if !defined(MLKEM_NAMESPACE_PREFIX)
+#define MLKEM_NAMESPACE_PREFIX MLKEM_DEFAULT_NAMESPACE_PREFIX
+#endif
 
 /******************************************************************************
  * Name:        FIPS202_NAMESPACE
  *
- * Description: The macros to use to namespace global symbols
+ * Description: The prefix to use to namespace global symbols
  *              from mlkem/fips202/.
+ *
+ *              This can also be set using CFLAGS.
+ *
  *****************************************************************************/
-#define FIPS202_NAMESPACE(sym) FIPS202_DEFAULT_NAMESPACE(sym)
+#if !defined(FIPS202_NAMESPACE_PREFIX)
+#define FIPS202_NAMESPACE_PREFIX FIPS202_DEFAULT_NAMESPACE_PREFIX
+#endif
 
 /******************************************************************************
  * Name:        MLKEM_USE_NATIVE
@@ -113,11 +123,7 @@
  * e.g., PQCP_MLKEM_NATIVE_FIPS202_C_
  */
 
-#define FIPS202_DEFAULT_NAMESPACE___(x1, x2) x1##_##x2
-#define FIPS202_DEFAULT_NAMESPACE__(x1, x2) FIPS202_DEFAULT_NAMESPACE___(x1, x2)
-
-#define FIPS202_DEFAULT_NAMESPACE(s) \
-  FIPS202_DEFAULT_NAMESPACE__(PQCP_MLKEM_NATIVE_FIPS202, s)
+#define FIPS202_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_FIPS202
 
 /*
  * The default MLKEM namespace is
@@ -127,19 +133,12 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_OPT_
  */
 
-#define MLKEM_DEFAULT_NAMESPACE___(x1, x2, x3) x1##_##x2##_##x3
-#define MLKEM_DEFAULT_NAMESPACE__(x1, x2, x3) \
-  MLKEM_DEFAULT_NAMESPACE___(x1, x2, x3)
-
 #if MLKEM_K == 2
-#define MLKEM_DEFAULT_NAMESPACE(s) \
-  MLKEM_DEFAULT_NAMESPACE__(PQCP_MLKEM_NATIVE, MLKEM512, s)
+#define MLKEM_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLKEM_K == 3
-#define MLKEM_DEFAULT_NAMESPACE(s) \
-  MLKEM_DEFAULT_NAMESPACE__(PQCP_MLKEM_NATIVE, MLKEM768, s)
+#define MLKEM_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768
 #elif MLKEM_K == 4
-#define MLKEM_DEFAULT_NAMESPACE(s) \
-  MLKEM_DEFAULT_NAMESPACE__(PQCP_MLKEM_NATIVE, MLKEM1024, s)
+#define MLKEM_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM1024
 #endif
 
 #endif /* MLkEM_NATIVE_CONFIG_H */

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -55,11 +55,13 @@
 #error MLKEM_K not set by config file
 #endif
 
-#ifndef MLKEM_NAMESPACE
-#error MLKEM_NAMESPACE not set by config file
+#ifndef MLKEM_NAMESPACE_PREFIX
+#error MLKEM_NAMESPACE_PREFIX not set by config file
 #endif
 
-#define BUILD_INFO_NAMESPACE(sym) MLKEM_NAMESPACE(sym)
+#define BUILD_INFO_CONCAT_(x, y) x##_##y
+#define BUILD_INFO_CONCAT(x, y) BUILD_INFO_CONCAT_(x, y)
+#define BUILD_INFO_NAMESPACE(sym) BUILD_INFO_CONCAT(MLKEM_NAMESPACE_PREFIX, sym)
 
 #endif /* BUILD_INFO_LVL */
 


### PR DESCRIPTION
Previously, the user could customize namespacing by providing macros `MLKEM_NAMESPACE(sym)` and `FIPS202_NAMESPACE(sym)`.

This mode of configuration is slightly inconvenient in that the namespace cannot be controlled from CFLAGS.

This commit addresses this, as follows: Instead of making the namespace macro configurable, make the namespace _prefix_ configurable, and derive the namespace macro: The config provides MLKEM_NAMESPACE_PREFIX and FIPS202_NAMESPACE_PREIFX, and then the derived MLKEM_NAMESPACE(sym) and FIPS202_NAMESPACE(sym) are the concatenation of that, an underscore `_`, and the symbol name `sym`.

All configs and examples are adjusted accordingly.
