### PR TITLE
Proposal: New API

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -28,52 +28,29 @@
  * This is to facilitate building multiple instances
  * of mlkem-native (e.g. with varying security levels)
  * within a single compilation unit. */
-#define pack_pk MLKEM_NAMESPACE_K(pack_pk)
-#define unpack_pk MLKEM_NAMESPACE_K(unpack_pk)
-#define pack_sk MLKEM_NAMESPACE_K(pack_sk)
-#define unpack_sk MLKEM_NAMESPACE_K(unpack_sk)
 #define pack_ciphertext MLKEM_NAMESPACE_K(pack_ciphertext)
 #define unpack_ciphertext MLKEM_NAMESPACE_K(unpack_ciphertext)
 #define matvec_mul MLKEM_NAMESPACE_K(matvec_mul)
 /* End of static namespacing */
 
-/*************************************************
- * Name:        pack_pk
- *
- * Description: Serialize the public key as concatenation of the
- *              serialized vector of polynomials pk
- *              and the public seed used to generate the matrix A.
- *
- * Arguments:   uint8_t *r: pointer to the output serialized public key
- *              polyvec *pk: pointer to the input public-key polyvec.
- *                Must have coefficients within [0,..,q-1].
- *              const uint8_t *seed: pointer to the input public seed
- **************************************************/
-static void pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], polyvec *pk,
-                    const uint8_t seed[MLKEM_SYMBYTES])
+
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_serialize_pk(uint8_t pks[MLKEM_INDCPA_PUBLICKEYBYTES],
+                         const mlkem_indcpa_public_key *pk)
 {
-  debug_assert_bound_2d(pk, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
-  polyvec_tobytes(r, pk);
-  memcpy(r + MLKEM_POLYVECBYTES, seed, MLKEM_SYMBYTES);
+  debug_assert_bound_2d(pk->pkpv, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
+  polyvec_tobytes(pks, &pk->pkpv);
+  memcpy(pks + MLKEM_POLYVECBYTES, pk->seed, MLKEM_SYMBYTES);
 }
 
-/*************************************************
- * Name:        unpack_pk
- *
- * Description: De-serialize public key from a byte array;
- *              approximate inverse of pack_pk
- *
- * Arguments:   - polyvec *pk: pointer to output public-key polynomial vector
- *                  Coefficients will be normalized to [0,..,q-1].
- *              - uint8_t *seed: pointer to output seed to generate matrix A
- *              - const uint8_t *packedpk: pointer to input serialized public
- *                  key.
- **************************************************/
-static void unpack_pk(polyvec *pk, uint8_t seed[MLKEM_SYMBYTES],
-                      const uint8_t packedpk[MLKEM_INDCPA_PUBLICKEYBYTES])
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_deserialize_pk(mlkem_indcpa_public_key *pk,
+                           const uint8_t pks[MLKEM_INDCPA_PUBLICKEYBYTES])
 {
-  polyvec_frombytes(pk, packedpk);
-  memcpy(seed, packedpk + MLKEM_POLYVECBYTES, MLKEM_SYMBYTES);
+  polyvec_frombytes(&pk->pkpv, pks);
+  memcpy(pk->seed, pks + MLKEM_POLYVECBYTES, MLKEM_SYMBYTES);
+  gen_matrix(pk->at, pk->seed, 1);
+
 
   /* NOTE: If a modulus check was conducted on the PK, we know at this
    * point that the coefficients of `pk` are unsigned canonical. The
@@ -81,35 +58,19 @@ static void unpack_pk(polyvec *pk, uint8_t seed[MLKEM_SYMBYTES],
    * work with the easily provable bound by UINT12_LIMIT. */
 }
 
-/*************************************************
- * Name:        pack_sk
- *
- * Description: Serialize the secret key
- *
- * Arguments:   - uint8_t *r: pointer to output serialized secret key
- *              - polyvec *sk: pointer to input vector of polynomials (secret
- *key)
- **************************************************/
-static void pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], polyvec *sk)
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_serialize_sk(uint8_t sks[MLKEM_INDCPA_SECRETKEYBYTES],
+                         const mlkem_indcpa_secret_key *sk)
 {
-  debug_assert_bound_2d(sk, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
-  polyvec_tobytes(r, sk);
+  debug_assert_bound_2d(&sk->skpv, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
+  polyvec_tobytes(sks, &sk->skpv);
 }
 
-/*************************************************
- * Name:        unpack_sk
- *
- * Description: De-serialize the secret key; inverse of pack_sk
- *
- * Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret
- *                key)
- *              - const uint8_t *packedsk: pointer to input serialized secret
- *                key
- **************************************************/
-static void unpack_sk(polyvec *sk,
-                      const uint8_t packedsk[MLKEM_INDCPA_SECRETKEYBYTES])
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_deserialize_sk(mlkem_indcpa_secret_key *sk,
+                           const uint8_t sks[MLKEM_INDCPA_SECRETKEYBYTES])
 {
-  polyvec_frombytes(sk, packedsk);
+  polyvec_frombytes(&sk->skpv, sks);
 }
 
 /*************************************************
@@ -253,6 +214,25 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed)
   }
 }
 
+
+static void transpose_matrix(polyvec a[MLKEM_K])
+{
+  unsigned int i, j, k;
+  int16_t t;
+  for (i = 0; i < MLKEM_K; i++)
+  {
+    for (j = i + 1; j < MLKEM_K; j++)
+    {
+      for (k = 0; k < MLKEM_N; k++)
+      {
+        t = a[i].vec[j].coeffs[k];
+        a[i].vec[j].coeffs[k] = a[j].vec[i].coeffs[k];
+        a[j].vec[i].coeffs[k] = t;
+      }
+    }
+  }
+}
+
 /*************************************************
  * Name:        matvec_mul
  *
@@ -289,14 +269,14 @@ __contract__(
 }
 
 MLKEM_NATIVE_INTERNAL_API
-void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
-                           uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
+void indcpa_keypair_derand(mlkem_indcpa_public_key *pk,
+                           mlkem_indcpa_secret_key *sk,
                            const uint8_t coins[MLKEM_SYMBYTES])
 {
   ALIGN uint8_t buf[2 * MLKEM_SYMBYTES];
   const uint8_t *publicseed = buf;
   const uint8_t *noiseseed = buf + MLKEM_SYMBYTES;
-  polyvec a[MLKEM_K], e, pkpv, skpv;
+  polyvec e;
   polyvec_mulcache skpv_cache;
 
   ALIGN uint8_t coins_with_domain_separator[MLKEM_SYMBYTES + 1];
@@ -317,58 +297,56 @@ void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
   VALGRIND_MAKE_MEM_DEFINED(publicseed, MLKEM_SYMBYTES);
 #endif
 
-  gen_matrix(a, publicseed, 0 /* no transpose */);
+  gen_matrix(pk->at, publicseed, 0 /* no transpose */);
 
 #if MLKEM_K == 2
-  poly_getnoise_eta1_4x(skpv.vec + 0, skpv.vec + 1, e.vec + 0, e.vec + 1,
-                        noiseseed, 0, 1, 2, 3);
+  poly_getnoise_eta1_4x(sk->skpv.vec + 0, sk->skpv.vec + 1, e.vec + 0,
+                        e.vec + 1, noiseseed, 0, 1, 2, 3);
 #elif MLKEM_K == 3
   /*
    * Only the first three output buffers are needed.
    * The laster parameter is a dummy that's overwritten later.
    */
-  poly_getnoise_eta1_4x(skpv.vec + 0, skpv.vec + 1, skpv.vec + 2,
-                        pkpv.vec + 0 /* irrelevant */, noiseseed, 0, 1, 2,
+  poly_getnoise_eta1_4x(sk->skpv.vec + 0, sk->skpv.vec + 1, sk->skpv.vec + 2,
+                        pk->pkpv.vec + 0 /* irrelevant */, noiseseed, 0, 1, 2,
                         0xFF /* irrelevant */);
   /* Same here */
   poly_getnoise_eta1_4x(e.vec + 0, e.vec + 1, e.vec + 2,
-                        pkpv.vec + 0 /* irrelevant */, noiseseed, 3, 4, 5,
+                        pk->pkpv.vec + 0 /* irrelevant */, noiseseed, 3, 4, 5,
                         0xFF /* irrelevant */);
 #elif MLKEM_K == 4
-  poly_getnoise_eta1_4x(skpv.vec + 0, skpv.vec + 1, skpv.vec + 2, skpv.vec + 3,
-                        noiseseed, 0, 1, 2, 3);
+  poly_getnoise_eta1_4x(sk->skpv.vec + 0, sk->skpv.vec + 1, sk->skpv.vec + 2,
+                        sk->skpv.vec + 3, noiseseed, 0, 1, 2, 3);
   poly_getnoise_eta1_4x(e.vec + 0, e.vec + 1, e.vec + 2, e.vec + 3, noiseseed,
                         4, 5, 6, 7);
 #endif
 
-  polyvec_ntt(&skpv);
+  polyvec_ntt(&sk->skpv);
   polyvec_ntt(&e);
+  polyvec_mulcache_compute(&skpv_cache, &sk->skpv);
+  matvec_mul(&pk->pkpv, pk->at, &sk->skpv, &skpv_cache);
+  polyvec_tomont(&pk->pkpv);
 
-  polyvec_mulcache_compute(&skpv_cache, &skpv);
-  matvec_mul(&pkpv, a, &skpv, &skpv_cache);
-  polyvec_tomont(&pkpv);
+  polyvec_add(&pk->pkpv, &e);
+  polyvec_reduce(&pk->pkpv);
+  polyvec_reduce(&sk->skpv);
 
-  polyvec_add(&pkpv, &e);
-  polyvec_reduce(&pkpv);
-  polyvec_reduce(&skpv);
-
-  pack_sk(sk, &skpv);
-  pack_pk(pk, &pkpv, publicseed);
+  memcpy(pk->seed, publicseed, MLKEM_SYMBYTES);
+  // tranpose matrix as encapsulation requires the transpose
+  transpose_matrix(pk->at);
 }
 
 
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
-                const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
+                const mlkem_indcpa_public_key *pk,
                 const uint8_t coins[MLKEM_SYMBYTES])
 {
-  ALIGN uint8_t seed[MLKEM_SYMBYTES];
-  polyvec sp, pkpv, ep, at[MLKEM_K], b;
+  polyvec sp, ep, b;
   poly v, k, epp;
   polyvec_mulcache sp_cache;
 
-  unpack_pk(&pkpv, seed, pk);
   poly_frommsg(&k, m);
 
 
@@ -381,8 +359,6 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
    */
   VALGRIND_MAKE_MEM_DEFINED(seed, MLKEM_SYMBYTES);
 #endif
-
-  gen_matrix(at, seed, 1 /* transpose */);
 
 #if MLKEM_K == 2
   poly_getnoise_eta1122_4x(sp.vec + 0, sp.vec + 1, ep.vec + 0, ep.vec + 1,
@@ -409,8 +385,8 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
   polyvec_ntt(&sp);
 
   polyvec_mulcache_compute(&sp_cache, &sp);
-  matvec_mul(&b, at, &sp, &sp_cache);
-  polyvec_basemul_acc_montgomery_cached(&v, &pkpv, &sp, &sp_cache);
+  matvec_mul(&b, pk->at, &sp, &sp_cache);
+  polyvec_basemul_acc_montgomery_cached(&v, &pk->pkpv, &sp, &sp_cache);
 
   polyvec_invntt_tomont(&b);
   poly_invntt_tomont(&v);
@@ -428,16 +404,15 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],
-                const uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES])
+                const mlkem_indcpa_secret_key *sk)
 {
-  polyvec b, skpv;
+  polyvec b;
   poly v, sb;
 
   unpack_ciphertext(&b, &v, c);
-  unpack_sk(&skpv, sk);
 
   polyvec_ntt(&b);
-  polyvec_basemul_acc_montgomery(&sb, &skpv, &b);
+  polyvec_basemul_acc_montgomery(&sb, &sk->skpv, &b);
   poly_invntt_tomont(&sb);
 
   poly_sub(&v, &sb);

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -10,6 +10,76 @@
 #include "common.h"
 #include "poly_k.h"
 
+typedef struct
+{
+  polyvec skpv;
+} mlkem_indcpa_secret_key;
+
+typedef struct
+{
+  polyvec at[MLKEM_K]; /* transposed matrix */
+  polyvec pkpv;
+  uint8_t seed[MLKEM_SYMBYTES];
+} mlkem_indcpa_public_key;
+
+
+#define indcpa_serialize_pk MLKEM_NAMESPACE_K(indcpa_serialize_pk)
+/*************************************************
+ * Name:        indcpa_serialize_pk
+ *
+ * Description: Serialize the public key as concatenation of the
+ *              serialized vector of polynomials pk
+ *              and the public seed used to generate the matrix A.
+ *
+ * Arguments:   uint8_t *pks: pointer to the output serialized public key
+ *              polyvec *pk: pointer to the input public-key.
+ **************************************************/
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_serialize_pk(uint8_t pks[MLKEM_INDCPA_PUBLICKEYBYTES],
+                         const mlkem_indcpa_public_key *pk);
+
+#define indcpa_deserialize_pk MLKEM_NAMESPACE_K(indcpa_deserialize_pk)
+/*************************************************
+ * Name:        indcpa_deserialize_pk
+ *
+ * Description: De-serialize public key from a byte array;
+ *              approximate inverse of indcpa_serialize_pk
+ *
+ * Arguments:   - mlkem_indcpa_public_key *pk: pointer to output public-key
+ *              - uint8_t *seed: pointer to output seed to generate matrix A
+ *              - const uint8_t *pks: pointer to input serialized public
+ *                  key.
+ **************************************************/
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_deserialize_pk(mlkem_indcpa_public_key *pk,
+                           const uint8_t pks[MLKEM_INDCPA_PUBLICKEYBYTES]);
+
+#define indcpa_serialize_sk MLKEM_NAMESPACE_K(indcpa_serialize_sk)
+/*************************************************
+ * Name:        indcpa_serialize_sk
+ *
+ * Description: Serialize the secret key
+ *
+ * Arguments:   - uint8_t *sks: pointer to output serialized secret key
+ *              - polyvec *sk: pointer to input secret key
+ **************************************************/
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_serialize_sk(uint8_t sks[MLKEM_INDCPA_SECRETKEYBYTES],
+                         const mlkem_indcpa_secret_key *sk);
+
+#define indcpa_deserialize_sk MLKEM_NAMESPACE_K(indcpa_deserialize_sk)
+/*************************************************
+ * Name:        indcpa_deserialize_sk
+ *
+ * Description: De-serialize the secret key; inverse of indcpa_serialize_sk
+ *
+ * Arguments:   - mlkem_indcpa_secret_key *sk: pointer to output secret key
+ *              - const uint8_t *sks: pointer to input serialized secret key
+ **************************************************/
+MLKEM_NATIVE_INTERNAL_API
+void indcpa_deserialize_sk(mlkem_indcpa_secret_key *sk,
+                           const uint8_t sks[MLKEM_INDCPA_SECRETKEYBYTES]);
+
 #define gen_matrix MLKEM_NAMESPACE_K(gen_matrix)
 /*************************************************
  * Name:        gen_matrix
@@ -41,20 +111,18 @@ __contract__(
  * Description: Generates public and private key for the CPA-secure
  *              public-key encryption scheme underlying ML-KEM
  *
- * Arguments:   - uint8_t *pk: pointer to output public key
- *                             (of length MLKEM_INDCPA_PUBLICKEYBYTES bytes)
- *              - uint8_t *sk: pointer to output private key
- *                             (of length MLKEM_INDCPA_SECRETKEYBYTES bytes)
+ * Arguments:   - mlkem_indcpa_public_key *pk: pointer to output public key
+ *              - mlkem_indcpa_secret_key *sk: pointer to output private key
  *              - const uint8_t *coins: pointer to input randomness
  *                             (of length MLKEM_SYMBYTES bytes)
  **************************************************/
 MLKEM_NATIVE_INTERNAL_API
-void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
-                           uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
+void indcpa_keypair_derand(mlkem_indcpa_public_key *pk,
+                           mlkem_indcpa_secret_key *sk,
                            const uint8_t coins[MLKEM_SYMBYTES])
 __contract__(
-  requires(memory_no_alias(pk, MLKEM_INDCPA_PUBLICKEYBYTES))
-  requires(memory_no_alias(sk, MLKEM_INDCPA_SECRETKEYBYTES))
+  requires(memory_no_alias(pk, sizeof(mlkem_indcpa_public_key)))
+  requires(memory_no_alias(sk, sizeof(mlkem_indcpa_secret_key)))
   requires(memory_no_alias(coins, MLKEM_SYMBYTES))
   assigns(object_whole(pk))
   assigns(object_whole(sk))
@@ -71,20 +139,19 @@ __contract__(
  *                            (of length MLKEM_INDCPA_BYTES bytes)
  *              - const uint8_t *m: pointer to input message
  *                                  (of length MLKEM_INDCPA_MSGBYTES bytes)
- *              - const uint8_t *pk: pointer to input public key
- *                                   (of length MLKEM_INDCPA_PUBLICKEYBYTES)
+ *              - const mlkem_indcpa_public_key *pk: pointer to input public key
  *              - const uint8_t *coins: pointer to input random coins used as
  *seed (of length MLKEM_SYMBYTES) to deterministically generate all randomness
  **************************************************/
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
-                const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
+                const mlkem_indcpa_public_key *pk,
                 const uint8_t coins[MLKEM_SYMBYTES])
 __contract__(
   requires(memory_no_alias(c, MLKEM_INDCPA_BYTES))
   requires(memory_no_alias(m, MLKEM_INDCPA_MSGBYTES))
-  requires(memory_no_alias(pk, MLKEM_INDCPA_PUBLICKEYBYTES))
+  requires(memory_no_alias(pk, sizeof(mlkem_indcpa_public_key)))
   requires(memory_no_alias(coins, MLKEM_SYMBYTES))
   assigns(object_whole(c))
 );
@@ -100,17 +167,17 @@ __contract__(
  *                            (of length MLKEM_INDCPA_MSGBYTES)
  *              - const uint8_t *c: pointer to input ciphertext
  *                                  (of length MLKEM_INDCPA_BYTES)
- *              - const uint8_t *sk: pointer to input secret key
- *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
+ *              - const mlkem_indcpa_secret_key *sk: pointer to input secret key
+ *
  **************************************************/
 MLKEM_NATIVE_INTERNAL_API
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],
-                const uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES])
+                const mlkem_indcpa_secret_key *sk)
 __contract__(
   requires(memory_no_alias(c, MLKEM_INDCPA_BYTES))
   requires(memory_no_alias(m, MLKEM_INDCPA_MSGBYTES))
-  requires(memory_no_alias(sk, MLKEM_INDCPA_SECRETKEYBYTES))
+  requires(memory_no_alias(sk, sizeof(mlkem_indcpa_secret_key)))
   assigns(object_whole(m))
 );
 

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -8,6 +8,7 @@
 
 #include "indcpa.h"
 #include "kem.h"
