### PR TITLE
Upgrade nix to use 24.11 channel

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -34,6 +34,11 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           script: |
+
+            if [[ ${{ inputs.nix-shell }} != '' ]]; then
+              nix-collect-garbage
+            fi
+
             cat >> $GITHUB_STEP_SUMMARY << EOF
               ## Setup
               Architecture: $(uname -m)

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -22,10 +22,14 @@ inputs:
   save_cache:
     description: Determine whether to save cache with primary key or not
     required: false
-    default: 'true'
+    default: 'false'
   gh_token:
     description: Github access token to use
     required: true
+  install:
+    required: false
+    description: Determine how to install nix ('installer' | 'apt')
+    default: 'installer'
 
 runs:
   using: composite
@@ -51,6 +55,23 @@ runs:
         fi
 
         nix --version
+    - name: Install nix via apt
+      if: ${{ steps.nix-pre-check.outputs.installed == 'false' && inputs.install == 'apt' }}
+      shell: bash
+      run: |
+        if [[ -f /.dockerenv ]]; then
+          apt install nix -y
+        else
+          sudo apt install nix -y
+        fi
+        mkdir -p ~/.config/nix
+        cat >> ~/.config/nix/nix.conf << EOF
+          experimental-features = nix-command flakes
+        EOF
+
+        if [[ ! -z $GH_TOKEN ]]; then
+          echo "access-tokens = github.com=$GH_TOKEN" >> ~/.config/nix/nix.conf
+        fi
     - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       if: ${{ steps.nix-pre-check.outputs.installed == 'false' }}
       with:
@@ -100,7 +121,11 @@ runs:
 
         echo NIX_SHELL="${{ inputs.devShell }}" >> $GITHUB_ENV
         nix_extra_flags="${{ inputs.verbose == 'false' && '--quiet' || '' }}"
