### PR TITLE
Monobuild: Build library file as intermediate

### DIFF
--- a/examples/monolithic_build/Makefile
+++ b/examples/monolithic_build/Makefile
@@ -6,10 +6,17 @@
 # Append cross-prefix for cross compilation
 # Remove or ignore for native builds
 CC  ?= gcc
+AR  ?= ar
 # When called from the root Makefile, CROSS_PREFIX has already been added here
 ifeq (,$(findstring $(CROSS_PREFIX),$(CC)))
 CC  := $(CROSS_PREFIX)$(CC)
 endif
+
+ifeq (,$(findstring $(CROSS_PREFIX),$(AR)))
+AR  := $(CROSS_PREFIX)$(AR)
+endif
+
+Q ?= @
 
 # Part A:
 #
@@ -37,12 +44,15 @@ RNG_SOURCE=$(wildcard test_only_rng/*.c)
 # Part C:
 #
 # Your application source code
-APP_SOURCE=main.c
-
-ALL_SOURCE=$(RNG_SOURCE) $(APP_SOURCE) $(MLKEM_NATIVE_SOURCE)
+APP_SOURCE=$(RNG_SOURCE) main.c
 
 BUILD_DIR=build
-BIN=test_binary
+BIN512=test_binary_mlkem512
+BIN768=test_binary_mlkem768
+BIN1024=test_binary_mlkem1024
+LIB512=libmlkem512.a
+LIB768=libmlkem768.a
+LIB1024=libmlkem1024.a
 
 CFLAGS := \
 	-Wall \
@@ -59,25 +69,63 @@ CFLAGS := \
 	-std=c99 \
 	-pedantic \
 	-MMD \
-        -DMLKEM_NATIVE_CONFIG_FILE="\"config_512.h\""\
-	$(CFLAGS)
+        $(CFLAGS)
 
 # Set this flag to give all non-global functions internal linkage
 CFLAGS += -DMLKEM_NATIVE_MONOBUILD
 
-BINARY_NAME_FULL=$(BUILD_DIR)/$(BIN)
+BIN512_FULL=$(BUILD_DIR)/$(BIN512)
+BIN768_FULL=$(BUILD_DIR)/$(BIN768)
+BIN1024_FULL=$(BUILD_DIR)/$(BIN1024)
 
-$(BINARY_NAME_FULL): $(ALL_SOURCE)
-	echo "$@"
-	mkdir -p $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INC) $^ -o $@
+LIB512_FULL=$(BUILD_DIR)/$(LIB512)
+LIB768_FULL=$(BUILD_DIR)/$(LIB768)
+LIB1024_FULL=$(BUILD_DIR)/$(LIB1024)
+
+$(LIB512_FULL): $(MLKEM_NATIVE_SOURCE)
+	$(Q)echo "$@"
+	$(Q)[ -d $(@) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c $(CFLAGS) -DMLKEM_NATIVE_CONFIG_FILE="\"config_512.h\"" $(INC) $^ -o $(BUILD_DIR)/mlkem_native512.o
+	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mlkem_native512.o
+	$(Q)strip -S $@
+
+$(LIB768_FULL): $(MLKEM_NATIVE_SOURCE)
+	$(Q)echo "$@"
+	$(Q)[ -d $(@) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c $(CFLAGS) -DMLKEM_NATIVE_CONFIG_FILE="\"config_768.h\"" $(INC) $^ -o $(BUILD_DIR)/mlkem_native768.o
+	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mlkem_native768.o
+	$(Q)strip -S $@
+
+$(LIB1024_FULL): $(MLKEM_NATIVE_SOURCE)
+	$(Q)echo "$@"
+	$(Q)[ -d $(@) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c $(CFLAGS) -DMLKEM_NATIVE_CONFIG_FILE="\"config_1024.h\"" $(INC) $^ -o $(BUILD_DIR)/mlkem_native1024.o
+	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mlkem_native1024.o
+	$(Q)strip -S $@
+
+$(BIN512_FULL): $(APP_SOURCE) $(LIB512_FULL)
+	$(Q)echo "$@"
+	$(Q)[ -d $(@) ] || mkdir -p $(@D)
+	$(Q)$(CC) $(CFLAGS) -DMLKEM_NATIVE_CONFIG_FILE="\"config_512.h\"" $(INC) $^ -o $@
+
+$(BIN768_FULL): $(APP_SOURCE) $(LIB768_FULL)
+	$(Q)echo "$@"
+	$(Q)[ -d $(@) ] || mkdir -p $(@D)
+	$(Q)$(CC) $(CFLAGS) -DMLKEM_NATIVE_CONFIG_FILE="\"config_768.h\"" $(INC) $^ -o $@
+
+$(BIN1024_FULL): $(APP_SOURCE) $(LIB1024_FULL)
+	$(Q)echo "$@"
+	$(Q)[ -d $(@) ] || mkdir -p $(@D)
+	$(Q)$(CC) $(CFLAGS) -DMLKEM_NATIVE_CONFIG_FILE="\"config_1024.h\"" $(INC) $^ -o $@
 
 all: build
 
-build: $(BINARY_NAME_FULL)
+build: $(BIN512_FULL) $(BIN768_FULL) $(BIN1024_FULL)
 
-run: $(BINARY_NAME_FULL)
-	$(EXEC_WRAPPER) ./$(BINARY_NAME_FULL)
+run: $(BIN512_FULL) $(BIN768_FULL) $(BIN1024_FULL)
+	$(Q)$(EXEC_WRAPPER) ./$(BIN512_FULL)
+	$(Q)$(EXEC_WRAPPER) ./$(BIN768_FULL)
+	$(Q)$(EXEC_WRAPPER) ./$(BIN1024_FULL)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/examples/monolithic_build/config_1024.h
+++ b/examples/monolithic_build/config_1024.h
@@ -18,7 +18,7 @@
  *
  *****************************************************************************/
 #ifndef MLKEM_K
-#define MLKEM_K 2 /* Change this for different security strengths */
+#define MLKEM_K 4 /* Change this for different security strengths */
 #endif
 
 /******************************************************************************

--- a/examples/monolithic_build/config_768.h
+++ b/examples/monolithic_build/config_768.h
@@ -18,7 +18,7 @@
  *
  *****************************************************************************/
 #ifndef MLKEM_K
-#define MLKEM_K 2 /* Change this for different security strengths */
+#define MLKEM_K 3 /* Change this for different security strengths */
 #endif
 
 /******************************************************************************

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -9,36 +9,36 @@
 
 #include "mlkem_native.h"
 
-static int test_keys_mlkem512(void)
+static int test_keys_mlkem(void)
 {
-  uint8_t pk[MLKEM512_PUBLICKEYBYTES];
-  uint8_t sk[MLKEM512_SECRETKEYBYTES];
-  uint8_t ct[MLKEM512_CIPHERTEXTBYTES];
-  uint8_t key_a[MLKEM512_BYTES];
-  uint8_t key_b[MLKEM512_BYTES];
+  uint8_t pk[MLKEM_PUBLICKEYBYTES(BUILD_INFO_LVL)];
+  uint8_t sk[MLKEM_SECRETKEYBYTES(BUILD_INFO_LVL)];
+  uint8_t ct[MLKEM_CIPHERTEXTBYTES(BUILD_INFO_LVL)];
+  uint8_t key_a[MLKEM_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
 
   /* Alice generates a public key */
-  mlkem512_keypair(pk, sk);
+  mlkem_keypair(pk, sk);
 
   /* Bob derives a secret key and creates a response */
-  mlkem512_enc(ct, key_b, pk);
+  mlkem_enc(ct, key_b, pk);
 
   /* Alice uses Bobs response to get her shared key */
-  mlkem512_dec(key_a, ct, sk);
+  mlkem_dec(key_a, ct, sk);
 
-  if (memcmp(key_a, key_b, MLKEM512_BYTES))
+  if (memcmp(key_a, key_b, MLKEM_BYTES))
   {
-    printf("[MLKEM-512] ERROR keys\n");
+    printf("[MLKEM] ERROR keys\n");
     return 1;
   }
 
-  printf("[MLKEM-512] OK\n");
+  printf("[MLKEM-%d] OK\n", BUILD_INFO_LVL);
   return 0;
 }
 
 int main(void)
 {
-  if (test_keys_mlkem512() != 0)
+  if (test_keys_mlkem() != 0)
   {
     return 1;
   }

--- a/examples/monolithic_build_multilevel/Makefile
+++ b/examples/monolithic_build_multilevel/Makefile
@@ -6,9 +6,14 @@
 # Append cross-prefix for cross compilation
 # Remove or ignore for native builds
 CC  ?= gcc
+AR  ?= ar
 # When called from the root Makefile, CROSS_PREFIX has already been added here
 ifeq (,$(findstring $(CROSS_PREFIX),$(CC)))
 CC  := $(CROSS_PREFIX)$(CC)
+endif
+
+ifeq (,$(findstring $(CROSS_PREFIX),$(AR)))
+AR  := $(CROSS_PREFIX)$(AR)
 endif
 
 # Part A:
@@ -37,12 +42,11 @@ RNG_SOURCE=$(wildcard test_only_rng/*.c)
 # Part C:
 #
 # Your application source code
-APP_SOURCE=main.c
-
-ALL_SOURCE=$(RNG_SOURCE) $(APP_SOURCE) $(MLKEM_NATIVE_SOURCE)
+APP_SOURCE=$(RNG_SOURCE) main.c
 
 BUILD_DIR=build
 BIN=test_binary
+LIB=libmlkem.a
 
 CFLAGS := \
 	-Wall \
@@ -63,8 +67,16 @@ CFLAGS := \
 CFLAGS += -DMLKEM_NATIVE_MONOBUILD
 
 BINARY_NAME_FULL=$(BUILD_DIR)/$(BIN)
+LIB_NAME_FULL=$(BUILD_DIR)/$(LIB)
 
-$(BINARY_NAME_FULL): $(ALL_SOURCE)
+$(LIB_NAME_FULL): $(MLKEM_NATIVE_SOURCE)
+	echo "$@"
+	mkdir -p $(BUILD_DIR)
+	$(CC) -c $(CFLAGS) $(INC) $^ -o $(BUILD_DIR)/mlkem_native.o
+	$(AR) rcs $@ $(BUILD_DIR)/mlkem_native.o
+	strip -S $@
+
+$(BINARY_NAME_FULL): $(APP_SOURCE) $(LIB_NAME_FULL)
 	echo "$@"
 	mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INC) $^ -o $@


### PR DESCRIPTION
This commit modifies the examples `monolithic_build` and `monolithic_build_multilevel` to create `libmlkemXXX.a` build artifacts as intermediate results, before linking against the application source.

Those intermediates are good targets for future code-size measurements, because in a monobuild the compiler has visibility into what is public and what is internal.
