### PR TITLE
Add AVX2 native polynomial compress/decompression

### DIFF
--- a/mlkem/compress.c
+++ b/mlkem/compress.c
@@ -13,7 +13,9 @@
 #include "debug.h"
 #include "verify.h"
 
-#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 || MLKEM_K == 3)
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || \
+    (MLKEM_K == 2 || MLKEM_K == 3)
+#if !defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D4)
 MLKEM_NATIVE_INTERNAL_API
 void poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4], const poly *a)
 {
@@ -39,7 +41,16 @@ void poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4], const poly *a)
     r[i * 4 + 3] = t[6] | (t[7] << 4);
   }
 }
+#else  /* MLKEM_USE_NATIVE_POLY_COMPRESS_D4 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4], const poly *a)
+{
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  poly_compress_d4_native(r, a->coeffs);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D4 */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D10)
 MLKEM_NATIVE_INTERNAL_API
 void poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10], const poly *a)
 {
@@ -69,7 +80,16 @@ void poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10], const poly *a)
     r[5 * j + 4] = (t[3] >> 2);
   }
 }
+#else  /* MLKEM_USE_NATIVE_POLY_COMPRESS_D10 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10], const poly *a)
+{
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  poly_compress_d10_native(r, a->coeffs);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D10 */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D4)
 MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_d4(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
 {
@@ -85,7 +105,16 @@ void poly_decompress_d4(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
 
   debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
+#else  /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D4 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_decompress_d4(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
+{
+  poly_decompress_d4_native(r->coeffs, a);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D4 */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D10)
 MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_d10(poly *r,
                          const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
@@ -116,10 +145,20 @@ void poly_decompress_d10(poly *r,
 
   debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
+#else  /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D10 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_decompress_d10(poly *r,
+                         const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
+{
+  poly_decompress_d10_native(r->coeffs, a);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D10 */
 #endif /* defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 \
           || MLKEM_K == 3) */
 
 #if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4
+#if !defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D5)
 MLKEM_NATIVE_INTERNAL_API
 void poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5], const poly *a)
 {
@@ -151,7 +190,16 @@ void poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5], const poly *a)
     r[i * 5 + 4] = 0xFF & ((t[6] >> 2) | (t[7] << 3));
   }
 }
+#else  /* MLKEM_USE_NATIVE_POLY_COMPRESS_D5 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5], const poly *a)
+{
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  poly_compress_d5_native(r, a->coeffs);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D5 */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D11)
 MLKEM_NATIVE_INTERNAL_API
 void poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11], const poly *a)
 {
@@ -188,7 +236,16 @@ void poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11], const poly *a)
     r[11 * j + 10] = (t[7] >> 3);
   }
 }