+#include "params.h"
 #include "randombytes.h"
 #include "symmetric.h"
 #include "verify.h"
@@ -101,22 +102,85 @@ static int check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
   return 0;
 }
 
-int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
-                              uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES],
-                              const uint8_t *coins)
+int crypto_kem_serialize_sk(uint8_t sks[MLKEM_INDCCA_SECRETKEYBYTES],
+                            const mlkem_secret_key *sk)
 {
-  indcpa_keypair_derand(pk, sk, coins);
-  memcpy(sk + MLKEM_INDCPA_SECRETKEYBYTES, pk, MLKEM_INDCCA_PUBLICKEYBYTES);
-  hash_h(sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, pk,
-         MLKEM_INDCCA_PUBLICKEYBYTES);
-  /* Value z for pseudo-random output on reject */
-  memcpy(sk + MLKEM_INDCCA_SECRETKEYBYTES - MLKEM_SYMBYTES,
-         coins + MLKEM_SYMBYTES, MLKEM_SYMBYTES);
+  indcpa_serialize_sk(sks, &sk->indcpa_sk);
+  indcpa_serialize_pk(sks + MLKEM_INDCPA_SECRETKEYBYTES, &sk->indcpa_pk);
+  memcpy(sks + MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES,
+         sk->hpk, MLKEM_SYMBYTES);
+  memcpy(sks + MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES +
+             MLKEM_SYMBYTES,
+         sk->z, MLKEM_SYMBYTES);
   return 0;
 }
 
