### PR TITLE
Remove antitrust.md

### DIFF
--- a/antitrust.md
+++ b/antitrust.md
@@ -1,8 +1,0 @@
-[//]: # (SPDX-License-Identifier: CC-BY-4.0)
-
-# Antitrust Policy Notice
-
-Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws.
-
-Examples of types of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation Antitrust Policy available at
-[https://www.linuxfoundation.org/antitrust-policy](https://www.linuxfoundation.org/antitrust-policy). If you have questions about these matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer Updegrove LLP, which provides legal counsel to the Linux Foundation.


### PR DESCRIPTION
This still originates from the GH template from which mlkem-native was created. It is about the meeting policy of the Linux Foundation and therefore misplaced here. This commit removes it.
