### PR TITLE
CBMC: Fix include path

### DIFF
--- a/mlkem/debug.h
+++ b/mlkem/debug.h
@@ -77,8 +77,7 @@ void mlkem_debug_check_bounds(const char *file, int line, const int16_t *ptr,
 
 /* When running CBMC, convert debug assertions into proof obligations */
 #elif defined(CBMC)
-
-#include "../cbmc.h"
+#include "cbmc.h"
 
 #define debug_assert(val) cassert(val)
 


### PR DESCRIPTION
When CBMC, debug assertions are transformed into proof obligations in debug.h. For this, debug.h includes cbmc.h, but using the wrong include path "../cbmc.h" which is still a remnant of debug.[ch] living in a separate debug/ directory. This only works because fips202/ happens to be another directory in the include path.

This commit fixes this minor slip by including "cbmc.h" from debug.h directly.