-int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
-                       uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
+int crypto_kem_deserialize_sk(mlkem_secret_key *sk,
+                              const uint8_t sks[MLKEM_INDCCA_SECRETKEYBYTES])
+{
+  if (check_sk(sks))
+  {
+    return -1;
+  }
+  indcpa_deserialize_sk(&sk->indcpa_sk, sks);
+  indcpa_deserialize_pk(&sk->indcpa_pk, sks + MLKEM_INDCPA_SECRETKEYBYTES);
+  memcpy(sk->hpk,
+         sks + MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES,
+         MLKEM_SYMBYTES);
+  memcpy(sk->z,
+         sks + MLKEM_INDCPA_SECRETKEYBYTES + MLKEM_INDCPA_PUBLICKEYBYTES +
+             MLKEM_SYMBYTES,
+         MLKEM_SYMBYTES);
+
+  return 0;
+}
+
+int crypto_kem_serialize_pk(uint8_t pks[MLKEM_INDCCA_PUBLICKEYBYTES],
+                            const mlkem_public_key *pk)
+{
+  indcpa_serialize_pk(pks, &pk->indcpa_pk);
+  return 0;
+}
+
+int crypto_kem_deserialize_pk(mlkem_public_key *pk,
+                              const uint8_t pks[MLKEM_INDCCA_PUBLICKEYBYTES])
+{
+  if (check_pk(pks))
+  {
+    return -1;
+  }
+  indcpa_deserialize_pk(&pk->indcpa_pk, pks);
+  hash_h(pk->hpk, pks, MLKEM_INDCCA_PUBLICKEYBYTES);
+  return 0;
+}
+
+int crypto_kem_keypair_derand(mlkem_public_key *pk, mlkem_secret_key *sk,
+                              const uint8_t *coins)
+{
+  indcpa_keypair_derand(&sk->indcpa_pk, &sk->indcpa_sk, coins);
+
+  // pre-compute H(pk)
+  uint8_t pks[MLKEM_INDCCA_PUBLICKEYBYTES];
+  indcpa_serialize_pk(pks, &sk->indcpa_pk);
+  hash_h(sk->hpk, pks, MLKEM_INDCCA_PUBLICKEYBYTES);
+
+  // copy over indcpa pk and H(pk) to public key
+  // pk is NULL during deserialization before decaps as the pk is not needed
+  if (pk != NULL)
+  {
+    memcpy(&pk->indcpa_pk, &sk->indcpa_pk, sizeof(mlkem_indcpa_public_key));
+    memcpy(pk->hpk, sk->hpk, MLKEM_SYMBYTES);
+  }
+
+  // Value z for pseudo-random output on reject
+  memcpy(sk->z, coins + MLKEM_SYMBYTES, MLKEM_SYMBYTES);
+
+  // seed to regenerate whole secret key
+  memcpy(sk->seed, coins, MLKEM_SYMBYTES);
+  return 0;
+}
+
+int crypto_kem_keypair(mlkem_public_key *pk, mlkem_secret_key *sk)
 {
   ALIGN uint8_t coins[2 * MLKEM_SYMBYTES];
   randombytes(coins, 2 * MLKEM_SYMBYTES);
@@ -125,35 +189,28 @@ int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
 }
 
 int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
