### PR TITLE
Add Valgrind-based constant-time tests

### DIFF
--- a/.github/actions/ct-test/action.yml
+++ b/.github/actions/ct-test/action.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: CT Test
+description: Builds the library with given flags and runs Valgrind-based constant-time tests
+
+inputs:
+  cflags:
+    description: CFLAGS to pass to compilation
+    default: ""
+
+runs:
+  using: composite
+  steps:
+      - shell: ${{ env.SHELL }}
+        run: |
+          make clean
+          tests func --exec-wrapper="valgrind --error-exitcode=1 --track-origins=yes" --cflags="-DENABLE_CT_TESTING -DNTESTS=50 ${{ inputs.cflags }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,9 @@ jobs:
          - name: clang-18
            shell: ci_clang18
            darwin: True
+         - name: clang-19
+           shell: ci_clang19
+           darwin: True
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,6 @@ jobs:
           kat: false
           acvp: false
           nix-shell: ${{ matrix.compiler.shell }}
-          cflags: "-O1" # _FORTIFY_SOURCE requires compiling with optimization
       - name: native build+functest (C90)
         if: ${{ matrix.compiler.darwin || matrix.target.runner != 'macos-latest' }}
         uses: ./.github/actions/multi-functest
@@ -324,7 +323,7 @@ jobs:
           kat: false
           acvp: false
           nix-shell: ${{ matrix.compiler.shell }}
-          cflags: "-O1 -std=c90" # _FORTIFY_SOURCE requires compiling with optimization
+          cflags: "-std=c90"
       - name: native build+functest (C99)
         if: ${{ matrix.compiler.darwin || matrix.target.runner != 'macos-latest' }}
         uses: ./.github/actions/multi-functest
@@ -336,7 +335,7 @@ jobs:
           kat: false
           acvp: false
           nix-shell: ${{ matrix.compiler.shell }}
-          cflags: "-O1 -std=c99" # _FORTIFY_SOURCE requires compiling with optimization
+          cflags: "-std=c99"
       - name: native build+functest (C11)
         if: ${{ matrix.compiler.darwin || matrix.target.runner != 'macos-latest' }}
         uses: ./.github/actions/multi-functest
@@ -348,7 +347,7 @@ jobs:
           kat: false
           acvp: false
           nix-shell: ${{ matrix.compiler.shell }}
-          cflags: "-O1 -std=c11" # _FORTIFY_SOURCE requires compiling with optimization
+          cflags: "-std=c11"
       - name: native build+functest (C17)
         if: ${{ (matrix.compiler.darwin || matrix.target.runner != 'macos-latest') &&
                 matrix.compiler.c17 }}
@@ -361,7 +360,7 @@ jobs:
           kat: false
           acvp: false
           nix-shell: ${{ matrix.compiler.shell }}
-          cflags: "-O1 -std=c17" # _FORTIFY_SOURCE requires compiling with optimization
+          cflags: "-std=c17"
   # The purpose of this job is to test non-default yet valid configurations
   config_variations:
     name: Non-standard configurations

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Constant-time tests
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check-ct:
+    name: CT test ${{ matrix.nix-shell }} ${{ matrix.system }} 
+    strategy:
+      fail-fast: false
+      matrix:
+        system: [ubuntu-latest, ubuntu-24.04-arm]
+        nix-shell:
+          - ci_clang14
+          - ci_clang15
+          - ci_clang16
+          - ci_clang17
+          - ci_clang18
+          - ci_clang19
+          - ci_gcc48
+          - ci_gcc49
+          - ci_gcc7
+          - ci_gcc11
+          - ci_gcc12
+          - ci_gcc13
+          - ci_gcc14
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup nix
+        uses: ./.github/actions/setup-shell
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: ${{ matrix.nix-shell }}
+      - name:  Build and run test (-Oz)
+        # -Oz got introduced in gcc12
+        if: ${{ matrix.nix-shell !=  'ci_gcc48' && matrix.nix-shell !=  'ci_gcc49' && matrix.nix-shell !=  'ci_gcc7' && matrix.nix-shell !=  'ci_gcc11'}}
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -Oz
+      - name:  Build and run test (-Os)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -Os
+      - name:  Build and run test (-O3)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O3
+      - name:  Build and run test (-Ofast)
+        # -Ofast got deprecated in clang19; -O3 -ffast-math should be used instead
+        if: ${{ matrix.nix-shell !=  'ci_clang19' }}
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -Ofast
+      - name:  Build and run test (-O3 -ffast-math)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O3 -ffast-math
+      - name:  Build and run test (-O2)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O2
+      - name:  Build and run test (-O1)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O1
+      - name:  Build and run test (-O0)
+        uses: ./.github/actions/ct-test
+        with:
+          cflags: -O0

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,28 @@
         "type": "github"
       }
     },
