### PR TITLE
CBMC: Remove redundant `0 <= ...` assertions in loop invariants

### DIFF
--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -72,7 +72,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4])
   unsigned i;
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N / 8)
+    invariant(i <= MLKEM_N / 8)
     invariant(array_abs_bound(r->coeffs, 0, 8 * i, 3)))
   {
     unsigned j;
@@ -82,7 +82,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4])
 
     for (j = 0; j < 8; j++)
     __loop__(
-      invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
+      invariant(i <= MLKEM_N / 8 && j <= 8)
       invariant(array_abs_bound(r->coeffs, 0, 8 * i + j, 3)))
     {
       const int16_t a = (d >> (4 * j + 0)) & 0x3;
@@ -109,7 +109,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
   unsigned i;
   for (i = 0; i < MLKEM_N / 4; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N / 4)
+    invariant(i <= MLKEM_N / 4)
     invariant(array_abs_bound(r->coeffs, 0, 4 * i, 4)))
   {
     unsigned j;
@@ -120,7 +120,7 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4])
 
     for (j = 0; j < 4; j++)
     __loop__(
-      invariant(i >= 0 && i <= MLKEM_N / 4 && j >= 0 && j <= 4)
+      invariant(i <= MLKEM_N / 4 && j <= 4)
       invariant(array_abs_bound(r->coeffs, 0, 4 * i + j, 4)))
     {
       const int16_t a = (d >> (6 * j + 0)) & 0x7;

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -119,8 +119,8 @@
   {                                                                    \
     unsigned qvar;                                                     \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
-        (((value_lb) <= (array_var[(qvar)])) &&                        \
-        ((array_var[(qvar)]) < (value_ub)))                            \
+        (((int)(value_lb) <= (array_var[(qvar)])) &&		       \
+         ((array_var[(qvar)]) < (int)(value_ub)))		       \
   }
 
 #define array_bound(array_var, qvar_lb, qvar_ub, value_lb, value_ub) \
@@ -134,6 +134,6 @@
  * bound in array_bound is inclusive, we have to raise it by 1.
  */
 #define array_abs_bound(arr, lb, ub, k) \
-  array_bound((arr), (lb), (ub), -(k) + 1, (k))
+  array_bound((arr), (lb), (ub), -((int)(k)) + 1, (k))
 
 #endif

--- a/mlkem/fips202/keccakf1600.c
+++ b/mlkem/fips202/keccakf1600.c
@@ -33,14 +33,14 @@ void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data,
 #if defined(SYS_LITTLE_ENDIAN)
   uint8_t *state_ptr = (uint8_t *)state + offset;
   for (i = 0; i < length; i++)
-  __loop__(invariant(0 <= i && i <= length))
+  __loop__(invariant(i <= length))
   {
     data[i] = state_ptr[i];
   }
 #else  /* SYS_LITTLE_ENDIAN */
   /* Portable version */
   for (i = 0; i < length; i++)
-  __loop__(invariant(0 <= i && i <= length))
+  __loop__(invariant(i <= length))
   {
     data[i] = (state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07))) & 0xFF;
   }
