### PR TITLE
Remove NTT_BOUND_NATIVE and INVNTT_BOUND_NATIVE

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -974,11 +974,6 @@
 #endif
 
 /* mlkem/native/aarch64/src/clean_impl.h */
-#if defined(INVNTT_BOUND_NATIVE)
-#undef INVNTT_BOUND_NATIVE
-#endif
-
-/* mlkem/native/aarch64/src/clean_impl.h */
 #if defined(MLKEM_NATIVE_ARITH_PROFILE_IMPL_H)
 #undef MLKEM_NATIVE_ARITH_PROFILE_IMPL_H
 #endif
@@ -1039,11 +1034,6 @@
 #endif
 
 /* mlkem/native/aarch64/src/opt_impl.h */
-#if defined(INVNTT_BOUND_NATIVE)
-#undef INVNTT_BOUND_NATIVE
-#endif
-
-/* mlkem/native/aarch64/src/opt_impl.h */
 #if defined(MLKEM_NATIVE_ARITH_PROFILE_IMPL_H)
 #undef MLKEM_NATIVE_ARITH_PROFILE_IMPL_H
 #endif
@@ -1086,11 +1076,6 @@
 /* mlkem/native/aarch64/src/opt_impl.h */
 #if defined(MLKEM_USE_NATIVE_REJ_UNIFORM)
 #undef MLKEM_USE_NATIVE_REJ_UNIFORM
-#endif
-
-/* mlkem/native/aarch64/src/opt_impl.h */
-#if defined(NTT_BOUND_NATIVE)
-#undef NTT_BOUND_NATIVE
 #endif
 
 /* mlkem/native/aarch64/src/rej_uniform_table.c */
@@ -1409,11 +1394,6 @@
 #endif
 
 /* mlkem/native/x86_64/src/default_impl.h */
-#if defined(INVNTT_BOUND_NATIVE)
-#undef INVNTT_BOUND_NATIVE
-#endif
-
-/* mlkem/native/x86_64/src/default_impl.h */
 #if defined(MLKEM_NATIVE_ARITH_PROFILE_IMPL_H)
 #undef MLKEM_NATIVE_ARITH_PROFILE_IMPL_H
 #endif
@@ -1468,11 +1448,6 @@
 #undef MLKEM_USE_NATIVE_REJ_UNIFORM
 #endif
 
-/* mlkem/native/x86_64/src/default_impl.h */
-#if defined(NTT_BOUND_NATIVE)
-#undef NTT_BOUND_NATIVE
-#endif
-
 /* mlkem/native/x86_64/src/rej_uniform_avx2.c */
 #if defined(empty_cu_rej_uniform_avx2)
 #undef empty_cu_rej_uniform_avx2
@@ -1481,11 +1456,6 @@
 /* mlkem/native/x86_64/src/rej_uniform_table.c */
 #if defined(empty_cu_avx2_rej_uniform_table)
 #undef empty_cu_avx2_rej_uniform_table
-#endif
-
-/* mlkem/ntt.c */
-#if defined(INVNTT_BOUND_REF)
-#undef INVNTT_BOUND_REF
 #endif
 
 /* mlkem/ntt.c */

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -379,46 +379,11 @@
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(MLKEM_CONCAT)
-#undef MLKEM_CONCAT
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_CONCAT_)
-#undef MLKEM_CONCAT_
-#endif
-
-/* mlkem/debug/debug.h */
 #if defined(MLKEM_DEBUG_H)
 #undef MLKEM_DEBUG_H
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_ERROR)
-#undef MLKEM_STATIC_ASSERT_ADD_ERROR
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_LINE0)
-#undef MLKEM_STATIC_ASSERT_ADD_LINE0
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_LINE1)
-#undef MLKEM_STATIC_ASSERT_ADD_LINE1
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_LINE2)
-#undef MLKEM_STATIC_ASSERT_ADD_LINE2
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_DEFINE)
-#undef MLKEM_STATIC_ASSERT_DEFINE
-#endif
-
-/* mlkem/debug/debug.h */
 #if defined(POLYVEC_BOUND)
 #undef POLYVEC_BOUND
 #endif
