### PR TITLE
Remove need for STATIC_ASSERT by rewriting bounds check with #if

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -1499,6 +1499,16 @@
 #endif
 
 /* mlkem/ntt.h */
+#if defined(INVNTT_BOUND)
+#undef INVNTT_BOUND
+#endif
+
+/* mlkem/ntt.h */
+#if defined(NTT_BOUND)
+#undef NTT_BOUND
+#endif
+
+/* mlkem/ntt.h */
 #if defined(poly_ntt)
 #undef poly_ntt
 #endif
@@ -1676,16 +1686,6 @@
 /* mlkem/poly.h */
 #if defined(POLY_H)
 #undef POLY_H
-#endif
-
-/* mlkem/poly.h */
-#if defined(INVNTT_BOUND)
-#undef INVNTT_BOUND
-#endif
-
-/* mlkem/poly.h */
-#if defined(NTT_BOUND)
-#undef NTT_BOUND
 #endif
 
 /* mlkem/poly.h */

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -1023,11 +1023,6 @@
 #undef MLKEM_USE_NATIVE_REJ_UNIFORM
 #endif
 
-/* mlkem/native/aarch64/src/clean_impl.h */
-#if defined(INVNTT_BOUND_NATIVE)
-#undef INVNTT_BOUND_NATIVE
-#endif
-
 /* mlkem/native/aarch64/src/consts.h */
 #if defined(MLKEM_NATIVE_AARCH64_CONSTS)
 #undef MLKEM_NATIVE_AARCH64_CONSTS
@@ -1086,16 +1081,6 @@
 /* mlkem/native/aarch64/src/opt_impl.h */
 #if defined(MLKEM_USE_NATIVE_REJ_UNIFORM)
 #undef MLKEM_USE_NATIVE_REJ_UNIFORM
-#endif
-
-/* mlkem/native/aarch64/src/opt_impl.h */
-#if defined(NTT_BOUND_NATIVE)
-#undef NTT_BOUND_NATIVE
-#endif
-
-/* mlkem/native/aarch64/src/opt_impl.h */
-#if defined(INVNTT_BOUND_NATIVE)
-#undef INVNTT_BOUND_NATIVE
 #endif
 
 /* mlkem/native/aarch64/src/rej_uniform_table.c */
@@ -1468,16 +1453,6 @@
 #undef MLKEM_USE_NATIVE_POLY_FROMBYTES
 #endif
 
-/* mlkem/native/x86_64/src/default_impl.h */
-#if defined(INVNTT_BOUND_NATIVE)
-#undef INVNTT_BOUND_NATIVE
-#endif
-
-/* mlkem/native/x86_64/src/default_impl.h */
-#if defined(NTT_BOUND_NATIVE)
-#undef NTT_BOUND_NATIVE
-#endif
-
 /* mlkem/native/x86_64/src/rej_uniform_avx2.c */
 #if defined(_mm256_cmpge_epu16)
 #undef _mm256_cmpge_epu16
@@ -1511,11 +1486,6 @@
 /* mlkem/ntt.c */
 #if defined(invntt_layer)
 #undef invntt_layer
-#endif
-
-/* mlkem/ntt.c */
-#if defined(INVNTT_BOUND_REF)
-#undef INVNTT_BOUND_REF
 #endif
 
 /* mlkem/ntt.h */

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -429,46 +429,6 @@
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(MLKEM_CONCAT_)
-#undef MLKEM_CONCAT_
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_CONCAT)
-#undef MLKEM_CONCAT
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_DEFINE)
-#undef MLKEM_STATIC_ASSERT_DEFINE
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_LINE0)
-#undef MLKEM_STATIC_ASSERT_ADD_LINE0
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_LINE1)
-#undef MLKEM_STATIC_ASSERT_ADD_LINE1
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_LINE2)
-#undef MLKEM_STATIC_ASSERT_ADD_LINE2
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(MLKEM_STATIC_ASSERT_ADD_ERROR)
-#undef MLKEM_STATIC_ASSERT_ADD_ERROR
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(STATIC_ASSERT)
-#undef STATIC_ASSERT
-#endif
-
-/* mlkem/debug/debug.h */
 #if defined(CASSERT)
 #undef CASSERT
 #endif

--- a/mlkem/debug/debug.h
+++ b/mlkem/debug/debug.h
@@ -158,27 +158,6 @@ void mlkem_debug_print_error(const char *file, int line, const char *msg);
                       "polyvec unsigned bound for " #ptr ".vec[i]");       \
   } while (0)
 
-#define MLKEM_CONCAT_(left, right) left##right
-#define MLKEM_CONCAT(left, right) MLKEM_CONCAT_(left, right)
-
-/* Following AWS-LC to define a C99-compliant static assert */
-#define MLKEM_STATIC_ASSERT_DEFINE(cond, msg)                            \
-  typedef struct                                                         \
-  {                                                                      \
-    unsigned int MLKEM_CONCAT(static_assertion_, msg) : (cond) ? 1 : -1; \
-  } MLKEM_CONCAT(MLKEM_NAMESPACE(static_assertion_), msg)                \
-      __attribute__((unused));
-
-#define MLKEM_STATIC_ASSERT_ADD_LINE0(cond, suffix) \
-  MLKEM_STATIC_ASSERT_DEFINE(cond, MLKEM_CONCAT(at_line_, suffix))
-#define MLKEM_STATIC_ASSERT_ADD_LINE1(cond, line, suffix) \
-  MLKEM_STATIC_ASSERT_ADD_LINE0(cond, MLKEM_CONCAT(line, suffix))
-#define MLKEM_STATIC_ASSERT_ADD_LINE2(cond, suffix) \
-  MLKEM_STATIC_ASSERT_ADD_LINE1(cond, __LINE__, suffix)
-#define MLKEM_STATIC_ASSERT_ADD_ERROR(cond, suffix) \
-  MLKEM_STATIC_ASSERT_ADD_LINE2(cond, MLKEM_CONCAT(_error_is_, suffix))
-#define STATIC_ASSERT(cond, error) MLKEM_STATIC_ASSERT_ADD_ERROR(cond, error)
-
 #else /* MLKEM_DEBUG */
 
 #define CASSERT(val, msg) \

