### PR TITLE
Benchmarks: Disable LTO

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,19 +31,19 @@ jobs:
           name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
           bench_pmu: PMU
           archflags: -mcpu=cortex-a72 -DSYS_AARCH64_SLOW_BARREL_SHIFTER
-          cflags: "-flto -DFORCE_AARCH64"
+          cflags: "-DFORCE_AARCH64"
           bench_extra_args: ""
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
-          cflags: "-flto -DFORCE_AARCH64"
+          cflags: "-DFORCE_AARCH64"
           bench_extra_args: ""
         - system: a55
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: "-flto -static -DFORCE_AARCH64 -DMLKEM_NATIVE_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/cortex_a55.h\\\\\\\""
+          cflags: "-static -DFORCE_AARCH64 -DMLKEM_NATIVE_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/cortex_a55.h\\\\\\\""
           bench_extra_args: -w exec-on-a55
         - system: bpi
           name: Bananapi bpi-f3 benchmarks
@@ -82,43 +82,43 @@ jobs:
             ec2_instance_type: t4g.small
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -mcpu=cortex-a76 -march=armv8.2-a
-            cflags: "-flto -DFORCE_AARCH64"
+            cflags: "-DFORCE_AARCH64"
             perf: PERF
           - name: Graviton3
             ec2_instance_type: c7g.medium
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv8.4-a+sha3
-            cflags: "-flto -DFORCE_AARCH64"
+            cflags: "-DFORCE_AARCH64"
             perf: PERF
           - name: Graviton4
             ec2_instance_type: c8g.medium
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv9-a+sha3
-            cflags: "-flto -DFORCE_AARCH64"
+            cflags: "-DFORCE_AARCH64"
             perf: PERF
           - name: AMD EPYC 4th gen (c7a)
             ec2_instance_type: c7a.medium
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver4
-            cflags: "-flto -DFORCE_X86_64"
+            cflags: "-DFORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 4th gen (c7i)
             ec2_instance_type: c7i.metal-24xl
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=sapphirerapids
-            cflags: "-flto -DFORCE_X86_64"
+            cflags: "-DFORCE_X86_64"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
             ec2_instance_type: c6a.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=znver3
-            cflags: "-flto -DFORCE_X86_64"
+            cflags: "-DFORCE_X86_64"
             perf: PMU
           - name: Intel Xeon 3rd gen (c6i)
             ec2_instance_type: c6i.large
             ec2_ami: ubuntu-latest (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -maes -march=icelake-server
-            cflags: "-flto -DFORCE_X86_64"
+            cflags: "-DFORCE_X86_64"
             perf: PMU
     uses: ./.github/workflows/bench_ec2_reusable.yml
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')


### PR DESCRIPTION
mlkem-native is safe to use with LTO, but consuming libraries might still not want to set it (for example, because options have to be uniform, and other code in the consuming library is not safe to be used with LTO).

It is therefore better to benchmark without LTO to avoid surprise performance drops when doing integration tests.