-                          uint8_t ss[MLKEM_SSBYTES],
-                          const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
+                          uint8_t ss[MLKEM_SSBYTES], const mlkem_public_key *pk,
                           const uint8_t coins[MLKEM_SYMBYTES])
 {
   ALIGN uint8_t buf[2 * MLKEM_SYMBYTES];
   /* Will contain key, coins */
   ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
 
-  if (check_pk(pk))
-  {
-    return -1;
-  }
-
   memcpy(buf, coins, MLKEM_SYMBYTES);
 
   /* Multitarget countermeasure for coins + contributory KEM */
-  hash_h(buf + MLKEM_SYMBYTES, pk, MLKEM_INDCCA_PUBLICKEYBYTES);
+  memcpy(buf + MLKEM_SYMBYTES, pk->hpk, MLKEM_SYMBYTES);
   hash_g(kr, buf, 2 * MLKEM_SYMBYTES);
 
   /* coins are in kr+MLKEM_SYMBYTES */
-  indcpa_enc(ct, buf, pk, kr + MLKEM_SYMBYTES);
+  indcpa_enc(ct, buf, &pk->indcpa_pk, kr + MLKEM_SYMBYTES);
 
   memcpy(ss, kr, MLKEM_SYMBYTES);
   return 0;
 }
 
 int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
-                   uint8_t ss[MLKEM_SSBYTES],
-                   const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
+                   uint8_t ss[MLKEM_SSBYTES], const mlkem_public_key *pk)
 {
   ALIGN uint8_t coins[MLKEM_SYMBYTES];
   randombytes(coins, MLKEM_SYMBYTES);
@@ -162,24 +219,16 @@ int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
 
 int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
                    const uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
-                   const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
+                   const mlkem_secret_key *sk)
 {
   uint8_t fail;
   ALIGN uint8_t buf[2 * MLKEM_SYMBYTES];
   /* Will contain key, coins */
   ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
-  const uint8_t *pk = sk + MLKEM_INDCPA_SECRETKEYBYTES;
-
-  if (check_sk(sk))
-  {
-    return -1;
-  }
-
-  indcpa_dec(buf, ct, sk);
+  indcpa_dec(buf, ct, &sk->indcpa_sk);
 
   /* Multitarget countermeasure for coins + contributory KEM */
-  memcpy(buf + MLKEM_SYMBYTES,
-         sk + MLKEM_INDCCA_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, MLKEM_SYMBYTES);
+  memcpy(buf + MLKEM_SYMBYTES, sk->hpk, MLKEM_SYMBYTES);
   hash_g(kr, buf, 2 * MLKEM_SYMBYTES);
 
   /* Recompute and compare ciphertext */
@@ -187,7 +236,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
     /* Temporary buffer */
     ALIGN uint8_t cmp[MLKEM_INDCCA_CIPHERTEXTBYTES];
     /* coins are in kr+MLKEM_SYMBYTES */
-    indcpa_enc(cmp, buf, pk, kr + MLKEM_SYMBYTES);
+    indcpa_enc(cmp, buf, &sk->indcpa_pk, kr + MLKEM_SYMBYTES);
     fail = ct_memcmp(ct, cmp, MLKEM_INDCCA_CIPHERTEXTBYTES);
   }
 
@@ -195,8 +244,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
   {
     /* Temporary buffer */
     ALIGN uint8_t tmp[MLKEM_SYMBYTES + MLKEM_INDCCA_CIPHERTEXTBYTES];
-    memcpy(tmp, sk + MLKEM_INDCCA_SECRETKEYBYTES - MLKEM_SYMBYTES,
-           MLKEM_SYMBYTES);
+    memcpy(tmp, sk->z, MLKEM_SYMBYTES);
     memcpy(tmp + MLKEM_SYMBYTES, ct, MLKEM_INDCCA_CIPHERTEXTBYTES);
     hash_j(ss, tmp, sizeof(tmp));
   }

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include "cbmc.h"
 #include "common.h"
