### PR TITLE
Turn debug assertions into CBMC constraints when CBMC is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![C90](https://img.shields.io/badge/language-C90-blue.svg)](https://web.archive.org/web/20200909074736if_/https://www.pdf-archive.com/2014/10/02/ansi-iso-9899-1990-1/ansi-iso-9899-1990-1.pdf)
 [![Apache](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-mlkem-native is a C90 implementation of [ML-KEM](https://doi.org/10.6028/NIST.FIPS.203.ipd) targeting
+mlkem-native is a C90 implementation of [ML-KEM](https://doi.org/10.6028/NIST.FIPS.203) targeting
 PC, mobile and server platforms. It is a fork of the ML-KEM [reference
 implementation](https://github.com/pq-crystals/kyber/tree/main/ref).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ mlkem-native alpha
 About
 -----
 
-mlkem-native is a C90 implementation of [ML-KEM](https://doi.org/10.6028/NIST.FIPS.203.ipd) targeting
+mlkem-native is a C90 implementation of [ML-KEM](https://doi.org/10.6028/NIST.FIPS.203) targeting
 PC, mobile and server platforms. It is a fork of the ML-KEM [reference
 implementation](https://github.com/pq-crystals/kyber/tree/main/ref).
 
@@ -17,7 +17,7 @@ out of bounds accesses, nor integer overflows during optimized modular arithmeti
 Release notes
 =============
 
-This is first official release of mlkem-native, a C90 implementation of [ML-KEM](https://doi.org/10.6028/NIST.FIPS.203.ipd) targeting
+This is first official release of mlkem-native, a C90 implementation of [ML-KEM](https://doi.org/10.6028/NIST.FIPS.203) targeting
 PC, mobile and server platforms.
 This alpha release of mlkem-native features complete backends in C, AArch64 and x86_64, offering state-of-the-art performance on most Arm, Intel and AMD platforms.
 

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -374,6 +374,16 @@
 #endif
 
 /* mlkem/debug/debug.h */
+#if defined(debug_assert)
+#undef debug_assert
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_abs_bound)
+#undef debug_assert_abs_bound
+#endif
+
+/* mlkem/debug/debug.h */
 #if defined(debug_assert_abs_bound)
 #undef debug_assert_abs_bound
 #endif
@@ -384,6 +394,21 @@
 #endif
 
 /* mlkem/debug/debug.h */
+#if defined(debug_assert_abs_bound_2d)
+#undef debug_assert_abs_bound_2d
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_abs_bound_2d)
+#undef debug_assert_abs_bound_2d
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_abs_bound_2d)
+#undef debug_assert_abs_bound_2d
+#endif
+
+/* mlkem/debug/debug.h */
 #if defined(debug_assert_bound)
 #undef debug_assert_bound
 #endif
@@ -391,6 +416,26 @@
 /* mlkem/debug/debug.h */
 #if defined(debug_assert_bound)
 #undef debug_assert_bound
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_bound)
+#undef debug_assert_bound
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_bound_2d)
+#undef debug_assert_bound_2d
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_bound_2d)
+#undef debug_assert_bound_2d
+#endif
+
+/* mlkem/debug/debug.h */
+#if defined(debug_assert_bound_2d)
+#undef debug_assert_bound_2d
 #endif
 
 /* mlkem/debug/debug.h */

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -119,13 +119,13 @@
   {                                                                    \
     unsigned qvar;                                                     \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
-        (((int)(value_lb) <= (array_var[(qvar)])) &&		       \
-         ((array_var[(qvar)]) < (int)(value_ub)))		       \
+        (((int)(value_lb) <= ((array_var)[(qvar)])) &&		       \
+         (((array_var)[(qvar)]) < (int)(value_ub)))		       \
   }
 
 #define array_bound(array_var, qvar_lb, qvar_ub, value_lb, value_ub) \
   array_bound_core(CBMC_CONCAT(_cbmc_idx, __LINE__), (qvar_lb),      \
-                   (qvar_ub), (array_var), (value_lb), (value_ub))
+      (qvar_ub), (array_var), (value_lb), (value_ub))
 /* clang-format on */
 
 /* Wrapper around array_bound operating on absolute values.

--- a/mlkem/debug/debug.h
+++ b/mlkem/debug/debug.h
@@ -50,11 +50,7 @@ void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
  *
  * val: Value that's asserted to be non-zero
  */
-#define debug_assert(val)                          \
-  do                                               \
-  {                                                \
-    mlkem_debug_assert(__FILE__, __LINE__, (val)); \
-  } while (0)
+#define debug_assert(val) mlkem_debug_assert(__FILE__, __LINE__, (val))
 
 /* Check bounds in array of int16_t's
  * ptr: Base of int16_t array; will be explicitly cast to int16_t*,
@@ -62,12 +58,9 @@ void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
  * len: Number of int16_t in array
  * value_lb: Inclusive lower value bound
  * value_ub: Exclusive upper value bound */
-#define debug_assert_bound(ptr, len, value_lb, value_ub)                 \
-  do                                                                     \
-  {                                                                      \
-    mlkem_debug_check_bounds(__FILE__, __LINE__, (const int16_t *)(ptr), \
-                             (len), (value_lb)-1, (value_ub));           \
-  } while (0)
+#define debug_assert_bound(ptr, len, value_lb, value_ub)                      \
+  mlkem_debug_check_bounds(__FILE__, __LINE__, (const int16_t *)(ptr), (len), \
+                           (value_lb)-1, (value_ub))
 
 /* Check absolute bounds in array of int16_t's
  * ptr: Base of array, expression of type int16_t*
@@ -75,6 +68,38 @@ void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
  * value_abs_bd: Exclusive absolute upper bound */
 #define debug_assert_abs_bound(ptr, len, value_abs_bd) \
   debug_assert_bound((ptr), (len), (-(value_abs_bd) + 1), (value_abs_bd))
+
+/* Version of bounds assertions for 2-dimensional arrays */
+#define debug_assert_bound_2d(ptr, len0, len1, value_lb, value_ub) \
+  debug_assert_bound((ptr), ((len0) * (len1)), (value_lb), (value_ub))
+
+#define debug_assert_abs_bound_2d(ptr, len0, len1, value_abs_bd) \
+  debug_assert_abs_bound((ptr), ((len0) * (len1)), (value_abs_bd))
+
+/* When running CBMC, convert debug assertions into proof obligations */
+#elif defined(CBMC)
+
+#include "../cbmc.h"
+
+#define debug_assert(val) cassert(val)
+
+#define debug_assert_bound(ptr, len, value_lb, value_ub) \
+  cassert(array_bound(((int16_t *)(ptr)), 0, (len), (value_lb), (value_ub)))
+
+#define debug_assert_abs_bound(ptr, len, value_abs_bd) \
+  cassert(array_abs_bound(((int16_t *)(ptr)), 0, (len), (value_abs_bd)))
+
+/* Because of https://github.com/diffblue/cbmc/issues/8570, we can't
+ * just use a single flattened array_bound(...) here. */
+#define debug_assert_bound_2d(ptr, M, N, value_lb, value_ub)           \
+  cassert(forall(kN, 0, (M),                                           \
+                 array_bound(&((int16_t(*)[(N)])(ptr))[kN][0], 0, (N), \
+                             (value_lb), (value_ub))))
+
+#define debug_assert_abs_bound_2d(ptr, M, N, value_abs_bd)                 \
+  cassert(forall(kN, 0, (M),                                               \
+                 array_abs_bound(&((int16_t(*)[(N)])(ptr))[kN][0], 0, (N), \
+                                 (value_abs_bd))))
 
 #else /* MLKEM_DEBUG */
 
@@ -90,6 +115,17 @@ void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
   do                                                   \
   {                                                    \
   } while (0)
+
+#define debug_assert_bound_2d(ptr, len0, len1, value_lb, value_ub) \
+  do                                                               \
+  {                                                                \
+  } while (0)
+
+#define debug_assert_abs_bound_2d(ptr, len0, len1, value_abs_bd) \
+  do                                                             \
+  {                                                              \
+  } while (0)
+
 
 #endif /* MLKEM_DEBUG */
 

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -51,7 +51,7 @@
 static void pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], polyvec *pk,
                     const uint8_t seed[MLKEM_SYMBYTES])
 {
-  debug_assert_abs_bound(pk, MLKEM_K * MLKEM_N, MLKEM_Q);
+  debug_assert_bound_2d(pk, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
   polyvec_tobytes(r, pk);
   memcpy(r + MLKEM_POLYVECBYTES, seed, MLKEM_SYMBYTES);
 }
@@ -91,7 +91,7 @@ static void unpack_pk(polyvec *pk, uint8_t seed[MLKEM_SYMBYTES],
  **************************************************/
 static void pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], polyvec *sk)
 {
-  debug_assert_abs_bound(sk, MLKEM_K * MLKEM_N, MLKEM_Q);
+  debug_assert_bound_2d(sk, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
   polyvec_tobytes(r, sk);
 }
 
@@ -353,7 +353,7 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
     i++;
   }
 
-  cassert(i == MLKEM_K * MLKEM_K);
+  debug_assert(i == MLKEM_K * MLKEM_K);
 
   /*
    * The public matrix is generated in NTT domain. If the native backend

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -307,17 +307,17 @@ __contract__(
  ************************************************************/
 static INLINE uint16_t scalar_signed_to_unsigned_q(int16_t c)
 __contract__(
-  requires(c >= -(MLKEM_Q - 1) && c <= (MLKEM_Q - 1))
-  ensures(return_value >= 0 && return_value <= (MLKEM_Q - 1))
+  requires(c > -MLKEM_Q && c < MLKEM_Q)
+  ensures(return_value >= 0 && return_value < MLKEM_Q)
   ensures(return_value == (int32_t)c + (((int32_t)c < 0) * MLKEM_Q)))
 {
+  debug_assert_abs_bound(&c, 1, MLKEM_Q);
+
   /* Add Q if c is negative, but in constant time */
   c = ct_sel_int16(c + MLKEM_Q, c, ct_cmask_neg_i16(c));
 
-  cassert(c >= 0);
-  cassert(c < MLKEM_Q);
-
   /* and therefore cast to uint16_t is safe. */
+  debug_assert_bound(&c, 1, 0, MLKEM_Q);
   return (uint16_t)c;
 }
 

--- a/mlkem/reduce.h
+++ b/mlkem/reduce.h
@@ -115,8 +115,7 @@ __contract__(
 )
 {
   int16_t res;
-  debug_assert((a > -(2 * UINT12_LIMIT * 32768)) &&
-               (a < (2 * UINT12_LIMIT * 32768)));
+  debug_assert_abs_bound(&a, 1, 2 * UINT12_LIMIT * 32768);
 
   res = montgomery_reduce_generic(a);
   /* Bounds:
@@ -125,7 +124,7 @@ __contract__(
    *       <= UINT12_LIMIT + (MLKEM_Q + 1) / 2
    *        < 2 * MLKEM_Q */
 
-  debug_assert(res > -2 * MLKEM_Q && res < 2 * MLKEM_Q);
+  debug_assert_abs_bound(&res, 1, 2 * MLKEM_Q);
   return res;
 }
 
@@ -151,7 +150,7 @@ __contract__(
 )
 {
   int16_t res;
-  debug_assert(b > -HALF_Q && b < HALF_Q);
+  debug_assert_abs_bound(&b, 1, HALF_Q);
 
   res = montgomery_reduce((int32_t)a * (int32_t)b);
   /* Bounds:
@@ -161,7 +160,7 @@ __contract__(
    *        < MLKEM_Q
    */
 
-  debug_assert(res > -MLKEM_Q && res < MLKEM_Q);
+  debug_assert_abs_bound(&res, 1, MLKEM_Q);
   return res;
 }
 
@@ -201,7 +200,10 @@ __contract__(
    * t is in -10 .. +10, so we need 32-bit math to
    * evaluate t * MLKEM_Q and the subsequent subtraction
    */
-  return (int16_t)(a - t * MLKEM_Q);
+  int16_t res = (int16_t)(a - t * MLKEM_Q);
+
+  debug_assert_abs_bound(&res, 1, HALF_Q);
+  return res;
 }
 
 #endif

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -5,6 +5,7 @@
 
 #include "rej_uniform.h"
 #include "arith_backend.h"
+#include "debug/debug.h"
 
 /* Static namespacing
  * This is to facilitate building multiple instances
@@ -58,6 +59,8 @@ __contract__(
   unsigned int ctr, pos;
   uint16_t val0, val1;
 
+  debug_assert_bound(r, offset, 0, MLKEM_Q);
+
   ctr = offset;
   pos = 0;
   /* pos + 3 cannot overflow due to the assumption buflen <= 4096 */
@@ -79,6 +82,8 @@ __contract__(
       r[ctr++] = val1;
     }
   }
+
+  debug_assert_bound(r, ctr, 0, MLKEM_Q);
   return ctr;
 }
 
