### PR TITLE
Add runtime option to break PCT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: "MLK_KEYGEN_PCT"
+      - name: "PCT enabled"
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -479,6 +479,19 @@ jobs:
           nistkat: false
           kat: true
           acvp: true
+      - name: "PCT enabled + broken"
+        run: |
+          make clean
+          CFLAGS='-DMLK_CONFIG_FILE=\"../test/break_pct_config.h\"' make func -j4
+          # PCT breakage is done at runtime via MLK_BREAK_PCT
+          make run_func                 # Should be OK
+          MLK_BREAK_PCT=0 make run_func # Should be OK
+          if (MLK_BREAK_PCT=1 make run_func 2>&1 >/dev/null); then
+             echo "PCT failure expected"
+             exit 1
+          else
+             echo "PCT failed as expected"
+          fi
       - name: "MLKEM_GEN_MATRIX_NBLOCKS=1"
         uses: ./.github/actions/multi-functest
         with:

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -145,6 +145,14 @@ static int check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
     goto cleanup;
   }
 
+#if defined(MLK_KEYGEN_PCT_BREAKAGE_TEST)
+  /* Deliberately break PCT for testing purposes */
+  if (mlk_break_pct())
+  {
+    ss_enc[0] = ~ss_enc[0];
+  }
+#endif /* MLK_KEYGEN_PCT_BREAKAGE_TEST */
+
   res = ct_memcmp(ss_enc, ss_dec, sizeof(ss_dec));
 
 cleanup:

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -291,7 +291,7 @@
  *              key generation.
  *
  *****************************************************************************/
-/* #define MLK_KEYGEN_PCT */
+#define MLK_KEYGEN_PCT
 
 /******************************************************************************
  * Name:        MLK_KEYGEN_PCT_BREAKAGE_TEST
@@ -303,15 +303,18 @@
  *              This option only has an effect if MLK_KEYGEN_PCT is set.
  *
  *****************************************************************************/
-/* #define MLK_KEYGEN_PCT_BREAKAGE_TEST
-   #if !defined(__ASSEMBLER__)
-   #include "sys.h"
-   static MLK_INLINE int mlk_break_pct(void)
-   {
-       ... return 0/1 depending on whether PCT should be broken ...
-   }
-   #endif
-*/
+#define MLK_KEYGEN_PCT_BREAKAGE_TEST
+#if !defined(__ASSEMBLER__)
+#include <stdlib.h>
+#include <string.h>
+#include "../mlkem/sys.h"
+static MLK_INLINE int mlk_break_pct(void)
+{
+  /* Break PCT if and only if MLK_BREAK_PCT is set to 1 */
+  const char *val = getenv("MLK_BREAK_PCT");
+  return val != NULL && strcmp(val, "1") == 0;
+}
+#endif
 
 /*************************  Config internals  ********************************/
 


### PR DESCRIPTION
This commit introduces a config option MLK_KEYGEN_PCT_BREAKAGE_TEST. When set, the user must provide a runtime (!) function mlk_break_pct() to indicate if the PCT should be made fail. If set, the shared secret in the PCT will be deliberately corrupted to make the PCT fail. A test is added to exercise the runtime breakage logic.
