### PR TITLE
Backend API: Remove dependence on poly_* structs

### DIFF
--- a/mlkem/compress.c
+++ b/mlkem/compress.c
@@ -307,7 +307,7 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a)
 {
   debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
-  poly_tobytes_native(r, a);
+  poly_tobytes_native(r, a->coeffs);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_TOBYTES */
 
@@ -335,7 +335,7 @@ void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
 MLKEM_NATIVE_INTERNAL_API
 void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
-  poly_frombytes_native(r, a);
+  poly_frombytes_native(r->coeffs, a);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -148,14 +148,14 @@ static void unpack_ciphertext(polyvec *b, poly *v,
 #define poly_permute_bitrev_to_custom \
   MLKEM_NAMESPACE_K(poly_permute_bitrev_to_custom)
 
-static INLINE void poly_permute_bitrev_to_custom(poly *data)
+static INLINE void poly_permute_bitrev_to_custom(int16_t data[MLKEM_N])
 __contract__(
   /* We don't specify that this should be a permutation, but only
    * that it does not change the bound established at the end of gen_matrix. */
-  requires(memory_no_alias(data, sizeof(poly)))
-  requires(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q))
+  requires(memory_no_alias(data, sizeof(int16_t) * MLKEM_N))
+  requires(array_bound(data, 0, MLKEM_N, 0, MLKEM_Q))
   assigns(memory_slice(data, sizeof(poly)))
-  ensures(array_bound(data->coeffs, 0, MLKEM_N, 0, MLKEM_Q))) { ((void)data); }
+  ensures(array_bound(data, 0, MLKEM_N, 0, MLKEM_Q))) { ((void)data); }
 #endif /* MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER */
 
 /* Not static for benchmarking */
@@ -244,7 +244,7 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
   {
     for (j = 0; j < MLKEM_K; j++)
     {
-      poly_permute_bitrev_to_custom(&a[i].vec[j]);
+      poly_permute_bitrev_to_custom(a[i].vec[j].coeffs);
     }
   }
 }

--- a/mlkem/native/aarch64/src/clean_impl.h
+++ b/mlkem/native/aarch64/src/clean_impl.h
@@ -12,9 +12,6 @@
 
 #include "arith_native_aarch64.h"
 
-#include "../../../poly.h"
-#include "../../../poly_k.h"
-
 /* Set of primitives that this backend replaces */
 #define MLKEM_USE_NATIVE_NTT
 #define MLKEM_USE_NATIVE_INTT
@@ -25,45 +22,46 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
 
-static INLINE void ntt_native(poly *data)
+static INLINE void ntt_native(int16_t data[MLKEM_N])
 {
-  ntt_asm_clean(data->coeffs, aarch64_ntt_zetas_layer01234,
-                aarch64_ntt_zetas_layer56);
+  ntt_asm_clean(data, aarch64_ntt_zetas_layer01234, aarch64_ntt_zetas_layer56);
 }
 
