### PR TITLE
CBMC: Switch to exclusive coefficient upper bounds

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -1559,8 +1559,8 @@
 #endif
 
 /* mlkem/params.h */
-#if defined(UINT12_MAX)
-#undef UINT12_MAX
+#if defined(UINT12_LIMIT)
+#undef UINT12_LIMIT
 #endif
 
 /* mlkem/params.h */

--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -73,7 +73,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4])
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 8)
-    invariant(array_abs_bound(r->coeffs, 0, 8 * i, 2)))
+    invariant(array_abs_bound(r->coeffs, 0, 8 * i, 3)))
   {
     unsigned j;
     uint32_t t = load32_littleendian(buf + 4 * i);
@@ -83,7 +83,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4])
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_abs_bound(r->coeffs, 0, 8 * i + j, 2)))
+      invariant(array_abs_bound(r->coeffs, 0, 8 * i + j, 3)))
     {
       const int16_t a = (d >> (4 * j + 0)) & 0x3;
       const int16_t b = (d >> (4 * j + 2)) & 0x3;
@@ -110,7 +110,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
   for (i = 0; i < MLKEM_N / 4; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 4)
-    invariant(array_abs_bound(r->coeffs, 0, 4 * i, 3)))
+    invariant(array_abs_bound(r->coeffs, 0, 4 * i, 4)))
   {
     unsigned j;
     const uint32_t t = load24_littleendian(buf + 3 * i);
@@ -121,7 +121,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
     for (j = 0; j < 4; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 4 && j >= 0 && j <= 4)
-      invariant(array_abs_bound(r->coeffs, 0, 4 * i + j, 3)))
+      invariant(array_abs_bound(r->coeffs, 0, 4 * i + j, 4)))
     {
       const int16_t a = (d >> (6 * j + 0)) & 0x7;
       const int16_t b = (d >> (6 * j + 3)) & 0x7;

--- a/mlkem/cbd.h
+++ b/mlkem/cbd.h
@@ -26,7 +26,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(buf, MLKEM_ETA1 * MLKEM_N / 4))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA1 + 1))
 );
 
 #if MLKEM_K == 2 || MLKEM_K == 4
