### PR TITLE
x86_64: Add CET instructions and check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,6 +481,32 @@ jobs:
           nistkat: true
           kat: false
           acvp: false
+  check-cf-protections:
+    name: Test control-flow protections  (${{ matrix.compiler.name }}, x86_64)
+    needs: [quickcheck, quickcheck-windows, quickcheck-c90, quickcheck-lib, examples, lint-markdown-link]
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+         - name: gcc-14
+           shell: ci_gcc14
+         - name: clang-19
+           shell: ci_clang19
+    # On AArch64 -fcf-protection is not supported anyway
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Test control-flow protections
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          cflags: "-Wl,-z,cet-report=error -fcf-protection=full"
+          func: true
+          nistkat: true
+          kat: false
+          acvp: false
+          nix-shell: ${{ matrix.compiler.shell }}
   # ensure that kem.h and mlkem_native.h; api.h and native backends are compatible
   check-apis:
     strategy:

--- a/dev/aarch64_clean/src/intt_clean.S
+++ b/dev/aarch64_clean/src/intt_clean.S
@@ -196,7 +196,7 @@
         .text
         .global MLK_ASM_NAMESPACE(intt_asm_clean)
         .balign 4
-MLK_ASM_NAMESPACE(intt_asm_clean):
+MLK_ASM_FN_SYMBOL(intt_asm_clean)
         push_stack
 
         // Setup constants

--- a/dev/aarch64_clean/src/ntt_clean.S
+++ b/dev/aarch64_clean/src/ntt_clean.S
@@ -168,7 +168,7 @@
         .text
         .global MLK_ASM_NAMESPACE(ntt_asm_clean)
         .balign 4
-MLK_ASM_NAMESPACE(ntt_asm_clean):
+MLK_ASM_FN_SYMBOL(ntt_asm_clean)
         push_stack
 
         mov wtmp, #3329

--- a/dev/aarch64_clean/src/poly_mulcache_compute_asm_clean.S
+++ b/dev/aarch64_clean/src/poly_mulcache_compute_asm_clean.S
@@ -46,7 +46,7 @@
         .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_clean)
         .text
         .balign 4
-MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_clean):
+MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_clean)
         mov wtmp, #3329
         dup modulus.8h, wtmp
 

--- a/dev/aarch64_clean/src/poly_reduce_asm_clean.S
+++ b/dev/aarch64_clean/src/poly_reduce_asm_clean.S
@@ -44,7 +44,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_reduce_asm_clean)
         .balign 4
-MLK_ASM_NAMESPACE(poly_reduce_asm_clean):
+MLK_ASM_FN_SYMBOL(poly_reduce_asm_clean)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/poly_tobytes_asm_clean.S
+++ b/dev/aarch64_clean/src/poly_tobytes_asm_clean.S
@@ -26,7 +26,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_tobytes_asm_clean)
         .balign 4
-MLK_ASM_NAMESPACE(poly_tobytes_asm_clean):
+MLK_ASM_FN_SYMBOL(poly_tobytes_asm_clean)
 
         mov count, #16
 poly_tobytes_asm_clean_asm_loop_start:

--- a/dev/aarch64_clean/src/poly_tomont_asm_clean.S
+++ b/dev/aarch64_clean/src/poly_tomont_asm_clean.S
@@ -39,7 +39,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_tomont_asm_clean)
         .balign 4
-MLK_ASM_NAMESPACE(poly_tomont_asm_clean):
+MLK_ASM_FN_SYMBOL(poly_tomont_asm_clean)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2_clean.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2_clean.S
@@ -143,7 +143,7 @@
         .text
         .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
         .balign 4
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
         push_stack
 
         mov wtmp, #3329

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3_clean.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3_clean.S
@@ -143,7 +143,7 @@
         .text
         .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
         .balign 4
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4_clean.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4_clean.S
@@ -143,7 +143,7 @@
         .text
         .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
         .balign 4
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/rej_uniform_asm_clean.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm_clean.S
@@ -116,7 +116,7 @@
     .text
     .global MLK_ASM_NAMESPACE(rej_uniform_asm_clean)
     .balign 4
-MLK_ASM_NAMESPACE(rej_uniform_asm_clean):
+MLK_ASM_FN_SYMBOL(rej_uniform_asm_clean)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80

