### PR TITLE
Debug: Reduce number of macros, assimilate to CBMC assertions

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -359,113 +359,38 @@
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(BOUND)
-#undef BOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(BOUND)
-#undef BOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(CASSERT)
-#undef CASSERT
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(CASSERT)
-#undef CASSERT
-#endif
-
-/* mlkem/debug/debug.h */
 #if defined(MLKEM_DEBUG_H)
 #undef MLKEM_DEBUG_H
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(POLYVEC_BOUND)
-#undef POLYVEC_BOUND
+#if defined(debug_assert)
+#undef debug_assert
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(POLYVEC_BOUND)
-#undef POLYVEC_BOUND
+#if defined(debug_assert)
+#undef debug_assert
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(POLYVEC_UBOUND)
-#undef POLYVEC_UBOUND
+#if defined(debug_assert_abs_bound)
+#undef debug_assert_abs_bound
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(POLYVEC_UBOUND)
-#undef POLYVEC_UBOUND
+#if defined(debug_assert_abs_bound)
+#undef debug_assert_abs_bound
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(POLY_BOUND)
-#undef POLY_BOUND
+#if defined(debug_assert_bound)
+#undef debug_assert_bound
 #endif
 
 /* mlkem/debug/debug.h */
-#if defined(POLY_BOUND)
-#undef POLY_BOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(POLY_BOUND_MSG)
-#undef POLY_BOUND_MSG
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(POLY_BOUND_MSG)
-#undef POLY_BOUND_MSG
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(POLY_UBOUND)
-#undef POLY_UBOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(POLY_UBOUND)
-#undef POLY_UBOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(POLY_UBOUND_MSG)
-#undef POLY_UBOUND_MSG
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(POLY_UBOUND_MSG)
-#undef POLY_UBOUND_MSG
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(SCALAR_BOUND)
-#undef SCALAR_BOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(SCALAR_BOUND)
-#undef SCALAR_BOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(STATIC_ASSERT)
-#undef STATIC_ASSERT
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(UBOUND)
-#undef UBOUND
-#endif
-
-/* mlkem/debug/debug.h */
-#if defined(UBOUND)
-#undef UBOUND
+#if defined(debug_assert_bound)
+#undef debug_assert_bound
 #endif
 
 /* mlkem/debug/debug.h */

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -13,7 +13,7 @@
 
 #define __contract__(x)
 #define __loop__(x)
-#define cassert(x, y)
+#define cassert(x)
 
 #else /* CBMC _is_ defined, therefore we're doing proof */
 
@@ -30,7 +30,7 @@
 #define invariant(...) __CPROVER_loop_invariant(__VA_ARGS__)
 #define decreases(...) __CPROVER_decreases(__VA_ARGS__)
 /* cassert to avoid confusion with in-built assert */
