### PR TITLE
Integration: Add liboqs META files

### DIFF
--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test liboqs integration
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check-oqs-source-list:
+    name: Check META.yml source list
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run file check
+        run: |
+          cd integration/liboqs
+          python3 liboqs-check-filelist.py

--- a/integration/liboqs/ML-KEM-1024_META.yml
+++ b/integration/liboqs/ML-KEM-1024_META.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2024 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0
+name: ML-KEM-1024
+type: kem
+claimed-nist-level: 5
+claimed-security: IND-CCA2
+length-public-key: 1568
+length-ciphertext: 1568
+length-secret-key: 3168
+length-shared-secret: 32
+nistkat-sha256: f580d851e5fb27e6876e5e203fa18be4cdbfd49e05d48fec3d3992c8f43a13e6
+testvectors-sha256: ff1a854b9b6761a70c65ccae85246fe0596a949e72eae0866a8a2a2d4ea54b10
+principal-submitters:
+  - Peter Schwabe
+auxiliary-submitters:
+  - Roberto Avanzi
+  - Joppe Bos
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Vadim Lyubashevsky
+  - John M. Schanck
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+  - name: ref
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=4 -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM1024_C
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_C_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h
+  - name: x86_64
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=4 -DFORCE_X86_64 -DMLKEM_NATIVE_ARITH_BACKEND_NAME=X86_64_DEFAULT -DMLKEM_USE_NATIVE -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_DEFAULT
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_DEFAULT_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_DEFAULT_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_DEFAULT_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h native/x86_64
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Linux
+          - Darwin
+        required_flags:
+          - avx2
+          - bmi2
+          - popcnt
+  - name: aarch64
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=4 -DFORCE_AARCH64 -DMLKEM_NATIVE_ARITH_BACKEND_NAME=AARCH64_OPT -DMLKEM_USE_NATIVE -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_OPT
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_OPT_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_OPT_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_OPT_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h native/aarch64
+    supported_platforms:
+      - architecture: arm_8
+        operating_systems:
+            - Linux
+            - Darwin
+        required_flags:
+            - asimd

--- a/integration/liboqs/ML-KEM-512_META.yml
+++ b/integration/liboqs/ML-KEM-512_META.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2024 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0
+name: ML-KEM-512
+type: kem
+claimed-nist-level: 1
+claimed-security: IND-CCA2
+length-public-key: 800
+length-ciphertext: 768
+length-secret-key: 1632
+length-shared-secret: 32
+nistkat-sha256: c70041a761e01cd6426fa60e9fd6a4412c2be817386c8d0f3334898082512782
+testvectors-sha256: 6730bb552c22d9d2176ffb5568e48eb30952cf1f065073ec5f9724f6a3c6ea85
+principal-submitters:
+  - Peter Schwabe
+auxiliary-submitters:
+  - Roberto Avanzi
+  - Joppe Bos
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Vadim Lyubashevsky
+  - John M. Schanck
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+  - name: ref
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=2 -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM512_C
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_C_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_C_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h
+  - name: x86_64
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=2 -DFORCE_X86_64 -DMLKEM_NATIVE_ARITH_BACKEND_NAME=X86_64_DEFAULT -DMLKEM_USE_NATIVE -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM512_X86_64_DEFAULT
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_DEFAULT_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_DEFAULT_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_DEFAULT_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h native/x86_64
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Linux
+          - Darwin
+        required_flags:
+          - avx2
+          - bmi2
+          - popcnt
+  - name: aarch64
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=2 -DFORCE_AARCH64 -DMLKEM_NATIVE_ARITH_BACKEND_NAME=AARCH64_OPT -DMLKEM_USE_NATIVE -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_OPT
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_OPT_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_OPT_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_OPT_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h native/aarch64
+    supported_platforms:
+      - architecture: arm_8
+        operating_systems:
+            - Linux
+            - Darwin
+        required_flags:
+            - asimd