@@ -47,7 +47,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(buf, MLKEM_ETA2 * MLKEM_N / 4))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA2))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA2 + 1))
 );
 #endif /* MLKEM_K == 2 || MLKEM_K == 4 */
 

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -163,10 +163,10 @@ __contract__(
   requires(memory_no_alias(seed[2], MLKEM_SYMBYTES + 2))
   requires(memory_no_alias(seed[3], MLKEM_SYMBYTES + 2))
   assigns(memory_slice(vec, sizeof(poly) * 4))
-  ensures(array_bound(vec[0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
-  ensures(array_bound(vec[1].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
-  ensures(array_bound(vec[2].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
-  ensures(array_bound(vec[3].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
+  ensures(array_bound(vec[0].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  ensures(array_bound(vec[1].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  ensures(array_bound(vec[2].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  ensures(array_bound(vec[3].coeffs, 0, MLKEM_N, 0, MLKEM_Q)))
 {
   /* Temporary buffers for XOF output before rejection sampling */
   uint8_t buf0[MLKEM_GEN_MATRIX_NBLOCKS * XOF_RATE];
@@ -207,10 +207,10 @@ __contract__(
        object_whole(buf1), object_whole(buf2), object_whole(buf3))
     invariant(ctr[0] <= MLKEM_N && ctr[1] <= MLKEM_N)
     invariant(ctr[2] <= MLKEM_N && ctr[3] <= MLKEM_N)
-    invariant(ctr[0] > 0 ==> array_bound(vec[0].coeffs, 0, ctr[0], 0, (MLKEM_Q - 1)))
-    invariant(ctr[1] > 0 ==> array_bound(vec[1].coeffs, 0, ctr[1], 0, (MLKEM_Q - 1)))
-    invariant(ctr[2] > 0 ==> array_bound(vec[2].coeffs, 0, ctr[2], 0, (MLKEM_Q - 1)))
-    invariant(ctr[3] > 0 ==> array_bound(vec[3].coeffs, 0, ctr[3], 0, (MLKEM_Q - 1))))
+    invariant(ctr[0] > 0 ==> array_bound(vec[0].coeffs, 0, ctr[0], 0, MLKEM_Q))
+    invariant(ctr[1] > 0 ==> array_bound(vec[1].coeffs, 0, ctr[1], 0, MLKEM_Q))
+    invariant(ctr[2] > 0 ==> array_bound(vec[2].coeffs, 0, ctr[2], 0, MLKEM_Q))
+    invariant(ctr[3] > 0 ==> array_bound(vec[3].coeffs, 0, ctr[3], 0, MLKEM_Q)))
   {
     xof_x4_squeezeblocks(buf0, buf1, buf2, buf3, 1, &statex);
     ctr[0] = rej_uniform(vec[0].coeffs, MLKEM_N, ctr[0], buf0, buflen);
@@ -231,7 +231,7 @@ __contract__(
   requires(memory_no_alias(entry, sizeof(poly)))
   requires(memory_no_alias(seed, MLKEM_SYMBYTES + 2))
   assigns(memory_slice(entry, sizeof(poly)))
-  ensures(array_bound(entry->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
+  ensures(array_bound(entry->coeffs, 0, MLKEM_N, 0, MLKEM_Q)))
 {
   xof_ctx state;
   uint8_t buf[MLKEM_GEN_MATRIX_NBLOCKS * XOF_RATE];
@@ -253,7 +253,7 @@ __contract__(
     assigns(ctr, state, memory_slice(entry, sizeof(poly)), object_whole(buf))
     invariant(0 <= ctr && ctr <= MLKEM_N)
     invariant(ctr > 0 ==> array_bound(entry->coeffs, 0, ctr,
-                                          0, (MLKEM_Q - 1))))
+                                          0, MLKEM_Q)))
   {
     xof_squeezeblocks(buf, 1, &state);
     ctr = rej_uniform(entry->coeffs, MLKEM_N, ctr, buf, buflen);
@@ -273,9 +273,9 @@ __contract__(
   /* We don't specify that this should be a permutation, but only
    * that it does not change the bound established at the end of gen_matrix. */
   requires(memory_no_alias(data, sizeof(poly)))
-  requires(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q - 1))
+  requires(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
   assigns(memory_slice(data, sizeof(poly)))
-  ensures(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q - 1))) { ((void)data); }
+  ensures(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q))) { ((void)data); }
 #endif /* MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER */
 
 /* Not static for benchmarking */
@@ -392,7 +392,7 @@ __contract__(
   requires(memory_no_alias(vc, sizeof(polyvec_mulcache)))
   requires(forall(k0, 0, MLKEM_K,
     forall(k1, 0, MLKEM_K,
-      array_abs_bound(a[k0].vec[k1].coeffs, 0, MLKEM_N, UINT12_MAX))))
+      array_bound(a[k0].vec[k1].coeffs, 0, MLKEM_N, 0, UINT12_LIMIT))))
   assigns(object_whole(out)))
 {
   unsigned i;

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -31,7 +31,7 @@ __contract__(
   requires(transposed == 0 || transposed == 1)
   assigns(object_whole(a))
   ensures(forall(x, 0, MLKEM_K, forall(y, 0, MLKEM_K,
-  array_bound(a[x].vec[y].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))));
+  array_bound(a[x].vec[y].coeffs, 0, MLKEM_N, 0, MLKEM_Q))));
 );
 
 #define indcpa_keypair_derand MLKEM_NAMESPACE(indcpa_keypair_derand)

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -97,9 +97,9 @@ static void ntt_layer(int16_t r[MLKEM_N], int len, int layer)
 __contract__(
   requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
   requires(1 <= layer && layer <= 7 && len == (MLKEM_N >> layer))
-  requires(array_abs_bound(r, 0, MLKEM_N, layer * MLKEM_Q - 1))
+  requires(array_abs_bound(r, 0, MLKEM_N, layer * MLKEM_Q))
   assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
-  ensures(array_abs_bound(r, 0, MLKEM_N, (layer + 1) * MLKEM_Q - 1)))
+  ensures(array_abs_bound(r, 0, MLKEM_N, (layer + 1) * MLKEM_Q)))
 {
   int start, k;
   /* `layer` is a ghost variable only needed in the CBMC specification */
@@ -110,11 +110,11 @@ __contract__(
   __loop__(
     invariant(0 <= start && start < MLKEM_N + 2 * len)
     invariant(0 <= k && k <= MLKEM_N / 2 && 2 * len * k == start + MLKEM_N)
-    invariant(array_abs_bound(r, 0, start, (layer * MLKEM_Q - 1) + MLKEM_Q))
-    invariant(array_abs_bound(r, start, MLKEM_N, layer * MLKEM_Q - 1)))
+    invariant(array_abs_bound(r, 0, start, layer * MLKEM_Q + MLKEM_Q))
+    invariant(array_abs_bound(r, start, MLKEM_N, layer * MLKEM_Q)))
   {
     int16_t zeta = zetas[k++];
-    ntt_butterfly_block(r, zeta, start, len, layer * MLKEM_Q - 1);
+    ntt_butterfly_block(r, zeta, start, len, layer * MLKEM_Q);
   }
 }
 
@@ -138,7 +138,7 @@ void poly_ntt(poly *p)
   for (len = 128, layer = 1; len >= 2; len >>= 1, layer++)
   __loop__(
     invariant(1 <= layer && layer <= 8 && len == (MLKEM_N >> layer))
-    invariant(array_abs_bound(r, 0, MLKEM_N, layer * MLKEM_Q - 1)))
+    invariant(array_abs_bound(r, 0, MLKEM_N, layer * MLKEM_Q)))
   {
     ntt_layer(r, len, layer);
   }

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -36,9 +36,9 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
-  requires(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_Q - 1))
+  requires(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_Q))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, NTT_BOUND - 1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, NTT_BOUND))
 );
 
 #define poly_invntt_tomont MLKEM_NAMESPACE(poly_invntt_tomont)
@@ -63,7 +63,7 @@ void poly_invntt_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, INVNTT_BOUND - 1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, INVNTT_BOUND))
 );
 
 #define basemul_cached MLKEM_NAMESPACE(basemul_cached)