--- a/mlkem/native/aarch64/src/clean_impl.h
+++ b/mlkem/native/aarch64/src/clean_impl.h
@@ -31,7 +31,6 @@ static INLINE void ntt_native(poly *data)
                 aarch64_ntt_zetas_layer56);
 }
 
-#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
 static INLINE void intt_native(poly *data)
 {
   intt_asm_clean(data->coeffs, aarch64_invntt_zetas_layer01234,

--- a/mlkem/native/aarch64/src/opt_impl.h
+++ b/mlkem/native/aarch64/src/opt_impl.h
@@ -25,14 +25,12 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
 
-#define NTT_BOUND_NATIVE (6 * MLKEM_Q)
 static INLINE void ntt_native(poly *data)
 {
   ntt_asm_opt(data->coeffs, aarch64_ntt_zetas_layer01234,
               aarch64_ntt_zetas_layer56);
 }
 
-#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
 static INLINE void intt_native(poly *data)
 {
   intt_asm_opt(data->coeffs, aarch64_invntt_zetas_layer01234,

--- a/mlkem/native/x86_64/src/default_impl.h
+++ b/mlkem/native/x86_64/src/default_impl.h
@@ -28,9 +28,6 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_POLY_FROMBYTES
 
-#define INVNTT_BOUND_NATIVE (8 * MLKEM_Q)
-#define NTT_BOUND_NATIVE (8 * MLKEM_Q)
-
 static INLINE void poly_permute_bitrev_to_custom(poly *data)
 {
   nttunpack_avx2((__m256i *)(data->coeffs), qdata.vec);

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -148,23 +148,16 @@ void poly_ntt(poly *p)
 }
 #else  /* MLKEM_USE_NATIVE_NTT */
 
-/* Check that bound for native NTT implies contractual bound */
-STATIC_ASSERT(NTT_BOUND_NATIVE <= NTT_BOUND, invntt_bound)
-
 MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *p)
 {
   POLY_BOUND_MSG(p, MLKEM_Q, "native ntt input");
   ntt_native(p);
-  POLY_BOUND_MSG(p, NTT_BOUND_NATIVE, "native ntt output");
+  POLY_BOUND_MSG(p, NTT_BOUND, "native ntt output");
 }
 #endif /* MLKEM_USE_NATIVE_NTT */
 
 #if !defined(MLKEM_USE_NATIVE_INTT)
-
-/* Check that bound for reference invNTT implies contractual bound */
-#define INVNTT_BOUND_REF (3 * MLKEM_Q / 4)
-STATIC_ASSERT(INVNTT_BOUND_REF <= INVNTT_BOUND, invntt_bound)
 
 /* Compute one layer of inverse NTT */
 static void invntt_layer(int16_t *r, int len, int layer)
@@ -232,18 +225,15 @@ void poly_invntt_tomont(poly *p)
     invntt_layer(p->coeffs, len, layer);
   }
 
-  POLY_BOUND_MSG(p, INVNTT_BOUND_REF, "ref intt output");
+  POLY_BOUND_MSG(p, INVNTT_BOUND, "ref intt output");
 }
 #else  /* MLKEM_USE_NATIVE_INTT */
-
-/* Check that bound for native invNTT implies contractual bound */
-STATIC_ASSERT(INVNTT_BOUND_NATIVE <= INVNTT_BOUND, invntt_bound)
 
 MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *p)
 {
   intt_native(p);
-  POLY_BOUND_MSG(p, INVNTT_BOUND_NATIVE, "native intt output");
+  POLY_BOUND_MSG(p, INVNTT_BOUND, "native intt output");
 }
 #endif /* MLKEM_USE_NATIVE_INTT */
 

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -14,6 +14,12 @@
 #define zetas MLKEM_NAMESPACE(zetas)
 extern const int16_t zetas[128];
 
+/* Absolute exclusive upper bound for the output of the inverse NTT */
+#define INVNTT_BOUND (8 * MLKEM_Q)
+
+/* Absolute exclusive upper bound for the output of the forward NTT */
+#define NTT_BOUND (8 * MLKEM_Q)
+
 #define poly_ntt MLKEM_NAMESPACE(poly_ntt)
 /*************************************************
  * Name:        poly_ntt

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -12,12 +12,6 @@
 #include "reduce.h"
 #include "verify.h"
 
-/* Absolute exclusive upper bound for the output of the inverse NTT */
-#define INVNTT_BOUND (8 * MLKEM_Q)
-
-/* Absolute exclusive upper bound for the output of the forward NTT */
-#define NTT_BOUND (8 * MLKEM_Q)
-
 /*
  * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial
  * coeffs[0] + X*coeffs[1] + X^2*coeffs[2] + ... + X^{n-1}*coeffs[n-1]


### PR DESCRIPTION
We conduct some basic static sanity checks on the values of NTT_BOUND and INVNTT_BOUND. Previously, those checks were done using a `STATIC_ASSERT` macro. The `STATIC_ASSERT` macro was otherwise not used.

This commit rewrites said bounds checks using plain `#if ...`. It therefore eliminates the need for `STATIC_ASSERT`, which is removed.
