### PR TITLE
Modify the CBMC Makefile "result" target to actually display proof results.

### DIFF
--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -953,6 +953,9 @@ result:
 	$(MAKE) -B _result
 	@ echo Running 'litani build'
 	$(LITANI) run-build
+	tail -4 $(LOGDIR)/result.txt
+	-grep FAILURE $(LOGDIR)/result.txt
+
 
 _property: $(LOGDIR)/property.xml
 property:


### PR DESCRIPTION
"make result" is very useful for checking individual proofs. This commit amends this Makefile target to display the last 4 lines of logs/results.txt following by any lines that contain the string "FAILURE".

This saves the user having to do "less logs/result.txt" (or similar) after every "make result".

For example, a successful proof now concludes:
```
Report was rendered at file:///tmp/nix-shell.kX96Ad/litani/runs/latest/html/index.html

** 0 of 11 failed (1 iterations)
VERIFICATION SUCCESSFUL
```
while a failing proof might show:
```
Report was rendered at file:///tmp/nix-shell.kX96Ad/litani/runs/latest/html/index.html

** 1 of 11 failed (2 iterations)
VERIFICATION FAILED

[PQCP_MLKEM_NATIVE_MLKEM768_scalar_compress_d11.postcondition.2] line 234 Check ensures clause of contract contract::PQCP_MLKEM_NATIVE_MLKEM768_scalar_compress_d11 for function PQCP_MLKEM_NATIVE_MLKEM768_scalar_compress_d11: FAILURE
```