@@ -486,11 +451,6 @@
 /* mlkem/debug/debug.h */
 #if defined(SCALAR_BOUND)
 #undef SCALAR_BOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(STATIC_ASSERT)
-#undef STATIC_ASSERT
 #endif
 
 /* mlkem/debug/debug.h */

--- a/mlkem/debug/debug.h
+++ b/mlkem/debug/debug.h
@@ -154,27 +154,6 @@ void mlkem_debug_check_bounds(const char *file, int line,
                       "polyvec unsigned bound for " #ptr ".vec[i]");       \
   } while (0)
 
-#define MLKEM_CONCAT_(left, right) left##right
-#define MLKEM_CONCAT(left, right) MLKEM_CONCAT_(left, right)
-
-/* Following AWS-LC to define a C99-compliant static assert */
-#define MLKEM_STATIC_ASSERT_DEFINE(cond, msg)                            \
-  typedef struct                                                         \
-  {                                                                      \
-    unsigned int MLKEM_CONCAT(static_assertion_, msg) : (cond) ? 1 : -1; \
-  } MLKEM_CONCAT(MLKEM_NAMESPACE(static_assertion_), msg)                \
-      __attribute__((unused));
-
-#define MLKEM_STATIC_ASSERT_ADD_LINE0(cond, suffix) \
-  MLKEM_STATIC_ASSERT_DEFINE(cond, MLKEM_CONCAT(at_line_, suffix))
-#define MLKEM_STATIC_ASSERT_ADD_LINE1(cond, line, suffix) \
-  MLKEM_STATIC_ASSERT_ADD_LINE0(cond, MLKEM_CONCAT(line, suffix))
-#define MLKEM_STATIC_ASSERT_ADD_LINE2(cond, suffix) \
-  MLKEM_STATIC_ASSERT_ADD_LINE1(cond, __LINE__, suffix)
-#define MLKEM_STATIC_ASSERT_ADD_ERROR(cond, suffix) \
-  MLKEM_STATIC_ASSERT_ADD_LINE2(cond, MLKEM_CONCAT(_error_is_, suffix))
-#define STATIC_ASSERT(cond, error) MLKEM_STATIC_ASSERT_ADD_ERROR(cond, error)
-
 #else /* MLKEM_DEBUG */
 
 #define CASSERT(val, msg) \

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -405,11 +405,6 @@ __contract__(
   }
 }
 
-#if NTT_BOUND > INT16_MAX - MLKEM_Q
-#error \
-    "The bound for the forward NTT is too large to ensure non-overflow in indcpa_keypair_derand"
-#endif
-
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
@@ -468,12 +463,6 @@ void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
 }
 
 
-#if (INVNTT_BOUND > INT16_MAX - MLKEM_ETA1) || \
-    (INVNTT_BOUND > INT16_MAX - MLKEM_ETA2 - MLKEM_Q)
-#error \
-    "The bound for the inverse NTT is too large to ensure non-overflow in indcpa_enc"
-#endif
-
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
@@ -529,12 +518,6 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
 
   pack_ciphertext(c, &b, &v);
 }
-
-/* Check that the arithmetic in indcpa_dec() does not overflow */
-#if INVNTT_BOUND > INT16_MAX - MLKEM_Q
-#error \
-    "The bound for the forward NTT is too large to ensure non-overflow in indcpa_dec"
-#endif
 
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],

--- a/mlkem/native/aarch64/src/clean_impl.h
+++ b/mlkem/native/aarch64/src/clean_impl.h
@@ -31,7 +31,6 @@ static INLINE void ntt_native(poly *data)
                 aarch64_ntt_zetas_layer56);
 }
 
