### PR TITLE
autogen/monobuild: Guard inclusion of FIPS-202 sources

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -13,13 +13,19 @@
  * mlkem-native
  */
 
+/* If parts of the mlkem-native source tree are not used,
+ * consider reducing this header via `unifdef`.
+ *
+ * Example:
+ * ```bash
+ * unifdef -UMLK_MONOBUILD_WITH_NATIVE_ARITH mlkem_native_monobuild.c
+ * ```
+ */
+
 #include "mlkem/sys.h"
 
 #include "mlkem/compress.c"
 #include "mlkem/debug.c"
-#include "mlkem/fips202/fips202.c"
-#include "mlkem/fips202/fips202x4.c"
-#include "mlkem/fips202/keccakf1600.c"
 #include "mlkem/indcpa.c"
 #include "mlkem/kem.c"
 #include "mlkem/poly.c"
@@ -27,6 +33,13 @@
 #include "mlkem/sampling.c"
 #include "mlkem/verify.c"
 #include "mlkem/zetas.c"
+
+#if !defined(MLK_MONOBUILD_CUSTOM_FIPS202)
+#include "mlkem/fips202/fips202.c"
+#include "mlkem/fips202/fips202x4.c"
+#include "mlkem/fips202/keccakf1600.c"
+#endif /* !MLK_MONOBUILD_CUSTOM_FIPS202 */
+
 #if defined(MLK_MONOBUILD_WITH_NATIVE_ARITH)
 #if defined(MLK_SYS_AARCH64)
 #include "mlkem/native/aarch64/src/aarch64_zetas.c"
@@ -40,6 +53,7 @@
 #include "mlkem/native/x86_64/src/rej_uniform_table.c"
 #endif /* MLK_SYS_X86_64 */
 #endif /* MLK_MONOBUILD_WITH_NATIVE_ARITH */
+
 #if defined(MLK_MONOBUILD_WITH_NATIVE_FIPS202)
 #if defined(MLK_SYS_AARCH64)
 #include "mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c"
@@ -220,44 +234,6 @@
 #undef debug_assert_bound_2d
 #undef mlkem_debug_assert
 #undef mlkem_debug_check_bounds
-/* mlkem/fips202/fips202.h */
-#undef FIPS202_X4_DEFAULT_IMPLEMENTATION
-#undef MLK_FIPS202_FIPS202_H
-#undef SHA3_256_HASHBYTES
-#undef SHA3_256_RATE
-#undef SHA3_384_RATE
-#undef SHA3_512_HASHBYTES
-#undef SHA3_512_RATE
-#undef SHAKE128_RATE
-#undef SHAKE256_RATE
-#undef sha3_256
-#undef sha3_512
-#undef shake128_absorb_once
-#undef shake128_init
-#undef shake128_release
-#undef shake128_squeezeblocks
-#undef shake128ctx
-#undef shake256
-/* mlkem/fips202/fips202_backend.h */
-#undef MLK_FIPS202_FIPS202_BACKEND_H
-/* mlkem/fips202/fips202x4.h */
-#undef MLK_FIPS202_FIPS202X4_H
-#undef shake128x4_absorb_once
-#undef shake128x4_init
-#undef shake128x4_release
-#undef shake128x4_squeezeblocks
-#undef shake128x4ctx
-#undef shake256x4
-/* mlkem/fips202/keccakf1600.h */
-#undef KECCAK_LANES
-#undef KECCAK_WAY
-#undef KeccakF1600_StateExtractBytes
-#undef KeccakF1600_StatePermute
-#undef KeccakF1600_StateXORBytes
-#undef KeccakF1600x4_StateExtractBytes
-#undef KeccakF1600x4_StatePermute
-#undef KeccakF1600x4_StateXORBytes
-#undef MLK_FIPS202_KECCAKF1600_H
 /* mlkem/poly.h */
 #undef MLK_INVNTT_BOUND
 #undef MLK_NTT_BOUND
@@ -333,6 +309,51 @@
 #undef MLK_CBMC_H
 #undef __contract__
 #undef __loop__