-        echo SHELL="$(which nix) develop $nix_extra_flags .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
+        if [[ ${{ inputs.install }} == 'apt' && ! -f /.dockerenv ]]; then
+          echo SHELL="sudo $(which nix) develop $nix_extra_flags .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
+        else
+          echo SHELL="$(which nix) develop $nix_extra_flags .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
+        fi
         echo "::endgroup::"
     - name: Prepare nix dev shell
       shell: ${{ env.SHELL }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -19,8 +19,8 @@ inputs:
   cache_prefix:
     description: Fixed prefix of ID of Github cache entries that should be removed.
     required: false
-  purge_cache:
-    description: Determine whether to purge cache with primary key or not
+  save_cache:
+    description: Determine whether to save cache with primary key or not
     required: false
     default: 'true'
   gh_token:
@@ -30,12 +30,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Nix install mode
-      shell: bash
-      run: |
-        if [[ ${{ runner.os }} != 'Linux' || $USER == 'root' ]]; then
-          echo "NIX_INSTALL_MODE=multi" >> $GITHUB_ENV
-        fi
     - name: Pre-check nix
       id: nix-pre-check
       if: ${{ env.NIX_SHELL == '' }}
@@ -51,64 +45,16 @@ runs:
 
         trap 'suppress $LINENO' ERR
 
+        if [[ $USER == 'root' ]]; then
+          mkdir -p /root
+          echo "HOME=/root" >> $GITHUB_ENV
+        fi
+
         nix --version
-        nix config show | grep -E "^trusted-users = .*$USER"
-        nix config show | grep -E "^experimental-features = .*flakes"
-        nix config show | grep -E "^experimental-features = .*nix-command"
-    - name: Install Nix
-      shell: bash
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       if: ${{ steps.nix-pre-check.outputs.installed == 'false' }}
-      env:
-        GH_TOKEN: ${{ inputs.gh_token }}
-      run: |
-        echo "::group::Nix installation"
-        mkdir -p ~/.config/nix
-
-        if [[ $NIX_INSTALL_MODE == 'multi' ]]; then
-          curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install \
-          --no-confirm \
-          --extra-conf "trusted-users = ${USER:-}" \
-          --extra-conf "experimental-features = nix-command flakes"
-        else
-          sh <(curl -L https://nixos.org/nix/install) --no-daemon
-
-        cat >> ~/.config/nix/nix.conf << EOF
-          trusted-users = ${USER:-}
-          experimental-features = nix-command flakes
-          substituters = https://cache.nixos.org/
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          max-jobs = auto
-        EOF
-        fi
-
-        if [[ ! -z $GH_TOKEN ]]; then
-           mkdir -p ~/.config/nix
-           echo "access-tokens = github.com=$GH_TOKEN" >> ~/.config/nix/nix.conf
-        fi
-
-        if command -v gh >/dev/null 2>&1; then
-          limit=$(gh api rate_limit --jq '.rate.remaining')
-          reset=$(gh api rate_limit --jq '.rate.reset')
-          now=$(date +%s)
-          if [[ $limit < 10 ]]; then
-            wait=$(( reset - now ))
-            echo "Rate limit remaining is $limit less then 10, waiting for $wait secs to retry"
-            sleep $wait
-          else
-            echo "Rate limit remaining is $limit greater than 10, no need to wait"
-          fi
-        else
-            echo "GitHub CLI is not installed."
-        fi
-
-        if [[ $NIX_INSTALL_MODE == 'multi' ]]; then
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-        else
-          . ~/.nix-profile/etc/profile.d/nix.sh
-        fi
-        echo "$(dirname $(which nix))" >> $GITHUB_PATH
-        nix profile install nixpkgs/nixos-24.05#sqlite
-        echo "::endgroup::"
+      with:
+        github_access_token: ${{ inputs.gh_token }}
     - name: Post-check nix
       id: nix-post-check
       continue-on-error: true
@@ -116,20 +62,21 @@ runs:
       run: |
         echo "::group::nix config"
         if [[ -z "${{ inputs.cache_prefix }}" ]]; then
-          cache_prefix="${{ runner.os }}-${{ runner.arch }}-${{ inputs.devShell }}"
+          cache_prefix="${{ runner.os }}-${{ runner.arch }}"
         else
           cache_prefix="${{ inputs.cache_prefix }}"
-        fi
-        if [[ ! -z $NIX_INSTALL_MODE ]]; then
-          cache_prefix="$cache_prefix-$NIX_INSTALL_MODE"
         fi
 
         echo "cache_prefix=$cache_prefix" >> $GITHUB_OUTPUT
 
-        nix config check
+        if [[ ${{ steps.nix-pre-check.outputs.installed }} == 'false' ]]; then
+          sudo chown -R $USER:nixbld /nix
+        fi
+
+        nix profile install nixpkgs/nixos-24.11#sqlite
         nix config show
         echo "::endgroup::"
-    - uses: nix-community/cache-nix-action@8351fb9f51c580c96c509987ebb99e38aed956ce # v5.2.1
+    - uses: nix-community/cache-nix-action@dab0514428ae3988852b7787a6d86a6fc571cc9d #v6.0.0
       id: cache
       if: ${{ env.NIX_CACHE_ENABLED != 1 && inputs.cache == 'true' }}
       continue-on-error: true
@@ -137,10 +84,11 @@ runs:
         primary-key: ${{ steps.nix-post-check.outputs.cache_prefix }}-${{ hashFiles('**/*.nix') }}
         restore-prefixes-first-match: ${{ steps.nix-post-check.outputs.cache_prefix }}
         gc-max-store-size-linux: 536870912
-        purge: ${{ inputs.purge_cache == 'true' }}
+        purge: ${{ inputs.save_cache == 'true' }}
+        save: ${{ inputs.save_cache == 'true' }}
         purge-prefixes: cache-${{ steps.nix-post-check.outputs.cache_prefix }}
         purge-created: 0
-        purge-primary-key: ${{ inputs.purge_cache == 'true' && 'always' || 'never' }}
+        purge-primary-key: ${{ inputs.save_cache == 'true' && 'always' || 'never' }}
         token: ${{ inputs.gh_token }}
     - name: Set Shell
       shell: bash -lo pipefail {0}

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -119,15 +119,10 @@ jobs:
           nix-shell: ci-linter
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
           nix-verbose: ${{ inputs.verbose }}
-      - name: Preprocess
-        id: preprocess
-        shell: bash
-        run: |
-          echo "nix-shell=${{ inputs.cbmc && 'ci-cbmc' || 'ci' }}${{ (inputs.compile_mode == 'cross' || inputs.compile_mode == 'all') && '-cross' || '' }}" >> $GITHUB_OUTPUT
       - name: Functional Tests
         uses: ./.github/actions/multi-functest
         with:
-          nix-shell: ${{ steps.preprocess.outputs.nix-shell }}
+          nix-shell: ${{ (inputs.compile_mode == 'cross' || inputs.compile_mode == 'all') && 'ci-cross' || 'ci' }}
           nix-cache: ${{ inputs.cbmc || inputs.compile_mode == 'cross' || inputs.compile_mode == 'all' }}
           nix-verbose: ${{ inputs.verbose }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
@@ -142,7 +137,7 @@ jobs:
         if: ${{ inputs.cbmc && (success() || failure()) }}
         uses: ./.github/actions/cbmc
         with:
-          nix-shell: ${{ steps.preprocess.outputs.nix-shell }}
+          nix-shell: ci-cbmc
           nix-verbose: ${{ inputs.verbose }}
           mlkem_k: ${{ inputs.cbmc_mlkem_k }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -44,7 +44,6 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           nix-shell: ${{ matrix.nix-shell }}
           nix-cache: true
-          nix-cache-prefix: valgrind-${{ runner.os }}-${{ runner.arch }}
       - name:  Build and run test (-Oz)
         # -Oz got introduced in gcc12
         if: ${{ matrix.nix-shell !=  'ci_valgrind-varlat_gcc48' && matrix.nix-shell !=  'ci_valgrind-varlat_gcc49' && matrix.nix-shell !=  'ci_valgrind-varlat_gcc7' && matrix.nix-shell !=  'ci_valgrind-varlat_gcc11'}}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -103,4 +103,4 @@ jobs:
           echo "$(dirname $(which nix))" >> $GITHUB_PATH
       - name: nix develop
         run: |
-          ${{ matrix.target.install == 'apt' && 'sudo' || '' }} nix develop --experimental-features "nix-command flakes"
+          ${{ matrix.target.install == 'apt' && 'sudo' || '' }} nix develop --experimental-features "nix-command flakes" --access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,6 +24,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_nix_cache:
+    permissions:
+      actions: 'write'
+      contents: 'read'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ ubuntu-24.04, ubuntu-24.04-arm, macos-latest ]
+    name: build nix cache (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-nix
+        with:
+          cache: true
+          verbose: true
+          save_cache: true
+          devShell: ci
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            nix develop --profile tmp
+            nix-collect-garbage
   develop_environment:
     strategy:
       fail-fast: false

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,7 @@ on:
       - 'flake.lock'
       - 'flake.nix'
       - 'nix/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,9 +45,20 @@ jobs:
           devShell: ci
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            # NOTE: we're not running cross compilation tests on macOS currently
+            #       and building cross compilation toolchain on macOS runner took
+            #       extremely long time
+            if [[ ${{ runner.os }} != 'macOS' ]]; then
+              nix develop .#ci-cross --profile tmp-cross
+              # GH ubuntu-24.04 image tend to run outof space
+              if [[ ${{ matrix.runner }} == 'ubuntu-24.04' ]]; then
+                nix-collect-garbage
+              fi
+            fi
             nix develop --profile tmp
             nix-collect-garbage
   develop_environment:
+    needs: [ build_nix_cache ]
     strategy:
       fail-fast: false
       matrix:
@@ -90,17 +102,15 @@ jobs:
           git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           git fetch origin --depth 1 $GITHUB_SHA
           git checkout FETCH_HEAD
-      - name: Install nix via apt
-        if: ${{ matrix.target.install == 'apt' }}
+      - uses: ./.github/actions/setup-nix
+        if: ${{ matrix.target.container == '' }}
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          devShell: default
+          verbose: true
+          cache: true
+          install: ${{ matrix.target.install }}
+      - name: nix develop (in container)
+        if: ${{ matrix.target.container != '' }}
         run: |
-          ${{ matrix.target.container == '' && 'sudo' || '' }} apt install nix -y
-      - name: Install nix via installer script
-        if: ${{ matrix.target.install == 'installer' }}
-        shell: bash
-        run: |
-          sh <(curl -L https://nixos.org/nix/install) --daemon
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          echo "$(dirname $(which nix))" >> $GITHUB_PATH
-      - name: nix develop
-        run: |
-          ${{ matrix.target.install == 'apt' && 'sudo' || '' }} nix develop --experimental-features "nix-command flakes" --access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}"
+          nix develop --experimental-features "nix-command flakes" --access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}"

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728740863,
-        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
+        "lastModified": 1738435198,
+        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3f9ad65a0bf298ed5847629a57808b97e6e8077",
+        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
@@ -38,11 +54,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1738410390,
+        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
         "type": "github"
       },
       "original": {
@@ -52,28 +68,12 @@
         "type": "github"
       }
     },
-    "nixpkgs2411": {
-      "locked": {
-        "lastModified": 1737404927,
-        "narHash": "sha256-e1WgPJpIYbOuokjgylcsuoEUCB4Jl2rQXa2LUD6XAG8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ae584d90cbd0396a422289ee3efb1f1c9d141dc3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "nixpkgs2411": "nixpkgs2411"
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -39,65 +39,73 @@
               })
             ];
           };