+#else  /* MLKEM_USE_NATIVE_POLY_COMPRESS_D11 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11], const poly *a)
+{
+  debug_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  poly_compress_d11_native(r, a->coeffs);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D11 */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D5)
 MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_d5(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
 {
@@ -232,7 +289,16 @@ void poly_decompress_d5(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
 
   debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
+#else  /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D5 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_decompress_d5(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
+{
+  poly_decompress_d5_native(r->coeffs, a);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D5 */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D11)
 MLKEM_NATIVE_INTERNAL_API
 void poly_decompress_d11(poly *r,
                          const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
@@ -268,6 +334,16 @@ void poly_decompress_d11(poly *r,
 
   debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 }
+#else  /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D11 */
+MLKEM_NATIVE_INTERNAL_API
+void poly_decompress_d11(poly *r,
+                         const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
+{
+  poly_decompress_d11_native(r->coeffs, a);
+  debug_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D11 */
+
 #endif /* MLKEM_NATIVE_MULTILEVEL_BUILD) || MLKEM_K == 4 */
 
 #if !defined(MLKEM_USE_NATIVE_POLY_TOBYTES)

--- a/mlkem/native/api.h
+++ b/mlkem/native/api.h
@@ -336,4 +336,155 @@ __contract__(
 );
 #endif /* MLKEM_USE_NATIVE_REJ_UNIFORM */
 
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || \
+    (MLKEM_K == 2 || MLKEM_K == 3)
+#if defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D4)
+/*************************************************
+ * Name:        poly_compress_d4_native
+ *
+ * Description: Compression (4 bits) and subsequent serialization of a
+ *              polynomial
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D4 bytes)
+ *              - const int16_t a[MLKEM_N]: pointer to input polynomial
+ *                  Coefficients must be unsigned canonical,
+ *                  i.e. in [0,1,..,MLKEM_Q-1].
+ **************************************************/
+static INLINE void poly_compress_d4_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4], const int16_t a[MLKEM_N]);
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D4 */
+
+#if defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D10)
+/*************************************************
+ * Name:        poly_compress_d10_native
+ *
+ * Description: Compression (10 bits) and subsequent serialization of a
+ *              polynomial
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D10 bytes)
+ *              - const int16_t a[MLKEM_N]: pointer to input polynomial
+ *                  Coefficients must be unsigned canonical,
+ *                  i.e. in [0,1,..,MLKEM_Q-1].
+ **************************************************/
+static INLINE void poly_compress_d10_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10], const int16_t a[MLKEM_N]);
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D10 */
+
+#if defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D4)
+/*************************************************
+ * Name:        poly_decompress_d4
+ *
+ * Description: De-serialization and subsequent decompression (dv bits) of a
+ *              polynomial; approximate inverse of poly_compress
+ *
+ * Arguments:   - int16_t r[MLKEM_N]: pointer to output polynomial
+ *              - const uint8_t *a: pointer to input byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D4 bytes)
+ *
+ * Upon return, the coefficients of the output polynomial are unsigned-canonical
+ * (non-negative and smaller than MLKEM_Q).
+ *
+ **************************************************/
+static INLINE void poly_decompress_d4_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4]);
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D4 */
+
+#if defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D10)
+/*************************************************
+ * Name:        poly_decompress_d10_native
+ *
+ * Description: De-serialization and subsequent decompression (10 bits) of a
+ *              polynomial; approximate inverse of poly_compress_d10
+ *
+ * Arguments:   - int16_t r[MLKEM_N]: pointer to output polynomial
+ *              - const uint8_t *a: pointer to input byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D10 bytes)
+ *
+ * Upon return, the coefficients of the output polynomial are unsigned-canonical
+ * (non-negative and smaller than MLKEM_Q).
+ *
+ **************************************************/
+static INLINE void poly_decompress_d10_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10]);
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D10 */
+#endif /* defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 \
+          || MLKEM_K == 3) */
+
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4
+#if defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D5)
+/*************************************************
+ * Name:        poly_compress_d5_native
+ *
+ * Description: Compression (5 bits) and subsequent serialization of a
+ *              polynomial
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D5 bytes)
+ *              - const int16_t a[MLKEM_N]: pointer to input polynomial
+ *                  Coefficients must be unsigned canonical,
+ *                  i.e. in [0,1,..,MLKEM_Q-1].
+ **************************************************/
+static INLINE void poly_compress_d5_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5], const int16_t a[MLKEM_N]);
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D5 */
+
+#if defined(MLKEM_USE_NATIVE_POLY_COMPRESS_D11)
+/*************************************************
+ * Name:        poly_compress_d11_native
+ *
+ * Description: Compression (11 bits) and subsequent serialization of a
+ *              polynomial
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D11 bytes)
+ *              - const int16_t a[MLKEM_N]: pointer to input polynomial
+ *                  Coefficients must be unsigned canonical,
+ *                  i.e. in [0,1,..,MLKEM_Q-1].
+ **************************************************/
+static INLINE void poly_compress_d11_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11], const int16_t a[MLKEM_N]);
+#endif /* MLKEM_USE_NATIVE_POLY_COMPRESS_D11 */
+
+#if defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D5)
+/*************************************************
+ * Name:        poly_decompress_d5_native
+ *
+ * Description: De-serialization and subsequent decompression (dv bits) of a
+ *              polynomial; approximate inverse of poly_compress
+ *
+ * Arguments:   - int16_t r[MLKEM_N]: pointer to output polynomial
+ *              - const uint8_t *a: pointer to input byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D5 bytes)
+ *
+ * Upon return, the coefficients of the output polynomial are unsigned-canonical
+ * (non-negative and smaller than MLKEM_Q).
+ *
+ **************************************************/
+static INLINE void poly_decompress_d5_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5]);
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D5 */
+
+#if defined(MLKEM_USE_NATIVE_POLY_DECOMPRESS_D11)
+/*************************************************
+ * Name:        poly_decompress_d11_native
+ *
+ * Description: De-serialization and subsequent decompression (11 bits) of a
+ *              polynomial; approximate inverse of poly_compress_d11
+ *
+ * Arguments:   - int16_t r[MLKEM_N]: pointer to output polynomial
+ *              - const uint8_t *a: pointer to input byte array
+ *                   (of length MLKEM_POLYCOMPRESSEDBYTES_D11 bytes)
+ *
+ * Upon return, the coefficients of the output polynomial are unsigned-canonical
+ * (non-negative and smaller than MLKEM_Q).
+ *
+ **************************************************/
+static INLINE void poly_decompress_d11_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11]);
+#endif /* MLKEM_USE_NATIVE_POLY_DECOMPRESS_D11 */
+#endif /* defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4 \
+        */
+
 #endif /* MLKEM_NATIVE_ARITH_NATIVE_API_H */

