### PR TITLE
Debug: Avoid reliance on C99 snprintf()

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -349,8 +349,8 @@
 #endif
 
 /* mlkem/debug/debug.c */
-#if defined(_ISOC99_SOURCE)
-#undef _ISOC99_SOURCE
+#if defined(MLKEM_NATIVE_DEBUG_ERROR_HEADER)
+#undef MLKEM_NATIVE_DEBUG_ERROR_HEADER
 #endif
 
 /* mlkem/debug/debug.c */
@@ -371,11 +371,6 @@
 /* mlkem/debug/debug.h */
 #if defined(mlkem_debug_check_bounds)
 #undef mlkem_debug_check_bounds
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(mlkem_debug_print_error)
-#undef mlkem_debug_print_error
 #endif
 
 /* mlkem/debug/debug.h */

--- a/mlkem/debug/debug.c
+++ b/mlkem/debug/debug.c
@@ -2,25 +2,27 @@
  * Copyright (c) 2024 The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0
  */
-#define _ISOC99_SOURCE
-#include "debug.h"
-#include <stdio.h>
+#include "common.h"
 
 #if defined(MLKEM_DEBUG)
 
-static char debug_buf[256];
+#include <stdio.h>
+#include "debug.h"
+
+#define MLKEM_NATIVE_DEBUG_ERROR_HEADER "[ERROR:%s:%04d] "
 
 void mlkem_debug_assert(const char *file, int line, const char *description,
                         const int val)
 {
   if (val == 0)
   {
-    snprintf(debug_buf, sizeof(debug_buf), "Assertion failed: %s (value %d)",
-             description, val);
-    mlkem_debug_print_error(file, line, debug_buf);
+    fprintf(stderr,
+            MLKEM_NATIVE_DEBUG_ERROR_HEADER "Assertion failed: %s (value %d)\n",
+            file, line, description, val);
     exit(1);
   }
 }
+
 void mlkem_debug_check_bounds(const char *file, int line,
                               const char *description, const int16_t *ptr,
                               unsigned len, int lower_bound_exclusive,
@@ -33,22 +35,17 @@ void mlkem_debug_check_bounds(const char *file, int line,
     int16_t val = ptr[i];
     if (!(val > lower_bound_exclusive && val < upper_bound_exclusive))
     {
-      snprintf(debug_buf, sizeof(debug_buf),
-               "%s, index %u, value %d out of bounds (%d,%d)", description, i,
-               (int)val, lower_bound_exclusive, upper_bound_exclusive);
-      mlkem_debug_print_error(file, line, debug_buf);
+      fprintf(stderr,
+              MLKEM_NATIVE_DEBUG_ERROR_HEADER
+              "%s, index %u, value %d out of bounds (%d,%d)\n",
+              file, line, description, i, (int)val, lower_bound_exclusive,
+              upper_bound_exclusive);
       err = 1;
     }
   }
 
   if (err == 1)
     exit(1);
-}
-
-void mlkem_debug_print_error(const char *file, int line, const char *msg)
-{
-  fprintf(stderr, "[ERROR:%s:%04d] %s\n", file, line, msg);
-  fflush(stderr);
 }
 
 #else /* MLKEM_DEBUG */

--- a/mlkem/debug/debug.h
+++ b/mlkem/debug/debug.h
@@ -52,10 +52,6 @@ void mlkem_debug_check_bounds(const char *file, int line,
                               unsigned len, int lower_bound_exclusive,
                               int upper_bound_exclusive);
 
-/* Print error message to stderr alongside file and line information */
-#define mlkem_debug_print_error MLKEM_NAMESPACE(mlkem_debug_print_error)
-void mlkem_debug_print_error(const char *file, int line, const char *msg);
-
 /* Check assertion, calling exit() upon failure
  *
  * val: Value that's asserted to be non-zero


### PR DESCRIPTION
* Fixes #644 

The debug functions in `debug/debug.c` so far depended on
`snprintf()`, which was added to the stdlib in C99.

To still be able to use it when C90 is used as the language
standard, the _ISOC99_SOURCE macro was manually set before
including `stdio.h`.

This is problematic even if we don't care about C90 debug mode, for two reasons:

- If mlkem-native is used in a monolihic (single-CU) build,
  the _ISOC99_SOURCE macro may already be set, leading to an
  error.
- More problematically, the monolithic build of mlkem-native
  undefines all defines, including `_ISOC99_SOURCE`, which
  may alter or break compilation of other sources to come.

Both could in principle be fixed, but it seems better to
simply avoid reliance on `_ISOC99_SOURCE`.

This commit removes the need for `_ISOC99_SOURCE` by rewriting
`debug.c` to use `fprintf` directly, and avoiding `snprintf()`
as a helper.