-#define cassert(...) __CPROVER_assert(__VA_ARGS__)
+#define cassert(x) __CPROVER_assert(x, "cbmc assertion failed")
 #define assume(...) __CPROVER_assume(__VA_ARGS__)
 
 /***************************************************

--- a/mlkem/debug/debug.c
+++ b/mlkem/debug/debug.c
@@ -7,24 +7,23 @@
 #if defined(MLKEM_DEBUG)
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "debug.h"
 
 #define MLKEM_NATIVE_DEBUG_ERROR_HEADER "[ERROR:%s:%04d] "
 
-void mlkem_debug_assert(const char *file, int line, const char *description,
-                        const int val)
+void mlkem_debug_assert(const char *file, int line, const int val)
 {
   if (val == 0)
   {
     fprintf(stderr,
-            MLKEM_NATIVE_DEBUG_ERROR_HEADER "Assertion failed: %s (value %d)\n",
-            file, line, description, val);
+            MLKEM_NATIVE_DEBUG_ERROR_HEADER "Assertion failed (value %d)\n",
+            file, line, val);
     exit(1);
   }
 }
 
-void mlkem_debug_check_bounds(const char *file, int line,
-                              const char *description, const int16_t *ptr,
+void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
                               unsigned len, int lower_bound_exclusive,
                               int upper_bound_exclusive)
 {
@@ -35,11 +34,12 @@ void mlkem_debug_check_bounds(const char *file, int line,
     int16_t val = ptr[i];
     if (!(val > lower_bound_exclusive && val < upper_bound_exclusive))
     {
-      fprintf(stderr,
-              MLKEM_NATIVE_DEBUG_ERROR_HEADER
-              "%s, index %u, value %d out of bounds (%d,%d)\n",
-              file, line, description, i, (int)val, lower_bound_exclusive,
-              upper_bound_exclusive);
+      fprintf(
+          stderr,
+          MLKEM_NATIVE_DEBUG_ERROR_HEADER
+          "Bounds assertion failed: Index %u, value %d out of bounds (%d,%d)\n",
+          file, line, i, (int)val, lower_bound_exclusive,
+          upper_bound_exclusive);
       err = 1;
     }
   }

--- a/mlkem/debug/debug.h
+++ b/mlkem/debug/debug.h
@@ -9,8 +9,6 @@
 
 #if defined(MLKEM_DEBUG)
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 /*************************************************
  * Name:        mlkem_debug_assert
@@ -22,12 +20,10 @@
  *
  * Arguments:   - file: filename
  *              - line: line number
- *              - description: Textual description of assertion
  *              - val: Value asserted to be non-zero
  **************************************************/
 #define mlkem_debug_assert MLKEM_NAMESPACE(mlkem_debug_assert)
-void mlkem_debug_assert(const char *file, int line, const char *description,
-                        const int val);
+void mlkem_debug_assert(const char *file, int line, const int val);
 
 /*************************************************
  * Name:        mlkem_debug_check_bounds
@@ -40,163 +36,60 @@ void mlkem_debug_assert(const char *file, int line, const char *description,
  *
  * Arguments:   - file: filename
  *              - line: line number
- *              - description: Textual description of check
  *              - ptr: Base of array to be checked
  *              - len: Number of int16_t in ptr
  *              - lower_bound_exclusive: Exclusive lower bound
  *              - upper_bound_exclusive: Exclusive upper bound
  **************************************************/
 #define mlkem_debug_check_bounds MLKEM_NAMESPACE(mlkem_debug_check_bounds)
-void mlkem_debug_check_bounds(const char *file, int line,
-                              const char *description, const int16_t *ptr,
+void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
                               unsigned len, int lower_bound_exclusive,
                               int upper_bound_exclusive);
 
 /* Check assertion, calling exit() upon failure
  *
  * val: Value that's asserted to be non-zero
- * msg: Message to print on failure
- *
- * Currently called CASSERT to avoid clash with CBMC assert.
  */
