### PR TITLE
Benchmarking: Use vector instructions on Banana Pi F3 

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,9 +46,9 @@ jobs:
           cflags: "-flto -static -DFORCE_AARCH64 -DMLKEM_NATIVE_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/cortex_a55.h\\\\\\\""
           bench_extra_args: -w exec-on-a55
         - system: bpi
-          name: Bananapi bpi-f3 benchmarks
+          name: SpacemiT K1 8 (Banana Pi F3) benchmarks
           bench_pmu: PERF
-          archflags: "-march=rv64imafdc_zicsr_zifencei"
+          archflags: "-march=rv64imafdcv_zicsr_zifencei"
           cflags: "-static"
           bench_extra_args: -w exec-on-bpi
           cross_prefix: riscv64-unknown-linux-gnu-


### PR DESCRIPTION
The SpacemiT K1 8 (Banana Pi F3) supports the RV vector extension
with 512-bit vectors.
Currently, in our benchamrks this remains unused as we compile with
`-march=rv64imafdc_zicsr_zifencei`.
Changing this to
`-march=rv64imafdcv_zicsr_zifencei` will make use of vector instructions
resulting in a significant speed-up.

| Benchmark suite | Current: a41d163217fd0482e7b5995c2038495b0e12d0fd | Previous: df9eb51fa5e87f09e101ce5dd30ff690f6e77fc7 | Ratio |
|-|-|-|-|
| `ML-KEM-512 keypair` | `225141` cycles | `308758` cycles | `0.73` |
| `ML-KEM-512 encaps` | `269656` cycles | `412471` cycles | `0.65` |
| `ML-KEM-512 decaps` | `343348` cycles | `554475` cycles | `0.62` |
| `ML-KEM-768 keypair` | `371206` cycles | `505135` cycles | `0.73` |
| `ML-KEM-768 encaps` | `429962` cycles | `635555` cycles | `0.68` |
| `ML-KEM-768 decaps` | `527673` cycles | `817507` cycles | `0.65` |
| `ML-KEM-1024 keypair` | `555406` cycles | `730906` cycles | `0.76` |
| `ML-KEM-1024 encaps` | `631268` cycles | `891441` cycles | `0.71` |
| `ML-KEM-1024 decaps` | `752417` cycles | `1107562` cycles | `0.68` |

see https://github.com/pq-code-package/mlkem-native/pull/742#pullrequestreview-2594517343

Thanks for catching this @rod-chapman - this will be a much better baseline for a future RVV backend.

Resolves https://github.com/pq-code-package/mlkem-native/issues/741