### PR TITLE
Delete cbmc-proof.txt marker files

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: CBMC
-description: Run CBMC proofs for MLKEM-C_AArch64
+description: Run CBMC proofs for mlkem-native
 
 inputs:
   nix-shell:

--- a/proofs/cbmc/KeccakF1600_StateExtractBytes/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600_StateExtractBytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600_StateExtractBytes_BE/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600_StateExtractBytes_BE/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600_StatePermute/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600_StatePermute/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600_StatePermute_native/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600_StatePermute_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600_StateXORBytes/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600_StateXORBytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600_StateXORBytes_BE/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600_StateXORBytes_BE/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600x4_StateExtractBytes/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600x4_StateExtractBytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600x4_StatePermute/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600x4_StatePermute/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600x4_StatePermute_native_x2/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600x4_StatePermute_native_x2/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600x4_StatePermute_native_x4/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600x4_StatePermute_native_x4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/KeccakF1600x4_StateXORBytes/cbmc-proof.txt
+++ b/proofs/cbmc/KeccakF1600x4_StateXORBytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/barrett_reduce/cbmc-proof.txt
+++ b/proofs/cbmc/barrett_reduce/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/check_pct/cbmc-proof.txt
+++ b/proofs/cbmc/check_pct/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/crypto_kem_dec/cbmc-proof.txt
+++ b/proofs/cbmc/crypto_kem_dec/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/crypto_kem_enc/cbmc-proof.txt
+++ b/proofs/cbmc/crypto_kem_enc/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/crypto_kem_enc_derand/cbmc-proof.txt
+++ b/proofs/cbmc/crypto_kem_enc_derand/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/crypto_kem_keypair/cbmc-proof.txt
+++ b/proofs/cbmc/crypto_kem_keypair/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/crypto_kem_keypair_derand/cbmc-proof.txt
+++ b/proofs/cbmc/crypto_kem_keypair_derand/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_cmask_neg_i16/cbmc-proof.txt
+++ b/proofs/cbmc/ct_cmask_neg_i16/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_cmask_nonzero_u16/cbmc-proof.txt
+++ b/proofs/cbmc/ct_cmask_nonzero_u16/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_cmask_nonzero_u8/cbmc-proof.txt
+++ b/proofs/cbmc/ct_cmask_nonzero_u8/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_cmov_zero/cbmc-proof.txt
+++ b/proofs/cbmc/ct_cmov_zero/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_memcmp/cbmc-proof.txt
+++ b/proofs/cbmc/ct_memcmp/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_sel_int16/cbmc-proof.txt
+++ b/proofs/cbmc/ct_sel_int16/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ct_sel_uint8/cbmc-proof.txt
+++ b/proofs/cbmc/ct_sel_uint8/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/fqmul/cbmc-proof.txt
+++ b/proofs/cbmc/fqmul/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/gen_matrix/cbmc-proof.txt
+++ b/proofs/cbmc/gen_matrix/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/gen_matrix_native/cbmc-proof.txt
+++ b/proofs/cbmc/gen_matrix_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/indcpa_dec/cbmc-proof.txt
+++ b/proofs/cbmc/indcpa_dec/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/indcpa_enc/cbmc-proof.txt
+++ b/proofs/cbmc/indcpa_enc/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/indcpa_keypair_derand/cbmc-proof.txt
+++ b/proofs/cbmc/indcpa_keypair_derand/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/invntt_layer/cbmc-proof.txt
+++ b/proofs/cbmc/invntt_layer/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/keccak_absorb_once/cbmc-proof.txt
+++ b/proofs/cbmc/keccak_absorb_once/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/keccak_absorb_once_x4/cbmc-proof.txt
+++ b/proofs/cbmc/keccak_absorb_once_x4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/keccak_squeeze_once/cbmc-proof.txt
+++ b/proofs/cbmc/keccak_squeeze_once/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/keccak_squeezeblocks/cbmc-proof.txt
+++ b/proofs/cbmc/keccak_squeezeblocks/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/keccak_squeezeblocks_x4/cbmc-proof.txt
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/matvec_mul/cbmc-proof.txt
+++ b/proofs/cbmc/matvec_mul/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/montgomery_reduce/cbmc-proof.txt
+++ b/proofs/cbmc/montgomery_reduce/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ntt_butterfly_block/cbmc-proof.txt
+++ b/proofs/cbmc/ntt_butterfly_block/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/ntt_layer/cbmc-proof.txt
+++ b/proofs/cbmc/ntt_layer/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_add/cbmc-proof.txt
+++ b/proofs/cbmc/poly_add/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_cbd_eta1/cbmc-proof.txt
+++ b/proofs/cbmc/poly_cbd_eta1/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_cbd_eta2/cbmc-proof.txt
+++ b/proofs/cbmc/poly_cbd_eta2/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_compress_du/cbmc-proof.txt
+++ b/proofs/cbmc/poly_compress_du/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_compress_dv/cbmc-proof.txt
+++ b/proofs/cbmc/poly_compress_dv/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_decompress_du/cbmc-proof.txt
+++ b/proofs/cbmc/poly_decompress_du/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_decompress_dv/cbmc-proof.txt
+++ b/proofs/cbmc/poly_decompress_dv/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_frombytes/cbmc-proof.txt
+++ b/proofs/cbmc/poly_frombytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_frombytes_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_frombytes_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_frommsg/cbmc-proof.txt
+++ b/proofs/cbmc/poly_frommsg/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_getnoise_eta1122_4x/cbmc-proof.txt
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_getnoise_eta1122_4x_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_getnoise_eta1_4x/cbmc-proof.txt
+++ b/proofs/cbmc/poly_getnoise_eta1_4x/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_getnoise_eta2/cbmc-proof.txt
+++ b/proofs/cbmc/poly_getnoise_eta2/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_invntt_tomont/cbmc-proof.txt
+++ b/proofs/cbmc/poly_invntt_tomont/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_invntt_tomont_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_invntt_tomont_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_mulcache_compute/cbmc-proof.txt
+++ b/proofs/cbmc/poly_mulcache_compute/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_mulcache_compute_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_mulcache_compute_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_ntt/cbmc-proof.txt
+++ b/proofs/cbmc/poly_ntt/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_ntt_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_ntt_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_reduce/cbmc-proof.txt
+++ b/proofs/cbmc/poly_reduce/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_reduce_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_reduce_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_rej_uniform/cbmc-proof.txt
+++ b/proofs/cbmc/poly_rej_uniform/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_rej_uniform_x4/cbmc-proof.txt
+++ b/proofs/cbmc/poly_rej_uniform_x4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_sub/cbmc-proof.txt
+++ b/proofs/cbmc/poly_sub/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_tobytes/cbmc-proof.txt
+++ b/proofs/cbmc/poly_tobytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_tobytes_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_tobytes_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_tomont/cbmc-proof.txt
+++ b/proofs/cbmc/poly_tomont/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_tomont_native/cbmc-proof.txt
+++ b/proofs/cbmc/poly_tomont_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/poly_tomsg/cbmc-proof.txt
+++ b/proofs/cbmc/poly_tomsg/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_add/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_add/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_compress_du/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_compress_du/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_decompress_du/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_decompress_du/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_frombytes/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_frombytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_invntt_tomont/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_invntt_tomont/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_mulcache_compute/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_mulcache_compute/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_ntt/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_ntt/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_reduce/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_reduce/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_tobytes/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_tobytes/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/polyvec_tomont/cbmc-proof.txt
+++ b/proofs/cbmc/polyvec_tomont/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/proof_guide.md
+++ b/proofs/cbmc/proof_guide.md
@@ -265,16 +265,14 @@ For mlkem-native, proof directories lie below `cbmc`.
 Create a new sub-directory in there, where the name of the directory is the name of the function. You don't need a
 namespacing prefix.
 
