### PR TITLE
Add AWS-LC integration test

### DIFF
--- a/.github/actions/setup-aws-lc/action.yml
+++ b/.github/actions/setup-aws-lc/action.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Setup AWS-LC
+description: Setup AWS-LC
+
+inputs:
+  dir:
+    description: Directory to fetch AWS-LC into
+    default: 'AWS-LC'
+  repository:
+    description: Repository to fetch from
+    default: 'aws/AWS-LC'
+  commit:
+    description: Commit to fetch
+    default: 'HEAD'
+  gh_token:
+    description: Github access token to use
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch AWS-LC
+      shell: bash
+      run: |
+        mkdir ${{ inputs.dir }} && cd ${{ inputs.dir }}
+        git config --global --add safe.directory $GITHUB_WORKSPACE/${{ inputs.dir }}
+        git init
+        git remote add origin $GITHUB_SERVER_URL/${{ inputs.repository }}
+        git fetch origin --depth 1 ${{ inputs.commit }}
+        git checkout FETCH_HEAD
+
+        # Remember AWS-LC directory
+        echo AWSLC_DIR="$GITHUB_WORKSPACE/${{ inputs.dir }}" >> $GITHUB_ENV

--- a/.github/actions/setup-aws-lc/action.yml
+++ b/.github/actions/setup-aws-lc/action.yml
@@ -32,3 +32,9 @@ runs:
 
         # Remember AWS-LC directory
         echo AWSLC_DIR="$GITHUB_WORKSPACE/${{ inputs.dir }}" >> $GITHUB_ENV
+        AWSLC_DIR=$GITHUB_WORKSPACE/${{ inputs.dir }}
+
+        # TEMPORARY: Patch up importer
+        if [[ "$(uname)" == "Darwin" ]]; then
+          sed -i '' 's/\$SED_I/"${SED_I[@]}"/g' $AWSLC_DIR/crypto/fipsmodule/ml_kem/importer.sh
+        fi

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -40,12 +40,32 @@ jobs:
     uses: ./.github/workflows/cbmc.yml
     secrets: inherit
   oqs_integration:
-    name: Integration
+    name: libOQS
     permissions:
       contents: 'read'
       id-token: 'write'
     needs: [ base ]
     uses: ./.github/workflows/integration-liboqs.yml
+    secrets: inherit
+  awslc_integration_fixed:
+    name: AWS-LC (412be9)
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/integration-awslc.yml
+    with:
+      commit: 412be9d1bb4f9d2f962dba1beac41249dbacdb55
+    secrets: inherit
+  awslc_integration_head:
+    name: AWS-LC (HEAD)
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/integration-awslc.yml
+    with:
+      commit: main
     secrets: inherit
   ct-test:
     name: Constant-time

