### PR TITLE
Correct setting of macOS taskpolicy variable

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -321,7 +321,7 @@ class Tests:
         if self.args.exec_wrapper is not None and self.args.exec_wrapper != "":
             res += self.args.exec_wrapper.split(" ")
         if self.args.mac_taskpolicy is not None:
-            res += ["taskpolicy", "-c", f"{mac_taskpolicy}"]
+            res += ["taskpolicy", "-c", f"{self.args.mac_taskpolicy}"]
 
         return res
 


### PR DESCRIPTION
Simple correction to Python to correctly pass the self.args.mac_taskpolicy
variable to the underlying execution command.
