### PR TITLE
CI: Only cache one valgrind per arch

### DIFF
--- a/.github/actions/ct-test/action.yml
+++ b/.github/actions/ct-test/action.yml
@@ -14,6 +14,28 @@ inputs:
 runs:
   using: composite
   steps:
+      - name: System info
+        shell: ${{ env.SHELL }}
+        run: |
+          ARCH=$(uname -m)
+          echo <<-EOF
+            ## Setup
+            Architecture: $ARCH
+            - $(uname -a)
+            - $(nix --version || echo 'nix not present')
+            - $(bash --version | grep -m1 "")
+            - $(python3 --version)
+            - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
+          EOF
+          cat >> $GITHUB_STEP_SUMMARY <<-EOF
+            ## Setup
+            Architecture: $ARCH
+            - $(uname -a)
+            - $(nix --version || echo 'nix not present')
+            - $(bash --version | grep -m1 "")
+            - $(python3 --version)
+            - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
+          EOF
       - shell: ${{ env.SHELL }}
         run: |
           make clean

--- a/.github/actions/setup-shell/action.yml
+++ b/.github/actions/setup-shell/action.yml
@@ -10,6 +10,9 @@ inputs:
   nix-cache:
     description: Determine whether to enable nix cache
     default: 'false'
+  nix-cache-prefix:
+    description: Fixed prefix of ID of Github cache entries that should be removed.
+    required: false
   nix-verbose:
     description: Determine wether to suppress nix log or not
     default: 'false'
@@ -35,6 +38,7 @@ runs:
         verbose: ${{ inputs.nix-verbose }}
         cache: ${{ inputs.nix-cache }}
         script: ${{ inputs.script }}
+        cache_prefix: ${{ inputs.nix-cache-prefix }}
     - name: Set custom shell
       shell: bash
       if: ${{ inputs.nix-shell == '' }}

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -44,6 +44,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           nix-shell: ${{ matrix.nix-shell }}
           nix-cache: true
+          nix-cache-prefix: valgrind-${{ runner.os }}-${{ runner.arch }}
       - name:  Build and run test (-Oz)
         # -Oz got introduced in gcc12
         if: ${{ matrix.nix-shell !=  'ci_valgrind-varlat_gcc48' && matrix.nix-shell !=  'ci_valgrind-varlat_gcc49' && matrix.nix-shell !=  'ci_valgrind-varlat_gcc7' && matrix.nix-shell !=  'ci_valgrind-varlat_gcc11'}}


### PR DESCRIPTION
We are using a patched valgrind for the ct tests
which is built in CI and  then cached in the Github Cache. Currently we are using many different compilers for these tests. Currently, for each of these compilers valgrind is recompiled and cached taking up 600-800 MB per
each of the 26 compiler/arch combinations.
We only have 10 GB of cache, so we are constantly triggering cache evictions.
This leads to painfully slow tests for other tests that due to that have to recompile gcc which takes around 45 minutes.

This commit changes the cache key for valgrind to only contain the OS and arch, but not the compiler version.