-          packages.cbmc = util.cbmc-pkgs;
-          packages.hol_light = pkgs.callPackage ./nix/hol_light { };
-          packages.s2n_bignum = pkgs.callPackage ./nix/s2n_bignum { };
-          packages.toolchain = util.core-pkgs;
 
-          devShells.default = util.wrapShell util.mkShell {
-            packages =
-              util.linters ++
-              builtins.attrValues
-                {
-                  inherit (config.packages) toolchain cbmc s2n_bignum;
-                  inherit (pkgs)
-                    direnv
-                    nix-direnv;
-                };
+          packages.linters = util.linters;
+          packages.cbmc = util.cbmc_pkgs;
+          packages.hol_light = util.hol_light';
+          packages.s2n_bignum = util.s2n_bignum;
+          packages.valgrind_varlat = util.valgrind_varlat;
+          packages.toolchains = util.toolchains;
+          packages.toolchains_native = util.toolchains_native;
+
+          devShells.default = util.mkShell {
+            packages = builtins.attrValues
+              {
+                inherit (config.packages) linters cbmc hol_light s2n_bignum toolchains_native;
+                inherit (pkgs)
+                  direnv
+                  nix-direnv;
+              } ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ config.packages.valgrind_varlat ];
           };
 
-          devShells.hol_light = util.wrapShell util.mkShell {
+          devShells.hol_light = util.mkShell {
             packages = builtins.attrValues {
               inherit (config.packages) hol_light s2n_bignum;
             };
           };
-
-          devShells.ci = util.wrapShell util.mkShell { packages = util.linters ++ util.core { cross = false; }; };
-          devShells.ci-bench = util.wrapShell util.mkShell { packages = util.core { cross = false; }; };
-          devShells.ci-cross = util.wrapShell util.mkShell { packages = util.linters ++ util.core { }; };
-          devShells.ci-cbmc = util.wrapShell util.mkShell { packages = util.core { cross = false; } ++ [ config.packages.cbmc ]; };
-          devShells.ci-cbmc-cross = util.wrapShell util.mkShell { packages = util.core { } ++ [ config.packages.cbmc ]; };
-          devShells.ci-linter = util.wrapShell pkgs.mkShellNoCC { packages = util.linters; };
-
-          devShells.ci_clang14 = util.wrapShell (util.mkShellWithCC pkgs.clang_14) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_clang15 = util.wrapShell (util.mkShellWithCC pkgs.clang_15) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_clang16 = util.wrapShell (util.mkShellWithCC pkgs.clang_16) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_clang17 = util.wrapShell (util.mkShellWithCC pkgs.clang_17) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_clang18 = util.wrapShell (util.mkShellWithCC pkgs.clang_18) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_clang19 = util.wrapShell (util.mkShellWithCC inputs.nixpkgs2411.legacyPackages.${system}.clang_19) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc48 = util.wrapShell (util.mkShellWithCC pkgs.gcc48) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc49 = util.wrapShell (util.mkShellWithCC pkgs.gcc49) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc7 = util.wrapShell (util.mkShellWithCC pkgs.gcc7) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc11 = util.wrapShell (util.mkShellWithCC pkgs.gcc11) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc12 = util.wrapShell (util.mkShellWithCC pkgs.gcc12) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc13 = util.wrapShell (util.mkShellWithCC pkgs.gcc13) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_gcc14 = util.wrapShell (util.mkShellWithCC pkgs.gcc14) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ pkgs.valgrind ]; hardeningDisable = [ "fortify" ]; };
+          devShells.ci = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchains_native; };
+          };
+          devShells.ci-bench = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) toolchains_native; };
+          };
+          devShells.ci-cbmc = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) cbmc toolchains_native; };
+          };
+          devShells.ci-cross = util.mkShell {
+            packages = builtins.attrValues { inherit (config.packages) linters toolchains; };
+          };
+          devShells.ci-linter = util.mkShellNoCC {
+            packages = builtins.attrValues { inherit (config.packages) linters; };
+          };
+          devShells.ci_clang14 = util.mkShellWithCC' pkgs.clang_14;
+          devShells.ci_clang15 = util.mkShellWithCC' pkgs.clang_15;
+          devShells.ci_clang16 = util.mkShellWithCC' pkgs.clang_16;
+          devShells.ci_clang17 = util.mkShellWithCC' pkgs.clang_17;
+          devShells.ci_clang18 = util.mkShellWithCC' pkgs.clang_18;
+          devShells.ci_clang19 = util.mkShellWithCC' pkgs.clang_19;
+          devShells.ci_gcc48 = util.mkShellWithCC' pkgs.gcc48;
+          devShells.ci_gcc49 = util.mkShellWithCC' pkgs.gcc49;
+          devShells.ci_gcc7 = util.mkShellWithCC' pkgs.gcc7;
+          devShells.ci_gcc11 = util.mkShellWithCC' pkgs.gcc11;
+          devShells.ci_gcc12 = util.mkShellWithCC' pkgs.gcc12;
+          devShells.ci_gcc13 = util.mkShellWithCC' pkgs.gcc13;
+          devShells.ci_gcc14 = util.mkShellWithCC' pkgs.gcc14;
 
           # valgrind with a patch for detecting variable-latency instructions