-static INLINE void intt_native(poly *data)
+static INLINE void intt_native(int16_t data[MLKEM_N])
 {
-  intt_asm_clean(data->coeffs, aarch64_invntt_zetas_layer01234,
+  intt_asm_clean(data, aarch64_invntt_zetas_layer01234,
                  aarch64_invntt_zetas_layer56);
 }
 
-static INLINE void poly_reduce_native(poly *data)
+static INLINE void poly_reduce_native(int16_t data[MLKEM_N])
 {
-  poly_reduce_asm_clean(data->coeffs);
-}
-static INLINE void poly_tomont_native(poly *data)
-{
-  poly_tomont_asm_clean(data->coeffs);
+  poly_reduce_asm_clean(data);
 }
 
-static INLINE void poly_mulcache_compute_native(poly_mulcache *x, const poly *y)
+static INLINE void poly_tomont_native(int16_t data[MLKEM_N])
 {
-  poly_mulcache_compute_asm_clean(x->coeffs, y->coeffs,
-                                  aarch64_zetas_mulcache_native,
+  poly_tomont_asm_clean(data);
+}
+
+static INLINE void poly_mulcache_compute_native(int16_t x[MLKEM_N / 2],
+                                                const int16_t y[MLKEM_N])
+{
+  poly_mulcache_compute_asm_clean(x, y, aarch64_zetas_mulcache_native,
                                   aarch64_zetas_mulcache_twisted_native);
 }
+
 static INLINE void polyvec_basemul_acc_montgomery_cached_native(
-    poly *r, const polyvec *a, const polyvec *b,
-    const polyvec_mulcache *b_cache)
+    int16_t r[MLKEM_N], const int16_t a[MLKEM_K * MLKEM_N],
+    const int16_t b[MLKEM_K * MLKEM_N],
+    const int16_t b_cache[MLKEM_K * (MLKEM_N / 2)])
 {
-  polyvec_basemul_acc_montgomery_cached_asm_clean(
-      r->coeffs, a->vec[0].coeffs, b->vec[0].coeffs, b_cache->vec[0].coeffs);
+  polyvec_basemul_acc_montgomery_cached_asm_clean(r, a, b, b_cache);
 }
 
 static INLINE void poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
-                                       const poly *a)
+                                       const int16_t a[MLKEM_N])
 {
-  poly_tobytes_asm_clean(r, a->coeffs);
+  poly_tobytes_asm_clean(r, a);
 }
 
 static INLINE int rej_uniform_native(int16_t *r, unsigned int len,

--- a/mlkem/native/aarch64/src/opt_impl.h
+++ b/mlkem/native/aarch64/src/opt_impl.h
@@ -10,10 +10,8 @@
 #else
 #define MLKEM_NATIVE_ARITH_PROFILE_IMPL_H
 
+#include "../../../params.h"
 #include "arith_native_aarch64.h"
-
-#include "../../../poly.h"
-#include "../../../poly_k.h"
 
 /* Set of primitives that this backend replaces */
 #define MLKEM_USE_NATIVE_NTT
@@ -25,45 +23,46 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
 
-static INLINE void ntt_native(poly *data)
+static INLINE void ntt_native(int16_t data[MLKEM_N])
 {
-  ntt_asm_opt(data->coeffs, aarch64_ntt_zetas_layer01234,
-              aarch64_ntt_zetas_layer56);
+  ntt_asm_opt(data, aarch64_ntt_zetas_layer01234, aarch64_ntt_zetas_layer56);
 }
 
-static INLINE void intt_native(poly *data)
+static INLINE void intt_native(int16_t data[MLKEM_N])
 {
-  intt_asm_opt(data->coeffs, aarch64_invntt_zetas_layer01234,
+  intt_asm_opt(data, aarch64_invntt_zetas_layer01234,
                aarch64_invntt_zetas_layer56);
 }
 
-static INLINE void poly_reduce_native(poly *data)
+static INLINE void poly_reduce_native(int16_t data[MLKEM_N])
 {
-  poly_reduce_asm_opt(data->coeffs);
-}
-static INLINE void poly_tomont_native(poly *data)
-{
-  poly_tomont_asm_opt(data->coeffs);
+  poly_reduce_asm_opt(data);
 }
 
-static INLINE void poly_mulcache_compute_native(poly_mulcache *x, const poly *y)
+static INLINE void poly_tomont_native(int16_t data[MLKEM_N])
 {
-  poly_mulcache_compute_asm_opt(x->coeffs, y->coeffs,
-                                aarch64_zetas_mulcache_native,
+  poly_tomont_asm_opt(data);
+}
+
+static INLINE void poly_mulcache_compute_native(int16_t x[MLKEM_N / 2],
+                                                const int16_t y[MLKEM_N])
+{
+  poly_mulcache_compute_asm_opt(x, y, aarch64_zetas_mulcache_native,
                                 aarch64_zetas_mulcache_twisted_native);
 }
+
 static INLINE void polyvec_basemul_acc_montgomery_cached_native(
-    poly *r, const polyvec *a, const polyvec *b,
-    const polyvec_mulcache *b_cache)
+    int16_t r[MLKEM_N], const int16_t a[MLKEM_K * MLKEM_N],
+    const int16_t b[MLKEM_K * MLKEM_N],
+    const int16_t b_cache[MLKEM_K * (MLKEM_N / 2)])
 {
-  polyvec_basemul_acc_montgomery_cached_asm_opt(
-      r->coeffs, a->vec[0].coeffs, b->vec[0].coeffs, b_cache->vec[0].coeffs);
+  polyvec_basemul_acc_montgomery_cached_asm_opt(r, a, b, b_cache);
 }
 
 static INLINE void poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
-                                       const poly *a)
+                                       const int16_t a[MLKEM_N])
 {
-  poly_tobytes_asm_opt(r, a->coeffs);
+  poly_tobytes_asm_opt(r, a);
 }
 
 static INLINE int rej_uniform_native(int16_t *r, unsigned int len,

--- a/mlkem/native/api.h
+++ b/mlkem/native/api.h
@@ -23,8 +23,7 @@
 #define MLKEM_NATIVE_ARITH_NATIVE_API_H
 
 #include <stdint.h>
-#include "../poly.h"
-#include "../poly_k.h"
+#include "../common.h"
 
 /*
  * This is the C<->native interface allowing for the drop-in of
@@ -65,9 +64,9 @@
  *              See the documentation of MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER
  *              for more information.
  *
- * Arguments:   - poly *p: pointer to in/output polynomial
+ * Arguments:   - int16_t p[MLKEM_N]: pointer to in/output polynomial
  **************************************************/
-static INLINE void ntt_native(poly *);
+static INLINE void ntt_native(int16_t p[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_NTT */
 
 #if defined(MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER)
@@ -96,10 +95,10 @@ and to/from bytes conversions."
  *
  *              This must only be defined if there is native code for
  *              all of (a) NTT, (b) invNTT, (c) basemul, (d) mulcache.
- * Arguments:   - poly *p: pointer to in/output polynomial
+ * Arguments:   - int16_t p[MLKEM_N]: pointer to in/output polynomial
  *
  **************************************************/
-static INLINE void poly_permute_bitrev_to_custom(poly *);
+static INLINE void poly_permute_bitrev_to_custom(int16_t p[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER */
 
 #if defined(MLKEM_USE_NATIVE_INTT)
@@ -117,7 +116,7 @@ static INLINE void poly_permute_bitrev_to_custom(poly *);
  *
  * Arguments:   - uint16_t *a: pointer to in/output polynomial
  **************************************************/
-static INLINE void intt_native(poly *);
+static INLINE void intt_native(int16_t p[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_INTT */
 
 #if defined(MLKEM_USE_NATIVE_POLY_REDUCE)
@@ -126,9 +125,9 @@ static INLINE void intt_native(poly *);
  *
  * Description: Applies modular reduction to all coefficients of a polynomial.
  *
- * Arguments:   - poly *r: pointer to input/output polynomial
+ * Arguments:   - int16_t r[MLKEM_N]: pointer to input/output polynomial
  **************************************************/
-static INLINE void poly_reduce_native(poly *);
+static INLINE void poly_reduce_native(int16_t p[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_POLY_REDUCE */
 
 #if defined(MLKEM_USE_NATIVE_POLY_TOMONT)
@@ -138,9 +137,9 @@ static INLINE void poly_reduce_native(poly *);
  * Description: Inplace conversion of all coefficients of a polynomial
  *              from normal domain to Montgomery domain
  *
- * Arguments:   - poly *r: pointer to input/output polynomial
+ * Arguments:   - int16_t r[MLKEM_N]: pointer to input/output polynomial
  **************************************************/
-static INLINE void poly_tomont_native(poly *);
+static INLINE void poly_tomont_native(int16_t p[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_POLY_TOMONT */
 
 #if defined(MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE)
@@ -165,8 +164,8 @@ static INLINE void poly_tomont_native(poly *);
  *              OUTPUT
  *              - cache: pointer to multiplication cache
  **************************************************/
-static INLINE void poly_mulcache_compute_native(poly_mulcache *cache,
-                                                const poly *poly);
+static INLINE void poly_mulcache_compute_native(int16_t cache[MLKEM_N / 2],
+                                                const int16_t poly[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE */
 
 #if defined(MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED)
@@ -189,8 +188,9 @@ static INLINE void poly_mulcache_compute_native(poly_mulcache *cache,
  *                   in NTT domain, and of the same order as a and b.
  **************************************************/
 static INLINE void polyvec_basemul_acc_montgomery_cached_native(
-    poly *r, const polyvec *a, const polyvec *b,
-    const polyvec_mulcache *b_cache);
+    int16_t r[MLKEM_N], const int16_t a[MLKEM_K * MLKEM_N],
+    const int16_t b[MLKEM_K * MLKEM_N],
+    const int16_t b_cache[MLKEM_K * (MLKEM_N / 2)]);
 #endif
 
 #if defined(MLKEM_USE_NATIVE_POLY_TOBYTES)
@@ -209,7 +209,7 @@ static INLINE void polyvec_basemul_acc_montgomery_cached_native(
  *                   (of MLKEM_POLYBYTES bytes)
  **************************************************/
 static INLINE void poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
-                                       const poly *a);
+                                       const int16_t a[MLKEM_N]);
 #endif /* MLKEM_USE_NATIVE_POLY_TOBYTES */
 
 #if defined(MLKEM_USE_NATIVE_POLY_FROMBYTES)
@@ -226,7 +226,7 @@ static INLINE void poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
  *              - a: const pointer to input byte aray
  *                   (of MLKEM_POLYBYTES bytes)
  **************************************************/
-static INLINE void poly_frombytes_native(poly *a,
+static INLINE void poly_frombytes_native(int16_t a[MLKEM_N],
                                          const uint8_t r[MLKEM_POLYBYTES]);
 #endif /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 

--- a/mlkem/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/src/arith_native_x86_64.h
@@ -9,7 +9,6 @@
 
 #include <immintrin.h>
 #include <stdint.h>
-#include "../../../poly_k.h"
 #include "consts.h"
 
 #define REJ_UNIFORM_AVX_NBLOCKS 3 /* See MLKEM_GEN_MATRIX_NBLOCKS */
@@ -44,8 +43,9 @@ void basemul_avx2(__m256i *r, const __m256i *a, const __m256i *b,
 #define polyvec_basemul_acc_montgomery_cached_avx2 \
   MLKEM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_avx2)
 void polyvec_basemul_acc_montgomery_cached_avx2(
-    poly *r, const polyvec *a, const polyvec *b,
-    const polyvec_mulcache *b_cache);
+    int16_t r[MLKEM_N], const int16_t a[MLKEM_K * MLKEM_N],
+    const int16_t b[MLKEM_K * MLKEM_N],
+    const int16_t b_cache[MLKEM_K * (MLKEM_N / 2)]);
 
 #define ntttobytes_avx2 MLKEM_NAMESPACE(ntttobytes_avx2)
 void ntttobytes_avx2(uint8_t *r, const __m256i *a, const __m256i *qdata);

--- a/mlkem/native/x86_64/src/basemul.c
+++ b/mlkem/native/x86_64/src/basemul.c
@@ -7,42 +7,42 @@
 
 #if defined(MLKEM_NATIVE_ARITH_BACKEND_X86_64_DEFAULT)
 
-#include "../../../poly.h"
-#include "../../../poly_k.h"
-
 #include "arith_native_x86_64.h"
 #include "consts.h"
 
-static void poly_basemul_montgomery_avx2(poly *r, const poly *a, const poly *b)
+static void poly_basemul_montgomery_avx2(int16_t r[MLKEM_N],
+                                         const int16_t a[MLKEM_N],
+                                         const int16_t b[MLKEM_N])
 {
-  basemul_avx2((__m256i *)r->coeffs, (const __m256i *)a->coeffs,
-               (const __m256i *)b->coeffs, qdata.vec);
+  basemul_avx2((__m256i *)r, (const __m256i *)a, (const __m256i *)b, qdata.vec);
 }
 
 /*
  * Implementation from Kyber reference repository
  * https://github.com/pq-crystals/kyber/blob/main/avx2
  */
-static void poly_add_avx2(poly *r, const poly *a, const poly *b)
+static void poly_add_avx2(int16_t r[MLKEM_N], const int16_t a[MLKEM_N],
+                          const int16_t b[MLKEM_N])
 {
   unsigned i;
   __m256i f0, f1;
 
   for (i = 0; i < MLKEM_N; i += 16)
   {
-    f0 = _mm256_load_si256((const __m256i *)&a->coeffs[i]);
-    f1 = _mm256_load_si256((const __m256i *)&b->coeffs[i]);
+    f0 = _mm256_load_si256((const __m256i *)&a[i]);
+    f1 = _mm256_load_si256((const __m256i *)&b[i]);
     f0 = _mm256_add_epi16(f0, f1);
-    _mm256_store_si256((__m256i *)&r->coeffs[i], f0);
+    _mm256_store_si256((__m256i *)&r[i], f0);
   }
 }
 
-void polyvec_basemul_acc_montgomery_cached_avx2(poly *r, const polyvec *a,
-                                                const polyvec *b,
-                                                const polyvec_mulcache *b_cache)
+void polyvec_basemul_acc_montgomery_cached_avx2(
+    int16_t r[MLKEM_N], const int16_t a[MLKEM_K * MLKEM_N],
+    const int16_t b[MLKEM_K * MLKEM_N],
+    const int16_t b_cache[MLKEM_K * (MLKEM_N / 2)])
 {
   unsigned i;
-  poly t;
+  int16_t t[MLKEM_N] ALIGN;
 
   /* TODO: Use mulcache for AVX2. So far, it is unused. */
   ((void)b_cache);
@@ -50,11 +50,11 @@ void polyvec_basemul_acc_montgomery_cached_avx2(poly *r, const polyvec *a,
   /* Coefficient-wise bound of each basemul is 2q.
    * Since we are accumulating at most 4 times, the
    * overall bound is 8q < INT16_MAX. */
-  poly_basemul_montgomery_avx2(r, &a->vec[0], &b->vec[0]);
+  poly_basemul_montgomery_avx2(r, &a[0], &b[0]);
   for (i = 1; i < MLKEM_K; i++)
   {
-    poly_basemul_montgomery_avx2(&t, &a->vec[i], &b->vec[i]);
-    poly_add_avx2(r, r, &t);
+    poly_basemul_montgomery_avx2(t, &a[i * MLKEM_N], &b[i * MLKEM_N]);
+    poly_add_avx2(r, r, t);
   }
 }
 

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -292,7 +292,7 @@ void poly_tomont(poly *r)
 MLKEM_NATIVE_INTERNAL_API
 void poly_tomont(poly *r)
 {
-  poly_tomont_native(r);
+  poly_tomont_native(r->coeffs);
   debug_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_TOMONT */
@@ -353,7 +353,7 @@ void poly_reduce(poly *r)
 MLKEM_NATIVE_INTERNAL_API
 void poly_reduce(poly *r)
 {
-  poly_reduce_native(r);
+  poly_reduce_native(r->coeffs);
   debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_REDUCE */
@@ -412,7 +412,7 @@ void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 MLKEM_NATIVE_INTERNAL_API
 void poly_mulcache_compute(poly_mulcache *x, const poly *a)
 {
-  poly_mulcache_compute_native(x, a);
+  poly_mulcache_compute_native(x->coeffs, a->coeffs);
   /* Omitting bounds assertion since native implementations may
    * decide not to use a mulcache. Note that the C backend implementation
    * of poly_basemul_montgomery_cached() does still include the check. */
@@ -553,7 +553,7 @@ MLKEM_NATIVE_INTERNAL_API
 void poly_ntt(poly *p)
 {
   debug_assert_abs_bound(p, MLKEM_N, MLKEM_Q);
-  ntt_native(p);
+  ntt_native(p->coeffs);
   debug_assert_abs_bound(p, MLKEM_N, NTT_BOUND);
 }
 #endif /* MLKEM_USE_NATIVE_NTT */
@@ -633,7 +633,7 @@ void poly_invntt_tomont(poly *p)
 MLKEM_NATIVE_INTERNAL_API
 void poly_invntt_tomont(poly *p)
 {
-  intt_native(p);
+  intt_native(p->coeffs);
   debug_assert_abs_bound(p, MLKEM_N, INVNTT_BOUND);
 }
 #endif /* MLKEM_USE_NATIVE_INTT */

--- a/mlkem/poly_k.c
+++ b/mlkem/poly_k.c
@@ -130,7 +130,9 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
   /* Omitting bounds assertion for cache since native implementations may
    * decide not to use a mulcache. Note that the C backend implementation
    * of poly_basemul_montgomery_cached() does still include the check. */
-  polyvec_basemul_acc_montgomery_cached_native(r, a, b, b_cache);
+  polyvec_basemul_acc_montgomery_cached_native(r->coeffs, (const int16_t *)a,
+                                               (const int16_t *)b,
+                                               (const int16_t *)b_cache);
 }
 #endif /* MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
 


### PR DESCRIPTION
* Based on #674 

This PR modifies the backend API to work directly with int16_t arrays rather than the poly_xxx structures.