-#define CASSERT(val, msg)                                 \
-  do                                                      \
-  {                                                       \
-    mlkem_debug_assert(__FILE__, __LINE__, (msg), (val)); \
+#define debug_assert(val)                          \
+  do                                               \
+  {                                                \
+    mlkem_debug_assert(__FILE__, __LINE__, (val)); \
   } while (0)
 
-/* Check absolute bounds of scalar
- * val: Scalar to be checked
- * abs_bound: Exclusive upper bound on absolute value to check
- * msg: Message to print on failure */
-#define SCALAR_BOUND(val, abs_bound, msg) \
-  CASSERT((val) > -(abs_bound) && (val) < (abs_bound), msg)
-
-/* Check that all coefficients in array of int16_t's are non-negative
- * and below an exclusive upper bound.
- *
- * ptr: Base of array, expression of type int16_t*
+/* Check bounds in array of int16_t's
+ * ptr: Base of int16_t array; will be explicitly cast to int16_t*,
+ *      so you may pass a byte-compatible type such as poly or polyvec.
  * len: Number of int16_t in array
- * high_bound: Exclusive upper bound on absolute value to check
- * msg: Message to print on failure */
-#define UBOUND(ptr, len, high_bound, msg)                                 \
-  do                                                                      \
-  {                                                                       \
-    mlkem_debug_check_bounds(__FILE__, __LINE__, (msg), (int16_t *)(ptr), \
-                             (len), -1, ((high_bound)));                  \
+ * value_lb: Inclusive lower value bound
+ * value_ub: Exclusive upper value bound */
+#define debug_assert_bound(ptr, len, value_lb, value_ub)                 \
+  do                                                                     \
+  {                                                                      \
+    mlkem_debug_check_bounds(__FILE__, __LINE__, (const int16_t *)(ptr), \
+                             (len), (value_lb)-1, (value_ub));           \
   } while (0)
 
 /* Check absolute bounds in array of int16_t's
  * ptr: Base of array, expression of type int16_t*
  * len: Number of int16_t in array
- * abs_bound: Exclusive upper bound on absolute value to check
- * msg: Message to print on failure */
-#define BOUND(ptr, len, abs_bound, msg)                                   \
-  do                                                                      \
-  {                                                                       \
-    mlkem_debug_check_bounds(__FILE__, __LINE__, (msg), (int16_t *)(ptr), \
-                             (len), -(abs_bound), (abs_bound));           \
-  } while (0)
-
-/* Check absolute bounds on coefficients in polynomial or mulcache
- * ptr: poly* or poly_mulcache* pointer to polynomial (cache) to check
- * abs_bound: Exclusive upper bound on absolute value to check
- * msg: Message to print on failure */
-#define POLY_BOUND_MSG(ptr, abs_bound, msg)                                    \
-  BOUND((ptr)->coeffs, (sizeof((ptr)->coeffs) / sizeof(int16_t)), (abs_bound), \
-        msg)
-
-/* Check unsigned bounds on coefficients in polynomial or mulcache
- * ptr: poly* or poly_mulcache* pointer to polynomial (cache) to check
- * ubound: Exclusive upper bound on value to check. Inclusive lower bound is 0.
- * msg: Message to print on failure */
-#define POLY_UBOUND_MSG(ptr, ubound, msg)                                    \
-  UBOUND((ptr)->coeffs, (sizeof((ptr)->coeffs) / sizeof(int16_t)), (ubound), \
-         msg)
-
-/* Check absolute bounds on coefficients in polynomial
- * ptr: poly* of poly_mulcache* pointer to polynomial (cache) to check
- * abs_bound: Exclusive upper bound on absolute value to check */
-#define POLY_BOUND(ptr, abs_bound) \
-  POLY_BOUND_MSG((ptr), (abs_bound), "poly absolute bound for " #ptr)
-
-/* Check unsigned bounds on coefficients in polynomial
- * ptr: poly* of poly_mulcache* pointer to polynomial (cache) to check
- * ubound: Exclusive upper bound on value to check. Inclusive lower bound is 0.
- */
-#define POLY_UBOUND(ptr, ubound) \
-  POLY_UBOUND_MSG((ptr), (ubound), "poly unsigned bound for " #ptr)
-
-/* Check absolute bounds on coefficients in vector of polynomials
- * ptr: polyvec* or polyvec_mulcache* pointer to vector of polynomials to check
- * abs_bound: Exclusive upper bound on absolute value to check */
-#define POLYVEC_BOUND(ptr, abs_bound)                                      \
-  do                                                                       \
-  {                                                                        \
-    unsigned _debug_polyvec_bound_idx;                                     \
-    for (_debug_polyvec_bound_idx = 0; _debug_polyvec_bound_idx < MLKEM_K; \
-         _debug_polyvec_bound_idx++)                                       \
-      POLY_BOUND_MSG(&(ptr)->vec[_debug_polyvec_bound_idx], (abs_bound),   \
-                     "polyvec absolute bound for " #ptr ".vec[i]");        \
-  } while (0)
-
-/* Check unsigned bounds on coefficients in vector of polynomials
- * ptr: polyvec* or polyvec_mulcache* pointer to vector of polynomials to check
- * ubound: Exclusive upper bound on value to check. Inclusive lower bound is 0.
- */
-#define POLYVEC_UBOUND(ptr, ubound)                                        \
-  do                                                                       \
-  {                                                                        \
-    unsigned _debug_polyvec_bound_idx;                                     \
-    for (_debug_polyvec_bound_idx = 0; _debug_polyvec_bound_idx < MLKEM_K; \
-         _debug_polyvec_bound_idx++)                                       \
-      POLY_UBOUND_MSG(&(ptr)->vec[_debug_polyvec_bound_idx], (ubound),     \
-                      "polyvec unsigned bound for " #ptr ".vec[i]");       \
-  } while (0)
+ * value_abs_bd: Exclusive absolute upper bound */
+#define debug_assert_abs_bound(ptr, len, value_abs_bd) \
+  debug_assert_bound((ptr), (len), (-(value_abs_bd) + 1), (value_abs_bd))
 
 #else /* MLKEM_DEBUG */
 
-#define CASSERT(val, msg) \
+#define debug_assert(val) \
   do                      \
   {                       \
   } while (0)
-#define SCALAR_BOUND(val, abs_bound, msg) \
-  do                                      \
-  {                                       \
+#define debug_assert_bound(ptr, len, value_lb, value_ub) \
+  do                                                     \
+  {                                                      \
   } while (0)
-#define BOUND(ptr, len, abs_bound, msg) \
-  do                                    \
-  {                                     \
+#define debug_assert_abs_bound(ptr, len, value_abs_bd) \
+  do                                                   \
+  {                                                    \
   } while (0)
-#define POLY_BOUND(ptr, abs_bound) \
-  do                               \
-  {                                \
-  } while (0)
-#define POLYVEC_BOUND(ptr, abs_bound) \
-  do                                  \
-  {                                   \
-  } while (0)
-#define POLY_BOUND_MSG(ptr, ubound, abs_bound) \
-  do                                           \
-  {                                            \
-  } while (0)
-#define UBOUND(ptr, len, high_bound, msg) \
-  do                                      \
-  {                                       \
-  } while (0)
-#define POLY_UBOUND(ptr, ubound) \
-  do                             \
-  {                              \
-  } while (0)
-#define POLYVEC_UBOUND(ptr, ubound) \
-  do                                \
-  {                                 \
-  } while (0)
-#define POLY_UBOUND_MSG(ptr, ubound, msg) \
-  do                                      \
-  {                                       \
-  } while (0)
-#define STATIC_ASSERT(cond, error)
 
 #endif /* MLKEM_DEBUG */
 

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -51,7 +51,7 @@
 static void pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], polyvec *pk,
                     const uint8_t seed[MLKEM_SYMBYTES])
 {
-  POLYVEC_BOUND(pk, MLKEM_Q);
+  debug_assert_abs_bound(pk, MLKEM_K * MLKEM_N, MLKEM_Q);
   polyvec_tobytes(r, pk);
   memcpy(r + MLKEM_POLYVECBYTES, seed, MLKEM_SYMBYTES);
 }
@@ -77,7 +77,7 @@ static void unpack_pk(polyvec *pk, uint8_t seed[MLKEM_SYMBYTES],
   /* NOTE: If a modulus check was conducted on the PK, we know at this
    * point that the coefficients of `pk` are unsigned canonical. The
    * specifications and proofs, however, do _not_ assume this, and instead
-   * work with the easily provable bound by 4096. */
+   * work with the easily provable bound by UINT12_LIMIT. */
 }
 
 /*************************************************
@@ -91,7 +91,7 @@ static void unpack_pk(polyvec *pk, uint8_t seed[MLKEM_SYMBYTES],
  **************************************************/
 static void pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], polyvec *sk)
 {
-  POLYVEC_BOUND(sk, MLKEM_Q);
+  debug_assert_abs_bound(sk, MLKEM_K * MLKEM_N, MLKEM_Q);
   polyvec_tobytes(r, sk);
 }
 
@@ -354,8 +354,7 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
     i++;
   }
 
-  cassert(i == MLKEM_K * MLKEM_K,
-          "gen_matrix: failed to generate whole matrix");
+  cassert(i == MLKEM_K * MLKEM_K);
 
   /*
    * The public matrix is generated in NTT domain. If the native backend

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -132,7 +132,7 @@ void poly_ntt(poly *p)
 {
   int len, layer;
   int16_t *r;
-  POLY_BOUND_MSG(p, MLKEM_Q, "ref ntt input");
+  debug_assert_abs_bound(p, MLKEM_N, MLKEM_Q);
   r = p->coeffs;
 
   for (len = 128, layer = 1; len >= 2; len >>= 1, layer++)
@@ -144,16 +144,16 @@ void poly_ntt(poly *p)
   }
 
   /* Check the stronger bound */
-  POLY_BOUND_MSG(p, NTT_BOUND, "ref ntt output");
+  debug_assert_abs_bound(p, MLKEM_N, NTT_BOUND);
 }
 #else  /* MLKEM_USE_NATIVE_NTT */
 
 MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *p)
 {
-  POLY_BOUND_MSG(p, MLKEM_Q, "native ntt input");
+  debug_assert_abs_bound(p, MLKEM_N, MLKEM_Q);
   ntt_native(p);
-  POLY_BOUND_MSG(p, NTT_BOUND, "native ntt output");
+  debug_assert_abs_bound(p, MLKEM_N, NTT_BOUND);
 }
 #endif /* MLKEM_USE_NATIVE_NTT */
 
@@ -225,7 +225,7 @@ void poly_invntt_tomont(poly *p)
     invntt_layer(p->coeffs, len, layer);
   }
 
