### PR TITLE
Set default to -march=native

### DIFF
--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -42,6 +42,7 @@ CFLAGS := \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \
 	-O3 \
+	-march=native \
 	-fomit-frame-pointer \
 	-std=c99 \
 	-pedantic \


### PR DESCRIPTION
In our benchmarks we always set -march=explicitly to get the best performance on the current platform.
While we know that this is needed, users of mlkem-native may not and simply run the bench script and be disappointed about performance.

This commit sets the default -march to native. It can be overwritten by passing a different march flag through the CFLAGS env variable.