+    "nixpkgs2411": {
+      "locked": {
+        "lastModified": 1737404927,
+        "narHash": "sha256-e1WgPJpIYbOuokjgylcsuoEUCB4Jl2rQXa2LUD6XAG8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae584d90cbd0396a422289ee3efb1f1c9d141dc3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs2411": "nixpkgs2411"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs2411.url = "github:NixOS/nixpkgs/nixos-24.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     flake-parts = {
@@ -43,12 +44,20 @@
           devShells.ci-cbmc-cross = util.wrapShell util.mkShell { packages = util.core { } ++ [ config.packages.cbmc ]; };
           devShells.ci-linter = util.wrapShell pkgs.mkShellNoCC { packages = util.linters; };
 
-          devShells.ci_clang18 = util.wrapShell (util.mkShellWithCC pkgs.clang_18) { packages = [ pkgs.python3 ]; };
-          devShells.ci_gcc48 = util.wrapShell (util.mkShellWithCC pkgs.gcc48) { packages = [ pkgs.python3 ]; };
-          devShells.ci_gcc49 = util.wrapShell (util.mkShellWithCC pkgs.gcc49) { packages = [ pkgs.python3 ]; };
-          devShells.ci_gcc7 = util.wrapShell (util.mkShellWithCC pkgs.gcc7) { packages = [ pkgs.python3 ]; };
-          devShells.ci_gcc11 = util.wrapShell (util.mkShellWithCC pkgs.gcc11) { packages = [ pkgs.python3 ]; };
-          devShells.ci_gcc14 = util.wrapShell (util.mkShellWithCC pkgs.gcc14) { packages = [ pkgs.python3 ]; };
+          devShells.ci_clang14 = util.wrapShell (util.mkShellWithCC pkgs.clang_14) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_clang15 = util.wrapShell (util.mkShellWithCC pkgs.clang_15) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_clang16 = util.wrapShell (util.mkShellWithCC pkgs.clang_16) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_clang17 = util.wrapShell (util.mkShellWithCC pkgs.clang_17) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_clang18 = util.wrapShell (util.mkShellWithCC pkgs.clang_18) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_clang19 = util.wrapShell (util.mkShellWithCC inputs.nixpkgs2411.legacyPackages.${system}.clang_19) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc48 = util.wrapShell (util.mkShellWithCC pkgs.gcc48) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc49 = util.wrapShell (util.mkShellWithCC pkgs.gcc49) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc7 = util.wrapShell (util.mkShellWithCC pkgs.gcc7) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc11 = util.wrapShell (util.mkShellWithCC pkgs.gcc11) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc12 = util.wrapShell (util.mkShellWithCC pkgs.gcc12) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc13 = util.wrapShell (util.mkShellWithCC pkgs.gcc13) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci_gcc14 = util.wrapShell (util.mkShellWithCC pkgs.gcc14) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+
         };
       flake = {
         devShell.x86_64-linux =

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -20,6 +20,10 @@
 
 #include "cbmc.h"
 
+#ifdef ENABLE_CT_TESTING
+#include <valgrind/memcheck.h>
+#endif
+
 /* Static namespacing
  * This is to facilitate building multiple instances
  * of mlkem-native (e.g. with varying security levels)
@@ -302,6 +306,17 @@ void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
 
   hash_g(buf, coins_with_domain_separator, MLKEM_SYMBYTES + 1);
 
+
+#ifdef ENABLE_CT_TESTING
+  /*
+   * Declassify the public seed.
+   * Required to use it in conditional-branches in rejection sampling.
+   * This is needed because all output of randombytes is marked as secret
+   * (=undefined)
+   */
+  VALGRIND_MAKE_MEM_DEFINED(publicseed, MLKEM_SYMBYTES);
+#endif
+
   gen_matrix(a, publicseed, 0 /* no transpose */);
 
 #if MLKEM_K == 2
@@ -355,6 +370,18 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
 
   unpack_pk(&pkpv, seed, pk);
   poly_frommsg(&k, m);
+
+
+#ifdef ENABLE_CT_TESTING
+  /*
+   * Declassify the public seed.
+   * Required to use it in conditional-branches in rejection sampling.
+   * This is needed because in re-encryption the publicseed originated from sk
+   * which is marked undefined.
+   */
+  VALGRIND_MAKE_MEM_DEFINED(seed, MLKEM_SYMBYTES);
+#endif
+
   gen_matrix(at, seed, 1 /* transpose */);
 
 #if MLKEM_K == 2

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -12,6 +12,10 @@
 #include "symmetric.h"
 #include "verify.h"
 
+#ifdef ENABLE_CT_TESTING
+#include <valgrind/memcheck.h>
+#endif
+
 /* Static namespacing
  * This is to facilitate building multiple instances
  * of mlkem-native (e.g. with varying security levels)
@@ -79,6 +83,15 @@ static int check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
    * no public information is leaked through the runtime or the return value
    * of this function.
    */
+
+#ifdef ENABLE_CT_TESTING
+  /* Declassify the public part of the secret key */
+  VALGRIND_MAKE_MEM_DEFINED(sk + MLKEM_INDCPA_SECRETKEYBYTES,
+                            MLKEM_INDCCA_PUBLICKEYBYTES);
+  VALGRIND_MAKE_MEM_DEFINED(
+      sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, MLKEM_SYMBYTES);
+#endif
+
   hash_h(test, sk + MLKEM_INDCPA_SECRETKEYBYTES, MLKEM_INDCCA_PUBLICKEYBYTES);
   if (memcmp(sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, test,
              MLKEM_SYMBYTES))

--- a/test/notrandombytes/notrandombytes.c
+++ b/test/notrandombytes/notrandombytes.c
@@ -15,6 +15,10 @@
 #include <stdint.h>
 #include "../../mlkem/randombytes.h"
 
+#ifdef ENABLE_CT_TESTING
+#include <valgrind/memcheck.h>
+#endif
+
 static uint32_t seed[32] = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3,
                             2, 3, 8, 4, 6, 2, 6, 4, 3, 3, 8, 3, 2, 7, 9, 5};
 static uint32_t in[12];
@@ -69,6 +73,11 @@ static void surf(void)
 
 void randombytes(uint8_t *buf, size_t n)
 {
+#ifdef ENABLE_CT_TESTING
+  uint8_t *buf_orig = buf;
+  size_t n_orig = n;
+#endif
+
   while (n > 0)
   {
     if (!outleft)
@@ -90,4 +99,12 @@ void randombytes(uint8_t *buf, size_t n)
     ++buf;
     --n;
   }
+
+#ifdef ENABLE_CT_TESTING
+  /*
+   * Mark all randombytes output as secret (undefined).
+   * Valgrind will propagate this to everything derived from it.
+   */
+  VALGRIND_MAKE_MEM_UNDEFINED(buf_orig, n_orig);
+#endif
 }

--- a/test/test_mlkem.c
+++ b/test/test_mlkem.c
@@ -12,7 +12,9 @@
 #include <valgrind/memcheck.h>
 #endif
 
+#ifndef NTESTS
 #define NTESTS 1000
+#endif
 
 static int test_keys(void)
 {

--- a/test/test_mlkem.c
+++ b/test/test_mlkem.c
@@ -8,6 +8,10 @@
 #include "../mlkem/mlkem_native.h"
 #include "../mlkem/randombytes.h"
 
+#ifdef ENABLE_CT_TESTING
+#include <valgrind/memcheck.h>
+#endif
+
 #define NTESTS 1000
 
 static int test_keys(void)
@@ -21,11 +25,22 @@ static int test_keys(void)
   /* Alice generates a public key */
   crypto_kem_keypair(pk, sk);
 
+#ifdef ENABLE_CT_TESTING
+  /* mark public key as public (=defined) */
+  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
+#endif
+
   /* Bob derives a secret key and creates a response */
   crypto_kem_enc(ct, key_b, pk);
 
   /* Alice uses Bobs response to get her shared key */
   crypto_kem_dec(key_a, ct, sk);
+
+#ifdef ENABLE_CT_TESTING
+  /* mark as defined, so we can compare */
+  VALGRIND_MAKE_MEM_DEFINED(key_a, CRYPTO_BYTES);
+  VALGRIND_MAKE_MEM_DEFINED(key_b, CRYPTO_BYTES);
+#endif
 
   if (memcmp(key_a, key_b, CRYPTO_BYTES))
   {
@@ -45,6 +60,11 @@ static int test_invalid_pk(void)
   int rc;
   /* Alice generates a public key */
   crypto_kem_keypair(pk, sk);
+
+#ifdef ENABLE_CT_TESTING
+  /* mark public key as public (=defined) */
+  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
+#endif
 
   /* Bob derives a secret key and creates a response */
   rc = crypto_kem_enc(ct, key_b, pk);
@@ -81,6 +101,11 @@ static int test_invalid_sk_a(void)
   /* Alice generates a public key */
   crypto_kem_keypair(pk, sk);
 
+#ifdef ENABLE_CT_TESTING
+  /* mark public key as public (=defined) */
+  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
+#endif
+
   /* Bob derives a secret key and creates a response */
   crypto_kem_enc(ct, key_b, pk);
 
@@ -97,6 +122,12 @@ static int test_invalid_sk_a(void)
     printf("ERROR test_invalid_sk_a\n");
     return 1;
   }
+
+#ifdef ENABLE_CT_TESTING
+  /* mark as defined, so we can compare */
+  VALGRIND_MAKE_MEM_DEFINED(key_a, CRYPTO_BYTES);
+  VALGRIND_MAKE_MEM_DEFINED(key_b, CRYPTO_BYTES);
+#endif
 
   if (!memcmp(key_a, key_b, CRYPTO_BYTES))
   {
@@ -118,6 +149,11 @@ static int test_invalid_sk_b(void)
 
   /* Alice generates a public key */
   crypto_kem_keypair(pk, sk);
+
+#ifdef ENABLE_CT_TESTING
+  /* mark public key as public (=defined) */
+  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
+#endif
 
   /* Bob derives a secret key and creates a response */
   crypto_kem_enc(ct, key_b, pk);
@@ -152,11 +188,25 @@ static int test_invalid_ciphertext(void)
   do
   {
     randombytes(&b, sizeof(uint8_t));
+
+#ifdef ENABLE_CT_TESTING
+    VALGRIND_MAKE_MEM_DEFINED(&b, sizeof(uint8_t));
+#endif
   } while (!b);
   randombytes((uint8_t *)&pos, sizeof(size_t));
 
+
+#ifdef ENABLE_CT_TESTING
+  VALGRIND_MAKE_MEM_DEFINED(&pos, sizeof(size_t));
+#endif
+
   /* Alice generates a public key */
   crypto_kem_keypair(pk, sk);
+
+#ifdef ENABLE_CT_TESTING
+  /* mark public key as public (=defined) */
+  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
+#endif
 
   /* Bob derives a secret key and creates a response */
   crypto_kem_enc(ct, key_b, pk);
@@ -166,6 +216,12 @@ static int test_invalid_ciphertext(void)
 
   /* Alice uses Bobs response to get her shared key */
   crypto_kem_dec(key_a, ct, sk);
+
+#ifdef ENABLE_CT_TESTING
+  /* mark as defined, so we can compare */
+  VALGRIND_MAKE_MEM_DEFINED(key_a, CRYPTO_BYTES);
+  VALGRIND_MAKE_MEM_DEFINED(key_b, CRYPTO_BYTES);
+#endif
 
   if (!memcmp(key_a, key_b, CRYPTO_BYTES))
   {


### PR DESCRIPTION
Resolves #462 

This extends the mlkem-native tests to support Valgrind-based constant-time tests following the ct-grind approach proposed by Adam Langley in https://github.com/agl/ctgrind.

The basic idea is to mark all output of randombytes as undefined (=secret). Valgrind will then track all values derived from that through the program and warn about any conditional branches and memory addressed depening on it.

In Kyber this leads to multiple false positives (i.e., branches depending on values that are actually public), that we resolve by explicitly declassifying that data (i.e., marking it defined). The cases where this happens are as follows:
1) In key generation: The expansion of the public matrix A uses rejection
   sampling which contains conditional branches. The seed used for that
   is output of randombytes, and, hence, Valgrind complains.
   However, this seed is public and part of the public ke.y
   We declassify the seed before calling gen_matrix.
2) In encapsulation: The same problem regarding gen_matrix occurs.
   We resolve this by declassifying the entire public key.
3) In encapsulation: Public key modulus check requires to check
   that each coefficient of the public key is correctly encoded.
   Currently this is implemented using a memcmp which has input-dependent
   timing. Declassifying the entire public key (as already done for
   2), resolves this already.
4) In decapsulation: The public key hash checks requires recomputing
   the hash of the public key and comparing it with the pre-computed hash.
   As both the (INDCPA) public key and the pre-computed hash are part
   of the secret key (and, hence, marked secret), we have to declassify
   both the public key and the hash of the public key.
5) In decapsulation: In re-encryption the matrix A needs to be expanded
   from the public seed using rejection sampling. We declassify the seed.
   (Technically, this is already covered by 4, but as we eventually
   may make the public key hash check optional, I opted for declassifying again)

We are testing
{x86 Ubuntu, Arm64 Ubuntu}
x
{gcc4,gcc7,gcc11,gcc12,gcc13,gcc14,clang14,clang15,clang16,clang17,clang18,clang19}
x
{-Oz,-Os,-O3,-O2,-O1,-O0,-Ofast,-O3 -ffast-math}
x
{C backend, native backend}

What is still left to do is adding a patched Valgrind covering variable-latency instructions from https://kyberslash.cr.yp.to/papers.html. I'll do that as a follow up. 