### PR TITLE
Properly lint+format all Python scripts

### DIFF
--- a/scripts/check-namespace
+++ b/scripts/check-namespace
@@ -68,10 +68,12 @@ def check_folder(folder, namespace):
 def make_mlkem_namespace(lvl):
     return [f"PQCP_MLKEM_NATIVE_MLKEM{lvl}"]
 
+
 def run():
     check_folder("test/build/mlkem512/mlkem", make_mlkem_namespace(512))
     check_folder("test/build/mlkem768/mlkem", make_mlkem_namespace(768))
     check_folder("test/build/mlkem1024/mlkem", make_mlkem_namespace(1024))
+
 
 if __name__ == "__main__":
     run()

--- a/scripts/format
+++ b/scripts/format
@@ -39,7 +39,7 @@ if ! command -v black 2>&1 >/dev/null; then
   echo "black not found. Are you running in a nix shell? See BUILDING.md."
   exit 1
 fi
-black --include "(scripts/tests|scripts/simpasm|scripts/autogen|\.py$)" "$ROOT"
+black --include "(scripts/tests|scripts/simpasm|scripts/autogen|scripts/check-namespace|\.py$)" "$ROOT"
 
 info "Formatting c files"
 if ! command -v clang-format 2>&1 >/dev/null; then

--- a/scripts/lint
+++ b/scripts/lint
@@ -48,7 +48,7 @@ checkerr "Lint shell" "$(shfmt -s -l -i 2 -ci -fn $(shfmt -f $(git grep -l '' :/
 echo "::endgroup::"
 
 echo "::group::Linting python scripts with black"
-if ! diff=$(black --check --diff -q --include "(scripts/tests|\.py$)" "$ROOT"); then
+if ! diff=$(black --check --diff -q --include "(scripts/tests|scripts/simpasm|scripts/autogen|scripts/check-namespace|\.py$)" "$ROOT"); then
   echo "::error title=Format error::$diff"
   SUCCESS=false
   echo ":x: Lint python" >>"$GITHUB_STEP_SUMMARY"

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -257,8 +257,8 @@ def simplify(logger, args, asm_input, asm_output=None):
             "",
             "",
             ".text",
-            ".balign 4"
-            ]
+            ".balign 4",
+        ]
 
         if args.preserve_preprocessor_directives is False:
             if platform.system() == "Darwin" and sym[0] == "_":


### PR DESCRIPTION
The simpasm script was only included in the format script, but not in the lint script. Wrong formatting was, hence, not detected before.
This commit fixed the formatting and also adds the script to the linter.
Same applies to the check-namespace script.

