### PR TITLE
[TEST] Update CBMC to #8573

### DIFF
--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -18,8 +18,8 @@ buildEnv {
         src = fetchFromGitHub {
           owner = "remi-delmas-3000";
           repo = old.pname;
-          rev = "contracts-predicates-units-no-fail";
-          hash = "sha256-63DdStiwIFAcjnN7MTqh+miCyrzBNnfCPZAt0ODQfk4";
+          rev = "contracts-obj-set--demonic";
+          hash = "sha256-FG6pTGlPpIwynsaMBgU1wdk7tZQllyImOKfHJjcjOJo";
         };
         patches = [
           ./0001-Do-not-download-sources-in-cmake.patch

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -16,10 +16,10 @@ buildEnv {
       cbmc = cbmc.overrideAttrs (old: rec {
         version = "d4757e2231b236ddd1d1933b4002a5aa4ca36db9"; # remember to adjust this in ../flake.nix too
         src = fetchFromGitHub {
-          owner = "diffblue";
+          owner = "remi-delmas-3000";
           repo = old.pname;
-          rev = "d4757e2231b236ddd1d1933b4002a5aa4ca36db9";
-          hash = "sha256-o0aiTm+HZXtzBQ94kfymkR5FHhARZvwWRjCk1p2U/P0";
+          rev = "contracts-predicates-units-no-fail";
+          hash = "sha256-63DdStiwIFAcjnN7MTqh+miCyrzBNnfCPZAt0ODQfk4";
         };
         patches = [
           ./0001-Do-not-download-sources-in-cmake.patch

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -14,12 +14,12 @@ buildEnv {
   paths =
     builtins.attrValues {
       cbmc = cbmc.overrideAttrs (old: rec {
-        version = "6.4.1"; # remember to adjust this in ../flake.nix too
+        version = "d4757e2231b236ddd1d1933b4002a5aa4ca36db9"; # remember to adjust this in ../flake.nix too
         src = fetchFromGitHub {
           owner = "diffblue";
           repo = old.pname;
-          rev = "${old.pname}-${version}";
-          hash = "sha256-O8aZTW+Eylshl9bmm9GzbljWB0+cj2liZHs2uScERkM=";
+          rev = "d4757e2231b236ddd1d1933b4002a5aa4ca36db9";
+          hash = "sha256-o0aiTm+HZXtzBQ94kfymkR5FHhARZvwWRjCk1p2U/P0";
         };
         patches = [
           ./0001-Do-not-download-sources-in-cmake.patch

--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -27,6 +27,7 @@ USE_DYNAMIC_FRAMES=1
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
 
+CBMCFLAGS += --no-array-field-sensitivity --arrays-uf-always --slice-formula
 FUNCTION_NAME = invntt_layer
 
 # If this proof is found to consume huge amounts of RAM, you can set the


### PR DESCRIPTION
This commit tests the mlkem-native CBMC proofs with https://github.com/diffblue/cbmc/pull/8573. This includes https://github.com/diffblue/cbmc/pull/8562 solving a soundness issue we previously reported, but was noted to sometimes cause performance regressions.

Opening this PR to check whether proofs remain functional and practical in mlkem-native.