+
+#if !defined(MLK_MONOBUILD_CUSTOM_FIPS202)
+/*
+ * Undefine macros from FIPS-202 files
+ */
+/* mlkem/fips202/fips202.h */
+#undef FIPS202_X4_DEFAULT_IMPLEMENTATION
+#undef MLK_FIPS202_FIPS202_H
+#undef SHA3_256_HASHBYTES
+#undef SHA3_256_RATE
+#undef SHA3_384_RATE
+#undef SHA3_512_HASHBYTES
+#undef SHA3_512_RATE
+#undef SHAKE128_RATE
+#undef SHAKE256_RATE
+#undef sha3_256
+#undef sha3_512
+#undef shake128_absorb_once
+#undef shake128_init
+#undef shake128_release
+#undef shake128_squeezeblocks
+#undef shake128ctx
+#undef shake256
+/* mlkem/fips202/fips202_backend.h */
+#undef MLK_FIPS202_FIPS202_BACKEND_H
+/* mlkem/fips202/fips202x4.h */
+#undef MLK_FIPS202_FIPS202X4_H
+#undef shake128x4_absorb_once
+#undef shake128x4_init
+#undef shake128x4_release
+#undef shake128x4_squeezeblocks
+#undef shake128x4ctx
+#undef shake256x4
+/* mlkem/fips202/keccakf1600.h */
+#undef KECCAK_LANES
+#undef KECCAK_WAY
+#undef KeccakF1600_StateExtractBytes
+#undef KeccakF1600_StatePermute
+#undef KeccakF1600_StateXORBytes
+#undef KeccakF1600x4_StateExtractBytes
+#undef KeccakF1600x4_StatePermute
+#undef KeccakF1600x4_StateXORBytes
+#undef MLK_FIPS202_KECCAKF1600_H
+#endif /* !MLK_MONOBUILD_CUSTOM_FIPS202 */
+
 #if defined(MLK_MONOBUILD_WITH_NATIVE_FIPS202)
 /*
  * Undefine macros from native code

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -663,23 +663,32 @@ def gen_monolithic_source_file(dry_run=False):
     def native(c):
         return "native/" in c
 
+    def fips202(c):
+        return "fips202" in c
+
+    def aarch64(c):
+        return "aarch64" in c
+
+    def x86_64(c):
+        return "x86_64" in c
+
     def native_fips202(c):
-        return native(c) and "fips202" in c
+        return native(c) and fips202(c)
 
     def native_arith(c):
-        return native(c) and not native_fips202(c)
+        return native(c) and not fips202(c)
 
     def native_fips202_aarch64(c):
-        return native_fips202(c) and "aarch64" in c
+        return native_fips202(c) and aarch64(c)
 
     def native_fips202_x86_64(c):
-        return native_fips202(c) and "x86_64" in c
+        return native_fips202(c) and x86_64(c)
 
     def native_arith_aarch64(c):
-        return native_arith(c) and "aarch64" in c
+        return native_arith(c) and aarch64(c)
 
     def native_arith_x86_64(c):
-        return native_arith(c) and "x86_64" in c
+        return native_arith(c) and x86_64(c)
 
     # List of level-specific source files
     # All other files only need including and building once
@@ -712,10 +721,25 @@ def gen_monolithic_source_file(dry_run=False):
         yield " * Monolithic compilation unit bundling all compilation units within mlkem-native"
         yield " */"
         yield ""
+        yield "/* If parts of the mlkem-native source tree are not used,"
+        yield " * consider reducing this header via `unifdef`."
+        yield " *"
+        yield " * Example:"
+        yield " * ```bash"
+        yield " * unifdef -UMLK_MONOBUILD_WITH_NATIVE_ARITH mlkem_native_monobuild.c"
+        yield " * ```"
+        yield " */"
+        yield ""
         yield '#include "mlkem/sys.h"'
         yield ""
-        for c in filter(lambda c: not native(c), c_sources):
+        for c in filter(lambda c: not native(c) and not fips202(c), c_sources):
             yield f'#include "{c}"'