@@ -94,9 +94,9 @@ __contract__(
   requires(memory_no_alias(r, 2 * sizeof(int16_t)))
   requires(memory_no_alias(a, 2 * sizeof(int16_t)))
   requires(memory_no_alias(b, 2 * sizeof(int16_t)))
-  requires(array_abs_bound(a, 0, 2, UINT12_MAX))
+  requires(array_bound(a, 0, 2, 0, UINT12_LIMIT))
   assigns(memory_slice(r, 2 * sizeof(int16_t)))
-  ensures(array_abs_bound(r, 0, 2, 2 * MLKEM_Q - 1))
+  ensures(array_abs_bound(r, 0, 2, 2 * MLKEM_Q))
 );
 
 

--- a/mlkem/params.h
+++ b/mlkem/params.h
@@ -17,7 +17,7 @@
 
 #define MLKEM_N 256
 #define MLKEM_Q 3329
-#define UINT12_MAX 4095
+#define UINT12_LIMIT 4096
 
 #define MLKEM_SYMBYTES 32 /* size in bytes of hashes, and seeds */
 #define MLKEM_SSBYTES 32  /* size in bytes of shared key */

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -89,7 +89,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
   for (j = 0; j < MLKEM_N / 8; j++)
   __loop__(
     invariant(0 <= j && j <= MLKEM_N / 8)
-    invariant(array_bound(r->coeffs, 0, 8 * j, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 8 * j, 0, MLKEM_Q)))
   {
     int k;
     uint16_t t[8];
@@ -108,7 +108,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
     for (k = 0; k < 8; k++)
     __loop__(
       invariant(0 <= k && k <= 8)
-      invariant(array_bound(r->coeffs, 0, 8 * j + k, 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 8 * j + k, 0, MLKEM_Q)))
     {
       r->coeffs[8 * j + k] = scalar_decompress_d11(t[k]);
     }
@@ -117,7 +117,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
   for (j = 0; j < MLKEM_N / 4; j++)
   __loop__(
     invariant(0 <= j && j <= MLKEM_N / 4)
-    invariant(array_bound(r->coeffs, 0, 4 * j, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 4 * j, 0, MLKEM_Q)))
   {
     int k;
     uint16_t t[4];
@@ -131,7 +131,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
     for (k = 0; k < 4; k++)
     __loop__(
       invariant(0 <= k && k <= 4)
-      invariant(array_bound(r->coeffs, 0, 4 * j + k, 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 4 * j + k, 0, MLKEM_Q)))
     {
       r->coeffs[4 * j + k] = scalar_decompress_d10(t[k]);
     }
@@ -156,7 +156,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_bound(t, 0, j, 0, 15)))
+      invariant(array_bound(t, 0, j, 0, 16)))
     {
       t[j] = scalar_compress_d4(a->coeffs[8 * i + j]);
     }