-#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
 static INLINE void intt_native(poly *data)
 {
   intt_asm_clean(data->coeffs, aarch64_invntt_zetas_layer01234,

--- a/mlkem/native/aarch64/src/opt_impl.h
+++ b/mlkem/native/aarch64/src/opt_impl.h
@@ -25,14 +25,12 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
 
-#define NTT_BOUND_NATIVE (6 * MLKEM_Q)
 static INLINE void ntt_native(poly *data)
 {
   ntt_asm_opt(data->coeffs, aarch64_ntt_zetas_layer01234,
               aarch64_ntt_zetas_layer56);
 }
 
-#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
 static INLINE void intt_native(poly *data)
 {
   intt_asm_opt(data->coeffs, aarch64_invntt_zetas_layer01234,

--- a/mlkem/native/x86_64/src/default_impl.h
+++ b/mlkem/native/x86_64/src/default_impl.h
@@ -28,9 +28,6 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_POLY_FROMBYTES
 
-#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
-#define NTT_BOUND_NATIVE (8 * MLKEM_Q)
-
 static INLINE void poly_permute_bitrev_to_custom(poly *data)
 {
   nttunpack_avx2((__m256i *)(data->coeffs), qdata.vec);

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -148,23 +148,16 @@ void poly_ntt(poly *p)
 }
 #else  /* MLKEM_USE_NATIVE_NTT */
 
-/* Check that bound for native NTT implies contractual bound */
-STATIC_ASSERT(NTT_BOUND_NATIVE <= NTT_BOUND, invntt_bound)
-
 MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *p)
 {
   POLY_BOUND_MSG(p, MLKEM_Q, "native ntt input");
   ntt_native(p);
-  POLY_BOUND_MSG(p, NTT_BOUND_NATIVE, "native ntt output");
+  POLY_BOUND_MSG(p, NTT_BOUND, "native ntt output");
 }
 #endif /* MLKEM_USE_NATIVE_NTT */
 
 #if !defined(MLKEM_USE_NATIVE_INTT)
-
-/* Check that bound for reference invNTT implies contractual bound */
-#define INVNTT_BOUND_REF (3 * MLKEM_Q / 4)
-STATIC_ASSERT(INVNTT_BOUND_REF <= INVNTT_BOUND, invntt_bound)
 
 /* Compute one layer of inverse NTT */
 static void invntt_layer(int16_t *r, int len, int layer)
@@ -232,18 +225,15 @@ void poly_invntt_tomont(poly *p)
     invntt_layer(p->coeffs, len, layer);
   }
 
-  POLY_BOUND_MSG(p, INVNTT_BOUND_REF, "ref intt output");
+  POLY_BOUND_MSG(p, INVNTT_BOUND, "ref intt output");
 }
 #else  /* MLKEM_USE_NATIVE_INTT */
-
-/* Check that bound for native invNTT implies contractual bound */
-STATIC_ASSERT(INVNTT_BOUND_NATIVE <= INVNTT_BOUND, invntt_bound)
 
 MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *p)
 {
   intt_native(p);
-  POLY_BOUND_MSG(p, INVNTT_BOUND_NATIVE, "native intt output");
+  POLY_BOUND_MSG(p, INVNTT_BOUND, "native intt output");
 }
 #endif /* MLKEM_USE_NATIVE_INTT */
 


### PR DESCRIPTION
The numeric macros NTT_BOUND_NATIVE and INVNTT_BOUND_NATIVE could be used by backends to specify an output bound for the forward and inverse NTT. We would then use STATIC_ASSERT's to check that those backend-specific bounds would imply the bounds (NTT_BOUND and INVNTT_BOUND) that the CBMC proofs work against.

The added value of NTT_BOUND_NATIVE and INVNTT_BOUND_NATIVE is questionable. In the end, what we care about is that the native NTT and invNTT adhere to the bounds that CBMC relies on. Any strengthening of the bounds may be good to know, but is otherwise an unnecessary complication of the code.

This commit removes NTT_BOUND_NATIVE and INVNTT_BOUND_NATIVE and uses the contractual bounds NTT_BOUND and INVNT_BOUND in their place.

------

Also, remove the need for `STATIC_ASSERT` by rewriting its use using a plain `#if`.