### PR TITLE
Fix `tests bench [--opt=ALL]` so it runs opt and non-opt benchmarks

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -323,7 +323,7 @@ class Tests:
         return [f"-j{self.args.j}"]
 
     def do_opt_all(self):
-        return self.args.opt.lower() == ["all"]
+        return self.args.opt.lower() == "all"
 
     def do_opt(self):
         return self.args.opt.lower() in ["all", "opt"]


### PR DESCRIPTION
* Fixes https://github.com/pq-code-package/mlkem-native/issues/652

Previously, `tests bench` and `tests bench --opt=ALL`  would only run the opt benchmarks. This was because of a bug in the helper `do_opt_all()` in the `tests` script. This commit fixes this bug, thereby restoring the desired behaviour.
