### PR TITLE
Add balign to all AArch64 asm

### DIFF
--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
@@ -163,9 +163,9 @@
 #define KECCAK_F1600_ROUNDS 24
 
 .text
-.balign 16
 .global MLKEM_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
 
+.balign 4
 MLKEM_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
     alloc_stack
     save_gprs

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
@@ -874,11 +874,10 @@
     ror sAmu, sAmu,#(64-36)
     ror sAsu, sAsu,#(64-55)
 .endm
-
 .global MLKEM_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
 .text
-.align 4
 
+.balign 4
 MLKEM_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
     alloc_stack
     save_gprs

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
@@ -859,8 +859,8 @@
 
 .global MLKEM_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
 .text
-.align 4
 
+.balign 4
 MLKEM_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
     alloc_stack
     save_gprs

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
@@ -877,8 +877,8 @@
 
 .global MLKEM_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
 .text
-.align 4
 
+.balign 4
 MLKEM_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
     alloc_stack
     save_gprs

--- a/mlkem/native/aarch64/src/intt_clean.S
+++ b/mlkem/native/aarch64/src/intt_clean.S
@@ -140,7 +140,6 @@
 // also matching PQClean.
 
 .text
-
         .global MLKEM_ASM_NAMESPACE(intt_asm_clean)
 
         in         .req x0
@@ -195,6 +194,7 @@
         ninv             .req v29
         ninv_tw          .req v30
 
+.balign 4
 MLKEM_ASM_NAMESPACE(intt_asm_clean):
         push_stack
 

--- a/mlkem/native/aarch64/src/intt_opt.S
+++ b/mlkem/native/aarch64/src/intt_opt.S
@@ -140,7 +140,6 @@
 // also matching PQClean.
 
 .text
-
         .global MLKEM_ASM_NAMESPACE(intt_asm_opt)
 
         in         .req x0
@@ -195,6 +194,7 @@
         ninv             .req v29
         ninv_tw          .req v30
 
+.balign 4
 MLKEM_ASM_NAMESPACE(intt_asm_opt):
         push_stack
 

--- a/mlkem/native/aarch64/src/ntt_clean.S
+++ b/mlkem/native/aarch64/src/ntt_clean.S
@@ -166,6 +166,7 @@
         .text
         .global MLKEM_ASM_NAMESPACE(ntt_asm_clean)
 
+        .balign 4
 MLKEM_ASM_NAMESPACE(ntt_asm_clean):
         push_stack
 

--- a/mlkem/native/aarch64/src/ntt_opt.S
+++ b/mlkem/native/aarch64/src/ntt_opt.S
@@ -167,6 +167,7 @@
         .text
         .global MLKEM_ASM_NAMESPACE(ntt_asm_opt)
 
+        .balign 4
 MLKEM_ASM_NAMESPACE(ntt_asm_opt):
         push_stack
 

--- a/mlkem/native/aarch64/src/poly_clean.S
+++ b/mlkem/native/aarch64/src/poly_clean.S
@@ -53,6 +53,7 @@
         modulus           .req v3
         modulus_twisted   .req v4
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_reduce_asm_clean):
 
         mov wtmp, #3329 // ML-KEM modulus
@@ -129,6 +130,7 @@ loop_start:
         modulus           .req v6
         modulus_twisted   .req v7
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_clean):
         mov wtmp, #3329
         dup modulus.8h, wtmp
@@ -195,6 +197,7 @@ mulcache_compute_loop_start:
         src   .req x1
         count .req x2
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_tobytes_asm_clean):
 
         mov count, #16
@@ -250,6 +253,7 @@ poly_tobytes_asm_clean_asm_loop_start:
 
         tmp0              .req v6
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_tomont_asm_clean):
 
         mov wtmp, #3329 // ML-KEM modulus

--- a/mlkem/native/aarch64/src/poly_opt.S
+++ b/mlkem/native/aarch64/src/poly_opt.S
@@ -53,6 +53,7 @@
         modulus           .req v3
         modulus_twisted   .req v4
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_reduce_asm_opt):
 
         mov wtmp, #3329 // ML-KEM modulus
@@ -292,6 +293,7 @@ MLKEM_ASM_NAMESPACE(poly_reduce_asm_opt):
         modulus           .req v6
         modulus_twisted   .req v7
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_opt):
         mov wtmp, #3329
         dup modulus.8h, wtmp
@@ -436,6 +438,7 @@ MLKEM_ASM_NAMESPACE(poly_mulcache_compute_asm_opt):
         src   .req x1
         count .req x2
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_tobytes_asm_opt):
 
         mov count, #16
@@ -491,6 +494,7 @@ poly_tobytes_asm_opt_asm_loop_start:
 
         tmp0              .req v6
 
+.balign 4
 MLKEM_ASM_NAMESPACE(poly_tomont_asm_opt):
 
         mov wtmp, #3329 // ML-KEM modulus

--- a/mlkem/native/aarch64/src/polyvec_clean.S
+++ b/mlkem/native/aarch64/src/polyvec_clean.S
@@ -140,6 +140,7 @@
 #if MLKEM_K == 2
 .global MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_clean)
 
+.balign 4
 MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_clean):
         push_stack
 
@@ -178,6 +179,7 @@ k2_loop_start:
 #if MLKEM_K == 3
 .global MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_clean)
 
+.balign 4
 MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_clean):
         push_stack
         mov wtmp, #3329
@@ -220,6 +222,7 @@ k3_loop_start:
 #if MLKEM_K == 4
 .global MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_clean)
 
+.balign 4
 MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_clean):
         push_stack
         mov wtmp, #3329

--- a/mlkem/native/aarch64/src/polyvec_opt.S
+++ b/mlkem/native/aarch64/src/polyvec_opt.S
@@ -140,6 +140,7 @@
 #if MLKEM_K == 2
 .global MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt)
 
+.balign 4
 MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt):
         push_stack
 
@@ -510,6 +511,7 @@ MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt):
 #if MLKEM_K == 3
 .global MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt)
 
+.balign 4
 MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt):
         push_stack
         mov wtmp, #3329
@@ -984,6 +986,7 @@ MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt):
 #if MLKEM_K == 4
 .global MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt)
 
+.balign 4
 MLKEM_ASM_NAMESPACE_K(polyvec_basemul_acc_montgomery_cached_asm_opt):
         push_stack
         mov wtmp, #3329

--- a/mlkem/native/aarch64/src/rej_uniform_asm_clean.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm_clean.S
@@ -113,8 +113,8 @@
     bits                        .req v31
 
 .text
-.align 4
 .global MLKEM_ASM_NAMESPACE(rej_uniform_asm_clean)
+.balign 4
 MLKEM_ASM_NAMESPACE(rej_uniform_asm_clean):
     push_stack
 


### PR DESCRIPTION
Resolves https://github.com/pq-code-package/mlkem-native/issues/702

This adds .balign 16 to all global assembly functions to resolve some warnings that show up with gcc 14.2.0.
I also switched all .align's to .balign for consistency. .balign 4 seems to be prefered over .align 4 for aligning to a 4-byte boundary as it is more consistent accross systems (balign always takes bytes, while align takes bytes one some systems and the two-power on most systems).
