### PR TITLE
CT: Mark random coins as secret outside of randombytes()

### DIFF
--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -188,7 +188,11 @@ int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
 {
   int res;
   MLK_ALIGN uint8_t coins[2 * MLKEM_SYMBYTES];
+
+  /* Acquire necessary randomness, and mark it as secret. */
   randombytes(coins, 2 * MLKEM_SYMBYTES);
+  MLK_CT_TESTING_SECRET(coins, sizeof(coins));
+
   res = crypto_kem_keypair_derand(pk, sk, coins);
 
   /* FIPS 203. Section 3.3 Destruction of intermediate values. */
@@ -236,7 +240,10 @@ int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
 {
   int res;
   MLK_ALIGN uint8_t coins[MLKEM_SYMBYTES];
+
   randombytes(coins, MLKEM_SYMBYTES);
+  MLK_CT_TESTING_SECRET(coins, sizeof(coins));
+
   res = crypto_kem_enc_derand(ct, ss, pk, coins);
 
   /* FIPS 203. Section 3.3 Destruction of intermediate values. */

--- a/test/notrandombytes/notrandombytes.c
+++ b/test/notrandombytes/notrandombytes.c
@@ -16,8 +16,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "../../mlkem/sys.h"
-
 static uint32_t seed[32] = {3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3,
                             2, 3, 8, 4, 6, 2, 6, 4, 3, 3, 8, 3, 2, 7, 9, 5};
 static uint32_t in[12];
@@ -79,11 +77,6 @@ static void surf(void)
 
 void randombytes(uint8_t *buf, size_t n)
 {
-#ifdef MLK_CT_TESTING_ENABLED
-  uint8_t *buf_orig = buf;
-  size_t n_orig = n;
-#endif
-
   while (n > 0)
   {
     if (!outleft)
@@ -105,10 +98,4 @@ void randombytes(uint8_t *buf, size_t n)
     ++buf;
     --n;
   }
-
-  /*
-   * Mark all randombytes output as secret (undefined).
-   * Valgrind will propagate this to everything derived from it.
-   */
-  MLK_CT_TESTING_SECRET(buf_orig, n_orig);
 }

--- a/test/test_mlkem.c
+++ b/test/test_mlkem.c
@@ -124,11 +124,8 @@ static int test_invalid_ciphertext(void)
   do
   {
     randombytes(&b, sizeof(uint8_t));
-    MLK_CT_TESTING_DECLASSIFY(&b, sizeof(uint8_t));
   } while (!b);
   randombytes((uint8_t *)&pos, sizeof(size_t));
-
-  MLK_CT_TESTING_DECLASSIFY(&pos, sizeof(size_t));
 
   /* Alice generates a public key */
   CHECK(crypto_kem_keypair(pk, sk) == 0);


### PR DESCRIPTION
Previously, valgrind CT tests would assume that the underlying randombytes() function would tag its output bytes as secret.

This commit changes this to explicitly tag the coins as secret in the ML-KEM source code.

This simplifies integration with other libraries using a custom randombytes() implementation, and makes the secret/declassify annotations with mlkem-native self-contained.