-          devShells.ci_valgrind-varlat_clang14 = util.wrapShell (util.mkShellWithCC pkgs.clang_14) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_clang15 = util.wrapShell (util.mkShellWithCC pkgs.clang_15) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_clang16 = util.wrapShell (util.mkShellWithCC pkgs.clang_16) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_clang17 = util.wrapShell (util.mkShellWithCC pkgs.clang_17) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_clang18 = util.wrapShell (util.mkShellWithCC pkgs.clang_18) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_clang19 = util.wrapShell (util.mkShellWithCC inputs.nixpkgs2411.legacyPackages.${system}.clang_19) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc48 = util.wrapShell (util.mkShellWithCC pkgs.gcc48) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc49 = util.wrapShell (util.mkShellWithCC pkgs.gcc49) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc7 = util.wrapShell (util.mkShellWithCC pkgs.gcc7) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc11 = util.wrapShell (util.mkShellWithCC pkgs.gcc11) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc12 = util.wrapShell (util.mkShellWithCC pkgs.gcc12) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc13 = util.wrapShell (util.mkShellWithCC pkgs.gcc13) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-          devShells.ci_valgrind-varlat_gcc14 = util.wrapShell (util.mkShellWithCC pkgs.gcc14) { packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind-varlat ]; hardeningDisable = [ "fortify" ]; };
-
+          devShells.ci_valgrind-varlat_clang14 = util.mkShellWithCC_valgrind' pkgs.clang_14;
+          devShells.ci_valgrind-varlat_clang15 = util.mkShellWithCC_valgrind' pkgs.clang_15;
+          devShells.ci_valgrind-varlat_clang16 = util.mkShellWithCC_valgrind' pkgs.clang_16;
+          devShells.ci_valgrind-varlat_clang17 = util.mkShellWithCC_valgrind' pkgs.clang_17;
+          devShells.ci_valgrind-varlat_clang18 = util.mkShellWithCC_valgrind' pkgs.clang_18;
+          devShells.ci_valgrind-varlat_clang19 = util.mkShellWithCC_valgrind' pkgs.clang_19;
+          devShells.ci_valgrind-varlat_gcc48 = util.mkShellWithCC_valgrind' pkgs.gcc48;
+          devShells.ci_valgrind-varlat_gcc49 = util.mkShellWithCC_valgrind' pkgs.gcc49;
+          devShells.ci_valgrind-varlat_gcc7 = util.mkShellWithCC_valgrind' pkgs.gcc7;
+          devShells.ci_valgrind-varlat_gcc11 = util.mkShellWithCC_valgrind' pkgs.gcc11;
+          devShells.ci_valgrind-varlat_gcc12 = util.mkShellWithCC_valgrind' pkgs.gcc12;
+          devShells.ci_valgrind-varlat_gcc13 = util.mkShellWithCC_valgrind' pkgs.gcc13;
+          devShells.ci_valgrind-varlat_gcc14 = util.mkShellWithCC_valgrind' pkgs.gcc14;
         };
       flake = {
         devShell.x86_64-linux =
@@ -111,13 +119,16 @@
               z3 = pkgs-unstable.z3;
             };
           in
