### PR TITLE
Add Mingw-w64 quickcheck on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,24 @@ jobs:
           # print compiler version
           cl
           nmake /f ./Makefile.Microsoft_nmake quickcheck
+  quickcheck-windows-mingw-w64:
+    strategy:
+      fail-fast: false
+      matrix:
+        mingw-version: [5.4.0, 11.2.0, 12.2.0, 13.2.0]
+    name: Quickcheck (Mingw-w64 ${{ matrix.mingw-version }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install MinGW-w64
+        run: choco install mingw --version=${{ matrix.mingw-version }} -y
+        shell: cmd
+      - name: make quickcheck
+        shell: bash
+        run: |
+          CC=gcc OPT=0 make quickcheck
+          CC=gcc make clean >/dev/null
+          CC=gcc OPT=1 make quickcheck
   quickcheck-lib:
     name: Quickcheck lib
     strategy:

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -8,6 +8,11 @@
 #include "../mlkem/fips202/fips202.h"
 #include "../mlkem/mlkem_native.h"
 
+#if defined(_WIN64) || defined(_WIN32)
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 #define NTESTS 1000
 
 static void print_hex(const char *label, const uint8_t *data, size_t size)
@@ -37,6 +42,13 @@ int main(void)
       64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
       80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
   };
+
+#if defined(_WIN64) || defined(_WIN32)
+  /* Disable automatic CRLF conversion on Windows to match testvector hashes */
+  _setmode(_fileno(stdout), _O_BINARY);
+#endif
+
+
   shake256(coins, sizeof(coins), seed, sizeof(seed));
 
   for (i = 0; i < NTESTS; i++)

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -11,6 +11,11 @@
 #include "../mlkem/mlkem_native.h"
 #include "../mlkem/randombytes.h"
 
+#if defined(_WIN64) || defined(_WIN32)
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 #if (MLKEM_K == 2)
 #define CRYPTO_ALGNAME "Kyber512"
 #elif (MLKEM_K == 3)
@@ -61,6 +66,12 @@ int main(void)
   int rc;
 
   int count = 0;
+
+#if defined(_WIN64) || defined(_WIN32)
+  /* Disable automatic CRLF conversion on Windows to match testvector hashes */
+  _setmode(_fileno(stdout), _O_BINARY);
+#endif
+
 
   fprintf(fh, "# %s\n\n", CRYPTO_ALGNAME);
 


### PR DESCRIPTION
This commit adds a quickcheck using the Mingw-w64 compiler on Windows.
We install Mingw-w64 using Chocolatey which comes preinstalled on the
Github Windows runners.

To make the testvector hashes match, we need to set stdout to binary mode as
otherwise \n gets automatically converted to \r\n causing the hash to not match.
We add this behind preprocessor conditionals in gen_KAT.c and gen_NISTKAT.c.

Note that our Makefile heavily depends on having a Linux-like shell for commands
such as tr. We work around this by running the quickcheck in a bash shell
(which comes with Git for Windows which is preinstalled on the runners).

Resolves #745.