+#include "indcpa.h"
 
 #if defined(MLKEM_NATIVE_CHECK_APIS)
 /* Include to ensure consistency between internal kem.h
@@ -34,6 +35,37 @@
 #define crypto_kem_dec MLKEM_NAMESPACE_K(dec)
 #endif
 
+typedef struct
+{
+  mlkem_indcpa_secret_key indcpa_sk;
+  mlkem_indcpa_public_key indcpa_pk;
+  uint8_t seed[MLKEM_SYMBYTES];
+  uint8_t z[MLKEM_SYMBYTES];
+  uint8_t hpk[MLKEM_SYMBYTES];
+} mlkem_secret_key;
+
+typedef struct
+{
+  mlkem_indcpa_public_key indcpa_pk;
+  uint8_t hpk[MLKEM_SYMBYTES];
+} mlkem_public_key;
+
+#define crypto_kem_serialize_sk MLKEM_NAMESPACE(serialize_sk)
+int crypto_kem_serialize_sk(uint8_t sks[MLKEM_INDCCA_SECRETKEYBYTES],
+                            const mlkem_secret_key *sk);
+
+#define crypto_kem_deserialize_sk MLKEM_NAMESPACE(deserialize_sk)
+int crypto_kem_deserialize_sk(mlkem_secret_key *sk,
+                              const uint8_t sks[MLKEM_INDCCA_SECRETKEYBYTES]);
+
+#define crypto_kem_serialize_pk MLKEM_NAMESPACE(serialize_pk)
+int crypto_kem_serialize_pk(uint8_t pks[MLKEM_INDCCA_PUBLICKEYBYTES],
+                            const mlkem_public_key *pk);
+
+#define crypto_kem_deserialize_pk MLKEM_NAMESPACE(deserialize_pk)
+int crypto_kem_deserialize_pk(mlkem_public_key *pk,
+                              const uint8_t pks[MLKEM_INDCCA_PUBLICKEYBYTES]);
+
 /*************************************************
  * Name:        crypto_kem_keypair_derand
  *
@@ -52,8 +84,7 @@
  **
  * Returns 0 (success)
  **************************************************/
-int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
-                              uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES],
+int crypto_kem_keypair_derand(mlkem_public_key *pk, mlkem_secret_key *sk,
                               const uint8_t *coins)
 __contract__(
   requires(memory_no_alias(pk, MLKEM_INDCCA_PUBLICKEYBYTES))
@@ -78,8 +109,7 @@ __contract__(
  *
  * Returns 0 (success)
  **************************************************/
-int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
-                       uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
+int crypto_kem_keypair(mlkem_public_key *pk, mlkem_secret_key *sk)
 __contract__(
   requires(memory_no_alias(pk, MLKEM_INDCCA_PUBLICKEYBYTES))
   requires(memory_no_alias(sk, MLKEM_INDCCA_SECRETKEYBYTES))
@@ -109,8 +139,7 @@ __contract__(
  * of FIPS203) fails.
  **************************************************/
 int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
-                          uint8_t ss[MLKEM_SSBYTES],
-                          const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
+                          uint8_t ss[MLKEM_SSBYTES], const mlkem_public_key *pk,
                           const uint8_t coins[MLKEM_SYMBYTES])
 __contract__(
   requires(memory_no_alias(ct, MLKEM_INDCCA_CIPHERTEXTBYTES))
@@ -140,8 +169,7 @@ __contract__(
  * of FIPS203) fails.
  **************************************************/
 int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
-                   uint8_t ss[MLKEM_SSBYTES],
-                   const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
+                   uint8_t ss[MLKEM_SSBYTES], const mlkem_public_key *pk)
 __contract__(
   requires(memory_no_alias(ct, MLKEM_INDCCA_CIPHERTEXTBYTES))
   requires(memory_no_alias(ss, MLKEM_SSBYTES))
@@ -172,7 +200,7 @@ __contract__(
  **************************************************/
 int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
                    const uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
-                   const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
+                   const mlkem_secret_key *sk)
 __contract__(
   requires(memory_no_alias(ss, MLKEM_SSBYTES))
   requires(memory_no_alias(ct, MLKEM_INDCCA_CIPHERTEXTBYTES))

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -25,6 +25,10 @@
 
 #include <stdint.h>
 
+// TODO: need to eliminate this
+#include "indcpa.h"
+#include "kem.h"
+
 /*************************** Build information ********************************/
 
 /*
@@ -114,107 +118,113 @@
 
 /****************************** Function API **********************************/
 
-/*************************************************
- * Name:        crypto_kem_keypair_derand
- *
- * Description: Generates public and private key
- *              for CCA-secure ML-KEM key encapsulation mechanism
- *
- * Arguments:   - uint8_t pk[]: pointer to output public key, an array of
- *                 length MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- *              - uint8_t sk[]: pointer to output private key, an array of
- *                  of MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
- *              - uint8_t *coins: pointer to input randomness, an array of
- *                  2*MLKEM_SYMBYTES uniformly random bytes.
- *
- * Returns 0 (success)
- **************************************************/
-int BUILD_INFO_NAMESPACE(keypair_derand)(
-    uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)],
-    uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)], const uint8_t *coins);
+// /*************************************************
+//  * Name:        crypto_kem_keypair_derand
+//  *
+//  * Description: Generates public and private key
+//  *              for CCA-secure ML-KEM key encapsulation mechanism
+//  *
+//  * Arguments:   - uint8_t pk[]: pointer to output public key, an array of
+//  *                 length MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+//  *              - uint8_t sk[]: pointer to output private key, an array of
+//  *                  of MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+//  *              - uint8_t *coins: pointer to input randomness, an array of
+//  *                  2*MLKEM_SYMBYTES uniformly random bytes.
+//  *
+//  * Returns 0 (success)
+//  **************************************************/
+// int BUILD_INFO_NAMESPACE(keypair_derand)(
+//     uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)],
+//     uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)], const uint8_t *coins);
 
-/*************************************************
- * Name:        crypto_kem_keypair
- *
- * Description: Generates public and private key
- *              for CCA-secure ML-KEM key encapsulation mechanism
- *
- * Arguments:   - uint8_t *pk: pointer to output public key, an array of
- *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- *              - uint8_t *sk: pointer to output private key, an array of
- *                 MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
- *
- * Returns 0 (success)
- **************************************************/
-int BUILD_INFO_NAMESPACE(keypair)(
-    uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)],
-    uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)]);
+// /*************************************************
+//  * Name:        crypto_kem_keypair
+//  *
+//  * Description: Generates public and private key
+//  *              for CCA-secure ML-KEM key encapsulation mechanism
+//  *
+//  * Arguments:   - uint8_t *pk: pointer to output public key, an array of
+//  *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+//  *              - uint8_t *sk: pointer to output private key, an array of
+//  *                 MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+//  *
+//  * Returns 0 (success)
+//  **************************************************/
+// int BUILD_INFO_NAMESPACE(keypair)(
+//     uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)],
+//     uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)]);
 
