### PR TITLE
CI: temporarily disable A72, A55, BPi

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,31 +27,32 @@ jobs:
       fail-fast: true
       matrix:
        target:
-        - system: rpi4
-          name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
-          bench_pmu: PMU
-          archflags: -mcpu=cortex-a72 -DMLK_SYS_AARCH64_SLOW_BARREL_SHIFTER
-          cflags: "-flto -DMLK_FORCE_AARCH64"
-          bench_extra_args: ""
+        # Temporarily disabled while we are restoring them
+        #- system: rpi4
+        #  name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
+        #  bench_pmu: PMU
+        #  archflags: -mcpu=cortex-a72 -DMLK_SYS_AARCH64_SLOW_BARREL_SHIFTER
+        #  cflags: "-flto -DMLK_FORCE_AARCH64"
+        #  bench_extra_args: ""
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
           cflags: "-flto -DMLK_FORCE_AARCH64"
           bench_extra_args: ""
-        - system: a55
-          name: Arm Cortex-A55 (Snapdragon 888) benchmarks
-          bench_pmu: PERF
-          archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: "-flto -static -DMLK_FORCE_AARCH64 -DMLK_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/meta_cortex_a55.h\\\\\\\""
-          bench_extra_args: -w exec-on-a55
-        - system: bpi
-          name: SpacemiT K1 8 (Banana Pi F3) benchmarks
-          bench_pmu: PERF
-          archflags: "-march=rv64imafdcv_zicsr_zifencei"
-          cflags: "-static"
-          bench_extra_args: -w exec-on-bpi
-          cross_prefix: riscv64-unknown-linux-gnu-
+        #- system: a55
+        #  name: Arm Cortex-A55 (Snapdragon 888) benchmarks
+        #  bench_pmu: PERF
+        #  archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
+        #  cflags: "-flto -static -DMLK_FORCE_AARCH64 -DMLK_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/meta_cortex_a55.h\\\\\\\""
+        #  bench_extra_args: -w exec-on-a55
+        #- system: bpi
+        #  name: SpacemiT K1 8 (Banana Pi F3) benchmarks
+        #  bench_pmu: PERF
+        #  archflags: "-march=rv64imafdcv_zicsr_zifencei"
+        #  cflags: "-static"
+        #  bench_extra_args: -w exec-on-bpi
+        #  cross_prefix: riscv64-unknown-linux-gnu-
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
     runs-on: self-hosted-${{ matrix.target.system }}
     steps:


### PR DESCRIPTION
We are currently expierencing some issues with out benchmarking CI due to one of our self-hosted runners dying last night.
This commit remporarily disables the affected jobs until the runner has been restored.