--- a/integration/liboqs/ML-KEM-768_META.yml
+++ b/integration/liboqs/ML-KEM-768_META.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2024 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0
+name: ML-KEM-768
+type: kem
+claimed-nist-level: 3
+claimed-security: IND-CCA2
+length-public-key: 1184
+length-ciphertext: 1088
+length-secret-key: 2400
+length-shared-secret: 32
+nistkat-sha256: 5352539586b6c3df58be6158a6250aeff402bd73060b0a3de68850ac074c17c3
+testvectors-sha256: 667c8ca2ca93729c0df6ff24588460bad1bbdbfb64ece0fe8563852a7ff348c6
+principal-submitters:
+  - Peter Schwabe
+auxiliary-submitters:
+  - Roberto Avanzi
+  - Joppe Bos
+  - Léo Ducas
+  - Eike Kiltz
+  - Tancrède Lepoint
+  - Vadim Lyubashevsky
+  - John M. Schanck
+  - Gregor Seiler
+  - Damien Stehlé
+implementations:
+  - name: ref
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=3 -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM768_C
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_C_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_C_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h
+  - name: x86_64
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=3 -DFORCE_X86_64 -DMLKEM_NATIVE_ARITH_BACKEND_NAME=X86_64_DEFAULT -DMLKEM_USE_NATIVE -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM768_X86_64_DEFAULT
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_DEFAULT_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_DEFAULT_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_DEFAULT_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h native/x86_64
+    supported_platforms:
+      - architecture: x86_64
+        operating_systems:
+          - Linux
+          - Darwin
+        required_flags:
+          - avx2
+          - bmi2
+          - popcnt
+  - name: aarch64
+    version: FIPS203
+    folder_name: mlkem
+    compile_opts: -DMLKEM_K=3 -DFORCE_AARCH64 -DMLKEM_NATIVE_ARITH_BACKEND_NAME=AARCH64_OPT -DMLKEM_USE_NATIVE -DMLKEM_NAMESPACE_PREFIX=PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_OPT
+    signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_OPT_keypair
+    signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_OPT_enc
+    signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_OPT_dec
+    sources: LICENSE arith_backend.h cbmc.h common.h compress.c compress.h config.h debug.c debug.h indcpa.c indcpa.h kem.c kem.h mlkem_native.h params.h poly.c poly.h poly_k.c poly_k.h sampling.c sampling.h symmetric.h sys.h verify.c verify.h zetas.c native/api.h native/default.h native/aarch64
+    supported_platforms:
+      - architecture: arm_8
+        operating_systems:
+            - Linux
+            - Darwin
+        required_flags:
+            - asimd

--- a/integration/liboqs/liboqs-check-filelist.py
+++ b/integration/liboqs/liboqs-check-filelist.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script makes sure that the sources in the liboqs meta files
+# are kept up to date.
+
+
+import yaml
+import os
+
+MLKEM_DIR = "../../mlkem"
+
+
+def load(fname):
+    with open(fname) as f:
+        return yaml.safe_load(f)
+
+
+def get_shared_sources():
+    # add files mlkem/*
+    sources = [f for f in os.listdir(MLKEM_DIR) if os.path.isfile(f"{MLKEM_DIR}/{f}")]
+    # add files mlkem/native/* (API definitions)
+    sources += [
+        f"native/{f}"
+        for f in os.listdir(f"{MLKEM_DIR}/native")
+        if os.path.isfile(f"{MLKEM_DIR}/native/{f}")
+    ]
+    # randombytes.h is provided by liboqs
+    sources.remove("randombytes.h")
+    return sources
+
+
+def get_native_sources(backend):
+    return [f"native/{backend}"]
+
+
+def check_implementation(impl):
+    name = impl["name"]
+    print(f"checking {name}")
+    ymlsources = impl["sources"]
+    ymlsources = ymlsources.split(" ")
+    sources = get_shared_sources()
+
+    if name != "ref":
+        sources += get_native_sources(name)
+
+    sources.sort()
+    ymlsources.sort()
+
+    if sources != ymlsources:
+        print(sources)
+        print(ymlsources)
+        raise Exception("mismatch of liboqs file list")
+
+
+def check_file(fname):
+    print(f"checking {fname}")
+    yml = load(fname)
+    implementations = yml["implementations"]
+    for implementation in implementations:
+        check_implementation(implementation)
+
+
+def check():
+    check_file("ML-KEM-512_META.yml")
+    check_file("ML-KEM-768_META.yml")
+    check_file("ML-KEM-1024_META.yml")
+
+
+if __name__ == "__main__":
+    check()

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -43,6 +43,7 @@ rec {
       native-gcc
     ]
     ++ builtins.attrValues {
+      inherit (pkgs.python3Packages) pyyaml;
       inherit (pkgs)
         python3
         qemu; # 8.2.4


### PR DESCRIPTION
liboqs requires META files providing meta data on the available implementations and required flags for building them.
To ease integration, we include the files in mlkem-native.

This commit also adds script that checks that the source list is kept up to date and runs it in CI.