-/*************************************************
- * Name:        crypto_kem_enc_derand
- *
- * Description: Generates cipher text and shared
- *              secret for given public key
- *
- * Arguments:   - uint8_t *ct: pointer to output cipher text, an array of
- *                 MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
- *              - uint8_t *ss: pointer to output shared secret, an array of
- *                 MLKEM_BYTES bytes.
- *              - const uint8_t *pk: pointer to input public key, an array of
- *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- *              - const uint8_t *coins: pointer to input randomness, an array of
- *                 MLKEM_SYMBYTES bytes.
- *
- * Returns 0 on success, and -1 if the public key modulus check (see Section 7.2
- * of FIPS203) fails.
- **************************************************/
-int BUILD_INFO_NAMESPACE(enc_derand)(
-    uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)], uint8_t ss[MLKEM_BYTES],
-    const uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)],
-    const uint8_t coins[MLKEM_SYMBYTES]);
+// /*************************************************
+//  * Name:        crypto_kem_enc_derand
+//  *
+//  * Description: Generates cipher text and shared
+//  *              secret for given public key
+//  *
+//  * Arguments:   - uint8_t *ct: pointer to output cipher text, an array of
+//  *                 MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
+//  *              - uint8_t *ss: pointer to output shared secret, an array of
+//  *                 MLKEM_BYTES bytes.
+//  *              - const uint8_t *pk: pointer to input public key, an array of
+//  *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+//  *              - const uint8_t *coins: pointer to input randomness, an array
+//  of
+//  *                 MLKEM_SYMBYTES bytes.
+//  *
+//  * Returns 0 on success, and -1 if the public key modulus check (see
+//  Section 7.2
+//  * of FIPS203) fails.
+//  **************************************************/
+// int BUILD_INFO_NAMESPACE(enc_derand)(
+//     uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)], uint8_t
+//     ss[MLKEM_BYTES], const uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)],
+//     const uint8_t coins[MLKEM_SYMBYTES]);
 
-/*************************************************
- * Name:        crypto_kem_enc
- *
- * Description: Generates cipher text and shared
- *              secret for given public key
- *
- * Arguments:   - uint8_t *ct: pointer to output cipher text, an array of
- *                 MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
- *              - uint8_t *ss: pointer to output shared secret, an array of
- *                 MLKEM_BYTES bytes.
- *              - const uint8_t *pk: pointer to input public key, an array of
- *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- *
- * Returns 0 on success, and -1 if the public key modulus check (see Section 7.2
- * of FIPS203) fails.
- **************************************************/
-int BUILD_INFO_NAMESPACE(enc)(
-    uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)], uint8_t ss[MLKEM_BYTES],
-    const uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)]);
+// /*************************************************
+//  * Name:        crypto_kem_enc
+//  *
+//  * Description: Generates cipher text and shared
+//  *              secret for given public key
+//  *
+//  * Arguments:   - uint8_t *ct: pointer to output cipher text, an array of
+//  *                 MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
+//  *              - uint8_t *ss: pointer to output shared secret, an array of
+//  *                 MLKEM_BYTES bytes.
+//  *              - const uint8_t *pk: pointer to input public key, an array of
+//  *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+//  *
+//  * Returns 0 on success, and -1 if the public key modulus check (see
+//  Section 7.2
+//  * of FIPS203) fails.
+//  **************************************************/
+// int BUILD_INFO_NAMESPACE(enc)(
+//     uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)], uint8_t
+//     ss[MLKEM_BYTES], const uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)]);
 
-/*************************************************
- * Name:        crypto_kem_dec
- *
- * Description: Generates shared secret for given
- *              cipher text and private key
- *
- * Arguments:   - uint8_t *ss: pointer to output shared secret, an array of
- *                 MLKEM_BYTES bytes.
- *              - const uint8_t *ct: pointer to input cipher text, an array of
- *                 MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
- *              - const uint8_t *sk: pointer to input private key, an array of
- *                 MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
- *
- * Returns 0 on success, and -1 if the secret key hash check (see Section 7.3 of
- * FIPS203) fails.
- *
- * On failure, ss will contain a pseudo-random value.
- **************************************************/
-int BUILD_INFO_NAMESPACE(dec)(
-    uint8_t ss[MLKEM_BYTES],
-    const uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)],
-    const uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)]);
+// /*************************************************
+//  * Name:        crypto_kem_dec
+//  *
+//  * Description: Generates shared secret for given
+//  *              cipher text and private key
+//  *
+//  * Arguments:   - uint8_t *ss: pointer to output shared secret, an array of
+//  *                 MLKEM_BYTES bytes.
+//  *              - const uint8_t *ct: pointer to input cipher text, an array
+//  of
+//  *                 MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
+//  *              - const uint8_t *sk: pointer to input private key, an array
+//  of
+//  *                 MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+//  *
+//  * Returns 0 on success, and -1 if the secret key hash check (see Section 7.3
+//  of
+//  * FIPS203) fails.
+//  *
+//  * On failure, ss will contain a pseudo-random value.
+//  **************************************************/
+// int BUILD_INFO_NAMESPACE(dec)(
+//     uint8_t ss[MLKEM_BYTES],
+//     const uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)],
+//     const uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)]);
 
 /****************************** Standard API *********************************/
 
@@ -232,11 +242,11 @@ int BUILD_INFO_NAMESPACE(dec)(
 #define CRYPTO_SYMBYTES MLKEM_SYMBYTES
 #define CRYPTO_BYTES MLKEM_BYTES
 
-#define crypto_kem_keypair_derand BUILD_INFO_NAMESPACE(keypair_derand)
-#define crypto_kem_keypair BUILD_INFO_NAMESPACE(keypair)
-#define crypto_kem_enc_derand BUILD_INFO_NAMESPACE(enc_derand)
-#define crypto_kem_enc BUILD_INFO_NAMESPACE(enc)
-#define crypto_kem_dec BUILD_INFO_NAMESPACE(dec)
+// #define crypto_kem_keypair_derand BUILD_INFO_NAMESPACE(keypair_derand)
+// #define crypto_kem_keypair BUILD_INFO_NAMESPACE(keypair)
+// #define crypto_kem_enc_derand BUILD_INFO_NAMESPACE(enc_derand)
+// #define crypto_kem_enc BUILD_INFO_NAMESPACE(enc)
+// #define crypto_kem_dec BUILD_INFO_NAMESPACE(dec)
 #endif /* BUILD_INFO_NO_STANDARD_API */
 
 /********************************* Cleanup ************************************/

--- a/test/bench_mlkem.c
+++ b/test/bench_mlkem.c
@@ -47,13 +47,17 @@ static void print_percentiles(const char *txt, uint64_t cyc[NTESTS])
 
 static int bench(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  mlkem_public_key pk;
+  mlkem_secret_key sk;
+  uint8_t pks[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sks[CRYPTO_SECRETKEYBYTES];
   uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
   uint8_t key_a[CRYPTO_BYTES];
   uint8_t key_b[CRYPTO_BYTES];
   unsigned char kg_rand[2 * CRYPTO_BYTES], enc_rand[CRYPTO_BYTES];
   uint64_t cycles_kg[NTESTS], cycles_enc[NTESTS], cycles_dec[NTESTS];
+  uint64_t cycles_ser_sk[NTESTS], cycles_deser_sk[NTESTS],
+      cycles_ser_pk[NTESTS], cycles_deser_pk[NTESTS];
 
   unsigned i, j;
   uint64_t t0, t1;
@@ -64,43 +68,103 @@ static int bench(void)
     randombytes(kg_rand, 2 * CRYPTO_BYTES);
     randombytes(enc_rand, CRYPTO_BYTES);
 
-    /* Key-pair generation */
+    // Key-pair generation
     for (j = 0; j < NWARMUP; j++)
     {
-      crypto_kem_keypair_derand(pk, sk, kg_rand);
+      crypto_kem_keypair_derand(&pk, &sk, kg_rand);
     }
 
     t0 = get_cyclecounter();
     for (j = 0; j < NITERATIONS; j++)
     {
-      crypto_kem_keypair_derand(pk, sk, kg_rand);
+      crypto_kem_keypair_derand(&pk, &sk, kg_rand);
     }
     t1 = get_cyclecounter();
     cycles_kg[i] = t1 - t0;
 
 
-    /* Encapsulation */
+    // Serialize secret key
     for (j = 0; j < NWARMUP; j++)
     {
-      crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
+      crypto_kem_serialize_sk(sks, &sk);
+    }
+
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERATIONS; j++)
+    {
+      crypto_kem_serialize_sk(sks, &sk);
+    }
+    t1 = get_cyclecounter();
+    cycles_ser_sk[i] = t1 - t0;
+
+
+
+    // Serialize public key
+    for (j = 0; j < NWARMUP; j++)
+    {
+      crypto_kem_serialize_pk(pks, &pk);
+    }
+
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERATIONS; j++)
+    {
+      crypto_kem_serialize_pk(pks, &pk);
+    }
+    t1 = get_cyclecounter();
+    cycles_ser_pk[i] = t1 - t0;
+
+
+    // Deserialize public key
+    for (j = 0; j < NWARMUP; j++)
+    {
+      crypto_kem_deserialize_pk(&pk, pks);
+    }
+
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERATIONS; j++)
+    {
+      crypto_kem_deserialize_pk(&pk, pks);
+    }
+    t1 = get_cyclecounter();
+    cycles_deser_pk[i] = t1 - t0;
+
+
+    // Encapsulation
+    for (j = 0; j < NWARMUP; j++)
+    {
+      crypto_kem_enc_derand(ct, key_a, &pk, enc_rand);
     }
     t0 = get_cyclecounter();
     for (j = 0; j < NITERATIONS; j++)
     {
-      crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
+      crypto_kem_enc_derand(ct, key_a, &pk, enc_rand);
     }
     t1 = get_cyclecounter();
     cycles_enc[i] = t1 - t0;
 