-That directory needs to contain 3 files.
+That directory needs to contain 2 files.
 
-* cbmc-proof.txt
 * Makefile
 * XXX_harness.c
 
 where "XXX" is the name of the function being proved - same as the directory name.
 
-We suggest that you copy these files from an existing proof directory and modify the latter two. The `cbmc-proof.txt`
-file is just a marker that says "this directory contains a CBMC proof" to the tools, so no modification is required.
+We suggest that you copy these files from an existing proof directory and modify the it according to your needs.
 
 ### Update Makefile
 

--- a/proofs/cbmc/rej_uniform/cbmc-proof.txt
+++ b/proofs/cbmc/rej_uniform/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/rej_uniform_native/cbmc-proof.txt
+++ b/proofs/cbmc/rej_uniform_native/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/rej_uniform_scalar/cbmc-proof.txt
+++ b/proofs/cbmc/rej_uniform_scalar/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/run-cbmc-proofs.py
+++ b/proofs/cbmc/run-cbmc-proofs.py
@@ -33,7 +33,7 @@ The tool is roughly equivalent to doing this:
 
         litani init --project "my-cool-project";
 
-        find . -name cbmc-proof.txt | while read -r proof; do
+        find . -name Makefile | while read -r proof; do
             pushd $(dirname ${proof});
 
             # The `make _report` rule adds a single proof to litani
@@ -130,7 +130,7 @@ def get_args():
         {
             "flags": ["--marker-file"],
             "metavar": "FILE",
-            "default": "cbmc-proof.txt",
+            "default": "Makefile",
             "help": (
                 "name of file that marks proof directories. Default: " "%(default)s"
             ),

--- a/proofs/cbmc/scalar_compress_d1/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_compress_d1/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_compress_d10/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_compress_d10/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_compress_d11/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_compress_d11/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_compress_d4/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_compress_d4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_compress_d5/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_compress_d5/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_decompress_d10/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_decompress_d10/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_decompress_d11/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_decompress_d11/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_decompress_d4/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_decompress_d4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_decompress_d5/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_decompress_d5/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/scalar_signed_to_unsigned_q/cbmc-proof.txt
+++ b/proofs/cbmc/scalar_signed_to_unsigned_q/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/sha3_256/cbmc-proof.txt
+++ b/proofs/cbmc/sha3_256/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/sha3_512/cbmc-proof.txt
+++ b/proofs/cbmc/sha3_512/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/shake128_absorb_once/cbmc-proof.txt
+++ b/proofs/cbmc/shake128_absorb_once/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/shake128_squeezeblocks/cbmc-proof.txt
+++ b/proofs/cbmc/shake128_squeezeblocks/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/shake128x4_absorb_once/cbmc-proof.txt
+++ b/proofs/cbmc/shake128x4_absorb_once/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/shake128x4_squeezeblocks/cbmc-proof.txt
+++ b/proofs/cbmc/shake128x4_squeezeblocks/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/shake256/cbmc-proof.txt
+++ b/proofs/cbmc/shake256/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.

--- a/proofs/cbmc/shake256x4/cbmc-proof.txt
+++ b/proofs/cbmc/shake256x4/cbmc-proof.txt
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# This file marks this directory as containing a CBMC proof.


### PR DESCRIPTION
Before, we placed an empty cbmc-proofs.txt file into a directory in proofs/cbmc to mark that this is a CBMC proof.
However, all directories except for lib are proofs. This commit changes the script to consider all directories in proofs/cbmc/ that have a Makefile as CBMC proofs.