+        yield ""
+        yield "#if !defined(MLK_MONOBUILD_CUSTOM_FIPS202)"
+        for c in filter(lambda c: not native(c) and fips202(c), c_sources):
+            yield f'#include "{c}"'
+        yield "#endif /* !MLK_MONOBUILD_CUSTOM_FIPS202 */"
+        yield ""
         yield "#if defined(MLK_MONOBUILD_WITH_NATIVE_ARITH)"
         yield "#if defined(MLK_SYS_AARCH64)"
         for c in filter(native_arith_aarch64, c_sources):
@@ -726,6 +750,7 @@ def gen_monolithic_source_file(dry_run=False):
             yield f'#include "{c}"'
         yield "#endif /* MLK_SYS_X86_64 */"
         yield "#endif /* MLK_MONOBUILD_WITH_NATIVE_ARITH */"
+        yield ""
         yield "#if defined(MLK_MONOBUILD_WITH_NATIVE_FIPS202)"
         yield "#if defined(MLK_SYS_AARCH64)"
         for c in filter(native_fips202_aarch64, c_sources):
@@ -743,7 +768,10 @@ def gen_monolithic_source_file(dry_run=False):
         yield ""
         yield "#if !defined(MLK_MONOBUILD_KEEP_SHARED_HEADERS)"
         yield from gen_monolithic_undef_all_core(
-            filt=lambda c: not native(c) and k_generic(c) and "cbmc.h" not in c,
+            filt=lambda c: not native(c)
+            and k_generic(c)
+            and not fips202(c)
+            and "cbmc.h" not in c,
             desc="MLKEM_K-generic files",
         )
         # Handle cbmc.h manually -- most #define's therein are only defined when CBMC is set
@@ -753,6 +781,14 @@ def gen_monolithic_source_file(dry_run=False):
         yield "#undef MLK_CBMC_H"
         yield "#undef __contract__"
         yield "#undef __loop__"
+        yield ""
+        yield "#if !defined(MLK_MONOBUILD_CUSTOM_FIPS202)"
+        yield from gen_monolithic_undef_all_core(
+            filt=lambda c: not native(c) and k_generic(c) and fips202(c),
+            desc="FIPS-202 files",
+        )
+        yield "#endif /* !MLK_MONOBUILD_CUSTOM_FIPS202 */"
+        yield ""
         yield "#if defined(MLK_MONOBUILD_WITH_NATIVE_FIPS202)"
         yield from gen_monolithic_undef_all_core(
             filt=native_fips202, desc="native code"

--- a/scripts/format
+++ b/scripts/format
@@ -46,17 +46,23 @@ if ! command -v clang-format 2>&1 >/dev/null; then
   echo "clang-format not found. Are you running in a nix shell? See BUILDING.md."
   exit 1
 fi
-clang-format -i $(git ls-files ":/*.c" ":/*.h" | xargs -I {} sh -c "[ ! -L {} ] && echo '{}'")
+
+nproc=$(getconf _NPROCESSORS_ONLN || echo 1)
+
+git ls-files -- ":/*.c" ":/*.h" | xargs -P $nproc -I {} sh -c '
+  # Ignore symlinks
+  if [[ ! -L {} ]]; then
+    clang-format -i {}
+  fi'
 
 info "Checking for eol"
 check-eol()
 {
-  for file in $(git ls-files -- ":/" ":/!:*.png"); do
+  git ls-files -- ":/" ":/!:*.png" | xargs -P $nproc -I {} sh -c '
     # Ignore symlinks
-    if [[ ! -L $file && $(tail -c1 "$file" | wc -l) == 0 ]]; then
-      echo "" >>"$file"
-      echo "$file"
-    fi
-  done
+    if [[ ! -L {} && $(tail -c1 "{}" | wc -l) == 0 ]]; then
+      echo "" >>"{}"
+      echo "{}"
+    fi'
 }
 check-eol


### PR DESCRIPTION
This commit makes the monobuild file more configurable by guarding the inclusion of fips202 files, as well as the #undef'ing of the macros they define, by !defined(MLK_MONOBUILD_CUSTOM_FIPS202).

This is needed for monobuilds with a custom FIPS-202, AWS-LC being one example.

A comment is added that the `unifdef` tool is useful for statically simplifying the monobuild file for reduced configurations.

Piggy-backing is a commit making `format` faster.