@@ -128,7 +128,7 @@ static const uint64_t KeccakF_RoundConstants[NROUNDS] = {
 
 void KeccakF1600_StatePermute(uint64_t *state)
 {
-  int round;
+  unsigned round;
 
   uint64_t Aba, Abe, Abi, Abo, Abu;
   uint64_t Aga, Age, Agi, Ago, Agu;
@@ -171,7 +171,7 @@ void KeccakF1600_StatePermute(uint64_t *state)
   Asu = state[24];
 
   for (round = 0; round < NROUNDS; round += 2)
-  __loop__(invariant(0 <= round && round <= NROUNDS && round % 2 == 0))
+  __loop__(invariant(round <= NROUNDS && round % 2 == 0))
   {
     /*    prepareTheta */
     BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -251,9 +251,8 @@ __contract__(
   while (ctr < MLKEM_N)
   __loop__(
     assigns(ctr, state, memory_slice(entry, sizeof(poly)), object_whole(buf))
-    invariant(0 <= ctr && ctr <= MLKEM_N)
-    invariant(ctr > 0 ==> array_bound(entry->coeffs, 0, ctr,
-                                          0, MLKEM_Q)))
+    invariant(ctr <= MLKEM_N)
+    invariant(array_bound(entry->coeffs, 0, ctr, 0, MLKEM_Q)))
   {
     xof_squeezeblocks(buf, 1, &state);
     ctr = rej_uniform(entry->coeffs, MLKEM_N, ctr, buf, buflen);
@@ -398,7 +397,7 @@ __contract__(
   for (i = 0; i < MLKEM_K; i++)
   __loop__(
     assigns(i, object_whole(out))
-    invariant(i >= 0 && i <= MLKEM_K))
+    invariant(i <= MLKEM_K))
   {
     polyvec_basemul_acc_montgomery_cached(&out->vec[i], &a[i], v, vc);
   }

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -22,13 +22,13 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
   unsigned j;
 #if (MLKEM_POLYCOMPRESSEDBYTES_DU == 352)
   for (j = 0; j < MLKEM_N / 8; j++)
-  __loop__(invariant(j >= 0 && j <= MLKEM_N / 8))
+  __loop__(invariant(j <= MLKEM_N / 8))
   {
     unsigned k;
     uint16_t t[8];
     for (k = 0; k < 8; k++)
     __loop__(
-      invariant(k >= 0 && k <= 8)
+      invariant(k <= 8)
       invariant(forall(r, 0, k, t[r] < (1u << 11))))
     {
       t[k] = scalar_compress_d11(a->coeffs[8 * j + k]);
@@ -53,13 +53,13 @@ void poly_compress_du(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DU], const poly *a)
 
 #elif (MLKEM_POLYCOMPRESSEDBYTES_DU == 320)
   for (j = 0; j < MLKEM_N / 4; j++)
-  __loop__(invariant(j >= 0 && j <= MLKEM_N / 4))
+  __loop__(invariant(j <= MLKEM_N / 4))
   {
     unsigned k;
     uint16_t t[4];
     for (k = 0; k < 4; k++)
     __loop__(
-      invariant(k >= 0 && k <= 4)
+      invariant(k <= 4)
       invariant(forall(r, 0, k, t[r] < (1u << 10))))
     {
       t[k] = scalar_compress_d10(a->coeffs[4 * j + k]);
@@ -88,10 +88,10 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 #if (MLKEM_POLYCOMPRESSEDBYTES_DU == 352)
   for (j = 0; j < MLKEM_N / 8; j++)
   __loop__(
-    invariant(0 <= j && j <= MLKEM_N / 8)
+    invariant(j <= MLKEM_N / 8)
     invariant(array_bound(r->coeffs, 0, 8 * j, 0, MLKEM_Q)))
   {
-    int k;
+    unsigned k;
     uint16_t t[8];
     uint8_t const *base = &a[11 * j];
     t[0] = 0x7FF & ((base[0] >> 0) | ((uint16_t)base[1] << 8));
@@ -107,7 +107,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 
     for (k = 0; k < 8; k++)
     __loop__(
-      invariant(0 <= k && k <= 8)
+      invariant(k <= 8)
       invariant(array_bound(r->coeffs, 0, 8 * j + k, 0, MLKEM_Q)))
     {
       r->coeffs[8 * j + k] = scalar_decompress_d11(t[k]);
@@ -116,10 +116,10 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 #elif (MLKEM_POLYCOMPRESSEDBYTES_DU == 320)
   for (j = 0; j < MLKEM_N / 4; j++)
   __loop__(
-    invariant(0 <= j && j <= MLKEM_N / 4)
+    invariant(j <= MLKEM_N / 4)
     invariant(array_bound(r->coeffs, 0, 4 * j, 0, MLKEM_Q)))
   {
-    int k;
+    unsigned k;
     uint16_t t[4];
     uint8_t const *base = &a[5 * j];
 
@@ -130,7 +130,7 @@ void poly_decompress_du(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DU])
 
     for (k = 0; k < 4; k++)
     __loop__(
-      invariant(0 <= k && k <= 4)
+      invariant(k <= 4)
       invariant(array_bound(r->coeffs, 0, 4 * j + k, 0, MLKEM_Q)))
     {
       r->coeffs[4 * j + k] = scalar_decompress_d10(t[k]);
@@ -149,13 +149,13 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
 
 #if (MLKEM_POLYCOMPRESSEDBYTES_DV == 128)
   for (i = 0; i < MLKEM_N / 8; i++)
-  __loop__(invariant(i >= 0 && i <= MLKEM_N / 8))
+  __loop__(invariant(i <= MLKEM_N / 8))
   {
     unsigned j;
     uint8_t t[8] = {0};
     for (j = 0; j < 8; j++)
     __loop__(
-      invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
+      invariant(i <= MLKEM_N / 8 && j <= 8)
       invariant(array_bound(t, 0, j, 0, 16)))
     {
       t[j] = scalar_compress_d4(a->coeffs[8 * i + j]);
@@ -168,13 +168,13 @@ void poly_compress_dv(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_DV], const poly *a)
   }
 #elif (MLKEM_POLYCOMPRESSEDBYTES_DV == 160)
   for (i = 0; i < MLKEM_N / 8; i++)
-  __loop__(invariant(i >= 0 && i <= MLKEM_N / 8))
+  __loop__(invariant(i <= MLKEM_N / 8))
   {
     unsigned j;
     uint8_t t[8] = {0};
     for (j = 0; j < 8; j++)
     __loop__(
-      invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
+      invariant(i <= MLKEM_N / 8 && j <= 8)
       invariant(array_bound(t, 0, j, 0, 32)))
     {
       t[j] = scalar_compress_d5(a->coeffs[8 * i + j]);
@@ -203,7 +203,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
 #if (MLKEM_POLYCOMPRESSEDBYTES_DV == 128)
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N / 2)
+    invariant(i <= MLKEM_N / 2)
     invariant(array_bound(r->coeffs, 0, 2 * i, 0, MLKEM_Q)))
   {
     r->coeffs[2 * i + 0] = scalar_decompress_d4((a[i] >> 0) & 0xF);
@@ -212,12 +212,12 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
 #elif (MLKEM_POLYCOMPRESSEDBYTES_DV == 160)
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N / 8)
+    invariant(i <= MLKEM_N / 8)
     invariant(array_bound(r->coeffs, 0, 8 * i, 0, MLKEM_Q)))
   {
     unsigned j;
     uint8_t t[8];
-    const int offset = i * 5;
+    const unsigned offset = i * 5;
     /*
      * Explicitly truncate to avoid warning about
      * implicit truncation in CBMC and unwind loop for ease
@@ -240,7 +240,7 @@ void poly_decompress_dv(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_DV])
     /* and copy to the correct slice in r[] */
     for (j = 0; j < 8; j++)
     __loop__(
-      invariant(j >= 0 && j <= 8 && i >= 0 && i <= MLKEM_N / 8)
+      invariant(j <= 8 && i <= MLKEM_N / 8)
       invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, MLKEM_Q)))
     {
       r->coeffs[8 * i + j] = scalar_decompress_d5(t[j]);
@@ -262,7 +262,7 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 
 
   for (i = 0; i < MLKEM_N / 2; i++)
-  __loop__(invariant(i >= 0 && i <= MLKEM_N / 2))
+  __loop__(invariant(i <= MLKEM_N / 2))
   {
     const uint16_t t0 = a->coeffs[2 * i];
     const uint16_t t1 = a->coeffs[2 * i + 1];
@@ -302,7 +302,7 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
   unsigned i;
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N / 2)
+    invariant(i <= MLKEM_N / 2)
     invariant(array_bound(r->coeffs, 0, 2 * i, 0, UINT12_LIMIT)))
   {
     const uint8_t t0 = a[3 * i + 0];
@@ -333,13 +333,13 @@ void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
 
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N / 8)
+    invariant(i <= MLKEM_N / 8)
     invariant(array_bound(r->coeffs, 0, 8 * i, 0, MLKEM_Q)))
   {
     unsigned j;
     for (j = 0; j < 8; j++)
     __loop__(
-      invariant(i >= 0 && i <  MLKEM_N / 8 && j >= 0 && j <= 8)
+      invariant(i <  MLKEM_N / 8 && j <= 8)
       invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, MLKEM_Q)))
     {
       /* Prevent the compiler from recognizing this as a bit selection */
@@ -357,13 +357,13 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *a)
   debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_N / 8; i++)
-  __loop__(invariant(i >= 0 && i <= MLKEM_N / 8))
+  __loop__(invariant(i <= MLKEM_N / 8))
   {
     unsigned j;
     msg[i] = 0;
     for (j = 0; j < 8; j++)
     __loop__(
-      invariant(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8))
+      invariant(i <= MLKEM_N / 8 && j <= 8))
     {
       uint32_t t = scalar_compress_d1(a->coeffs[8 * i + j]);
       msg[i] |= t << j;
@@ -468,7 +468,7 @@ void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
   for (i = 0; i < MLKEM_N / 4; i++)
   __loop__(
     assigns(i, object_whole(r))
-    invariant(i >= 0 && i <= MLKEM_N / 4)
+    invariant(i <= MLKEM_N / 4)
     invariant(array_abs_bound(r->coeffs, 0, 4 * i, 2 * MLKEM_Q)))
   {
     basemul_cached(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
@@ -488,7 +488,7 @@ void poly_tomont(poly *r)
   const int16_t f = (1ULL << 32) % MLKEM_Q; /* 1353 */
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N)
+    invariant(i <= MLKEM_N)
     invariant(array_abs_bound(r->coeffs ,0, i, MLKEM_Q)))
   {
     r->coeffs[i] = fqmul(r->coeffs[i], f);
@@ -512,7 +512,7 @@ void poly_reduce(poly *r)
   unsigned i;
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N)
+    invariant(i <= MLKEM_N)
     invariant(array_bound(r->coeffs, 0, i, 0, MLKEM_Q)))
   {
     /* Barrett reduction, giving signed canonical representative */
@@ -538,7 +538,7 @@ void poly_add(poly *r, const poly *b)
   unsigned i;
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N)
+    invariant(i <= MLKEM_N)
     invariant(forall(k0, i, MLKEM_N, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
     invariant(forall(k1, 0, i, r->coeffs[k1] == loop_entry(*r).coeffs[k1] + b->coeffs[k1])))
   {
@@ -552,7 +552,7 @@ void poly_sub(poly *r, const poly *b)
   unsigned i;
   for (i = 0; i < MLKEM_N; i++)
   __loop__(
-    invariant(i >= 0 && i <= MLKEM_N)
+    invariant(i <= MLKEM_N)
     invariant(forall(k0, i, MLKEM_N, r->coeffs[k0] == loop_entry(*r).coeffs[k0]))
     invariant(forall(k1, 0, i, r->coeffs[k1] == loop_entry(*r).coeffs[k1] - b->coeffs[k1])))
   {
@@ -566,7 +566,7 @@ void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 {
   unsigned i;
   for (i = 0; i < MLKEM_N / 4; i++)
-  __loop__(invariant(i >= 0 && i <= MLKEM_N / 4))
+  __loop__(invariant(i <= MLKEM_N / 4))
   {
     x->coeffs[2 * i + 0] = fqmul(a->coeffs[4 * i + 1], zetas[64 + i]);
     x->coeffs[2 * i + 1] = fqmul(a->coeffs[4 * i + 3], -zetas[64 + i]);

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -268,7 +268,7 @@ __contract__(
 
   for (i = 0; i < len; i++)
   __loop__(
-    invariant(i >= 0 && i <= len)
+    invariant(i <= len)
     invariant((r == 0) == (forall(k, 0, i, (a[k] == b[k])))))
   {
     r |= a[i] ^ b[i];

--- a/proofs/cbmc/invntt_layer/invntt_layer_harness.c
+++ b/proofs/cbmc/invntt_layer/invntt_layer_harness.c
@@ -6,11 +6,11 @@
 #include "common.h"
 
 #define invntt_layer MLKEM_NAMESPACE(invntt_layer)
-void invntt_layer(int16_t *p, int len, int layer);
+void invntt_layer(int16_t *p, unsigned len, unsigned layer);
 
 void harness(void)
 {
   int16_t *a;
-  int len, layer;
+  unsigned len, layer;
   invntt_layer(a, len, layer);
 }

--- a/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
+++ b/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
@@ -6,12 +6,13 @@
 #include "common.h"
 
 #define ntt_butterfly_block MLKEM_NAMESPACE(ntt_butterfly_block)
-void ntt_butterfly_block(int16_t *r, int16_t root, int start, int len,
+void ntt_butterfly_block(int16_t *r, int16_t root, unsigned start, unsigned len,
                          int bound);
 
 void harness(void)
 {
   int16_t *r, root;
-  int start, stride, bound;
+  unsigned start, stride;
+  int bound;
   ntt_butterfly_block(r, root, start, stride, bound);
 }

--- a/proofs/cbmc/ntt_layer/ntt_layer_harness.c
+++ b/proofs/cbmc/ntt_layer/ntt_layer_harness.c
@@ -5,11 +5,11 @@
 #include "poly.h"
 
 #define ntt_layer MLKEM_NAMESPACE(ntt_layer)
-void ntt_layer(int16_t *p, int len, int layer);
+void ntt_layer(int16_t *p, unsigned len, unsigned layer);
 
 void harness(void)
 {
   int16_t *a;
-  int len, layer;
+  unsigned len, layer;
   ntt_layer(a, len, layer);
 }

--- a/proofs/cbmc/proof_guide.md
+++ b/proofs/cbmc/proof_guide.md
@@ -203,7 +203,7 @@ void zero_array_correct (uint8_t *dst, int len)
     for (i = 0; i < len; i++)
     __loop__(
       assigns(i, object_whole(dst))
-      invariant(i >= 0 && i <= len)
+      invariant(i <= len)
       invariant(forall(j, 0, i, dst[j] == 0))
       decreases(len - i))
     {
@@ -488,12 +488,10 @@ Therefore, we add:
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(
     assigns(i, object_whole(r))
-    invariant(i >= 0 && i <= MLKEM_N / 2)
+    invariant(i <= MLKEM_N / 2)
     decreases(MLKEM_N / 2 - i))
   { ... }
 ```
-
-Note that the invariant `i >= 0` could be ommitted since `i` is of an `unsigned` integer type. It is given here for clarity only.
 
 Another small set of changes is required to make CBMC happy with the loop body. By default, CBMC is pedantic and warns
 about conversions that truncate values or lose information via an implicit type conversion.


### PR DESCRIPTION
Previously, we were using `int` as the type of loop indices, which requires loop invariants of the form `0 <= i`.

With the recent switch to `unsigned` indices, those invariants are automatic and can be removed for improved readability. This commit does that.

Along the way, it is noticed that some of the NTT proofs still used integral loop indices. Those are changed along the way.