--- a/mlkem/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/src/arith_native_x86_64.h
@@ -56,4 +56,29 @@ void nttfrombytes_avx2(__m256i *r, const uint8_t *a, const __m256i *qdata);
 #define tomont_avx2 MLKEM_NAMESPACE(tomont_avx2)
 void tomont_avx2(__m256i *r, const __m256i *qdata);
 
+#define poly_compress_d4_avx2 MLKEM_NAMESPACE(poly_compress_d4_avx2)
+void poly_compress_d4_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
+                           const __m256i *RESTRICT a);
+#define poly_decompress_d4_avx2 MLKEM_NAMESPACE(poly_decompress_d4_avx2)
+void poly_decompress_d4_avx2(__m256i *RESTRICT r,
+                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4]);
+#define poly_compress_d10_avx2 MLKEM_NAMESPACE(poly_compress10_avx2)
+void poly_compress_d10_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
+                            const __m256i *RESTRICT a);
+#define poly_decompress_d10_avx2 MLKEM_NAMESPACE(poly_decompress10_avx2)
+void poly_decompress_d10_avx2(__m256i *RESTRICT r,
+                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10]);
+#define poly_compress_d5_avx2 MLKEM_NAMESPACE(poly_compress_d5_avx2)
+void poly_compress_d5_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
+                           const __m256i *RESTRICT a);
+#define poly_decompress_d5_avx2 MLKEM_NAMESPACE(poly_decompress_d5_avx2)
+void poly_decompress_d5_avx2(__m256i *RESTRICT r,
+                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5]);
+#define poly_compress_d11_avx2 MLKEM_NAMESPACE(poly_compress11_avx2)
+void poly_compress_d11_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
+                            const __m256i *RESTRICT a);
+#define poly_decompress_d11_avx2 MLKEM_NAMESPACE(poly_decompress11_avx2)
+void poly_decompress_d11_avx2(__m256i *RESTRICT r,
+                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11]);
+
 #endif /* MLKEM_X86_64_NATIVE_H */