-  POLY_BOUND_MSG(p, INVNTT_BOUND, "ref intt output");
+  debug_assert_abs_bound(p, MLKEM_N, INVNTT_BOUND);
 }
 #else  /* MLKEM_USE_NATIVE_INTT */
 
@@ -233,7 +233,7 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *p)
 {
   intt_native(p);
-  POLY_BOUND_MSG(p, INVNTT_BOUND, "native intt output");
+  debug_assert_abs_bound(p, MLKEM_N, INVNTT_BOUND);
 }
 #endif /* MLKEM_USE_NATIVE_INTT */
 
@@ -242,8 +242,7 @@ void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
                     int16_t b_cached)
 {
   int32_t t0, t1;
-
-  BOUND(a, 2, 4096, "basemul input bound");
+  debug_assert_bound(a, 2, 0, UINT12_LIMIT);
 
   t0 = (int32_t)a[1] * b_cached;
   t0 += (int32_t)a[0] * b[0];
@@ -254,5 +253,5 @@ void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
   r[0] = montgomery_reduce(t0);
   r[1] = montgomery_reduce(t1);
 
-  BOUND(r, 2, 2 * MLKEM_Q, "basemul output bound");
+  debug_assert_abs_bound(r, 2, 2 * MLKEM_Q);
 }

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -81,7 +81,7 @@ __contract__(
  *                   Upon return, coefficients are bound by
  *                   2*MLKEM_Q in absolute value.
  *            - a: Pointer to first input polynomial
- *                   Must be coefficient-wise < 4096 in absolute value.
+ *                   Every coefficient must be in [0..4095]
  *            - b: Pointer to second input polynomial
  *                   Can have arbitrary int16_t coefficients
  *            - b_cached: Some precomputed value, typically derived from

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -145,7 +145,7 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 {
   unsigned i;
-  POLY_UBOUND(a, MLKEM_Q);
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
 #if (MLKEM_POLYCOMPRESSEDBYTES_DV == 128)
   for (i = 0; i < MLKEM_N / 8; i++)
@@ -250,7 +250,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
 #error "MLKEM_POLYCOMPRESSEDBYTES_DV needs to be in {128, 160}"
 #endif
 
-  POLY_UBOUND(r, MLKEM_Q);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
 
 #if !defined(MLKEM_USE_NATIVE_POLY_TOBYTES)
@@ -258,7 +258,7 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 {
   unsigned i;
-  POLY_UBOUND(a, MLKEM_Q);
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
 
   for (i = 0; i < MLKEM_N / 2; i++)
@@ -290,7 +290,7 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 MLKEM_NATIVE_INTERNAL_API
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 {
-  POLY_UBOUND(a, MLKEM_Q);
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
   poly_tobytes_native(r, a);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_TOBYTES */
@@ -313,7 +313,7 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
   }
 
   /* Note that the coefficients are not canonical */
-  POLY_UBOUND(r, 4096);
+  debug_assert_bound(r, MLKEM_N, 0, UINT12_LIMIT);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 MLKEM_NATIVE_INTERNAL_API
@@ -347,14 +347,14 @@ void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
       r->coeffs[8 * i + j] = ct_sel_int16(HALF_Q, 0, msg[i] & mask);
     }
   }
-  POLY_BOUND_MSG(r, MLKEM_Q, "poly_frommsg output");
+  debug_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 
 MLKEM_NATIVE_INTERNAL_API
 void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *a)
 {
   unsigned i;
-  POLY_UBOUND(a, MLKEM_Q);
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(invariant(i >= 0 && i <= MLKEM_N / 8))
@@ -398,10 +398,10 @@ void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
   poly_cbd_eta1(r2, buf2);
   poly_cbd_eta1(r3, buf3);
 
-  POLY_BOUND_MSG(r0, MLKEM_ETA1 + 1, "poly_getnoise_eta1_4x output 0");
-  POLY_BOUND_MSG(r1, MLKEM_ETA1 + 1, "poly_getnoise_eta1_4x output 1");
-  POLY_BOUND_MSG(r2, MLKEM_ETA1 + 1, "poly_getnoise_eta1_4x output 2");
-  POLY_BOUND_MSG(r3, MLKEM_ETA1 + 1, "poly_getnoise_eta1_4x output 3");
+  debug_assert_abs_bound(r0, MLKEM_N, MLKEM_ETA1 + 1);
+  debug_assert_abs_bound(r1, MLKEM_N, MLKEM_ETA1 + 1);
+  debug_assert_abs_bound(r2, MLKEM_N, MLKEM_ETA1 + 1);
+  debug_assert_abs_bound(r3, MLKEM_N, MLKEM_ETA1 + 1);
 }
 
 #if MLKEM_K == 2 || MLKEM_K == 4