--- a/dev/aarch64_opt/src/intt_opt.S
+++ b/dev/aarch64_opt/src/intt_opt.S
@@ -196,7 +196,7 @@
         .text
         .global MLK_ASM_NAMESPACE(intt_asm_opt)
         .balign 4
-MLK_ASM_NAMESPACE(intt_asm_opt):
+MLK_ASM_FN_SYMBOL(intt_asm_opt)
         push_stack
 
         // Setup constants

--- a/dev/aarch64_opt/src/ntt_opt.S
+++ b/dev/aarch64_opt/src/ntt_opt.S
@@ -169,7 +169,7 @@
         .text
         .global MLK_ASM_NAMESPACE(ntt_asm_opt)
         .balign 4
-MLK_ASM_NAMESPACE(ntt_asm_opt):
+MLK_ASM_FN_SYMBOL(ntt_asm_opt)
         push_stack
 
         mov wtmp, #3329

--- a/dev/aarch64_opt/src/poly_mulcache_compute_asm_opt.S
+++ b/dev/aarch64_opt/src/poly_mulcache_compute_asm_opt.S
@@ -47,7 +47,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_opt)
         .balign 4
-MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_opt)
         mov wtmp, #3329
         dup modulus.8h, wtmp
 

--- a/dev/aarch64_opt/src/poly_reduce_asm_opt.S
+++ b/dev/aarch64_opt/src/poly_reduce_asm_opt.S
@@ -44,7 +44,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_reduce_asm_opt)
         .balign 4
-MLK_ASM_NAMESPACE(poly_reduce_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_reduce_asm_opt)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp

--- a/dev/aarch64_opt/src/poly_tobytes_asm_opt.S
+++ b/dev/aarch64_opt/src/poly_tobytes_asm_opt.S
@@ -26,7 +26,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_tobytes_asm_opt)
         .balign 4
-MLK_ASM_NAMESPACE(poly_tobytes_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_tobytes_asm_opt)
 
         mov count, #16
 poly_tobytes_asm_opt_asm_loop_start:

--- a/dev/aarch64_opt/src/poly_tomont_asm_opt.S
+++ b/dev/aarch64_opt/src/poly_tomont_asm_opt.S
@@ -40,7 +40,7 @@
         .text
         .global MLK_ASM_NAMESPACE(poly_tomont_asm_opt)
         .balign 4
-MLK_ASM_NAMESPACE(poly_tomont_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_tomont_asm_opt)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2_opt.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2_opt.S
@@ -143,7 +143,7 @@
         .text
         .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
         .balign 4
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
         push_stack
 
         mov wtmp, #3329

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3_opt.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3_opt.S
@@ -143,7 +143,7 @@
         .text
         .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
         .balign 4
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4_opt.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4_opt.S
@@ -143,7 +143,7 @@
         .text
         .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
         .balign 4
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp

--- a/dev/aarch64_opt/src/rej_uniform_asm_clean.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm_clean.S
@@ -117,7 +117,7 @@
     .text
     .global MLK_ASM_NAMESPACE(rej_uniform_asm_clean)
     .balign 4
-MLK_ASM_NAMESPACE(rej_uniform_asm_clean):
+MLK_ASM_FN_SYMBOL(rej_uniform_asm_clean)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
@@ -167,7 +167,7 @@
     .text
     .global MLK_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
     .balign 4
-MLK_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x1_scalar_asm_opt)
     alloc_stack
     save_gprs
 

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -313,7 +313,7 @@
     .text
     .global MLK_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
     .balign 4
-MLK_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_asm_clean)
     alloc_stack
     save_vregs
     mov const_addr, input_rc

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm_clean.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm_clean.S
@@ -342,7 +342,7 @@
     .global MLK_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
     .balign 4
 
-MLK_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x2_v84a_asm_clean)
     alloc_stack
     save_vregs
     mov const_addr, input_rc

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
@@ -382,7 +382,7 @@
     .text
     .global MLK_ASM_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
     .balign 4
-MLK_ASM_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x2_v8a_v84a_asm_hybrid)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
@@ -880,7 +880,7 @@
     .text
     .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
     .balign 4
-MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
@@ -862,7 +862,7 @@
     .text
     .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
     .balign 4
-MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
@@ -880,7 +880,7 @@
     .text
     .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
     .balign 4
-MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/x86_64/src/basemul.S
+++ b/dev/x86_64/src/basemul.S
@@ -116,7 +116,7 @@ vmovdqa		%ymm11,(64*\off+48)*2(%rdi)
 .text
 .global MLK_ASM_NAMESPACE(basemul_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(basemul_avx2):
+MLK_ASM_FN_SYMBOL(basemul_avx2)
 mov		%rsp,%r8
 and		$-32,%rsp
 sub		$32,%rsp

--- a/dev/x86_64/src/intt.S
+++ b/dev/x86_64/src/intt.S
@@ -244,7 +244,7 @@ vmovdqa		%ymm11,(64*\off+176)*2(%rdi)
 .text
 .global MLK_ASM_NAMESPACE(invntt_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(invntt_avx2):
+MLK_ASM_FN_SYMBOL(invntt_avx2)
 vmovdqa         MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
 
 intt_levels0t5	0

--- a/dev/x86_64/src/ntt.S
+++ b/dev/x86_64/src/ntt.S
@@ -208,7 +208,7 @@ vmovdqa		%ymm11,(128*\off+112)*2(%rdi)
 .text
 .global MLK_ASM_NAMESPACE(ntt_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(ntt_avx2):
+MLK_ASM_FN_SYMBOL(ntt_avx2)
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
 
 level0		0

--- a/dev/x86_64/src/nttfrombytes.S
+++ b/dev/x86_64/src/nttfrombytes.S
@@ -19,7 +19,7 @@
 .text
 .global MLK_ASM_NAMESPACE(nttfrombytes_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(nttfrombytes_avx2):
+MLK_ASM_FN_SYMBOL(nttfrombytes_avx2)
 #consts
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMASK*2(%rdx),%ymm0
 call		nttfrombytes128_avx

--- a/dev/x86_64/src/nttpack.S
+++ b/dev/x86_64/src/nttpack.S
@@ -19,7 +19,7 @@
 .text
 .global MLK_ASM_NAMESPACE(nttpack_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(nttpack_avx2):
+MLK_ASM_FN_SYMBOL(nttpack_avx2)
 #load
 vmovdqa		(%rdi),%ymm4
 vmovdqa		32(%rdi),%ymm5

--- a/dev/x86_64/src/ntttobytes.S
+++ b/dev/x86_64/src/ntttobytes.S
@@ -19,7 +19,7 @@
 .text
 .global MLK_ASM_NAMESPACE(ntttobytes_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(ntttobytes_avx2):
+MLK_ASM_FN_SYMBOL(ntttobytes_avx2)
 #consts
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rdx),%ymm0
 call		ntttobytes128_avx

--- a/dev/x86_64/src/nttunpack.S
+++ b/dev/x86_64/src/nttunpack.S
@@ -19,7 +19,7 @@
 .text
 .global MLK_ASM_NAMESPACE(nttunpack_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(nttunpack_avx2):
+MLK_ASM_FN_SYMBOL(nttunpack_avx2)
 call		nttunpack128_avx2
 add		$256,%rdi
 call		nttunpack128_avx2

--- a/dev/x86_64/src/reduce.S
+++ b/dev/x86_64/src/reduce.S
@@ -23,7 +23,7 @@
 .text
 .global MLK_ASM_NAMESPACE(reduce_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(reduce_avx2):
+MLK_ASM_FN_SYMBOL(reduce_avx2)
 #consts
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XV*2(%rsi),%ymm1

--- a/dev/x86_64/src/tomont.S
+++ b/dev/x86_64/src/tomont.S
@@ -22,7 +22,7 @@
 .text
 .global MLK_ASM_NAMESPACE(tomont_avx2)
 .balign 4
-MLK_ASM_NAMESPACE(tomont_avx2):
+MLK_ASM_FN_SYMBOL(tomont_avx2)
 #consts
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
 vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMONTSQLO*2(%rsi),%ymm1

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -68,6 +68,7 @@
  */
 /* mlkem/common.h */
 #undef MLK_ARITH_BACKEND_NAME
+#undef MLK_ASM_FN_SYMBOL
 #undef MLK_ASM_NAMESPACE
 #undef MLK_COMMON_H
 #undef MLK_EMPTY_CU
@@ -282,6 +283,7 @@
 /* mlkem/sys.h */
 #undef MLK_ALIGN
 #undef MLK_ALWAYS_INLINE
+#undef MLK_CET_ENDBR
 #undef MLK_DEFAULT_ALIGN
 #undef MLK_INLINE
 #undef MLK_RESTRICT

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -72,6 +72,17 @@
 #define MLK_ASM_NAMESPACE(sym) MLK_PREFIX_UNDERSCORE(MLK_NAMESPACE(sym))
 #endif
 
+/*
+ * On X86_64 if control-flow protections (CET) are enabled (through
+ * -fcf-protection=), we add an endbr64 instruction at every global function
+ * label.  See sys.h for more details
+ */
+#if defined(MLK_SYS_X86_64)
+#define MLK_ASM_FN_SYMBOL(sym) MLK_ASM_NAMESPACE(sym) : MLK_CET_ENDBR
+#else
+#define MLK_ASM_FN_SYMBOL(sym) MLK_ASM_NAMESPACE(sym) :
+#endif
+
 /* We aim to simplify the user's life by supporting builds where
  * all source files are included, even those that are not needed.
  * Those files are appropriately guarded and will be empty when unneeded.

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm_opt.S
@@ -41,7 +41,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
-MLK_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x1_scalar_asm_opt)
 
         sub	sp, sp, #0x80
         stp	x19, x20, [sp, #0x20]

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -53,7 +53,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
-MLK_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_asm_clean)
 
         sub	sp, sp, #0xa0
         stp	d8, d9, [sp]

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm_clean.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm_clean.S
@@ -53,7 +53,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
-MLK_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x2_v84a_asm_clean)
 
         sub	sp, sp, #0xa0
         stp	d8, d9, [sp]

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
@@ -53,7 +53,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
-MLK_ASM_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x2_v8a_v84a_asm_hybrid)
 
         sub	sp, sp, #0xa0
         stp	x19, x20, [sp, #0x40]

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
@@ -43,7 +43,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
-MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
 
         sub	sp, sp, #0xe0
         stp	x19, x20, [sp, #0x30]

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
@@ -41,7 +41,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
-MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
 
         sub	sp, sp, #0xe0
         stp	x19, x20, [sp, #0x30]

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
@@ -43,7 +43,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
-MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
 
         sub	sp, sp, #0xe0
         stp	x19, x20, [sp, #0x30]

--- a/mlkem/native/aarch64/src/intt_opt.S
+++ b/mlkem/native/aarch64/src/intt_opt.S
@@ -36,7 +36,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(intt_asm_opt)
-MLK_ASM_NAMESPACE(intt_asm_opt):
+MLK_ASM_FN_SYMBOL(intt_asm_opt)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]

--- a/mlkem/native/aarch64/src/ntt_opt.S
+++ b/mlkem/native/aarch64/src/ntt_opt.S
@@ -37,7 +37,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(ntt_asm_opt)
-MLK_ASM_NAMESPACE(ntt_asm_opt):
+MLK_ASM_FN_SYMBOL(ntt_asm_opt)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]

--- a/mlkem/native/aarch64/src/poly_mulcache_compute_asm_opt.S
+++ b/mlkem/native/aarch64/src/poly_mulcache_compute_asm_opt.S
@@ -16,7 +16,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_opt)
-MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_opt)
 
         mov	w5, #0xd01              // =3329
         dup	v6.8h, w5

--- a/mlkem/native/aarch64/src/poly_reduce_asm_opt.S
+++ b/mlkem/native/aarch64/src/poly_reduce_asm_opt.S
@@ -16,7 +16,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_reduce_asm_opt)
-MLK_ASM_NAMESPACE(poly_reduce_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_reduce_asm_opt)
 
         mov	w2, #0xd01              // =3329
         dup	v3.8h, w2

--- a/mlkem/native/aarch64/src/poly_tobytes_asm_opt.S
+++ b/mlkem/native/aarch64/src/poly_tobytes_asm_opt.S
@@ -16,7 +16,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_tobytes_asm_opt)
-MLK_ASM_NAMESPACE(poly_tobytes_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_tobytes_asm_opt)
 
         mov	x2, #0x10               // =16
 

--- a/mlkem/native/aarch64/src/poly_tomont_asm_opt.S
+++ b/mlkem/native/aarch64/src/poly_tomont_asm_opt.S
@@ -16,7 +16,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_tomont_asm_opt)
-MLK_ASM_NAMESPACE(poly_tomont_asm_opt):
+MLK_ASM_FN_SYMBOL(poly_tomont_asm_opt)
 
         mov	w2, #0xd01              // =3329
         dup	v4.8h, w2

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2_opt.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2_opt.S
@@ -23,7 +23,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3_opt.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3_opt.S
@@ -23,7 +23,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4_opt.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4_opt.S
@@ -23,7 +23,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
-MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt):
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]

--- a/mlkem/native/aarch64/src/rej_uniform_asm_clean.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm_clean.S
@@ -32,7 +32,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(rej_uniform_asm_clean)
-MLK_ASM_NAMESPACE(rej_uniform_asm_clean):
+MLK_ASM_FN_SYMBOL(rej_uniform_asm_clean)
 
         sub	sp, sp, #0x240
         mov	x7, #0x1                // =1

--- a/mlkem/native/x86_64/src/basemul.S
+++ b/mlkem/native/x86_64/src/basemul.S
@@ -19,7 +19,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(basemul_avx2)
-MLK_ASM_NAMESPACE(basemul_avx2):
+MLK_ASM_FN_SYMBOL(basemul_avx2)
 
         movq	%rsp, %r8
         andq	$-0x20, %rsp

--- a/mlkem/native/x86_64/src/intt.S
+++ b/mlkem/native/x86_64/src/intt.S
@@ -22,7 +22,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(invntt_avx2)
-MLK_ASM_NAMESPACE(invntt_avx2):
+MLK_ASM_FN_SYMBOL(invntt_avx2)
 
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0x60(%rsi), %ymm2

--- a/mlkem/native/x86_64/src/ntt.S
+++ b/mlkem/native/x86_64/src/ntt.S
@@ -19,7 +19,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(ntt_avx2)
-MLK_ASM_NAMESPACE(ntt_avx2):
+MLK_ASM_FN_SYMBOL(ntt_avx2)
 
         vmovdqa	(%rsi), %ymm0
         vpbroadcastq	0x140(%rsi), %ymm15

--- a/mlkem/native/x86_64/src/nttfrombytes.S
+++ b/mlkem/native/x86_64/src/nttfrombytes.S
@@ -20,7 +20,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(nttfrombytes_avx2)
-MLK_ASM_NAMESPACE(nttfrombytes_avx2):
+MLK_ASM_FN_SYMBOL(nttfrombytes_avx2)
 
         vmovdqa	0xe0(%rdx), %ymm0
         callq	nttfrombytes128_avx

--- a/mlkem/native/x86_64/src/nttpack.S
+++ b/mlkem/native/x86_64/src/nttpack.S
@@ -20,7 +20,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(nttpack_avx2)
-MLK_ASM_NAMESPACE(nttpack_avx2):
+MLK_ASM_FN_SYMBOL(nttpack_avx2)
 
         vmovdqa	(%rdi), %ymm4
         vmovdqa	0x20(%rdi), %ymm5

--- a/mlkem/native/x86_64/src/ntttobytes.S
+++ b/mlkem/native/x86_64/src/ntttobytes.S
@@ -20,7 +20,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(ntttobytes_avx2)
-MLK_ASM_NAMESPACE(ntttobytes_avx2):
+MLK_ASM_FN_SYMBOL(ntttobytes_avx2)
 
         vmovdqa	(%rdx), %ymm0
         callq	ntttobytes128_avx

--- a/mlkem/native/x86_64/src/nttunpack.S
+++ b/mlkem/native/x86_64/src/nttunpack.S
@@ -20,7 +20,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(nttunpack_avx2)
-MLK_ASM_NAMESPACE(nttunpack_avx2):
+MLK_ASM_FN_SYMBOL(nttunpack_avx2)
 
         callq	nttunpack128_avx2
         addq	$0x100, %rdi            # imm = 0x100

--- a/mlkem/native/x86_64/src/reduce.S
+++ b/mlkem/native/x86_64/src/reduce.S
@@ -25,7 +25,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(reduce_avx2)
-MLK_ASM_NAMESPACE(reduce_avx2):
+MLK_ASM_FN_SYMBOL(reduce_avx2)
 
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0x40(%rsi), %ymm1

--- a/mlkem/native/x86_64/src/tomont.S
+++ b/mlkem/native/x86_64/src/tomont.S
@@ -24,7 +24,7 @@
 .text
 .balign 4
 .global MLK_ASM_NAMESPACE(tomont_avx2)
-MLK_ASM_NAMESPACE(tomont_avx2):
+MLK_ASM_FN_SYMBOL(tomont_avx2)
 
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0xa0(%rsi), %ymm1

--- a/mlkem/sys.h
+++ b/mlkem/sys.h
@@ -109,4 +109,30 @@
 #define MLK_ALIGN /* No known support for alignment constraints */
 #endif
 
+
+/* New X86_64 CPUs support Conflow-flow protection using the CET instructions.
+ * When enabled (through -fcf-protection=), all compilation units (including
+ * empty ones) need to support CET for this to work.
+ * For assembly, this means that source files need to signal support for
+ * CET by setting the appropriate note.gnu.property section.
+ * This can be achieved by including the <cet.h> header in all assembly file.
+ * This file also provides the _CET_ENDBR macro which needs to be placed at
+ * every potential target of an indirect branch.
+ * If CET is enabled _CET_ENDBR maps to the endbr64 instruction, otherwise
+ * it is empty.
+ * In case the compiler does not support CET (e.g., <gcc8, <clang11),
+ * the __CET__ macro is not set and we default to nothing.
+ * Note that we only issue _CET_ENDBR instructions through the MLK_ASM_FN_SYMBOL
+ * macro as the global symbols are the only possible targets of indirect
+ * branches in our code.
+ */
+#if defined(MLK_SYS_X86_64)
+#if defined(__CET__)
+#include <cet.h>
+#define MLK_CET_ENDBR _CET_ENDBR
+#else
+#define MLK_CET_ENDBR
+#endif
+#endif
+
 #endif /* MLK_SYS_H */

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1056,7 +1056,14 @@ def synchronize_backends(
         delete=delete,
         force_cross=force_cross,
         no_simplify=no_simplify,
-        cflags="-Imlkem/native/x86_64/src/ -mavx2",
+        # Turn off control-flow protection (CET) explicitly. Newer versions of
+        # clang turn it on by default and insert endbr64 instructions at every
+        # global symbol.
+        # We insert endbr64 instruction manually via the MLK_ASM_FN_SYMBOL
+        # macro.
+        # This leads to duplicate endbr64 instructions causing a failure when
+        # comparing the object code before and after simplification.
+        cflags="-Imlkem/native/x86_64/src/ -mavx2 -fcf-protection=none",
     )
 
 

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -629,7 +629,7 @@ def get_checked_defines():
     for c, d in get_defines():
         if d.startswith("_") and is_allowed(d, c) is False:
             raise Exception(
-                f"{d} from {c}:{i} starts with an underscore, which is not allowed for mlkem-native macros. "
+                f"{d} from {c}: starts with an underscore, which is not allowed for mlkem-native macros. "
                 f"If this is an mlkem-native specific macro, please pick a different name. "
                 f"If this is an external macro, it likely needs removing from `gen_monolithic_undef_all_core()` in `scripts/autogen` -- check this!"
             )

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -278,7 +278,7 @@ def simplify(logger, args, asm_input, asm_output=None):
         else:
             autogen_header += [
                 f".global {sym}",
-                f"{sym}:",
+                f"{sym.replace('MLK_ASM_NAMESPACE', 'MLK_ASM_FN_SYMBOL')}",
                 "",
             ]
             simplified_header = header


### PR DESCRIPTION
Modern x86_64 support hardware features through the CET instructions to protect
against return-oriented programming (ROP) attacks. Those protections can be
enabled through -fcf-protection=.
For this to work, all compilation units (including assembly) need to support
CET.

This commit adds support and contains two main changes:

1) Each assembly file needs to set the the appropriate note.gnu.property
 section to signal that it does support CET. We achieve this by including cet.h
 in all assembly files which sets the required properties.
 Note that this applies also to empty compilation units (e.g., the aarch64
 assembly files when compiling for x86_64).

2) Each label that can potentially be a target of an indirect branch needs
 to start with en endbr64 instruction, otherwise the branch faults.
 Our assembly does not use indirect branches and, hence, any internal branching
 is unaffected by this.
 However, the global symbols may potentially be targets of indirect branches
 (they don't seem to be though). To address this, we add endb64 to every global
 symbol by using the _CET_ENDBR macro provided by cet.h. Note that this is
 only adding the instruction in case CET is enabled.
 We introduce a new macro MLK_ASM_FN_SYMBOL that adds this automatically for
 X86 systems. This way our assembly simplification scripts are unaffected as
 the endbr64 instructions are out of scope.

Resolves #762 