### PR TITLE
Change unsigned to __CPROVER_size_t inside quantified expressions

### DIFF
--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -81,14 +81,14 @@
 #define forall(qvar, qvar_lb, qvar_ub, predicate)                 \
   __CPROVER_forall                                                \
   {                                                               \
-    unsigned qvar;                                                \
+    __CPROVER_size_t qvar;                                        \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==> (predicate)   \
   }
 
-#define EXISTS(qvar, qvar_lb, qvar_ub, predicate)         \
+#define EXISTS(qvar, qvar_lb, qvar_ub, predicate)               \
   __CPROVER_exists                                              \
   {                                                             \
-    unsigned qvar;                                              \
+    __CPROVER_size_t qvar;                                      \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) && (predicate)  \
   }
 /* clang-format on */
@@ -118,7 +118,7 @@
                          value_lb, value_ub)                           \
   __CPROVER_forall                                                     \
   {                                                                    \
-    unsigned qvar;                                                     \
+    __CPROVER_size_t qvar;                                             \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==>                    \
         (((int)(value_lb) <= ((array_var)[(qvar)])) &&		       \
          (((array_var)[(qvar)]) < (int)(value_ub)))		       \


### PR DESCRIPTION
CBMC team have suggested that "__CPROVER_size_t" would be more appropriate for the type of the quantified variable inside a quantified expression.

This PR makes that change inside the macros in cbmc.h only to determine potential impact of this change.
