### PR TITLE
Fix include guard for clean AArch64 native implementation

### DIFF
--- a/dev/aarch64_clean/src/rej_uniform_asm_clean.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm_clean.S
@@ -19,8 +19,8 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if defined(MLKEM_NATIVE_ARITH_BACKEND_AARCH64_CLEAN) || \
-    defined(MLKEM_NATIVE_ARITH_BACKEND_AARCH64_OPT)
+#if defined(MLKEM_NATIVE_ARITH_BACKEND_AARCH64_CLEAN) && \
+    !defined(MLKEM_NATIVE_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
 // We save the output on the stack first, and copy to the actual
@@ -404,5 +404,5 @@ return:
     .unreq bits
 
 /* simpasm: footer-start */
-#endif /* defined(MLKEM_NATIVE_ARITH_BACKEND_AARCH64_CLEAN) ||
-          defined(MLKEM_NATIVE_ARITH_BACKEND_AARCH64_OPT) */
+#endif /* MLKEM_NATIVE_ARITH_BACKEND_AARCH64_CLEAN &&
+          !MLKEM_NATIVE_MULTILEVEL_BUILD_NO_SHARED */


### PR DESCRIPTION
* Fix https://github.com/pq-code-package/mlkem-native/issues/749