@@ -418,7 +418,7 @@ void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES],
 
   poly_cbd_eta2(r, buf);
 
-  POLY_BOUND_MSG(r, MLKEM_ETA1 + 1, "poly_getnoise_eta2 output");
+  debug_assert_abs_bound(r, MLKEM_N, MLKEM_ETA1 + 1);
 }
 #endif /* MLKEM_K == 2 || MLKEM_K == 4 */
 
@@ -451,10 +451,10 @@ void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
   poly_cbd_eta2(r2, buf2[0]);
   poly_cbd_eta2(r3, buf2[1]);
 
-  POLY_BOUND_MSG(r0, MLKEM_ETA1 + 1, "poly_getnoise_eta1122_4x output 0");
-  POLY_BOUND_MSG(r1, MLKEM_ETA1 + 1, "poly_getnoise_eta1122_4x output 1");
-  POLY_BOUND_MSG(r2, MLKEM_ETA2 + 1, "poly_getnoise_eta1122_4x output 2");
-  POLY_BOUND_MSG(r3, MLKEM_ETA2 + 1, "poly_getnoise_eta1122_4x output 3");
+  debug_assert_abs_bound(r0, MLKEM_N, MLKEM_ETA1 + 1);
+  debug_assert_abs_bound(r1, MLKEM_N, MLKEM_ETA1 + 1);
+  debug_assert_abs_bound(r2, MLKEM_N, MLKEM_ETA2 + 1);
+  debug_assert_abs_bound(r3, MLKEM_N, MLKEM_ETA2 + 1);
 }
 #endif /* MLKEM_K == 2 */
 
