### PR TITLE
Remove ubuntu-20.04 jobs (due to GH deprecating the runners)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -41,9 +41,6 @@ jobs:
           - runner: macos-latest
             container:
             install: 'installer'
-          - runner: ubuntu-20.04
-            container:
-            install: 'installer'
           - runner: ubuntu-22.04
             container:
             install: 'installer'


### PR DESCRIPTION
Github deprecated Ubuntu 20.04 action runners on 2025-02-01 and will stop supporting them 2025-04-01.
See https://github.com/actions/runner-images/issues/11101 This commit removes the single workflow (nix) where we do rely on the ubuntu-20.04 runners.

We remove them early as Github is scheduling brownouts starting March 4 to make people aware of this change.