### PR TITLE
Benchmarks: Add new benchmarking shell

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: true
   nix-shell:
     description: Run in the specified Nix environment if exists
-    default: "ci_gcc14"
+    default: "ci-bench"
   nix-cache:
     description: Determine whether to enable nix cache
     default: 'false'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -65,7 +65,7 @@ jobs:
           store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }}
           bench_extra_args: ${{ matrix.target.bench_extra_args }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci_gcc14' }}
+          nix-shell: ${{ matrix.target.cross_prefix != '' && 'ci-cross' || 'ci-bench' }}
           cross_prefix: ${{ matrix.target.cross_prefix }}
 
   ec2_all:

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: ./.github/actions/bench
         if: ${{ inputs.opt == 'all' || inputs.opt == 'opt' }}
         with:
-          nix-shell: 'ci_gcc14'
+          nix-shell: 'ci-bench'
           custom-shell: 'bash'
           nix-cache: false
           nix-verbose: ${{ inputs.verbose }}
@@ -183,7 +183,7 @@ jobs:
       - uses: ./.github/actions/bench
         if: ${{ inputs.opt == 'all' || inputs.opt == 'no_opt' }}
         with:
-          nix-shell: 'ci_gcc14'
+          nix-shell: 'ci-bench'
           custom-shell: 'bash'
           nix-cache: false
           nix-verbose: ${{ inputs.verbose }}

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
           };
 
           devShells.ci = util.wrapShell util.mkShell { packages = util.linters ++ util.core { cross = false; }; };
+          devShells.ci-bench = util.wrapShell util.mkShell { packages = util.core { cross = false; }; };
           devShells.ci-cross = util.wrapShell util.mkShell { packages = util.linters ++ util.core { }; };
           devShells.ci-cbmc = util.wrapShell util.mkShell { packages = util.core { cross = false; } ++ [ config.packages.cbmc ]; };
           devShells.ci-cbmc-cross = util.wrapShell util.mkShell { packages = util.core { } ++ [ config.packages.cbmc ]; };


### PR DESCRIPTION
https://github.com/pq-code-package/mlkem-native/pull/747 switched the benchmarking from the ci shell to the ci-gcc14 shell. While this is sufficient for most platforms, it breaks benchmarks on platforms that do not run the Github actions locally, but instead need binaries copied over the network and run through ssh.

This PR fixes that as well and adds a new dedicated benchmarking shell which is the same as the ci shell prior to #740.
