### PR TITLE
Benchmarks: Switch to ci_gcc14 shell instead of ci

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: true
   nix-shell:
     description: Run in the specified Nix environment if exists
-    default: "ci"
+    default: "ci_gcc14"
   nix-cache:
     description: Determine whether to enable nix cache
     default: 'false'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -65,7 +65,7 @@ jobs:
           store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
           bench_extra_args: ${{ matrix.target.bench_extra_args }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci' }}
+          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci_gcc14' }}
           cross_prefix: ${{ matrix.target.cross_prefix }}
 
   ec2_all:

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: ./.github/actions/bench
         if: ${{ inputs.opt == 'all' || inputs.opt == 'opt' }}
         with:
-          nix-shell: ''
+          nix-shell: 'ci_gcc14'
           custom-shell: 'bash'
           nix-cache: false
           nix-verbose: ${{ inputs.verbose }}
@@ -183,7 +183,7 @@ jobs:
       - uses: ./.github/actions/bench
         if: ${{ inputs.opt == 'all' || inputs.opt == 'no_opt' }}
         with:
-          nix-shell: ''
+          nix-shell: 'ci_gcc14'
           custom-shell: 'bash'
           nix-cache: false
           nix-verbose: ${{ inputs.verbose }}


### PR DESCRIPTION
https://github.com/pq-code-package/mlkem-native/pull/740 added
linters to the main ci nix shell - however that includes the
heavyweight LLVM. This breaks our benchmarking.

This commit switches to the more lightweight ci_gcc14 shell.