@@ -463,7 +463,7 @@ void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
                                     const poly_mulcache *b_cache)
 {
   unsigned i;
-  POLY_BOUND(b_cache, 4096);
+  debug_assert_bound(a, MLKEM_N, 0, UINT12_LIMIT);
 
   for (i = 0; i < MLKEM_N / 4; i++)
   __loop__(
@@ -476,6 +476,8 @@ void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
     basemul_cached(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2],
                    &b->coeffs[4 * i + 2], b_cache->coeffs[2 * i + 1]);
   }
+
+  debug_assert_abs_bound(r, MLKEM_N, 2 * MLKEM_Q);
 }
 
 #if !defined(MLKEM_USE_NATIVE_POLY_TOMONT)
@@ -492,14 +494,14 @@ void poly_tomont(poly *r)
     r->coeffs[i] = fqmul(r->coeffs[i], f);
   }
 
-  POLY_BOUND(r, MLKEM_Q);
+  debug_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_TOMONT */
 MLKEM_NATIVE_INTERNAL_API
 void poly_tomont(poly *r)
 {
   poly_tomont_native(r);
-  POLY_BOUND(r, MLKEM_Q);
+  debug_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_TOMONT */
 
@@ -519,14 +521,14 @@ void poly_reduce(poly *r)
     r->coeffs[i] = scalar_signed_to_unsigned_q(t);
   }
 