@@ -175,7 +175,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_bound(t, 0, j, 0, 31)))
+      invariant(array_bound(t, 0, j, 0, 32)))
     {
       t[j] = scalar_compress_d5(a->coeffs[8 * i + j]);
     }
@@ -204,7 +204,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 2)
-    invariant(array_bound(r->coeffs, 0, 2 * i, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 2 * i, 0, MLKEM_Q)))
   {
     r->coeffs[2 * i + 0] = scalar_decompress_d4((a[i] >> 0) & 0xF);
     r->coeffs[2 * i + 1] = scalar_decompress_d4((a[i] >> 4) & 0xF);
@@ -213,7 +213,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 8)
-    invariant(array_bound(r->coeffs, 0, 8 * i, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 8 * i, 0, MLKEM_Q)))
   {
     unsigned j;
     uint8_t t[8];
@@ -241,7 +241,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(j >= 0 && j <= 8 && i >= 0 && i <= MLKEM_N / 8)
-      invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, MLKEM_Q)))
     {
       r->coeffs[8 * i + j] = scalar_decompress_d5(t[j]);
     }
@@ -303,7 +303,7 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 2)
-    invariant(array_bound(r->coeffs, 0, 2 * i, 0, UINT12_MAX)))
+    invariant(array_bound(r->coeffs, 0, 2 * i, 0, UINT12_LIMIT)))
   {
     const uint8_t t0 = a[3 * i + 0];
     const uint8_t t1 = a[3 * i + 1];
@@ -334,13 +334,13 @@ void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N / 8)
-    invariant(array_bound(r->coeffs, 0, 8 * i, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, 8 * i, 0, MLKEM_Q)))
   {
     unsigned j;
     for (j = 0; j < 8; j++)
     __loop__(
       invariant(i >= 0 && i <  MLKEM_N / 8 && j >= 0 && j <= 8)
-      invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, (MLKEM_Q - 1))))
+      invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, MLKEM_Q)))
     {
       /* Prevent the compiler from recognizing this as a bit selection */
       uint8_t mask = value_barrier_u8(1u << j);
@@ -469,7 +469,7 @@ void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
   __loop__(
     assigns(i, object_whole(r))
     invariant(i >= 0 && i <= MLKEM_N / 4)
-    invariant(array_abs_bound(r->coeffs, 0, 4 * i, 2 * MLKEM_Q - 1)))
+    invariant(array_abs_bound(r->coeffs, 0, 4 * i, 2 * MLKEM_Q)))
   {
     basemul_cached(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
                    b_cache->coeffs[2 * i]);
@@ -487,7 +487,7 @@ void poly_tomont(poly *r)
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N)
-    invariant(array_abs_bound(r->coeffs ,0, i, (MLKEM_Q - 1))))
+    invariant(array_abs_bound(r->coeffs ,0, i, MLKEM_Q)))
   {
     r->coeffs[i] = fqmul(r->coeffs[i], f);
   }
@@ -511,7 +511,7 @@ void poly_reduce(poly *r)
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
     invariant(i >= 0 && i <= MLKEM_N)
-    invariant(array_bound(r->coeffs, 0, i, 0, (MLKEM_Q - 1))))
+    invariant(array_bound(r->coeffs, 0, i, 0, MLKEM_Q)))
   {
     /* Barrett reduction, giving signed canonical representative */
     int16_t t = barrett_reduce(r->coeffs[i]);

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -339,7 +339,7 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
   assigns(memory_slice(r, MLKEM_POLYCOMPRESSEDBYTES_DU))
 );
 
@@ -364,7 +364,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
 );
 
 #define poly_compress_dv MLKEM_NAMESPACE(poly_compress_dv)
@@ -385,7 +385,7 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYCOMPRESSEDBYTES_DV))
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
   assigns(object_whole(r))
 );
 
@@ -411,7 +411,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYCOMPRESSEDBYTES_DV))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(object_whole(r))
-  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
 );
 
 #define poly_tobytes MLKEM_NAMESPACE(poly_tobytes)
