### PR TITLE
Normalize naming of NTT Layers

### DIFF
--- a/dev/aarch64_clean/src/aarch64_zetas.c
+++ b/dev/aarch64_clean/src/aarch64_zetas.c
@@ -20,7 +20,7 @@
  * Table of zeta values used in the AArch64 forward NTT
  * See autogen for details.
  */
-MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {
+MLK_ALIGN const int16_t aarch64_ntt_zetas_layer12345[] = {
     -1600, -15749, -749,  -7373,  -40,   -394,   -687, -6762, 630,  6201,
     -1432, -14095, 848,   8347,   0,     0,      1062, 10453, 296,  2914,
     -882,  -8682,  0,     0,      -1410, -13879, 1339, 13180, 1476, 14529,
@@ -31,7 +31,7 @@ MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {
     0,     0,      -1583, -15582, -1355, -13338, 821,  8081,  0,    0,
 };
 
-MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {
+MLK_ALIGN const int16_t aarch64_ntt_zetas_layer67[] = {
     289,    289,    331,    331,    -76,    -76,    -1573,  -1573,  2845,
     2845,   3258,   3258,   -748,   -748,   -15483, -15483, 17,     17,
     583,    583,    1637,   1637,   -1041,  -1041,  167,    167,    5739,
@@ -77,7 +77,7 @@ MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {
     10129,  10129,  -3878,  -3878,  -11566, -11566,
 };
 
-MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {
+MLK_ALIGN const int16_t aarch64_invntt_zetas_layer12345[] = {
     1583,  15582,  -821,  -8081,  1355,  13338,  0,     0,      -569,  -5601,
     450,   4429,   936,   9213,   0,     0,      69,    679,    447,   4400,
     -535,  -5266,  0,     0,      543,   5345,   1235,  12156,  -1426, -14036,
@@ -88,7 +88,7 @@ MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {
     -848,  -8347,  1432,  14095,  -630,  -6201,  687,   6762,   0,     0,
 };
 
-MLK_ALIGN const int16_t aarch64_invntt_zetas_layer56[] = {
+MLK_ALIGN const int16_t aarch64_invntt_zetas_layer67[] = {
     -910,   -910,   -1227,  -1227,  219,    219,    855,    855,    -8957,
     -8957,  -12078, -12078, 2156,   2156,   8416,   8416,   1175,   1175,
     394,    394,    -1029,  -1029,  -1212,  -1212,  11566,  11566,  3878,

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -8,21 +8,21 @@
 #include <stdint.h>
 #include "../../../common.h"
 
-#define aarch64_ntt_zetas_layer01234 MLK_NAMESPACE(aarch64_ntt_zetas_layer01234)
-#define aarch64_ntt_zetas_layer56 MLK_NAMESPACE(aarch64_ntt_zetas_layer56)
-#define aarch64_invntt_zetas_layer01234 \
-  MLK_NAMESPACE(aarch64_invntt_zetas_layer01234)
-#define aarch64_invntt_zetas_layer56 MLK_NAMESPACE(aarch64_invntt_zetas_layer56)
+#define aarch64_ntt_zetas_layer12345 MLK_NAMESPACE(aarch64_ntt_zetas_layer12345)
+#define aarch64_ntt_zetas_layer67 MLK_NAMESPACE(aarch64_ntt_zetas_layer67)
+#define aarch64_invntt_zetas_layer12345 \
+  MLK_NAMESPACE(aarch64_invntt_zetas_layer12345)
+#define aarch64_invntt_zetas_layer67 MLK_NAMESPACE(aarch64_invntt_zetas_layer67)
 #define aarch64_zetas_mulcache_native \
   MLK_NAMESPACE(aarch64_zetas_mulcache_native)
 #define aarch64_zetas_mulcache_twisted_native \
   MLK_NAMESPACE(aarch64_zetas_mulcache_twisted_native)
 #define rej_uniform_table MLK_NAMESPACE(rej_uniform_table)
 
-extern const int16_t aarch64_ntt_zetas_layer01234[];
-extern const int16_t aarch64_ntt_zetas_layer56[];
-extern const int16_t aarch64_invntt_zetas_layer01234[];
-extern const int16_t aarch64_invntt_zetas_layer56[];
+extern const int16_t aarch64_ntt_zetas_layer12345[];
+extern const int16_t aarch64_ntt_zetas_layer67[];
+extern const int16_t aarch64_invntt_zetas_layer12345[];
+extern const int16_t aarch64_invntt_zetas_layer67[];
 extern const int16_t aarch64_zetas_mulcache_native[];
 extern const int16_t aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t rej_uniform_table[];

--- a/dev/aarch64_clean/src/clean_impl.h
+++ b/dev/aarch64_clean/src/clean_impl.h
@@ -26,13 +26,13 @@
 
 static MLK_INLINE void ntt_native(int16_t data[MLKEM_N])
 {
-  ntt_asm_clean(data, aarch64_ntt_zetas_layer01234, aarch64_ntt_zetas_layer56);
+  ntt_asm_clean(data, aarch64_ntt_zetas_layer12345, aarch64_ntt_zetas_layer67);
 }
 
 static MLK_INLINE void intt_native(int16_t data[MLKEM_N])
 {
-  intt_asm_clean(data, aarch64_invntt_zetas_layer01234,
-                 aarch64_invntt_zetas_layer56);
+  intt_asm_clean(data, aarch64_invntt_zetas_layer12345,
+                 aarch64_invntt_zetas_layer67);
 }
 
 static MLK_INLINE void poly_reduce_native(int16_t data[MLKEM_N])

--- a/dev/aarch64_clean/src/intt_clean.S
+++ b/dev/aarch64_clean/src/intt_clean.S
@@ -74,22 +74,22 @@
         mls     \a\().8h, t0.8h,    consts.h[0]
 .endm
 
-.macro load_roots_012
-        ldr q_root0, [r01234_ptr], #32
-        ldr q_root1, [r01234_ptr, #-16]
+.macro load_roots_123
+        ldr q_root0, [r12345_ptr], #32
+        ldr q_root1, [r12345_ptr, #-16]
 .endm
 
-.macro load_next_roots_34
-        ldr q_root0, [r01234_ptr], #16
+.macro load_next_roots_45
+        ldr q_root0, [r12345_ptr], #16
 .endm
 
-.macro load_next_roots_56
-        ldr q_root0,    [r56_ptr], #(6*16)
-        ldr q_root0_tw, [r56_ptr, #(-6*16 + 1*16)]
-        ldr q_root1,    [r56_ptr, #(-6*16 + 2*16)]
-        ldr q_root1_tw, [r56_ptr, #(-6*16 + 3*16)]
-        ldr q_root2,    [r56_ptr, #(-6*16 + 4*16)]
-        ldr q_root2_tw, [r56_ptr, #(-6*16 + 5*16)]
+.macro load_next_roots_67
+        ldr q_root0,    [r67_ptr], #(6*16)
+        ldr q_root0_tw, [r67_ptr, #(-6*16 + 1*16)]
+        ldr q_root1,    [r67_ptr, #(-6*16 + 2*16)]
+        ldr q_root1_tw, [r67_ptr, #(-6*16 + 3*16)]
+        ldr q_root2,    [r67_ptr, #(-6*16 + 4*16)]
+        ldr q_root2_tw, [r67_ptr, #(-6*16 + 5*16)]
 .endm
 
 .macro transpose4 data
@@ -142,8 +142,8 @@
 // also matching PQClean.
 
         in         .req x0
-        r01234_ptr .req x1
-        r56_ptr    .req x2
+        r12345_ptr .req x1
+        r67_ptr    .req x2
 
         inp     .req x3
         count   .req x4
@@ -234,7 +234,7 @@ scale_start:
         mov count, #8
 
         .p2align 2
-layer3456_start:
+layer4567_start:
 
         ldr q_data0, [inp, #(16*0)]
         ldr q_data1, [inp, #(16*1)]
@@ -243,7 +243,7 @@ layer3456_start:
 
         transpose4 data // manual ld4
 
-        load_next_roots_56
+        load_next_roots_67
 
         // Layer 7
         gs_butterfly_v data0, data1, root1, root1_tw
@@ -262,7 +262,7 @@ layer3456_start:
 
         transpose4 data
 
-        load_next_roots_34
+        load_next_roots_45
 
         // Layer 5
         gs_butterfly data0, data1, root0, 2, 3
@@ -289,16 +289,16 @@ layer3456_start:
         str q_data3, [inp, #(-64 + 16*3)]
 
         subs count, count, #1
-        cbnz count, layer3456_start
+        cbnz count, layer4567_start
 
         // ---------------------------------------------------------------------
 
         mov count, #4
-        load_roots_012
+        load_roots_123
 
         .p2align 2
 
-layer012_start:
+layer123_start:
 
         ldr q_data0, [in, #0]
         ldr q_data1, [in, #(1*(512/8))]
@@ -337,15 +337,15 @@ layer012_start:
         str q_data3, [in, #(-16 + 3*(512/8))]
 
         subs count, count, #1
-        cbnz count, layer012_start
+        cbnz count, layer123_start
 
         pop_stack
         ret
 
 /****************** REGISTER DEALLOCATIONS *******************/
     .unreq in
-    .unreq r01234_ptr
-    .unreq r56_ptr
+    .unreq r12345_ptr
+    .unreq r67_ptr
     .unreq inp
     .unreq count
     .unreq wtmp

--- a/dev/aarch64_clean/src/ntt_clean.S
+++ b/dev/aarch64_clean/src/ntt_clean.S
@@ -62,22 +62,22 @@
         add \a\().8h, \a\().8h, tmp.8h
 .endm
 
-.macro load_roots_012
-        ldr q_root0, [r01234_ptr], #32
-        ldr q_root1, [r01234_ptr, #-16]
+.macro load_roots_123
+        ldr q_root0, [r12345_ptr], #32
+        ldr q_root1, [r12345_ptr, #-16]
 .endm
 
-.macro load_next_roots_34
-        ldr q_root0, [r01234_ptr], #16
+.macro load_next_roots_45
+        ldr q_root0, [r12345_ptr], #16
 .endm
 
-.macro load_next_roots_56
-        ldr q_root0,    [r56_ptr], #(6*16)
-        ldr q_root0_tw, [r56_ptr, #(-6*16 + 1*16)]
-        ldr q_root1,    [r56_ptr, #(-6*16 + 2*16)]
-        ldr q_root1_tw, [r56_ptr, #(-6*16 + 3*16)]
-        ldr q_root2,    [r56_ptr, #(-6*16 + 4*16)]
-        ldr q_root2_tw, [r56_ptr, #(-6*16 + 5*16)]
+.macro load_next_roots_67
+        ldr q_root0,    [r67_ptr], #(6*16)
+        ldr q_root0_tw, [r67_ptr, #(-6*16 + 1*16)]
+        ldr q_root1,    [r67_ptr, #(-6*16 + 2*16)]
+        ldr q_root1_tw, [r67_ptr, #(-6*16 + 3*16)]
+        ldr q_root2,    [r67_ptr, #(-6*16 + 4*16)]
+        ldr q_root2_tw, [r67_ptr, #(-6*16 + 5*16)]
 .endm
 
 .macro transpose4 data
@@ -118,8 +118,8 @@
 
         // Arguments
         in         .req x0 // Input/output buffer
-        r01234_ptr .req x1 // twiddles for layer 0,1,2,3,4
-        r56_ptr    .req x2 // twiddles for layer 5,6
+        r12345_ptr .req x1 // twiddles for layer 0,1,2,3,4
+        r67_ptr    .req x2 // twiddles for layer 5,6
 
         inp     .req x3
         count   .req x4
@@ -179,7 +179,7 @@ MLK_ASM_FN_SYMBOL(ntt_asm_clean)
         mov inp, in
         mov count, #4
 
-        load_roots_012
+        load_roots_123
 
         .p2align 2
 
@@ -196,7 +196,7 @@ MLK_ASM_FN_SYMBOL(ntt_asm_clean)
         //
         // See test/test_bounds.py for more details.
 
-layer012_start:
+layer123_start:
 
         ldr q_data0, [in, #0]
         ldr q_data1, [in, #(1*(512/8))]
@@ -232,20 +232,20 @@ layer012_start:
         str q_data7, [in, #(-16 + 7*(512/8))]
 
         subs count, count, #1
-        cbnz count, layer012_start
+        cbnz count, layer123_start
 
         mov in, inp
         mov count, #8
 
         .p2align 2
-layer3456_start:
+layer4567_start:
 
         ldr q_data0, [in, #(16*0)]
         ldr q_data1, [in, #(16*1)]
         ldr q_data2, [in, #(16*2)]
         ldr q_data3, [in, #(16*3)]
 
-        load_next_roots_34
+        load_next_roots_45
 
         ct_butterfly data0, data2, root0, 0, 1
         ct_butterfly data1, data3, root0, 0, 1
@@ -253,7 +253,7 @@ layer3456_start:
         ct_butterfly data2, data3, root0, 4, 5
 
         transpose4 data
-        load_next_roots_56
+        load_next_roots_67
 
         ct_butterfly_v data0, data2, root0, root0_tw
         ct_butterfly_v data1, data3, root0, root0_tw
@@ -268,15 +268,15 @@ layer3456_start:
         str q_data3, [in, #(-16*1)]
 
         subs count, count, #1
-        cbnz count, layer3456_start
+        cbnz count, layer4567_start
 
         pop_stack
         ret
 
 /****************** REGISTER DEALLOCATIONS *******************/
     .unreq in
-    .unreq r01234_ptr
-    .unreq r56_ptr
+    .unreq r12345_ptr
+    .unreq r67_ptr
     .unreq inp
     .unreq count
     .unreq wtmp

--- a/dev/aarch64_opt/src/aarch64_zetas.c
+++ b/dev/aarch64_opt/src/aarch64_zetas.c
@@ -20,7 +20,7 @@
  * Table of zeta values used in the AArch64 forward NTT
  * See autogen for details.
  */
-MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {
+MLK_ALIGN const int16_t aarch64_ntt_zetas_layer12345[] = {
     -1600, -15749, -749,  -7373,  -40,   -394,   -687, -6762, 630,  6201,
     -1432, -14095, 848,   8347,   0,     0,      1062, 10453, 296,  2914,
     -882,  -8682,  0,     0,      -1410, -13879, 1339, 13180, 1476, 14529,
@@ -31,7 +31,7 @@ MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {
     0,     0,      -1583, -15582, -1355, -13338, 821,  8081,  0,    0,
 };
 
-MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {
+MLK_ALIGN const int16_t aarch64_ntt_zetas_layer67[] = {
     289,    289,    331,    331,    -76,    -76,    -1573,  -1573,  2845,
     2845,   3258,   3258,   -748,   -748,   -15483, -15483, 17,     17,
     583,    583,    1637,   1637,   -1041,  -1041,  167,    167,    5739,
@@ -77,7 +77,7 @@ MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {
     10129,  10129,  -3878,  -3878,  -11566, -11566,
 };
 
-MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {
+MLK_ALIGN const int16_t aarch64_invntt_zetas_layer12345[] = {
     1583,  15582,  -821,  -8081,  1355,  13338,  0,     0,      -569,  -5601,
     450,   4429,   936,   9213,   0,     0,      69,    679,    447,   4400,
     -535,  -5266,  0,     0,      543,   5345,   1235,  12156,  -1426, -14036,
@@ -88,7 +88,7 @@ MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {
     -848,  -8347,  1432,  14095,  -630,  -6201,  687,   6762,   0,     0,
 };
 
-MLK_ALIGN const int16_t aarch64_invntt_zetas_layer56[] = {
+MLK_ALIGN const int16_t aarch64_invntt_zetas_layer67[] = {
     -910,   -910,   -1227,  -1227,  219,    219,    855,    855,    -8957,
     -8957,  -12078, -12078, 2156,   2156,   8416,   8416,   1175,   1175,
     394,    394,    -1029,  -1029,  -1212,  -1212,  11566,  11566,  3878,

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -8,21 +8,21 @@
 #include <stdint.h>
 #include "../../../common.h"
 
-#define aarch64_ntt_zetas_layer01234 MLK_NAMESPACE(aarch64_ntt_zetas_layer01234)
-#define aarch64_ntt_zetas_layer56 MLK_NAMESPACE(aarch64_ntt_zetas_layer56)
-#define aarch64_invntt_zetas_layer01234 \
-  MLK_NAMESPACE(aarch64_invntt_zetas_layer01234)
-#define aarch64_invntt_zetas_layer56 MLK_NAMESPACE(aarch64_invntt_zetas_layer56)
+#define aarch64_ntt_zetas_layer12345 MLK_NAMESPACE(aarch64_ntt_zetas_layer12345)
+#define aarch64_ntt_zetas_layer67 MLK_NAMESPACE(aarch64_ntt_zetas_layer67)
+#define aarch64_invntt_zetas_layer12345 \
+  MLK_NAMESPACE(aarch64_invntt_zetas_layer12345)
+#define aarch64_invntt_zetas_layer67 MLK_NAMESPACE(aarch64_invntt_zetas_layer67)
 #define aarch64_zetas_mulcache_native \
   MLK_NAMESPACE(aarch64_zetas_mulcache_native)
 #define aarch64_zetas_mulcache_twisted_native \
   MLK_NAMESPACE(aarch64_zetas_mulcache_twisted_native)
 #define rej_uniform_table MLK_NAMESPACE(rej_uniform_table)
 
-extern const int16_t aarch64_ntt_zetas_layer01234[];
-extern const int16_t aarch64_ntt_zetas_layer56[];
-extern const int16_t aarch64_invntt_zetas_layer01234[];
-extern const int16_t aarch64_invntt_zetas_layer56[];
+extern const int16_t aarch64_ntt_zetas_layer12345[];
+extern const int16_t aarch64_ntt_zetas_layer67[];
+extern const int16_t aarch64_invntt_zetas_layer12345[];
+extern const int16_t aarch64_invntt_zetas_layer67[];
 extern const int16_t aarch64_zetas_mulcache_native[];
 extern const int16_t aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t rej_uniform_table[];

--- a/dev/aarch64_opt/src/intt_opt.S
+++ b/dev/aarch64_opt/src/intt_opt.S
@@ -74,22 +74,22 @@
         mls     \a\().8h, t0.8h,    consts.h[0]
 .endm
 
-.macro load_roots_012
-        ldr q_root0, [r01234_ptr], #32
-        ldr q_root1, [r01234_ptr, #-16]
+.macro load_roots_123
+        ldr q_root0, [r12345_ptr], #32
+        ldr q_root1, [r12345_ptr, #-16]
 .endm
 
-.macro load_next_roots_34
-        ldr q_root0, [r01234_ptr], #16
+.macro load_next_roots_45
+        ldr q_root0, [r12345_ptr], #16
 .endm
 
-.macro load_next_roots_56
-        ldr q_root0,    [r56_ptr], #(6*16)
-        ldr q_root0_tw, [r56_ptr, #(-6*16 + 1*16)]
-        ldr q_root1,    [r56_ptr, #(-6*16 + 2*16)]
-        ldr q_root1_tw, [r56_ptr, #(-6*16 + 3*16)]
-        ldr q_root2,    [r56_ptr, #(-6*16 + 4*16)]
-        ldr q_root2_tw, [r56_ptr, #(-6*16 + 5*16)]
+.macro load_next_roots_67
+        ldr q_root0,    [r67_ptr], #(6*16)
+        ldr q_root0_tw, [r67_ptr, #(-6*16 + 1*16)]
+        ldr q_root1,    [r67_ptr, #(-6*16 + 2*16)]
+        ldr q_root1_tw, [r67_ptr, #(-6*16 + 3*16)]
+        ldr q_root2,    [r67_ptr, #(-6*16 + 4*16)]
+        ldr q_root2_tw, [r67_ptr, #(-6*16 + 5*16)]
 .endm
 
 .macro transpose4 data
@@ -142,8 +142,8 @@
 // also matching PQClean.
 
         in         .req x0
-        r01234_ptr .req x1
-        r56_ptr    .req x2
+        r12345_ptr .req x1
+        r67_ptr    .req x2
 
         inp     .req x3
         count   .req x4
@@ -275,7 +275,7 @@ scale_start:
         // ldr q28, [x2, #-16]             // ...................*...........
 
         sub count, count, #1
-layer3456_start:
+layer4567_start:
                                                 // Instructions:    83
                                                 // Expected cycles: 94
                                                 // Expected IPC:    0.88
@@ -461,7 +461,7 @@ layer3456_start:
         // str q11, [x3, #(-64 + 16*3)]               // .......................................................~........'....................................................................................*
 
         sub count, count, #1
-        cbnz count, layer3456_start
+        cbnz count, layer4567_start
                                                 // Instructions:    72
                                                 // Expected cycles: 79
                                                 // Expected IPC:    0.91
@@ -628,7 +628,7 @@ layer3456_start:
         // ---------------------------------------------------------------------
 
         mov count, #4
-        load_roots_012
+        load_roots_123
 
         .p2align 2
 
@@ -675,7 +675,7 @@ layer3456_start:
         // add v23.8H, v28.8H, v13.8H      // .................*.............
 
         sub count, count, #1
-layer012_start:
+layer123_start:
                                                 // Instructions:    76
                                                 // Expected cycles: 84
                                                 // Expected IPC:    0.90
@@ -847,7 +847,7 @@ layer012_start:
         // str q11, [x0, #(-16 + 3*(512/8))]          // ........................~..'................................................................................*
 
         sub count, count, #1
-        cbnz count, layer012_start
+        cbnz count, layer123_start
                                                 // Instructions:    64
                                                 // Expected cycles: 66
                                                 // Expected IPC:    0.97
@@ -1000,8 +1000,8 @@ layer012_start:
 
 /****************** REGISTER DEALLOCATIONS *******************/
     .unreq in
-    .unreq r01234_ptr
-    .unreq r56_ptr
+    .unreq r12345_ptr
+    .unreq r67_ptr
     .unreq inp
     .unreq count
     .unreq wtmp

--- a/dev/aarch64_opt/src/ntt_opt.S
+++ b/dev/aarch64_opt/src/ntt_opt.S
@@ -62,22 +62,22 @@
         add \a\().8h, \a\().8h, tmp.8h
 .endm
 
-.macro load_roots_012
-        ldr q_root0, [r01234_ptr], #32
-        ldr q_root1, [r01234_ptr, #-16]
+.macro load_roots_123
+        ldr q_root0, [r12345_ptr], #32
+        ldr q_root1, [r12345_ptr, #-16]
 .endm
 
-.macro load_next_roots_34
-        ldr q_root0, [r01234_ptr], #16
+.macro load_next_roots_45
+        ldr q_root0, [r12345_ptr], #16
 .endm
 
-.macro load_next_roots_56
-        ldr q_root0,    [r56_ptr], #(6*16)
-        ldr q_root0_tw, [r56_ptr, #(-6*16 + 1*16)]
-        ldr q_root1,    [r56_ptr, #(-6*16 + 2*16)]
-        ldr q_root1_tw, [r56_ptr, #(-6*16 + 3*16)]
-        ldr q_root2,    [r56_ptr, #(-6*16 + 4*16)]
-        ldr q_root2_tw, [r56_ptr, #(-6*16 + 5*16)]
+.macro load_next_roots_67
+        ldr q_root0,    [r67_ptr], #(6*16)
+        ldr q_root0_tw, [r67_ptr, #(-6*16 + 1*16)]
+        ldr q_root1,    [r67_ptr, #(-6*16 + 2*16)]
+        ldr q_root1_tw, [r67_ptr, #(-6*16 + 3*16)]
+        ldr q_root2,    [r67_ptr, #(-6*16 + 4*16)]
+        ldr q_root2_tw, [r67_ptr, #(-6*16 + 5*16)]
 .endm
 
 .macro transpose4 data
@@ -118,8 +118,8 @@
 
         // Arguments
         in         .req x0 // Input/output buffer
-        r01234_ptr .req x1 // twiddles for layer 0,1,2,3,4
-        r56_ptr    .req x2 // twiddles for layer 5,6
+        r12345_ptr .req x1 // twiddles for layer 1,2,3,4,5
+        r67_ptr    .req x2 // twiddles for layer 6,7
 
         inp     .req x3
         count   .req x4
@@ -180,7 +180,7 @@ MLK_ASM_FN_SYMBOL(ntt_asm_opt)
         mov inp, in
         mov count, #4
 
-        load_roots_012
+        load_roots_123
 
         .p2align 2
 
@@ -912,8 +912,8 @@ ntt_opt_loop1:
 
 /****************** REGISTER DEALLOCATIONS *******************/
     .unreq in
-    .unreq r01234_ptr
-    .unreq r56_ptr
+    .unreq r12345_ptr
+    .unreq r67_ptr
     .unreq inp
     .unreq count
     .unreq wtmp

--- a/dev/aarch64_opt/src/opt_impl.h
+++ b/dev/aarch64_opt/src/opt_impl.h
@@ -25,13 +25,13 @@
 
 static MLK_INLINE void ntt_native(int16_t data[MLKEM_N])
 {
-  ntt_asm_opt(data, aarch64_ntt_zetas_layer01234, aarch64_ntt_zetas_layer56);
+  ntt_asm_opt(data, aarch64_ntt_zetas_layer12345, aarch64_ntt_zetas_layer67);
 }
 
 static MLK_INLINE void intt_native(int16_t data[MLKEM_N])
 {
-  intt_asm_opt(data, aarch64_invntt_zetas_layer01234,
-               aarch64_invntt_zetas_layer56);
+  intt_asm_opt(data, aarch64_invntt_zetas_layer12345,
+               aarch64_invntt_zetas_layer67);
 }
 
 static MLK_INLINE void poly_reduce_native(int16_t data[MLKEM_N])

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -427,10 +427,10 @@
 #undef MLK_NATIVE_AARCH64_META_H
 /* mlkem/native/aarch64/src/arith_native_aarch64.h */
 #undef MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H
-#undef aarch64_invntt_zetas_layer01234
-#undef aarch64_invntt_zetas_layer56
-#undef aarch64_ntt_zetas_layer01234
-#undef aarch64_ntt_zetas_layer56
+#undef aarch64_invntt_zetas_layer12345
+#undef aarch64_invntt_zetas_layer67
+#undef aarch64_ntt_zetas_layer12345
+#undef aarch64_ntt_zetas_layer67
 #undef aarch64_zetas_mulcache_native
 #undef aarch64_zetas_mulcache_twisted_native
 #undef intt_asm_opt

--- a/mlkem/native/aarch64/src/aarch64_zetas.c
+++ b/mlkem/native/aarch64/src/aarch64_zetas.c
@@ -20,7 +20,7 @@
  * Table of zeta values used in the AArch64 forward NTT
  * See autogen for details.
  */
-MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {
+MLK_ALIGN const int16_t aarch64_ntt_zetas_layer12345[] = {
     -1600, -15749, -749,  -7373,  -40,   -394,   -687, -6762, 630,  6201,
     -1432, -14095, 848,   8347,   0,     0,      1062, 10453, 296,  2914,
     -882,  -8682,  0,     0,      -1410, -13879, 1339, 13180, 1476, 14529,
@@ -31,7 +31,7 @@ MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {
     0,     0,      -1583, -15582, -1355, -13338, 821,  8081,  0,    0,
 };
 
-MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {
+MLK_ALIGN const int16_t aarch64_ntt_zetas_layer67[] = {
     289,    289,    331,    331,    -76,    -76,    -1573,  -1573,  2845,
     2845,   3258,   3258,   -748,   -748,   -15483, -15483, 17,     17,
     583,    583,    1637,   1637,   -1041,  -1041,  167,    167,    5739,
@@ -77,7 +77,7 @@ MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {
     10129,  10129,  -3878,  -3878,  -11566, -11566,
 };
 
-MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {
+MLK_ALIGN const int16_t aarch64_invntt_zetas_layer12345[] = {
     1583,  15582,  -821,  -8081,  1355,  13338,  0,     0,      -569,  -5601,
     450,   4429,   936,   9213,   0,     0,      69,    679,    447,   4400,
     -535,  -5266,  0,     0,      543,   5345,   1235,  12156,  -1426, -14036,
@@ -88,7 +88,7 @@ MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {
     -848,  -8347,  1432,  14095,  -630,  -6201,  687,   6762,   0,     0,
 };
 
-MLK_ALIGN const int16_t aarch64_invntt_zetas_layer56[] = {
+MLK_ALIGN const int16_t aarch64_invntt_zetas_layer67[] = {
     -910,   -910,   -1227,  -1227,  219,    219,    855,    855,    -8957,
     -8957,  -12078, -12078, 2156,   2156,   8416,   8416,   1175,   1175,
     394,    394,    -1029,  -1029,  -1212,  -1212,  11566,  11566,  3878,

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -8,21 +8,21 @@
 #include <stdint.h>
 #include "../../../common.h"
 
-#define aarch64_ntt_zetas_layer01234 MLK_NAMESPACE(aarch64_ntt_zetas_layer01234)
-#define aarch64_ntt_zetas_layer56 MLK_NAMESPACE(aarch64_ntt_zetas_layer56)
-#define aarch64_invntt_zetas_layer01234 \
-  MLK_NAMESPACE(aarch64_invntt_zetas_layer01234)
-#define aarch64_invntt_zetas_layer56 MLK_NAMESPACE(aarch64_invntt_zetas_layer56)
+#define aarch64_ntt_zetas_layer12345 MLK_NAMESPACE(aarch64_ntt_zetas_layer12345)
+#define aarch64_ntt_zetas_layer67 MLK_NAMESPACE(aarch64_ntt_zetas_layer67)
+#define aarch64_invntt_zetas_layer12345 \
+  MLK_NAMESPACE(aarch64_invntt_zetas_layer12345)
+#define aarch64_invntt_zetas_layer67 MLK_NAMESPACE(aarch64_invntt_zetas_layer67)
 #define aarch64_zetas_mulcache_native \
   MLK_NAMESPACE(aarch64_zetas_mulcache_native)
 #define aarch64_zetas_mulcache_twisted_native \
   MLK_NAMESPACE(aarch64_zetas_mulcache_twisted_native)
 #define rej_uniform_table MLK_NAMESPACE(rej_uniform_table)
 
-extern const int16_t aarch64_ntt_zetas_layer01234[];
-extern const int16_t aarch64_ntt_zetas_layer56[];
-extern const int16_t aarch64_invntt_zetas_layer01234[];
-extern const int16_t aarch64_invntt_zetas_layer56[];
+extern const int16_t aarch64_ntt_zetas_layer12345[];
+extern const int16_t aarch64_ntt_zetas_layer67[];
+extern const int16_t aarch64_invntt_zetas_layer12345[];
+extern const int16_t aarch64_invntt_zetas_layer67[];
 extern const int16_t aarch64_zetas_mulcache_native[];
 extern const int16_t aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t rej_uniform_table[];

--- a/mlkem/native/aarch64/src/intt_opt.S
+++ b/mlkem/native/aarch64/src/intt_opt.S
@@ -92,7 +92,7 @@ scale_start:
         ldur	q28, [x2, #-0x10]
         sub	x4, x4, #0x1
 
-layer3456_start:
+layer4567_start:
         trn1	v12.4s, v26.4s, v8.4s
         trn2	v26.4s, v26.4s, v8.4s
         trn2	v8.4s, v24.4s, v16.4s
@@ -177,7 +177,7 @@ layer3456_start:
         ldur	q4, [x2, #-0x20]
         ldur	q28, [x2, #-0x10]
         sub	x4, x4, #0x1
-        cbnz	x4, layer3456_start
+        cbnz	x4, layer4567_start
         trn1	v11.4s, v26.4s, v8.4s
         trn2	v24.4s, v24.4s, v16.4s
         trn2	v26.4s, v26.4s, v8.4s
@@ -267,7 +267,7 @@ layer3456_start:
         ldr	q15, [x0, #0x40]
         sub	x4, x4, #0x1
 
-layer012_start:
+layer123_start:
         sub	v12.8h, v11.8h, v15.8h
         add	v26.8h, v11.8h, v15.8h
         sub	v8.8h, v24.8h, v16.8h
@@ -345,7 +345,7 @@ layer012_start:
         add	v19.8h, v24.8h, v16.8h
         add	v23.8h, v28.8h, v13.8h
         sub	x4, x4, #0x1
-        cbnz	x4, layer012_start
+        cbnz	x4, layer123_start
         add	v10.8h, v11.8h, v15.8h
         sub	v12.8h, v28.8h, v13.8h
         sub	v11.8h, v11.8h, v15.8h

--- a/mlkem/native/aarch64/src/opt_impl.h
+++ b/mlkem/native/aarch64/src/opt_impl.h
@@ -25,13 +25,13 @@
 
 static MLK_INLINE void ntt_native(int16_t data[MLKEM_N])
 {
-  ntt_asm_opt(data, aarch64_ntt_zetas_layer01234, aarch64_ntt_zetas_layer56);
+  ntt_asm_opt(data, aarch64_ntt_zetas_layer12345, aarch64_ntt_zetas_layer67);
 }
 
 static MLK_INLINE void intt_native(int16_t data[MLKEM_N])
 {
-  intt_asm_opt(data, aarch64_invntt_zetas_layer01234,
-               aarch64_invntt_zetas_layer56);
+  intt_asm_opt(data, aarch64_invntt_zetas_layer12345,
+               aarch64_invntt_zetas_layer67);
 }
 
 static MLK_INLINE void poly_reduce_native(int16_t data[MLKEM_N])

--- a/proofs/hol_light/arm/mlkem/mlkem_intt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_intt.S
@@ -94,7 +94,7 @@ scale_start:
         ldur	q28, [x2, #-0x10]
         sub	x4, x4, #0x1
 
-layer3456_start:
+layer4567_start:
         trn1	v12.4s, v26.4s, v8.4s
         trn2	v26.4s, v26.4s, v8.4s
         trn2	v8.4s, v24.4s, v16.4s
@@ -179,7 +179,7 @@ layer3456_start:
         ldur	q4, [x2, #-0x20]
         ldur	q28, [x2, #-0x10]
         sub	x4, x4, #0x1
-        cbnz	x4, layer3456_start
+        cbnz	x4, layer4567_start
         trn1	v11.4s, v26.4s, v8.4s
         trn2	v24.4s, v24.4s, v16.4s
         trn2	v26.4s, v26.4s, v8.4s
@@ -269,7 +269,7 @@ layer3456_start:
         ldr	q15, [x0, #0x40]
         sub	x4, x4, #0x1
 
-layer012_start:
+layer123_start:
         sub	v12.8h, v11.8h, v15.8h
         add	v26.8h, v11.8h, v15.8h
         sub	v8.8h, v24.8h, v16.8h
@@ -347,7 +347,7 @@ layer012_start:
         add	v19.8h, v24.8h, v16.8h
         add	v23.8h, v28.8h, v13.8h
         sub	x4, x4, #0x1
-        cbnz	x4, layer012_start
+        cbnz	x4, layer123_start
         add	v10.8h, v11.8h, v15.8h
         sub	v12.8h, v28.8h, v13.8h
         sub	v11.8h, v11.8h, v15.8h

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -148,6 +148,8 @@ def prepare_root_for_barrett(root):
 def gen_aarch64_root_of_unity_for_block(layer, block, inv=False):
     # We are computing a negacyclic NTT; the twiddles needed here is
     # the second half of the twiddles for a cyclic NTT of twice the size.
+    # For ease of calculating the roots, layers are numbers 0 through 6
+    # in this function.
     log = bitreverse(pow(2, layer) + block, 7)
     if inv is True:
         log = -log
@@ -155,8 +157,8 @@ def gen_aarch64_root_of_unity_for_block(layer, block, inv=False):
     return root, root_twisted
 
 
-def gen_aarch64_fwd_ntt_zetas_layer01234():
-    # Layers 0,1,2 are merged
+def gen_aarch64_fwd_ntt_zetas_layer12345():
+    # Layers 1,2,3 are merged
     yield from gen_aarch64_root_of_unity_for_block(0, 0)
     yield from gen_aarch64_root_of_unity_for_block(1, 0)
     yield from gen_aarch64_root_of_unity_for_block(1, 1)
@@ -166,8 +168,8 @@ def gen_aarch64_fwd_ntt_zetas_layer01234():
     yield from gen_aarch64_root_of_unity_for_block(2, 3)
     yield from (0, 0)  # Padding
 
-    # Layers 3,4,5,6 are merged, but we emit roots for 3,4
-    # in separate arrays than those for 5,6
+    # Layers 4,5,6,7 are merged, but we emit roots for 4,5
+    # in separate arrays than those for 6,7
     for block in range(8):  # There are 8 blocks in Layer 4
         yield from gen_aarch64_root_of_unity_for_block(3, block)
         yield from gen_aarch64_root_of_unity_for_block(4, 2 * block + 0)
@@ -175,9 +177,9 @@ def gen_aarch64_fwd_ntt_zetas_layer01234():
         yield from (0, 0)  # Padding
 
 
-def gen_aarch64_fwd_ntt_zetas_layer56():
-    # Layers 3,4,5,6 are merged, but we emit roots for 3,4
-    # in separate arrays than those for 5,6
+def gen_aarch64_fwd_ntt_zetas_layer67():
+    # Layers 4,5,6,7 are merged, but we emit roots for 4,5
+    # in separate arrays than those for 6,7
     for block in range(8):
 
         def double_ith(t, i):
@@ -226,16 +228,16 @@ def gen_aarch64_fwd_ntt_zetas_layer56():
             )
 
 
-def gen_aarch64_inv_ntt_zetas_layer01234():
-    # Layers 3,4,5,6 are merged, but we emit roots for 3,4
-    # in separate arrays than those for 5,6
+def gen_aarch64_inv_ntt_zetas_layer12345():
+    # Layers 4,5,6,7 are merged, but we emit roots for 4,5
+    # in separate arrays than those for 6,7
     for block in range(8):  # There are 8 blocks in Layer 4
         yield from gen_aarch64_root_of_unity_for_block(3, block, inv=True)
         yield from gen_aarch64_root_of_unity_for_block(4, 2 * block + 0, inv=True)
         yield from gen_aarch64_root_of_unity_for_block(4, 2 * block + 1, inv=True)
         yield from (0, 0)  # Padding
 
-    # Layers 0,1,2 are merged
+    # Layers 1,2,3 are merged
     yield from gen_aarch64_root_of_unity_for_block(0, 0, inv=True)
     yield from gen_aarch64_root_of_unity_for_block(1, 0, inv=True)
     yield from gen_aarch64_root_of_unity_for_block(1, 1, inv=True)
@@ -246,9 +248,9 @@ def gen_aarch64_inv_ntt_zetas_layer01234():
     yield from (0, 0)  # Padding
 
 
-def gen_aarch64_inv_ntt_zetas_layer56():
-    # Layers 3,4,5,6 are merged, but we emit roots for 3,4
-    # in separate arrays than those for 5,6
+def gen_aarch64_inv_ntt_zetas_layer67():
+    # Layers 4,5,6,7 are merged, but we emit roots for 4,5
+    # in separate arrays than those for 6,7
     for block in range(8):
 
         def double_ith(t, i):
@@ -326,20 +328,20 @@ def gen_aarch64_fwd_ntt_zeta_file(dry_run=False):
         yield " * Table of zeta values used in the AArch64 forward NTT"
         yield " * See autogen for details."
         yield " */"
-        yield "MLK_ALIGN const int16_t aarch64_ntt_zetas_layer01234[] = {"
-        yield from map(lambda t: str(t) + ",", gen_aarch64_fwd_ntt_zetas_layer01234())
+        yield "MLK_ALIGN const int16_t aarch64_ntt_zetas_layer12345[] = {"
+        yield from map(lambda t: str(t) + ",", gen_aarch64_fwd_ntt_zetas_layer12345())
         yield "};"
         yield ""
-        yield "MLK_ALIGN const int16_t aarch64_ntt_zetas_layer56[] = {"
-        yield from map(lambda t: str(t) + ",", gen_aarch64_fwd_ntt_zetas_layer56())
+        yield "MLK_ALIGN const int16_t aarch64_ntt_zetas_layer67[] = {"
+        yield from map(lambda t: str(t) + ",", gen_aarch64_fwd_ntt_zetas_layer67())
         yield "};"
         yield ""
-        yield "MLK_ALIGN const int16_t aarch64_invntt_zetas_layer01234[] = {"
-        yield from map(lambda t: str(t) + ",", gen_aarch64_inv_ntt_zetas_layer01234())
+        yield "MLK_ALIGN const int16_t aarch64_invntt_zetas_layer12345[] = {"
+        yield from map(lambda t: str(t) + ",", gen_aarch64_inv_ntt_zetas_layer12345())
         yield "};"
         yield ""
-        yield "MLK_ALIGN const int16_t aarch64_invntt_zetas_layer56[] = {"
-        yield from map(lambda t: str(t) + ",", gen_aarch64_inv_ntt_zetas_layer56())
+        yield "MLK_ALIGN const int16_t aarch64_invntt_zetas_layer67[] = {"
+        yield from map(lambda t: str(t) + ",", gen_aarch64_inv_ntt_zetas_layer67())
         yield "};"
         yield ""
         yield "MLK_ALIGN const int16_t aarch64_zetas_mulcache_native[] = {"
@@ -532,12 +534,12 @@ def gen_avx2_fwd_ntt_zetas():
         yield from (r for l in root_pairs for r in l[1])
         yield from (r for l in root_pairs for r in l[0])
 
-    # Layers 0 twiddle
+    # Layers 1 twiddle
     yield from gen_twiddles_many(0, 0, range(1), 4)
     # Padding so that the subsequent twiddles are 16-byte aligned
     yield from [0] * 8
 
-    # Layer 1-6 twiddles, separated by whether they belong to the upper or lower half
+    # Layer 2-7 twiddles, separated by whether they belong to the upper or lower half
     for i in range(2):
         yield from gen_twiddles_many(1, i * (2**0), range(1), 16)
         yield from gen_twiddles_many(2, i * (2**1), range(2), 8)

--- a/scripts/check-magic
+++ b/scripts/check-magic
@@ -74,7 +74,7 @@ def check_magic_numbers():
             continue
         content = content.split("\n")
         # Use negative lookbefore and lookahead to exclude numbers
-        # that occur as part of identifiers (e.g. layer01234 or 199901L)
+        # that occur as part of identifiers (e.g. layer12345 or 199901L)
         pattern = r'(?<![0-9a-zA-Z/_-])([-]?\d{4,})(?![0-9a-zA-Z_-])'
         enabled = True
         magic_dict = {'MLKEM_Q': mlkem_q}


### PR DESCRIPTION
The C code and other documentation consistently refer to the "layers" of the NTT as "1" through "7".

Previously, the assembly language back-end for AArch64 referred to the layers as "0" through "6".

This PR changes the AArch64 back-end to use "1" through "7" for consistency with the C code throughout.
The Intel back-end is unaffected.