@@ -99,7 +104,11 @@ unsigned int rej_uniform(int16_t *r, unsigned int target, unsigned int offset,
   /* Sample from large buffer with full lane as much as possible. */
   ret = rej_uniform_native(r + offset, target - offset, buf, buflen);
   if (ret != -1)
-    return offset + (unsigned)ret;
+  {
+    unsigned res = offset + (unsigned)ret;
+    debug_assert_bound(r, res, 0, MLKEM_Q);
+    return res;
+  }
 
   return rej_uniform_scalar(r, target, offset, buf, buflen);
 }

--- a/proofs/cbmc/poly_basemul_montgomery_cached/Makefile
+++ b/proofs/cbmc/poly_basemul_montgomery_cached/Makefile
@@ -38,6 +38,8 @@ FUNCTION_NAME = poly_basemul_montgomery_cached
 # This function is large enough to need...
 CBMC_OBJECT_BITS = 8
 
+CBMCFLAGS += --no-array-field-sensitivity --arrays-uf-always --slice-formula
+
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("mlkem/poly.c") in PROJECT_SOURCES).

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
@@ -13,7 +13,7 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLKEM_NAMESPACE)polyvec_basemul_acc_montgomery_cached.3:4 # Largest value of MLKEM_K
+UNWINDSET += $(MLKEM_NAMESPACE)polyvec_basemul_acc_montgomery_cached.0:4 # Largest value of MLKEM_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/polyvec.c

--- a/proofs/cbmc/polyvec_compress_du/Makefile
+++ b/proofs/cbmc/polyvec_compress_du/Makefile
@@ -13,7 +13,7 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLKEM_NAMESPACE)polyvec_compress_du.1:4 # Largest value of MLKEM_K
+UNWINDSET += $(MLKEM_NAMESPACE)polyvec_compress_du.0:4 # Largest value of MLKEM_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/polyvec.c


### PR DESCRIPTION
* Based on #663 

Previously, runtime assertions via debug_assert_xxx and CBMC
assertions via cassert(...) were separate.

This commit modifies the implementation of the debug assertion
macros so that when CBMC is used, debug assertions are intepreted
as proof obligations.

This removes some redundancy and non-uniformity in the code,
and also reduces the likelihood that debug assertions and CBMC
contracts get out of sync. In some case, this actually happened,
and the commit fixes this. The commit also adds further bounds
assertions in alignment with pre/post conditions.

A slight nuisance is that the debug assertions cannot flatten
nested structures like polyvec for the bounds check, running
into issue https://github.com/diffblue/cbmc/issues/8570. We
work around this by introducing a new `xxx_2d` (for 2-dimensional)
macro which takes two dimensions and uses a two-step array
access, circumventing the above CBMC issue.