@@ -434,7 +434,7 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 __contract__(
   requires(memory_no_alias(r, MLKEM_POLYBYTES))
   requires(memory_no_alias(a, sizeof(poly)))
-  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
   assigns(object_whole(r))
 );
 
@@ -459,7 +459,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYBYTES))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, UINT12_MAX))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, UINT12_LIMIT))
 );
 
 
@@ -478,7 +478,7 @@ __contract__(
   requires(memory_no_alias(msg, MLKEM_INDCPA_MSGBYTES))
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(object_whole(r))
-  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
 );
 
 #define poly_tomsg MLKEM_NAMESPACE(poly_tomsg)
@@ -496,7 +496,7 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *r)
 __contract__(
   requires(memory_no_alias(msg, MLKEM_INDCPA_MSGBYTES))
   requires(memory_no_alias(r, sizeof(poly)))
-  requires(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  requires(array_bound(r->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
   assigns(object_whole(msg))
 );
 
@@ -534,10 +534,10 @@ __contract__(
   assigns(memory_slice(r2, sizeof(poly)))
   assigns(memory_slice(r3, sizeof(poly)))
   ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1));
+    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1));
 );
 #elif MLKEM_K == 4
 __contract__(
@@ -549,10 +549,10 @@ __contract__(
   assigns(memory_slice(r2, sizeof(poly)))
   assigns(memory_slice(r3, sizeof(poly)))
   ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1));
+    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1));
 );
 #elif MLKEM_K == 3
 __contract__(
@@ -565,10 +565,10 @@ __contract__(
   assigns(memory_slice(r2, sizeof(poly)))
   assigns(memory_slice(r3, sizeof(poly)))
   ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1));
+    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1));
 );
 #endif /* MLKEM_K */
 
@@ -602,7 +602,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   requires(memory_no_alias(seed, MLKEM_SYMBYTES))
   assigns(object_whole(r))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA2))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_ETA2 + 1))
 );
 #endif /* MLKEM_K == 2 || MLKEM_K == 4 */
 
@@ -631,10 +631,10 @@ __contract__(
    r1 == r0 + 1 && r3 == r2 + 1 && !same_object(r0, r2)))
   requires(memory_no_alias(seed, MLKEM_SYMBYTES))
   assigns(object_whole(r0), object_whole(r1), object_whole(r2), object_whole(r3))
-  ensures(array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1)
-     && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1)
-     && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA2)
-     && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA2));
+  ensures(array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+     && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
+     && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA2 + 1)
+     && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA2 + 1));
 );
 #endif /* MLKEM_K == 2 */
 
@@ -667,9 +667,9 @@ __contract__(
   requires(memory_no_alias(a, sizeof(poly)))
   requires(memory_no_alias(b, sizeof(poly)))
   requires(memory_no_alias(b_cache, sizeof(poly_mulcache)))
-  requires(array_abs_bound(a->coeffs, 0, MLKEM_N, UINT12_MAX))
+  requires(array_bound(a->coeffs, 0, MLKEM_N, 0, UINT12_LIMIT))
   assigns(object_whole(r))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, 2 * MLKEM_Q - 1))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, 2 * MLKEM_Q))
 );
 
 #define poly_tomont MLKEM_NAMESPACE(poly_tomont)
@@ -688,7 +688,7 @@ void poly_tomont(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, (MLKEM_Q - 1)))
+  ensures(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_Q))
 );
 
 #define poly_mulcache_compute MLKEM_NAMESPACE(poly_mulcache_compute)
@@ -745,7 +745,7 @@ void poly_reduce(poly *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(poly)))
   assigns(memory_slice(r, sizeof(poly)))