--- a/.github/workflows/integration-awslc.yml
+++ b/.github/workflows/integration-awslc.yml
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: AWS-LC
+permissions:
+  contents: read
+on:
+  workflow_call:
+    inputs:
+      commit:
+        type: string
+        description: Commit to test against
+        default: main
+      repository:
+        type: string
+        description: Repository to fetch
+        default: aws/aws-lc
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.commit }}
+  cancel-in-progress: true
+
+env:
+  DEPENDENCIES: 'cmake golang unifdef'
+
+jobs:
+  aws_lc_integration_fips:
+    strategy:
+      fail-fast: false
+      matrix:
+        system: [ubuntu-latest, pqcp-arm64]
+        fips: [0,1]
+    name: AWS-LC FIPS test (${{ matrix.system }}, FIPS=${{ matrix.fips }})
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-os
+        with:
+          packages: ${{ env.DEPENDENCIES }}
+      - uses: ./.github/actions/setup-aws-lc
+        with:
+          repository: ${{ inputs.repository }}
+          commit: ${{ inputs.commit }}
+      - name: Run importer
+        run: |
+          cd $AWSLC_DIR/crypto/fipsmodule/ml_kem
+          rm -rf mlkem
+          GITHUB_REPOSITORY=$GITHUB_REPOSITORY GITHUB_SHA=$GITHUB_SHA ./importer.sh --force
+      - name: Build+Test AWS-LC (FIPS=${{ matrix.fips }})
+        run: |
+          cd $AWSLC_DIR
+          mkdir build
+          cd build
+          cmake -DFIPS=${{ matrix.fips }} ..
+          cd ..
+
+          cmake --build ./build --target all
+          cmake --build ./build --target run_tests
+  posix:
+    # This is a partial parallelization of the run_posix_tests.sh script
+    strategy:
+      max-parallel: 16
+      fail-fast: false
+      matrix:
+        system: [ubuntu-latest, pqcp-arm64]
+        test:
+          - name: Debug mode
+            flags: -DENABLE_DILITHIUM=ON
+          - name: Release mode
+            flags: -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+          - name: Small compilation
+            flags: -DOPENSSL_SMALL=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+          - name: No-ASM
+            flags: -DOPENSSL_NO_ASM=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+          - name: Shared
+            flags: -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+          - name: Pre-Gen ASM
+            flags: -DDISABLE_PERL=ON -DENABLE_DILITHIUM=ON
+          - name: DIT
+            flags: -DENABLE_DATA_INDEPENDENT_TIMING=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_DILITHIUM=ON
+    name: Posix test (${{ matrix.test.name }}, ${{ matrix.system }})
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-os
+        with:
+          packages: ${{ env.DEPENDENCIES }}
+      - uses: ./.github/actions/setup-aws-lc
+        with:
+          repository: ${{ inputs.repository }}
+          commit: ${{ inputs.commit }}
+      - name: Run importer
+        run: |
+          cd $AWSLC_DIR/crypto/fipsmodule/ml_kem
+          GITHUB_REPOSITORY=$GITHUB_REPOSITORY GITHUB_SHA=$GITHUB_SHA ./importer.sh --force
+      - name: Run test
+        run: |
+          cd $AWSLC_DIR
+          source tests/ci/common_posix_setup.sh
+          build_and_test ${{ matrix.test.flags }}
+  prefix:
+    # This is a parallelization of the run_prefix_tests.sh script
+    strategy:
+      max-parallel: 8
+      fail-fast: false
+      matrix:
+        system: [ubuntu-latest, pqcp-arm64, macos-latest, macos-13]
+        test:
+          - name: Prefix+Debug
+            flags:
+          - name: Prefix+Release
+            flags: -DCMAKE_BUILD_TYPE=Release
+    name: Prefix test (${{ matrix.test.name }}, ${{ matrix.system }})
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-os
+        with:
+          packages: ${{ env.DEPENDENCIES }}
+      - uses: ./.github/actions/setup-aws-lc
+        with:
+          repository: ${{ inputs.repository }}
+          commit: ${{ inputs.commit }}
+      - name: Run importer
+        run: |
+          cd $AWSLC_DIR/crypto/fipsmodule/ml_kem
+          GITHUB_REPOSITORY=$GITHUB_REPOSITORY GITHUB_SHA=$GITHUB_SHA ./importer.sh --force
+      - name: Run test
+        run: |
+          cd $AWSLC_DIR
+          source tests/ci/common_posix_setup.sh
+          build_prefix_and_test ${{ matrix.flags }}


### PR DESCRIPTION
This commit extends the CI with an integration test for AWS-LC.

The CI checks that mlkem-native successfully integrates into
AWS-LC by building and running basic tests of AWS-LC in FIPS
and non-FIPS mode.

We test both against a fixed commit and main. Testing against a
fixed known-good commit in AWS-LC means we note if we break the
integration. Testing against main means we note if a change in
AWS-LC breaks the integration. The latter is out of our control,
and we may need to temporarily ignore failures, but we should
be aware.