-    /* Decapsulation */
+    // Deserialize secret key
     for (j = 0; j < NWARMUP; j++)
     {
-      crypto_kem_dec(key_b, ct, sk);
+      crypto_kem_deserialize_sk(&sk, sks);
     }
     t0 = get_cyclecounter();
     for (j = 0; j < NITERATIONS; j++)
     {
-      crypto_kem_dec(key_b, ct, sk);
+      crypto_kem_deserialize_sk(&sk, sks);
+    }
+    t1 = get_cyclecounter();
+    cycles_deser_sk[i] = t1 - t0;
+
+
+    // Decapsulation
+    for (j = 0; j < NWARMUP; j++)
+    {
+      crypto_kem_dec(key_b, ct, &sk);
+    }
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERATIONS; j++)
+    {
+      crypto_kem_dec(key_b, ct, &sk);
     }
     t1 = get_cyclecounter();
     cycles_dec[i] = t1 - t0;
@@ -117,8 +181,19 @@ static int bench(void)
   qsort(cycles_enc, NTESTS, sizeof(uint64_t), cmp_uint64_t);
   qsort(cycles_dec, NTESTS, sizeof(uint64_t), cmp_uint64_t);
 
+  qsort(cycles_ser_sk, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+  qsort(cycles_ser_pk, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+  qsort(cycles_deser_sk, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+  qsort(cycles_deser_pk, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+
   print_median("keypair", cycles_kg);
+  print_median("serialize_pk", cycles_ser_pk);
+  print_median("serialize_sk", cycles_ser_sk);
+
+  print_median("deserialize_pk", cycles_deser_pk);
   print_median("encaps", cycles_enc);
+
+  print_median("deserialize_sk", cycles_deser_sk);
   print_median("decaps", cycles_dec);
 
   printf("\n");
@@ -126,7 +201,13 @@ static int bench(void)
   print_percentile_legend();
 
   print_percentiles("keypair", cycles_kg);
+  print_percentiles("serialize_pk", cycles_ser_pk);
+  print_percentiles("serialize_sk", cycles_ser_sk);
+
+  print_percentiles("deserialize_pk", cycles_deser_pk);
   print_percentiles("encaps", cycles_enc);
+
+  print_percentiles("deserialize_sk", cycles_deser_sk);
   print_percentiles("decaps", cycles_dec);
 
   return 0;

--- a/test/test_mlkem.c
+++ b/test/test_mlkem.c
@@ -19,25 +19,20 @@
 
 static int test_keys(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  mlkem_public_key pk;
+  mlkem_secret_key sk;
   uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
   uint8_t key_a[CRYPTO_BYTES];
   uint8_t key_b[CRYPTO_BYTES];
 
-  /* Alice generates a public key */
-  crypto_kem_keypair(pk, sk);
+  // Alice generates a public key
+  crypto_kem_keypair(&pk, &sk);
 
-#ifdef ENABLE_CT_TESTING
-  /* mark public key as public (=defined) */
-  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
-#endif
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, &pk);
 
-  /* Bob derives a secret key and creates a response */
-  crypto_kem_enc(ct, key_b, pk);
-
-  /* Alice uses Bobs response to get her shared key */
-  crypto_kem_dec(key_a, ct, sk);
+  // Alice uses Bobs response to get her shared key
+  crypto_kem_dec(key_a, ct, &sk);
 
 #ifdef ENABLE_CT_TESTING
   /* mark as defined, so we can compare */
@@ -54,23 +49,64 @@ static int test_keys(void)
   return 0;
 }
 
+static int test_keys_serialized(void)
+{
+  mlkem_public_key pk;
+  mlkem_secret_key sk;
+  uint8_t pks[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sks[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key_a[CRYPTO_BYTES];
+  uint8_t key_b[CRYPTO_BYTES];
+
+  // Alice generates a public key
+  crypto_kem_keypair(&pk, &sk);
+
+  // serialize keys
+  crypto_kem_serialize_pk(pks, &pk);
+  crypto_kem_serialize_sk(sks, &sk);
+
+  // zero out keys to be sure serialization works properly
+  memset(&pk, 0, sizeof(mlkem_public_key));
+  memset(&sk, 0, sizeof(mlkem_secret_key));
+
+  // deserialize keys
+  crypto_kem_deserialize_pk(&pk, pks);
+  crypto_kem_deserialize_sk(&sk, sks);
+
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, &pk);
+
+  // Alice uses Bobs response to get her shared key
+  crypto_kem_dec(key_a, ct, &sk);
+
+  if (memcmp(key_a, key_b, CRYPTO_BYTES))
+  {
+    printf("ERROR keys (serialized)\n");
+    return 1;
+  }
+
+  return 0;
+}
+
 static int test_invalid_pk(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pks[CRYPTO_PUBLICKEYBYTES];
+  mlkem_public_key pk;
+  mlkem_secret_key sk;
   uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
   uint8_t key_b[CRYPTO_BYTES];
   int rc;
-  /* Alice generates a public key */
-  crypto_kem_keypair(pk, sk);
+  // Alice generates a public key
+  crypto_kem_keypair(&pk, &sk);
 
-#ifdef ENABLE_CT_TESTING
-  /* mark public key as public (=defined) */
-  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
-#endif
 
-  /* Bob derives a secret key and creates a response */
-  rc = crypto_kem_enc(ct, key_b, pk);
+  crypto_kem_serialize_pk(pks, &pk);
+  memset(&pk, 0, sizeof(mlkem_public_key));
+  crypto_kem_deserialize_pk(&pk, pks);
+
+  // Bob derives a secret key and creates a response
+  rc = crypto_kem_enc(ct, key_b, &pk);
 
   if (rc)
   {
@@ -78,11 +114,12 @@ static int test_invalid_pk(void)
     return 1;
   }
 
-  /* set first public key coefficient to 4095 (0xFFF) */
-  pk[0] = 0xFF;
-  pk[1] |= 0x0F;
-  /* Bob derives a secret key and creates a response */
-  rc = crypto_kem_enc(ct, key_b, pk);
+  // set first public key coefficient to 4095 (0xFFF)
+  pks[0] = 0xFF;
+  pks[1] |= 0x0F;
+
+  memset(&pk, 0, sizeof(mlkem_public_key));
+  rc = crypto_kem_deserialize_pk(&pk, pks);
 
   if (!rc)
   {
@@ -94,32 +131,30 @@ static int test_invalid_pk(void)
 
 static int test_invalid_sk_a(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  mlkem_public_key pk;
+  mlkem_secret_key sk;
+  uint8_t sks[CRYPTO_SECRETKEYBYTES];
   uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
   uint8_t key_a[CRYPTO_BYTES];
   uint8_t key_b[CRYPTO_BYTES];
   int rc;
 
-  /* Alice generates a public key */
-  crypto_kem_keypair(pk, sk);
+  // Alice generates a public key
+  crypto_kem_keypair(&pk, &sk);
 
-#ifdef ENABLE_CT_TESTING
-  /* mark public key as public (=defined) */
-  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
-#endif
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, &pk);
 
-  /* Bob derives a secret key and creates a response */
-  crypto_kem_enc(ct, key_b, pk);
 
-  /* Replace first part of secret key with random values */
-  randombytes(sk, 10);
+  crypto_kem_serialize_sk(sks, &sk);
+  memset(&sk, 0, sizeof(mlkem_secret_key));
+  // Replace first part of secret key with random values
+  randombytes(sks, 10);
+  crypto_kem_deserialize_sk(&sk, sks);
 
-  /*
-   * Alice uses Bobs response to get her shared key
-   * This should fail due to wrong sk
-   */
-  rc = crypto_kem_dec(key_a, ct, sk);
+  // Alice uses Bobs response to get her shared key
+  // This should fail due to wrong sk
+  rc = crypto_kem_dec(key_a, ct, &sk);
   if (rc)
   {
     printf("ERROR test_invalid_sk_a\n");
@@ -141,47 +176,11 @@ static int test_invalid_sk_a(void)
   return 0;
 }
 
-static int test_invalid_sk_b(void)
-{
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_a[CRYPTO_BYTES];
-  uint8_t key_b[CRYPTO_BYTES];
-  int rc;
-
-  /* Alice generates a public key */
-  crypto_kem_keypair(pk, sk);
-
-#ifdef ENABLE_CT_TESTING
-  /* mark public key as public (=defined) */
-  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
-#endif
-
-  /* Bob derives a secret key and creates a response */
-  crypto_kem_enc(ct, key_b, pk);
-
-  /* Replace H(pk) with radom values; */
-  randombytes(sk + CRYPTO_SECRETKEYBYTES - 64, 32);
-
-  /*
-   * Alice uses Bobs response to get her shared key
-   * This should fail due to the input validation
-   */
-  rc = crypto_kem_dec(key_a, ct, sk);
-  if (!rc)
-  {
-    printf("ERROR test_invalid_sk_b\n");
-    return 1;
-  }
-
-  return 0;
-}
 
 static int test_invalid_ciphertext(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  mlkem_public_key pk;
+  mlkem_secret_key sk;
   uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
   uint8_t key_a[CRYPTO_BYTES];
   uint8_t key_b[CRYPTO_BYTES];
@@ -198,27 +197,17 @@ static int test_invalid_ciphertext(void)
   } while (!b);
   randombytes((uint8_t *)&pos, sizeof(size_t));
 
+  // Alice generates a public key
+  crypto_kem_keypair(&pk, &sk);
 
-#ifdef ENABLE_CT_TESTING
-  VALGRIND_MAKE_MEM_DEFINED(&pos, sizeof(size_t));
-#endif
-
-  /* Alice generates a public key */
-  crypto_kem_keypair(pk, sk);
-
-#ifdef ENABLE_CT_TESTING
-  /* mark public key as public (=defined) */
-  VALGRIND_MAKE_MEM_DEFINED(pk, CRYPTO_PUBLICKEYBYTES);
-#endif
-
-  /* Bob derives a secret key and creates a response */
-  crypto_kem_enc(ct, key_b, pk);
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, &pk);
 
   /* Change some byte in the ciphertext (i.e., encapsulated key) */
   ct[pos % CRYPTO_CIPHERTEXTBYTES] ^= b;
 
-  /* Alice uses Bobs response to get her shared key */
-  crypto_kem_dec(key_a, ct, sk);
+  // Alice uses Bobs response to get her shared key
+  crypto_kem_dec(key_a, ct, &sk);
 
 #ifdef ENABLE_CT_TESTING
   /* mark as defined, so we can compare */
@@ -272,7 +261,7 @@ static int test_poly_compress_no_overflow(void)
     poly_decompress_d10(&s, r);
   }
 #endif /* defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 \
-          || MLKEM_K == 3) */
+|| MLKEM_K == 3) */
 
 #if defined(MLKEM_NATIVE_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4
   {
@@ -315,9 +304,9 @@ int main(void)
   for (i = 0; i < NTESTS; i++)
   {
     r = test_keys();
+    r |= test_keys_serialized();
     r |= test_invalid_pk();
     r |= test_invalid_sk_a();
-    r |= test_invalid_sk_b();
     r |= test_invalid_ciphertext();
     r |= test_poly_compress_no_overflow();
     if (r)


### PR DESCRIPTION
This PR rebases an old proposal for extending the API to allow operating on validated+expanded keys. 
Benefit of this is that in case you can keep the keys expanded, you get much better performance. This is particularly useful for an ephemeral use-case (e.g., TLS), where the secret key never has to leave memory.

This is far from being ready, but I'd like to kick off a discussion on how the API should look like.
One point I do not like about this anymore is that it _changes_ the signature of the previous API - It would be cleaner to just add new functions and implement the old 3-function API on top of the new API. Downside of that is that we will have a lot of functions.

Once we have consensus on _how_ to do this, there is still some work to do here: I have not addressed C90 complaince, constant-time tests, and CBMC proofs. Also currently the user (through `mlkem_native.h`) requires to know the details of the key structs - this should be changed to be a generic `uint8_t` array of the right size.