-  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1)))
+  ensures(array_bound(r->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
 );
 
 #define poly_add MLKEM_NAMESPACE(poly_add)

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -103,7 +103,7 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
    * in the higher level bounds reasoning. It is thus best to omit
    * them from the spec to not unnecessarily constraint native implementations.
    */
-  cassert(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_K * (2 * MLKEM_Q - 1)),
+  cassert(array_abs_bound(r->coeffs, 0, MLKEM_N, MLKEM_K * 2 * MLKEM_Q),
           "polyvec_basemul_acc_montgomery_cached output bounds");
   /* TODO: Integrate CBMC assertion into POLY_BOUND if CBMC is set */
   POLY_BOUND(r, MLKEM_K * 2 * MLKEM_Q);

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -40,7 +40,7 @@ __contract__(
   requires(memory_no_alias(r, MLKEM_POLYVECCOMPRESSEDBYTES_DU))
   requires(memory_no_alias(a, sizeof(polyvec)))
   requires(forall(k0, 0, MLKEM_K,
-         array_bound(a->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
+         array_bound(a->vec[k0].coeffs, 0, MLKEM_N, 0, MLKEM_Q)))
   assigns(object_whole(r))
 );
 
@@ -64,7 +64,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(object_whole(r))
   ensures(forall(k0, 0, MLKEM_K,
-         array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
+         array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, MLKEM_Q)))
 );
 
 #define polyvec_tobytes MLKEM_NAMESPACE(polyvec_tobytes)
@@ -84,7 +84,7 @@ __contract__(
   requires(memory_no_alias(a, sizeof(polyvec)))
   requires(memory_no_alias(r, MLKEM_POLYVECBYTES))
   requires(forall(k0, 0, MLKEM_K,
-         array_bound(a->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
+         array_bound(a->vec[k0].coeffs, 0, MLKEM_N, 0, MLKEM_Q)))
   assigns(object_whole(r))
 );
 
@@ -107,7 +107,7 @@ __contract__(
   requires(memory_no_alias(a, MLKEM_POLYVECBYTES))
   assigns(object_whole(r))
   ensures(forall(k0, 0, MLKEM_K,
-        array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, UINT12_MAX)))
+        array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, UINT12_LIMIT)))
 );
 
 #define polyvec_ntt MLKEM_NAMESPACE(polyvec_ntt)
@@ -130,10 +130,10 @@ void polyvec_ntt(polyvec *r)
 __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   requires(forall(j, 0, MLKEM_K,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (MLKEM_Q - 1))))
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, MLKEM_Q)))
   assigns(object_whole(r))
   ensures(forall(j, 0, MLKEM_K,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (NTT_BOUND - 1))))
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, NTT_BOUND)))
 );
 
 #define polyvec_invntt_tomont MLKEM_NAMESPACE(polyvec_invntt_tomont)
@@ -158,7 +158,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(object_whole(r))
   ensures(forall(j, 0, MLKEM_K,
-  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (INVNTT_BOUND - 1))))
+  array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, INVNTT_BOUND)))
 );
 
 #define polyvec_basemul_acc_montgomery \
@@ -180,7 +180,7 @@ __contract__(
   requires(memory_no_alias(a, sizeof(polyvec)))
   requires(memory_no_alias(b, sizeof(polyvec)))
   requires(forall(k1, 0, MLKEM_K,
-    array_abs_bound(a->vec[k1].coeffs, 0, MLKEM_N, UINT12_MAX)))
+    array_bound(a->vec[k1].coeffs, 0, MLKEM_N, 0, UINT12_LIMIT)))
   assigns(memory_slice(r, sizeof(poly)))
 );
 
@@ -214,7 +214,7 @@ __contract__(
   requires(memory_no_alias(b, sizeof(polyvec)))
   requires(memory_no_alias(b_cache, sizeof(polyvec_mulcache)))
   requires(forall(k1, 0, MLKEM_K,
-    array_abs_bound(a->vec[k1].coeffs, 0, MLKEM_N, UINT12_MAX)))
+     array_bound(a->vec[k1].coeffs, 0, MLKEM_N, 0, UINT12_LIMIT)))
   assigns(memory_slice(r, sizeof(poly)))
 );
 
@@ -275,7 +275,7 @@ __contract__(
   requires(memory_no_alias(r, sizeof(polyvec)))
   assigns(object_whole(r))
   ensures(forall(k0, 0, MLKEM_K,
-    array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, (MLKEM_Q - 1))))
+    array_bound(r->vec[k0].coeffs, 0, MLKEM_N, 0, MLKEM_Q)))
 );
 
 #define polyvec_add MLKEM_NAMESPACE(polyvec_add)
@@ -326,7 +326,7 @@ __contract__(
   assigns(memory_slice(r, sizeof(polyvec)))
   assigns(object_whole(r))
   ensures(forall(j, 0, MLKEM_K,
-    array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, (MLKEM_Q - 1))))
+    array_abs_bound(r->vec[j].coeffs, 0, MLKEM_N, MLKEM_Q)))
 );
 
 #endif