-          util.wrapShell util.mkShell {
+          util.mkShell {
             packages =
-              util.core { } ++
-              util.linters ++
               [
-                util.cbmc
-              ];
+                util.linters
+                util.cbmc_pkgs
+                util.hol_light'
+                util.s2n_bignum
+                util.toolchains
+              ]
+              ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind_varlat ];
           };
         # The usual flake attributes can be defined here, including system-
         # agnostic ones like nixosModule and system-enumerating ones, although

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
                 util.cbmc_pkgs
                 util.hol_light'
                 util.s2n_bignum
-                util.toolchains
+                util.toolchains_native
               ]
               ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ util.valgrind_varlat ];
           };

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -6,7 +6,6 @@
 , bitwuzla
 , ninja
 , cadical
-, libgcc
 , z3
 }:
 
@@ -19,13 +18,9 @@ buildEnv {
         src = fetchFromGitHub {
           owner = "diffblue";
           repo = old.pname;
-          rev = "${old.pname}-${version}";
+          tag = "${old.pname}-${version}";
           hash = "sha256-O8aZTW+Eylshl9bmm9GzbljWB0+cj2liZHs2uScERkM=";
         };
-        patches = [
-          ./0001-Do-not-download-sources-in-cmake.patch
-        ];
-        nativeBuildInputs = old.nativeBuildInputs ++ [ libgcc ];
       });
       litani = callPackage ./litani.nix { }; # 1.29.0
       cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.10

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -20,8 +20,8 @@ rec {
     then pkgs.clang_15
     else wrap-gcc pkgs;
 
-  # cross is for determining whether to install the cross toolchain or not
-  core = { cross ? true }:
+  # cross is for determining whether to install the cross toolchain dependencies or not
+  _toolchains = { cross ? true }:
     let
       x86_64-gcc = wrap-gcc pkgs.pkgsCross.gnu64;
       aarch64-gcc = wrap-gcc pkgs.pkgsCross.aarch64-multiplatform;
@@ -35,7 +35,7 @@ rec {
       #   and won't just work for now
       # - equip all toolchains if cross is explicitly set to true
       # - On some machines, `native-gcc` needed to be evaluated lastly (placed as the last element of the toolchain list), or else would result in environment variables (CC, AR, ...) overriding issue.
-    pkgs.lib.optionals cross [ x86_64-gcc aarch64-gcc riscv64-gcc ]
+    pkgs.lib.optionals cross [ pkgs.qemu x86_64-gcc aarch64-gcc riscv64-gcc ]
     ++ pkgs.lib.optionals (cross && pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64) [ aarch64_be-gcc ]
     ++ pkgs.lib.optionals cross [ native-gcc ]
     # NOTE: Tools in /Library/Developer/CommandLineTools/usr/bin on macOS are inaccessible in the Nix shell. This issue is addressed in https://github.com/NixOS/nixpkgs/pull/353893 but hasn’t been merged into the 24.11 channel yet. As a workaround, we include this dependency for macOS temporary. 
@@ -43,28 +43,36 @@ rec {
     ++ builtins.attrValues {
       inherit (pkgs.python3Packages) sympy pyyaml;
       inherit (pkgs)
-        python3
-        qemu; # 8.2.4
+        gnumake
+        python3;
     };
 
-  core-pkgs = pkgs.symlinkJoin {
-    name = "toolchain join";
-    paths = core { };
-  };
-
-  wrapShell = mkShell: attrs:
-    mkShell (attrs // {
+  # NOTE: idiomatic nix way of properly setting the $CC in a nix shell
+  mkShellWithCC = cc: attrs: (pkgs.mkShellNoCC.override { stdenv = pkgs.overrideCC pkgs.stdenv cc; }) (
+    attrs // {
       shellHook = ''
         export PATH=$PWD/scripts:$PATH
       '';
-    });
-
-  # NOTE: idiomatic nix way of properly setting the $CC in a nix shell
-  mkShellWithCC = cc: pkgs.mkShellNoCC.override { stdenv = pkgs.overrideCC pkgs.stdenv cc; };
+    }
+  );
+  mkShellNoCC = mkShellWithCC null;
   mkShell = mkShellWithCC native-gcc;
 
-  linters =
-    builtins.attrValues {
+  mkShellWithCC' = cc:
+    mkShellWithCC cc {
+      packages = [ pkgs.python3 ];
+      hardeningDisable = [ "fortify" ];
+    };
+  mkShellWithCC_valgrind' = cc:
+    mkShellWithCC cc {
+      packages = [ pkgs.python3 ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ valgrind_varlat ];
+      hardeningDisable = [ "fortify" ];
+    };
+
+  # some customized packages
+  linters = pkgs.symlinkJoin {
+    name = "pqcp-linters";
+    paths = builtins.attrValues {
       clang-tools = pkgs.clang-tools.overrideAttrs {
         unwrapped = pkgs.llvmPackages_17.clang-unwrapped;
       };
@@ -79,9 +87,23 @@ rec {
       inherit (pkgs.python3Packages)
         mpmath sympy black;
     };
+  };
 
-  cbmc-pkgs = pkgs.callPackage ./cbmc {
+  cbmc_pkgs = pkgs.callPackage ./cbmc {
     inherit cbmc bitwuzla z3;
   };
-  valgrind-varlat = pkgs.callPackage ./valgrind { };
+
+  valgrind_varlat = pkgs.callPackage ./valgrind { };
+  hol_light' = pkgs.callPackage ./hol_light { };
+  s2n_bignum = pkgs.callPackage ./s2n_bignum { };
+
+  toolchains = pkgs.symlinkJoin {
+    name = "toolchains";
+    paths = _toolchains { };
+  };
+
+  toolchains_native = pkgs.symlinkJoin {
+    name = "toolchains-native";
+    paths = _toolchains { cross = false; };
+  };
 }

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-{ pkgs, bitwuzla, z3 }:
+{ pkgs, cbmc, bitwuzla, z3 }:
 rec {
   glibc-join = p: p.buildPackages.symlinkJoin {
     name = "glibc-join";
@@ -17,7 +17,7 @@ rec {
 
   native-gcc =
     if pkgs.stdenv.isDarwin
-    then null
+    then pkgs.clang_15
     else wrap-gcc pkgs;
 
   # cross is for determining whether to install the cross toolchain or not
@@ -35,13 +35,11 @@ rec {
       #   and won't just work for now
       # - equip all toolchains if cross is explicitly set to true
       # - On some machines, `native-gcc` needed to be evaluated lastly (placed as the last element of the toolchain list), or else would result in environment variables (CC, AR, ...) overriding issue.
-    pkgs.lib.optionals (cross && !pkgs.stdenv.isDarwin) [
-      (pkgs.lib.optional (! pkgs.stdenv.isx86_64) x86_64-gcc)
-      (pkgs.lib.optional (! pkgs.stdenv.isAarch64) aarch64-gcc)
-      (pkgs.lib.optional (pkgs.stdenv.isx86_64 || pkgs.stdenv.isAarch64) riscv64-gcc)
-      (pkgs.lib.optional (pkgs.stdenv.isx86_64) aarch64_be-gcc)
-      native-gcc
-    ]
+    pkgs.lib.optionals cross [ x86_64-gcc aarch64-gcc riscv64-gcc ]
+    ++ pkgs.lib.optionals (cross && pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64) [ aarch64_be-gcc ]
+    ++ pkgs.lib.optionals cross [ native-gcc ]
+    # NOTE: Tools in /Library/Developer/CommandLineTools/usr/bin on macOS are inaccessible in the Nix shell. This issue is addressed in https://github.com/NixOS/nixpkgs/pull/353893 but hasn’t been merged into the 24.11 channel yet. As a workaround, we include this dependency for macOS temporary. 
+    ++ pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.git ]
     ++ builtins.attrValues {
       inherit (pkgs.python3Packages) sympy pyyaml;
       inherit (pkgs)
@@ -49,20 +47,15 @@ rec {
         qemu; # 8.2.4
     };
 
+  core-pkgs = pkgs.symlinkJoin {
+    name = "toolchain join";
+    paths = core { };
+  };
+
   wrapShell = mkShell: attrs:
     mkShell (attrs // {
       shellHook = ''
         export PATH=$PWD/scripts:$PATH
-      '' +
-      # NOTE: we don't support nix gcc toolchains for darwin system, therefore explicitly setting environment variables like CC, AR, AS, ... is required
-      pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-        export CC=gcc
-        export CXX=g++
-        for cmd in \
-            ar as ld nm objcopy objdump readelf ranlib strip strings size windres
-        do
-            export ''${cmd^^}=$cmd
-        done
       '';
     });
 
@@ -84,11 +77,11 @@ rec {
         shfmt;
 
       inherit (pkgs.python3Packages)
-        sympy black;
+        mpmath sympy black;
     };
 
-  cbmc = pkgs.callPackage ./cbmc {
-    inherit bitwuzla z3;
+  cbmc-pkgs = pkgs.callPackage ./cbmc {
+    inherit cbmc bitwuzla z3;
   };
   valgrind-varlat = pkgs.callPackage ./valgrind { };
 }

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -336,7 +336,9 @@ def _main():
         "-p", "--preserve-preprocessor-directives", default=False, action="store_true"
     )
     parser.add_argument("-v", "--verbose", default=False, action="store_true")
-    parser.add_argument("--cc", type=str, default="gcc")
+    parser.add_argument(
+        "--cc", type=str, default="gcc" if platform.system() != "Darwin" else "clang"
+    )
     parser.add_argument("--nm", type=str, default="nm")
     parser.add_argument("--objdump", type=str, default="objdump")
     parser.add_argument("--cflags", type=str)

--- a/test/mk/auto.mk
+++ b/test/mk/auto.mk
@@ -25,5 +25,12 @@ endif
 
 # darwin aarch64
 else ifeq ($(HOST_PLATFORM),Darwin-arm64)
+ifeq ($(CROSS_PREFIX),)
 	CFLAGS += -DMLK_FORCE_AARCH64
+else ifneq ($(findstring x86_64, $(CROSS_PREFIX)),)
+	CFLAGS += -DMLK_FORCE_X86_64
+else ifneq ($(findstring aarch64, $(CROSS_PREFIX)),)
+	CFLAGS += -DMLK_FORCE_AARCH64
+else
+endif
 endif

--- a/test/mk/rules.mk
+++ b/test/mk/rules.mk
@@ -27,13 +27,13 @@ $(BUILD_DIR)/%.a: $(CONFIG)
 	$(eval _LIB := $(subst $(BUILD_DIR)/lib,,$(@:%.a=%)))
 	$(eval _CFLAGS := $(subst -static,,$(CFLAGS)))
 
-ifneq ($(findstring Darwin,$(HOST_PLATFORM)),) # if is on macOS
+ifeq ($(findstring Darwin,$(HOST_PLATFORM))$(CROSS_PREFIX),Darwin) # if is on native macOS
 	$(Q)echo "int main(void) {return 0;}" \
 		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
 		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
 		 -Imlkem $(wildcard test/notrandombytes/*.c) -o $(@:%.a=%_tmp.a.out)
 	$(Q)rm -f $(@:%.a=%_tmp.a.out)
-else                                           # if not on macOS
+else                                           # if not on macOS or cross compiling on macOS
 	$(Q)echo "int main(void) {return 0;}" \
 		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
 		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \


### PR DESCRIPTION
<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
- Upgrade nix channel to 24.11
- Keep 24.05 for gcc48 and gcc49, as both are deprecated in 24.11.
- Clean up redundant Nix wrapper functions for easier maintenance.
- Set Clang 15 as the default compiler for macOS to prevent namespace checking issues in CI (Clang 16 seems to cause failures). A follow-up PR is needed to properly resolve this.
- As noted in `nix/util.nix`: 
  - Tools in /Library/Developer/CommandLineTools/usr/bin on macOS are inaccessible in the Nix shell. This issue is addressed in https://github.com/NixOS/nixpkgs/pull/353893 but hasn’t been merged into the 24.11 channel yet. As a workaround, we include the `git` dependency for macOS temporary. 
- Refactored Nix installation and cache setup in setup-nix action:  
  - Nix cache is now built per os-arch instead of combinations of OS, architecture, shell, and root/non-root users.
  - Only the `build_nix_cache` job in `nix` workflow can build, save, and replace the cache.
  - For other workflows that depend on the Nix cache:
    - If started before the Nix cache is built:
      - They fetch an old cache that matches the prefix `$os-$arch`.
      - They build missing dependencies from scratch but do not save derivations as a cache.
    - If started after the Nix cache is built:
      - They successfully fetch the Nix cache using the primary key (`$os-$arch-$hash`).
      - Even if they modify the Nix store, they do not save the updated cache.
  - With the current approach, we can avoid race conditions when using the Nix cache, thereby reducing the risk of hitting the GitHub cache limit frequently.


**Performed local tests**:
 - [ ] `lint` passing
 - [ ] `tests all` passing
 - [ ] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