--- a/mlkem/native/x86_64/src/compress_avx2.c
+++ b/mlkem/native/x86_64/src/compress_avx2.c
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2024 The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Implementation from Kyber reference repository
+ * https://github.com/pq-crystals/kyber/blob/main/avx2 */
+
+#include "../../../common.h"
+
+#if defined(MLKEM_NATIVE_ARITH_BACKEND_X86_64_DEFAULT)
+
+#include <immintrin.h>
+#include <stdint.h>
+#include <string.h>
+#include "arith_native_x86_64.h"
+#include "consts.h"
+
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || \
+    (MLKEM_K == 2 || MLKEM_K == 3)
+void poly_compress_d4_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
+                           const __m256i *RESTRICT a)
+{
+  unsigned int i;
+  __m256i f0, f1, f2, f3;
+  const __m256i v =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XV / 16]);
+  const __m256i shift1 = _mm256_set1_epi16(1 << 9);
+  const __m256i mask = _mm256_set1_epi16(15);
+  const __m256i shift2 = _mm256_set1_epi16((16 << 8) + 1);
+  const __m256i permdidx = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
+
+  for (i = 0; i < MLKEM_N / 64; i++)
+  {
+    f0 = _mm256_load_si256(&a[4 * i + 0]);
+    f1 = _mm256_load_si256(&a[4 * i + 1]);
+    f2 = _mm256_load_si256(&a[4 * i + 2]);
+    f3 = _mm256_load_si256(&a[4 * i + 3]);
+    f0 = _mm256_mulhi_epi16(f0, v);
+    f1 = _mm256_mulhi_epi16(f1, v);
+    f2 = _mm256_mulhi_epi16(f2, v);
+    f3 = _mm256_mulhi_epi16(f3, v);
+    f0 = _mm256_mulhrs_epi16(f0, shift1);
+    f1 = _mm256_mulhrs_epi16(f1, shift1);
+    f2 = _mm256_mulhrs_epi16(f2, shift1);
+    f3 = _mm256_mulhrs_epi16(f3, shift1);
+    f0 = _mm256_and_si256(f0, mask);
+    f1 = _mm256_and_si256(f1, mask);
+    f2 = _mm256_and_si256(f2, mask);
+    f3 = _mm256_and_si256(f3, mask);
+    f0 = _mm256_packus_epi16(f0, f1);
+    f2 = _mm256_packus_epi16(f2, f3);
+    f0 = _mm256_maddubs_epi16(f0, shift2);
+    f2 = _mm256_maddubs_epi16(f2, shift2);
+    f0 = _mm256_packus_epi16(f0, f2);
+    f0 = _mm256_permutevar8x32_epi32(f0, permdidx);
+    _mm256_storeu_si256((__m256i *)&r[32 * i], f0);
+  }
+}
+
+void poly_decompress_d4_avx2(__m256i *RESTRICT r,
+                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
+{
+  unsigned int i;
+  __m128i t;
+  __m256i f;
+  const __m256i q =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XQ / 16]);
+  const __m256i shufbidx =
+      _mm256_set_epi8(7, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3,
+                      3, 2, 2, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0);
+  const __m256i mask = _mm256_set1_epi32(0x00F0000F);
+  const __m256i shift = _mm256_set1_epi32((128 << 16) + 2048);
+
+  for (i = 0; i < MLKEM_N / 16; i++)
+  {
+    t = _mm_loadl_epi64((__m128i *)&a[8 * i]);
+    f = _mm256_broadcastsi128_si256(t);
+    f = _mm256_shuffle_epi8(f, shufbidx);
+    f = _mm256_and_si256(f, mask);
+    f = _mm256_mullo_epi16(f, shift);
+    f = _mm256_mulhrs_epi16(f, q);
+    _mm256_store_si256(&r[i], f);
+  }
+}
+
+void poly_compress_d10_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
+                            const __m256i *RESTRICT a)
+{
+  unsigned int i;
+  __m256i f0, f1, f2;
+  __m128i t0, t1;
+  const __m256i v =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XV / 16]);
+  const __m256i v8 = _mm256_slli_epi16(v, 3);
+  const __m256i off = _mm256_set1_epi16(15);
+  const __m256i shift1 = _mm256_set1_epi16(1 << 12);
+  const __m256i mask = _mm256_set1_epi16(1023);
+  const __m256i shift2 =
+      _mm256_set1_epi64x((1024LL << 48) + (1LL << 32) + (1024 << 16) + 1);
+  const __m256i sllvdidx = _mm256_set1_epi64x(12);
+  const __m256i shufbidx =
+      _mm256_set_epi8(8, 4, 3, 2, 1, 0, -1, -1, -1, -1, -1, -1, 12, 11, 10, 9,
+                      -1, -1, -1, -1, -1, -1, 12, 11, 10, 9, 8, 4, 3, 2, 1, 0);
+
+  for (i = 0; i < MLKEM_N / 16; i++)
+  {
+    f0 = _mm256_load_si256(&a[i]);
+    f1 = _mm256_mullo_epi16(f0, v8);
+    f2 = _mm256_add_epi16(f0, off);
+    f0 = _mm256_slli_epi16(f0, 3);
+    f0 = _mm256_mulhi_epi16(f0, v);
+    f2 = _mm256_sub_epi16(f1, f2);
+    f1 = _mm256_andnot_si256(f1, f2);
+    f1 = _mm256_srli_epi16(f1, 15);
+    f0 = _mm256_sub_epi16(f0, f1);
+    f0 = _mm256_mulhrs_epi16(f0, shift1);
+    f0 = _mm256_and_si256(f0, mask);
+    f0 = _mm256_madd_epi16(f0, shift2);
+    f0 = _mm256_sllv_epi32(f0, sllvdidx);
+    f0 = _mm256_srli_epi64(f0, 12);
+    f0 = _mm256_shuffle_epi8(f0, shufbidx);
+    t0 = _mm256_castsi256_si128(f0);
+    t1 = _mm256_extracti128_si256(f0, 1);
+    t0 = _mm_blend_epi16(t0, t1, 0xE0);
+    _mm_storeu_si128((__m128i *)&r[20 * i + 0], t0);
+    memcpy(&r[20 * i + 16], &t1, 4);
+  }
+}
+
+void poly_decompress_d10_avx2(__m256i *RESTRICT r,
+                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
+{
+  unsigned int i;
+  __m256i f;
+  const __m256i q = _mm256_set1_epi32((MLKEM_Q << 16) + 4 * MLKEM_Q);
+  const __m256i shufbidx =
+      _mm256_set_epi8(11, 10, 10, 9, 9, 8, 8, 7, 6, 5, 5, 4, 4, 3, 3, 2, 9, 8,
+                      8, 7, 7, 6, 6, 5, 4, 3, 3, 2, 2, 1, 1, 0);
+  const __m256i sllvdidx = _mm256_set1_epi64x(4);
+  const __m256i mask = _mm256_set1_epi32((32736 << 16) + 8184);
+
+  for (i = 0; i < (MLKEM_N / 16) - 1; i++)
+  {
+    f = _mm256_loadu_si256((__m256i *)&a[20 * i]);
+    f = _mm256_permute4x64_epi64(f, 0x94);
+    f = _mm256_shuffle_epi8(f, shufbidx);
+    f = _mm256_sllv_epi32(f, sllvdidx);
+    f = _mm256_srli_epi16(f, 1);
+    f = _mm256_and_si256(f, mask);
+    f = _mm256_mulhrs_epi16(f, q);
+    _mm256_store_si256(&r[i], f);
+  }
+
+  /* Handle load in last iteration especially to avoid buffer overflow */
+  memcpy(&f, &a[20 * i], 20);
+  /* The rest is the same */
+  f = _mm256_permute4x64_epi64(f, 0x94);
+  f = _mm256_shuffle_epi8(f, shufbidx);
+  f = _mm256_sllv_epi32(f, sllvdidx);
+  f = _mm256_srli_epi16(f, 1);
+  f = _mm256_and_si256(f, mask);
+  f = _mm256_mulhrs_epi16(f, q);
+  _mm256_store_si256(&r[i], f);
+}
+
+#endif /* defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 \
+          || MLKEM_K == 3) */
+
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4
+void poly_compress_d5_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
+                           const __m256i *RESTRICT a)
+{
+  unsigned int i;
+  __m256i f0, f1;
+  __m128i t0, t1;
+  const __m256i v =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XV / 16]);
+  const __m256i shift1 = _mm256_set1_epi16(1 << 10);
+  const __m256i mask = _mm256_set1_epi16(31);
+  const __m256i shift2 = _mm256_set1_epi16((32 << 8) + 1);
+  const __m256i shift3 = _mm256_set1_epi32((1024 << 16) + 1);
+  const __m256i sllvdidx = _mm256_set1_epi64x(12);
+  const __m256i shufbidx =
+      _mm256_set_epi8(8, -1, -1, -1, -1, -1, 4, 3, 2, 1, 0, -1, 12, 11, 10, 9,
+                      -1, 12, 11, 10, 9, 8, -1, -1, -1, -1, -1, 4, 3, 2, 1, 0);
+
+  for (i = 0; i < MLKEM_N / 32; i++)
+  {
+    f0 = _mm256_load_si256(&a[2 * i + 0]);
+    f1 = _mm256_load_si256(&a[2 * i + 1]);
+    f0 = _mm256_mulhi_epi16(f0, v);
+    f1 = _mm256_mulhi_epi16(f1, v);
+    f0 = _mm256_mulhrs_epi16(f0, shift1);
+    f1 = _mm256_mulhrs_epi16(f1, shift1);
+    f0 = _mm256_and_si256(f0, mask);
+    f1 = _mm256_and_si256(f1, mask);
+    f0 = _mm256_packus_epi16(f0, f1);
+    f0 = _mm256_maddubs_epi16(
+        f0, shift2); /* a0 a1 a2 a3 b0 b1 b2 b3 a4 a5 a6 a7 b4 b5 b6 b7 */
+    f0 = _mm256_madd_epi16(f0, shift3); /* a0 a1 b0 b1 a2 a3 b2 b3 */
+    f0 = _mm256_sllv_epi32(f0, sllvdidx);
+    f0 = _mm256_srlv_epi64(f0, sllvdidx);
+    f0 = _mm256_shuffle_epi8(f0, shufbidx);
+    t0 = _mm256_castsi256_si128(f0);
+    t1 = _mm256_extracti128_si256(f0, 1);
+    t0 = _mm_blendv_epi8(t0, t1, _mm256_castsi256_si128(shufbidx));
+    _mm_storeu_si128((__m128i *)&r[20 * i + 0], t0);
+    memcpy(&r[20 * i + 16], &t1, 4);
+  }
+}
+
+void poly_decompress_d5_avx2(__m256i *RESTRICT r,
+                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
+{
+  unsigned int i;
+  __m128i t;
+  __m256i f;
+  int16_t ti;
+  const __m256i q =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XQ / 16]);
+  const __m256i shufbidx =
+      _mm256_set_epi8(9, 9, 9, 8, 8, 8, 8, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4,
+                      3, 3, 3, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0);
+  const __m256i mask = _mm256_set_epi16(248, 1984, 62, 496, 3968, 124, 992, 31,
+                                        248, 1984, 62, 496, 3968, 124, 992, 31);
+  const __m256i shift = _mm256_set_epi16(128, 16, 512, 64, 8, 256, 32, 1024,
+                                         128, 16, 512, 64, 8, 256, 32, 1024);
+
+  for (i = 0; i < MLKEM_N / 16; i++)
+  {
+    t = _mm_loadl_epi64((__m128i *)&a[10 * i + 0]);
+    memcpy(&ti, &a[10 * i + 8], 2);
+    t = _mm_insert_epi16(t, ti, 4);
+    f = _mm256_broadcastsi128_si256(t);
+    f = _mm256_shuffle_epi8(f, shufbidx);
+    f = _mm256_and_si256(f, mask);
+    f = _mm256_mullo_epi16(f, shift);
+    f = _mm256_mulhrs_epi16(f, q);
+    _mm256_store_si256(&r[i], f);
+  }
+}
+
+void poly_compress_d11_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
+                            const __m256i *RESTRICT a)
+{
+  unsigned int i;
+  __m256i f0, f1, f2;
+  __m128i t0, t1;
+  const __m256i v =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XV / 16]);
+  const __m256i v8 = _mm256_slli_epi16(v, 3);
+  const __m256i off = _mm256_set1_epi16(36);
+  const __m256i shift1 = _mm256_set1_epi16(1 << 13);
+  const __m256i mask = _mm256_set1_epi16(2047);
+  const __m256i shift2 =
+      _mm256_set1_epi64x((2048LL << 48) + (1LL << 32) + (2048 << 16) + 1);
+  const __m256i sllvdidx = _mm256_set1_epi64x(10);
+  const __m256i srlvqidx = _mm256_set_epi64x(30, 10, 30, 10);
+  const __m256i shufbidx =
+      _mm256_set_epi8(4, 3, 2, 1, 0, 0, -1, -1, -1, -1, 10, 9, 8, 7, 6, 5, -1,
+                      -1, -1, -1, -1, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+
+  for (i = 0; i < (MLKEM_N / 16) - 1; i++)
+  {
+    f0 = _mm256_load_si256(&a[i]);
+    f1 = _mm256_mullo_epi16(f0, v8);
+    f2 = _mm256_add_epi16(f0, off);
+    f0 = _mm256_slli_epi16(f0, 3);
+    f0 = _mm256_mulhi_epi16(f0, v);
+    f2 = _mm256_sub_epi16(f1, f2);
+    f1 = _mm256_andnot_si256(f1, f2);
+    f1 = _mm256_srli_epi16(f1, 15);
+    f0 = _mm256_sub_epi16(f0, f1);
+    f0 = _mm256_mulhrs_epi16(f0, shift1);
+    f0 = _mm256_and_si256(f0, mask);
+    f0 = _mm256_madd_epi16(f0, shift2);
+    f0 = _mm256_sllv_epi32(f0, sllvdidx);
+    f1 = _mm256_bsrli_epi128(f0, 8);
+    f0 = _mm256_srlv_epi64(f0, srlvqidx);
+    f1 = _mm256_slli_epi64(f1, 34);
+    f0 = _mm256_add_epi64(f0, f1);
+    f0 = _mm256_shuffle_epi8(f0, shufbidx);
+    t0 = _mm256_castsi256_si128(f0);
+    t1 = _mm256_extracti128_si256(f0, 1);
+    t0 = _mm_blendv_epi8(t0, t1, _mm256_castsi256_si128(shufbidx));
+    _mm_storeu_si128((__m128i *)&r[22 * i + 0], t0);
+    _mm_storel_epi64((__m128i *)&r[22 * i + 16], t1);
+  }
+
+  f0 = _mm256_load_si256(&a[i]);
+  f1 = _mm256_mullo_epi16(f0, v8);
+  f2 = _mm256_add_epi16(f0, off);
+  f0 = _mm256_slli_epi16(f0, 3);
+  f0 = _mm256_mulhi_epi16(f0, v);
+  f2 = _mm256_sub_epi16(f1, f2);
+  f1 = _mm256_andnot_si256(f1, f2);
+  f1 = _mm256_srli_epi16(f1, 15);
+  f0 = _mm256_sub_epi16(f0, f1);
+  f0 = _mm256_mulhrs_epi16(f0, shift1);
+  f0 = _mm256_and_si256(f0, mask);
+  f0 = _mm256_madd_epi16(f0, shift2);
+  f0 = _mm256_sllv_epi32(f0, sllvdidx);
+  f1 = _mm256_bsrli_epi128(f0, 8);
+  f0 = _mm256_srlv_epi64(f0, srlvqidx);
+  f1 = _mm256_slli_epi64(f1, 34);
+  f0 = _mm256_add_epi64(f0, f1);
+  f0 = _mm256_shuffle_epi8(f0, shufbidx);
+  t0 = _mm256_castsi256_si128(f0);
+  t1 = _mm256_extracti128_si256(f0, 1);
+  t0 = _mm_blendv_epi8(t0, t1, _mm256_castsi256_si128(shufbidx));
+  _mm_storeu_si128((__m128i *)&r[22 * i + 0], t0);
+  /* Handle store in last iteration especially to avoid overflow */
+  memcpy(&r[22 * i + 16], &t1, 6);
+}
+
+void poly_decompress_d11_avx2(__m256i *RESTRICT r,
+                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
+{
+  unsigned int i;
+  __m256i f;
+  const __m256i q =
+      _mm256_load_si256(&qdata.vec[AVX2_BACKEND_DATA_OFFSET_16XQ / 16]);
+  const __m256i shufbidx =
+      _mm256_set_epi8(13, 12, 12, 11, 10, 9, 9, 8, 8, 7, 6, 5, 5, 4, 4, 3, 10,
+                      9, 9, 8, 7, 6, 6, 5, 5, 4, 3, 2, 2, 1, 1, 0);
+  const __m256i srlvdidx = _mm256_set_epi32(0, 0, 1, 0, 0, 0, 1, 0);
+  const __m256i srlvqidx = _mm256_set_epi64x(2, 0, 2, 0);
+  const __m256i shift =
+      _mm256_set_epi16(4, 32, 1, 8, 32, 1, 4, 32, 4, 32, 1, 8, 32, 1, 4, 32);
+  const __m256i mask = _mm256_set1_epi16(32752);
+
+  for (i = 0; i < (MLKEM_N / 16) - 1; i++)
+  {
+    f = _mm256_loadu_si256((__m256i *)&a[22 * i]);
+    f = _mm256_permute4x64_epi64(f, 0x94);
+    f = _mm256_shuffle_epi8(f, shufbidx);
+    f = _mm256_srlv_epi32(f, srlvdidx);
+    f = _mm256_srlv_epi64(f, srlvqidx);
+    f = _mm256_mullo_epi16(f, shift);
+    f = _mm256_srli_epi16(f, 1);
+    f = _mm256_and_si256(f, mask);
+    f = _mm256_mulhrs_epi16(f, q);
+    _mm256_store_si256(&r[i], f);
+  }
+
+  /* Handle load of last iteration especially */
+  memcpy(&f, &a[22 * i], 22);
+  /* The rest of the iteration is the same */
+  f = _mm256_permute4x64_epi64(f, 0x94);
+  f = _mm256_shuffle_epi8(f, shufbidx);
+  f = _mm256_srlv_epi32(f, srlvdidx);
+  f = _mm256_srlv_epi64(f, srlvqidx);
+  f = _mm256_mullo_epi16(f, shift);
+  f = _mm256_srli_epi16(f, 1);
+  f = _mm256_and_si256(f, mask);
+  f = _mm256_mulhrs_epi16(f, q);
+  _mm256_store_si256(&r[i], f);
+}
+
+#endif /* MLKEM_NATIVE_MULTILEVEL_BUILD || MLKEM_K == 4 */
+
+#else /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
+
+MLKEM_NATIVE_EMPTY_CU(avx2_poly_compress)
+
+#endif /* MLKEM_NATIVE_ARITH_BACKEND_X86_64_DEFAULT */

--- a/mlkem/native/x86_64/src/default_impl.h
+++ b/mlkem/native/x86_64/src/default_impl.h
@@ -26,6 +26,14 @@
 #define MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_POLY_FROMBYTES
+#define MLKEM_USE_NATIVE_POLY_COMPRESS_D4
+#define MLKEM_USE_NATIVE_POLY_COMPRESS_D5
+#define MLKEM_USE_NATIVE_POLY_COMPRESS_D10
+#define MLKEM_USE_NATIVE_POLY_COMPRESS_D11
+#define MLKEM_USE_NATIVE_POLY_DECOMPRESS_D4
+#define MLKEM_USE_NATIVE_POLY_DECOMPRESS_D5
+#define MLKEM_USE_NATIVE_POLY_DECOMPRESS_D10
+#define MLKEM_USE_NATIVE_POLY_DECOMPRESS_D11
 
 static INLINE void poly_permute_bitrev_to_custom(int16_t data[MLKEM_N])
 {
@@ -91,5 +99,59 @@ static INLINE void poly_frombytes_native(int16_t r[MLKEM_N],
 {
   nttfrombytes_avx2((__m256i *)r, a, qdata.vec);
 }
+
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || \
+    (MLKEM_K == 2 || MLKEM_K == 3)
+static INLINE void poly_compress_d4_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4], const int16_t a[MLKEM_N])
+{
+  poly_compress_d4_avx2(r, (const __m256i *)a);
+}
+
+static INLINE void poly_compress_d10_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10], const int16_t a[MLKEM_N])
+{
+  poly_compress_d10_avx2(r, (const __m256i *)a);
+}
+
+static INLINE void poly_decompress_d4_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
+{
+  poly_decompress_d4_avx2((__m256i *)r, a);
+}
+
+static INLINE void poly_decompress_d10_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
+{
+  poly_decompress_d10_avx2((__m256i *)r, a);
+}
+#endif /* defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 \
+          || MLKEM_K == 3) */
+
+#if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4
+static INLINE void poly_compress_d5_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5], const int16_t a[MLKEM_N])
+{
+  poly_compress_d5_avx2(r, (const __m256i *)a);
+}
+
+static INLINE void poly_compress_d11_native(
+    uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11], const int16_t a[MLKEM_N])
+{
+  poly_compress_d11_avx2(r, (const __m256i *)a);
+}
+
+static INLINE void poly_decompress_d5_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
+{
+  poly_decompress_d5_avx2((__m256i *)r, a);
+}
+
+static INLINE void poly_decompress_d11_native(
+    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
+{
+  poly_decompress_d11_avx2((__m256i *)r, a);
+}
+#endif /* MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED || MLKEM_K == 4 */
 
 #endif /* MLKEM_NATIVE_ARITH_PROFILE_IMPL_H */


### PR DESCRIPTION
This commit extends the arithmetic natice interface by the
polynomial compression routines
- poly_compress_d4
- poly_compress_d5
- poly_compress_d10
- poly_compress_d11
- poly_decompress_d4
- poly_decompress_d5
- poly_decompress_d10
- poly_decompress_d11

It also imports the native implementation in AVX2 intrinsics
provided by the official Kyber implementation.

Care has to be taken to not overflow the input buffer during
the vectorization. The official Kyber implementation _does_
overflow them, but ensures at the call-sites that sufficient
space is available, and that no relevant data is overwritten.

While this seems to work, it is difficult to reason about this
code, and it moreover prevents a unified interfaces for the native
(de)compression routines.

To remedy, this commit adds tail-loop handling for the (de)compression
routines that overflow their input buffers in the offical Kyber implementation,
reading/writing only as much as is actually needed.

A test is added which invokes the individual (de)compression routines
with minimal input buffers. When used with address sanitization, this
would catch a potential overflow.