-  POLY_UBOUND(r, MLKEM_Q);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_REDUCE */
 MLKEM_NATIVE_INTERNAL_API
 void poly_reduce(poly *r)
 {
   poly_reduce_native(r);
-  POLY_UBOUND(r, MLKEM_Q);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_REDUCE */
 
@@ -569,14 +571,14 @@ void poly_mulcache_compute(poly_mulcache *x, const poly *a)
     x->coeffs[2 * i + 0] = fqmul(a->coeffs[4 * i + 1], zetas[64 + i]);
     x->coeffs[2 * i + 1] = fqmul(a->coeffs[4 * i + 3], -zetas[64 + i]);
   }
-  POLY_BOUND(x, MLKEM_Q);
+  debug_assert_abs_bound(x, MLKEM_N / 2, MLKEM_Q);
 }
 #else  /* MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE */
 MLKEM_NATIVE_INTERNAL_API
 void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 {
   poly_mulcache_compute_native(x, a);
-  /* Omitting POLY_BOUND(x, MLKEM_Q) since native implementations may
+  /* Omitting bounds assertion since native implementations may
    * decide not to use a mulcache. Note that the C backend implementation
    * of poly_basemul_montgomery_cached() does still include the check. */
 }

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -314,8 +314,8 @@ __contract__(
   /* Add Q if c is negative, but in constant time */
   c = ct_sel_int16(c + MLKEM_Q, c, ct_cmask_neg_i16(c));
 
-  cassert(c >= 0, "scalar_signed_to_unsigned_q result lower bound");
-  cassert(c < MLKEM_Q, "scalar_signed_to_unsigned_q result upper bound");
+  cassert(c >= 0);
+  cassert(c < MLKEM_Q);
 
   /* and therefore cast to uint16_t is safe. */
   return (uint16_t)c;
@@ -649,8 +649,7 @@ __contract__(
  *              Bounds:
  *              - a is assumed to be coefficient-wise < q in absolute value.
  *
- *              The result is coefficient-wise bound by 3/2 q in absolute
- *              value.
+ *              The result is coefficient-wise bound by 2*q in absolute value.
  *
  * Arguments:   - poly *r: pointer to output polynomial
  *              - const poly *a: pointer to first input polynomial

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -194,7 +194,7 @@ __contract__(
  *              using mulcache for second operand.
  *
  *              Bounds:
- *              - a is assumed to be coefficient-wise < 4096 in absolute value.
+ *              - Every coefficient of a is assumed to be in [0..4095]
  *              - No bounds guarantees for the coefficients in the result.
  *
  * Arguments:   - poly *r: pointer to output polynomial

--- a/mlkem/reduce.h
+++ b/mlkem/reduce.h
@@ -109,13 +109,14 @@ static INLINE int16_t montgomery_reduce_generic(int32_t a)
  **************************************************/
 static INLINE int16_t montgomery_reduce(int32_t a)
 __contract__(
-  requires(a > -(2 * 4096 * 32768))
-  requires(a <  (2 * 4096 * 32768))
+  requires(a > -(2 * UINT12_LIMIT * 32768))
+  requires(a <  (2 * UINT12_LIMIT * 32768))
   ensures(return_value > -2 * MLKEM_Q && return_value < 2 * MLKEM_Q)
 )
 {
   int16_t res;
-  SCALAR_BOUND(a, 2 * UINT12_LIMIT * 32768, "montgomery_reduce input");
+  debug_assert((a > -(2 * UINT12_LIMIT * 32768)) &&
+               (a < (2 * UINT12_LIMIT * 32768)));
 
   res = montgomery_reduce_generic(a);
   /* Bounds:
@@ -124,7 +125,7 @@ __contract__(
    *       <= UINT12_LIMIT + (MLKEM_Q + 1) / 2
    *        < 2 * MLKEM_Q */
 
-  SCALAR_BOUND(res, 2 * MLKEM_Q, "montgomery_reduce output");
+  debug_assert(res > -2 * MLKEM_Q && res < 2 * MLKEM_Q);
   return res;
 }
 
@@ -150,7 +151,7 @@ __contract__(
 )
 {
   int16_t res;
-  SCALAR_BOUND(b, HALF_Q, "fqmul input");
+  debug_assert(b > -HALF_Q && b < HALF_Q);
 
   res = montgomery_reduce((int32_t)a * (int32_t)b);
   /* Bounds:
@@ -160,7 +161,7 @@ __contract__(
    *        < MLKEM_Q
    */
 
-  SCALAR_BOUND(res, MLKEM_Q, "fqmul output");
+  debug_assert(res > -MLKEM_Q && res < MLKEM_Q);
   return res;
 }
 


### PR DESCRIPTION
Previously, debug.h provided a host of bounds checking assertions, such as POLY_BOUND, POLY_UBOUND, POLY_BOUND_MSG, POLYVEC_BOUND, ...

This commit simplifies debug.h by reducing to three assertions
- debug_assert: For any boolean valued assertion
- debug_assert_bound: For a lower+upper bounds assertion on an array, akin to the CBMC assertion array_bound
- debug_assert_abs_bound: For an absolute bounds assertion on an array, akin to the CBMC assertion array_abs_bound.

Moreover, assertion strings are removed: The filename and linenumber already provide enough information to locate the issue when an assertion fails -- the additional text clutters the code and doesn't add much.

While adjusting the code, two smaller issues were noted and fixed:
- The debug assertions had gone out of sync with the CBMC specs for the basemul functions: The CBMC spec would assert that the a-input is coefficient-wise in [0..4095], while the debug assertions would assert an absolute bound. This is unified by using bound by [0..4095] as proved correct by CBMC.
- In `poly_basemul_montgomery_cached`, a debug assertion was placed on the mulcache what should have been placed on the a-input. This is fixed.
- The documentation of `poly_basemul_montgomery_cached` had gone out of sync with the CBMC assertions: The documentation still stated the older output bound by 3/2q, while the CBMC assertions showed only 2q. This change stemmed from the recent relaxation of input bounds from MLKEM_Q -> 4096. Also, there was no debug-assertion for the post-condition, which is added.