--- a/mlkem/reduce.h
+++ b/mlkem/reduce.h
@@ -115,13 +115,13 @@ __contract__(
 )
 {
   int16_t res;
-  SCALAR_BOUND(a, 2 * UINT12_MAX * 32768, "montgomery_reduce input");
+  SCALAR_BOUND(a, 2 * UINT12_LIMIT * 32768, "montgomery_reduce input");
 
   res = montgomery_reduce_generic(a);
   /* Bounds:
    * |res| <= ceil(|a| / 2^16) + (MLKEM_Q + 1) / 2
-   *       <= ceil(2 * UINT12_MAX * 32768 / 65536) + (MLKEM_Q + 1) / 2
-   *       <= UINT12_MAX + (MLKEM_Q + 1) / 2
+   *       <= ceil(2 * UINT12_LIMIT * 32768 / 65536) + (MLKEM_Q + 1) / 2
+   *       <= UINT12_LIMIT + (MLKEM_Q + 1) / 2
    *        < 2 * MLKEM_Q */
 
   SCALAR_BOUND(res, 2 * MLKEM_Q, "montgomery_reduce output");

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -49,10 +49,10 @@ __contract__(
   requires(offset <= target && target <= 4096 && buflen <= 4096 && buflen % 3 == 0)
   requires(memory_no_alias(r, sizeof(int16_t) * target))
   requires(memory_no_alias(buf, buflen))
-  requires(offset > 0 ==> array_bound(r, 0, offset, 0, (MLKEM_Q - 1)))
+  requires(offset > 0 ==> array_bound(r, 0, offset, 0, MLKEM_Q))
   assigns(memory_slice(r, sizeof(int16_t) * target))
   ensures(offset <= return_value && return_value <= target)
-  ensures(return_value > 0 ==> array_bound(r, 0, return_value, 0, (MLKEM_Q - 1)))
+  ensures(return_value > 0 ==> array_bound(r, 0, return_value, 0, MLKEM_Q))
 )
 {
   unsigned int ctr, pos;
@@ -64,7 +64,7 @@ __contract__(
   while (ctr < target && pos + 3 <= buflen)
   __loop__(
     invariant(offset <= ctr && ctr <= target && pos <= buflen)
-    invariant(ctr > 0 ==> array_bound(r, 0, ctr, 0, (MLKEM_Q - 1))))
+    invariant(ctr > 0 ==> array_bound(r, 0, ctr, 0, MLKEM_Q)))
   {
     val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
     val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;

--- a/mlkem/rej_uniform.h
+++ b/mlkem/rej_uniform.h
@@ -54,9 +54,9 @@ __contract__(
   requires(offset <= target && target <= 4096 && buflen <= 4096 && buflen % 3 == 0)
   requires(memory_no_alias(r, sizeof(int16_t) * target))
   requires(memory_no_alias(buf, buflen))
-  requires(offset > 0 ==> array_bound(r, 0, offset, 0, (MLKEM_Q - 1)))
+  requires(offset > 0 ==> array_bound(r, 0, offset, 0, MLKEM_Q))
   assigns(memory_slice(r, sizeof(int16_t) * target))
   ensures(offset <= return_value && return_value <= target)
-  ensures(return_value > 0 ==> array_bound(r, 0, return_value, 0, (MLKEM_Q - 1)))
+  ensures(return_value > 0 ==> array_bound(r, 0, return_value, 0, MLKEM_Q))
 );
 #endif


### PR DESCRIPTION
* Resolves #324 

Previously, the coefficient bounds in `array_bound(...)` and `array_abs_bound(...)` were inclusive. This was somewhat inconvenient since (a) it required a lot of `-1` in places where the exclusive upper bound was more natural to work woth, and (b) it was a deviation from the runtime debug assertions `POLY_BOUND` which would use exclusive bounds.

This commit switches `array_bound` to use an exclusive upper bound. The lower bound remains inclusive. For `array_abs_bound`, we switch to an exclusive absolute bound.

The macro `UINT12_MAX` (mapping to 4095) is replaced by UINT12_LIMIT, mapping to 4096. Uses of `array_abs_bound(..., UINT12_MAX) are replaced by `array_bound(..., 0, UINT12_LIMIT)`, since we never deal with negative numbers bound by UINT12_LIMIT.
