### PR TITLE
Remove opt clean suffixes from AArch64 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ undefined behaviour in C, including out of bounds memory accesses and integer ov
 all C code in [mlkem/*](mlkem) and [mlkem/fips202/*](mlkem/fips202) involved in running mlkem-native with its C backend.
 See [proofs/cbmc](proofs/cbmc) for details.
 
-HOL-Light functional correctness proofs for the optimized AArch64 NTT [ntt_opt.S](mlkem/native/aarch64/src/ntt_opt.S) and inverse NTT [intt_opt.S](mlkem/native/aarch64/src/intt_opt.S)
+HOL-Light functional correctness proofs for the optimized AArch64 NTT [ntt.S](dev/aarch64_opt/src/ntt.S) and inverse NTT [intt.S](dev/aarch64_opt/src/intt.S)
 can be found in [proofs/hol_light/arm](proofs/hol_light/arm). These proofs were contributed by John Harrison, and are
 utilizing the verification infrastructure provided by [s2n-bignum](https://github.com/awslabs/s2n-bignum) infrastructure.
 
@@ -80,8 +80,8 @@ offers three backends for C, AArch64 and x86_64 - if you'd like contribute new b
 PR.
 
 Our AArch64 assembly is developed using [SLOTHY](https://github.com/slothy-optimizer/slothy): We write
-'clean' assembly by hand and automate micro-optimizations (e.g. see the [clean](dev/aarch64_clean/src/ntt_clean.S)
-vs [optimized](mlkem/native/aarch64/src/ntt_opt.S) AArch64 NTT). See [dev/README.md](dev/README.md) for more details.
+'clean' assembly by hand and automate micro-optimizations (e.g. see the [clean](dev/aarch64_clean/src/ntt.S)
+vs [optimized](dev/aarch64_opt/src/ntt.S) AArch64 NTT). See [dev/README.md](dev/README.md) for more details.
 
 ## How should I use mlkem-native?
 

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -29,44 +29,49 @@ extern const int16_t mlk_aarch64_zetas_mulcache_native[];
 extern const int16_t mlk_aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t mlk_rej_uniform_table[];
 
-#define mlk_ntt_asm_clean MLK_NAMESPACE(ntt_asm_clean)
-void mlk_ntt_asm_clean(int16_t *, const int16_t *, const int16_t *);
+#define mlk_ntt_asm MLK_NAMESPACE(ntt_asm)
+void mlk_ntt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_intt_asm_clean MLK_NAMESPACE(intt_asm_clean)
-void mlk_intt_asm_clean(int16_t *, const int16_t *, const int16_t *);
+#define mlk_intt_asm MLK_NAMESPACE(intt_asm)
+void mlk_intt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_rej_uniform_asm_clean MLK_NAMESPACE(rej_uniform_asm_clean)
-unsigned mlk_rej_uniform_asm_clean(int16_t *r, const uint8_t *buf,
-                                   unsigned buflen, const uint8_t *table);
+#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
+unsigned mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
+                             const uint8_t *table);
 
-#define mlk_poly_reduce_asm_clean MLK_NAMESPACE(poly_reduce_asm_clean)
-void mlk_poly_reduce_asm_clean(int16_t *);
+#define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
+void mlk_poly_reduce_asm(int16_t *);
 
-#define mlk_poly_tomont_asm_clean MLK_NAMESPACE(poly_tomont_asm_clean)
-void mlk_poly_tomont_asm_clean(int16_t *);
+#define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
+void mlk_poly_tomont_asm(int16_t *);
 
-#define mlk_poly_mulcache_compute_asm_clean \
-  MLK_NAMESPACE(poly_mulcache_compute_asm_clean)
-void mlk_poly_mulcache_compute_asm_clean(int16_t *, const int16_t *,
-                                         const int16_t *, const int16_t *);
+#define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
+void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
+                                   const int16_t *);
 
 
-#define mlk_poly_tobytes_asm_clean MLK_NAMESPACE(poly_tobytes_asm_clean)
-void mlk_poly_tobytes_asm_clean(uint8_t *r, const int16_t *a);
+#define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
+void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_clean \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_clean(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_clean \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_clean(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_clean \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_clean(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
 #endif /* MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H */

--- a/dev/aarch64_clean/src/clean_impl.h
+++ b/dev/aarch64_clean/src/clean_impl.h
@@ -26,59 +26,58 @@
 
 static MLK_INLINE void mlk_ntt_native(int16_t data[MLKEM_N])
 {
-  mlk_ntt_asm_clean(data, mlk_aarch64_ntt_zetas_layer12345,
-                    mlk_aarch64_ntt_zetas_layer67);
+  mlk_ntt_asm(data, mlk_aarch64_ntt_zetas_layer12345,
+              mlk_aarch64_ntt_zetas_layer67);
 }
 
 static MLK_INLINE void mlk_intt_native(int16_t data[MLKEM_N])
 {
-  mlk_intt_asm_clean(data, mlk_aarch64_invntt_zetas_layer12345,
-                     mlk_aarch64_invntt_zetas_layer67);
+  mlk_intt_asm(data, mlk_aarch64_invntt_zetas_layer12345,
+               mlk_aarch64_invntt_zetas_layer67);
 }
 
 static MLK_INLINE void mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
-  mlk_poly_reduce_asm_clean(data);
+  mlk_poly_reduce_asm(data);
 }
 
 static MLK_INLINE void mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
-  mlk_poly_tomont_asm_clean(data);
+  mlk_poly_tomont_asm(data);
 }
 
 static MLK_INLINE void mlk_poly_mulcache_compute_native(
     int16_t x[MLKEM_N / 2], const int16_t y[MLKEM_N])
 {
-  mlk_poly_mulcache_compute_asm_clean(
-      x, y, mlk_aarch64_zetas_mulcache_native,
-      mlk_aarch64_zetas_mulcache_twisted_native);
+  mlk_poly_mulcache_compute_asm(x, y, mlk_aarch64_zetas_mulcache_native,
+                                mlk_aarch64_zetas_mulcache_twisted_native);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_clean(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_clean(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_clean(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
                                                const int16_t a[MLKEM_N])
 {
-  mlk_poly_tobytes_asm_clean(r, a);
+  mlk_poly_tobytes_asm(r, a);
 }
 
 static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
@@ -89,7 +88,7 @@ static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
   {
     return -1;
   }
-  return (int)mlk_rej_uniform_asm_clean(r, buf, buflen, mlk_rej_uniform_table);
+  return (int)mlk_rej_uniform_asm(r, buf, buflen, mlk_rej_uniform_table);
 }
 
 #endif /* MLK_ARITH_PROFILE_IMPL_H */

--- a/dev/aarch64_clean/src/intt.S
+++ b/dev/aarch64_clean/src/intt.S
@@ -194,9 +194,9 @@
         ninv_tw          .req v30
 
         .text
-        .global MLK_ASM_NAMESPACE(intt_asm_clean)
+        .global MLK_ASM_NAMESPACE(intt_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(intt_asm_clean)
+MLK_ASM_FN_SYMBOL(intt_asm)
         push_stack
 
         // Setup constants

--- a/dev/aarch64_clean/src/ntt.S
+++ b/dev/aarch64_clean/src/ntt.S
@@ -166,9 +166,9 @@
         t3  .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(ntt_asm_clean)
+        .global MLK_ASM_NAMESPACE(ntt_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(ntt_asm_clean)
+MLK_ASM_FN_SYMBOL(ntt_asm)
         push_stack
 
         mov wtmp, #3329

--- a/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
@@ -43,10 +43,10 @@
         modulus           .req v6
         modulus_twisted   .req v7
 
-        .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_clean)
+        .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm)
         .text
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_clean)
+MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm)
         mov wtmp, #3329
         dup modulus.8h, wtmp
 

--- a/dev/aarch64_clean/src/poly_reduce_asm.S
+++ b/dev/aarch64_clean/src/poly_reduce_asm.S
@@ -42,9 +42,9 @@
         modulus_twisted   .req v4
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_reduce_asm_clean)
+        .global MLK_ASM_NAMESPACE(poly_reduce_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_reduce_asm_clean)
+MLK_ASM_FN_SYMBOL(poly_reduce_asm)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/poly_tobytes_asm.S
+++ b/dev/aarch64_clean/src/poly_tobytes_asm.S
@@ -24,12 +24,12 @@
         count .req x2
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_tobytes_asm_clean)
+        .global MLK_ASM_NAMESPACE(poly_tobytes_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_tobytes_asm_clean)
+MLK_ASM_FN_SYMBOL(poly_tobytes_asm)
 
         mov count, #16
-poly_tobytes_asm_clean_asm_loop_start:
+poly_tobytes_asm_asm_loop_start:
         ld2 {data0.8h, data1.8h}, [src], #32
 
         // r[3 * i + 0] = (t0 >> 0);
@@ -47,7 +47,7 @@ poly_tobytes_asm_clean_asm_loop_start:
         st3 {out0.8b, out1.8b, out2.8b}, [dst], #24
 
         subs count, count, #1
-        cbnz count, poly_tobytes_asm_clean_asm_loop_start
+        cbnz count, poly_tobytes_asm_asm_loop_start
         ret
 
         .unreq data0

--- a/dev/aarch64_clean/src/poly_tomont_asm.S
+++ b/dev/aarch64_clean/src/poly_tomont_asm.S
@@ -37,9 +37,9 @@
         tmp0              .req v6
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_tomont_asm_clean)
+        .global MLK_ASM_NAMESPACE(poly_tomont_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_tomont_asm_clean)
+MLK_ASM_FN_SYMBOL(poly_tomont_asm)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -12,7 +12,7 @@
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
-    (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3)
+    (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2)
 /* simpasm: header-end */
 
 // Input:
@@ -141,10 +141,11 @@
         t0   .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
+        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
         .balign 4
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2)
         push_stack
+
         mov wtmp, #3329
         dup modulus.8h, wtmp
 
@@ -156,18 +157,13 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
         add a1_ptr, a0_ptr, #(1 * 512)
         add b1_ptr, b0_ptr, #(1 * 512)
         add b1_cache_ptr, b0_cache_ptr, #(1 * 512/2)
-        add a2_ptr, a0_ptr, #(2 * 512)
-        add b2_ptr, b0_ptr, #(2 * 512)
-        add b2_cache_ptr, b0_cache_ptr, #(2 * 512/2)
 
         mov count, #(MLKEM_N / 16)
-k3_loop_start:
+k2_loop_start:
 
         load_polys aa, bb, a0_ptr, b0_ptr, b0_cache_ptr
         pmull res, aa, bb
         load_polys aa, bb, a1_ptr, b1_ptr, b1_cache_ptr
-        pmlal res, aa, bb
-        load_polys aa, bb, a2_ptr, b2_ptr, b2_cache_ptr
         pmlal res, aa, bb
 
         montgomery_reduce_long out0, res0
@@ -176,7 +172,7 @@ k3_loop_start:
         st2_wrap out, out
 
         subs count, count, #1
-        cbnz count, k3_loop_start
+        cbnz count, k2_loop_start
 
         pop_stack
         ret
@@ -217,6 +213,7 @@ k3_loop_start:
     .unreq t0
 
 /* simpasm: footer-start */
+
 #endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
-          (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3) */
+          (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2) */

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -12,7 +12,7 @@
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
-    (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2)
+    (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3)
 /* simpasm: header-end */
 
 // Input:
@@ -141,11 +141,10 @@
         t0   .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
+        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
         .balign 4
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3)
         push_stack
-
         mov wtmp, #3329
         dup modulus.8h, wtmp
 
@@ -157,13 +156,18 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
         add a1_ptr, a0_ptr, #(1 * 512)
         add b1_ptr, b0_ptr, #(1 * 512)
         add b1_cache_ptr, b0_cache_ptr, #(1 * 512/2)
+        add a2_ptr, a0_ptr, #(2 * 512)
+        add b2_ptr, b0_ptr, #(2 * 512)
+        add b2_cache_ptr, b0_cache_ptr, #(2 * 512/2)
 
         mov count, #(MLKEM_N / 16)
-k2_loop_start:
+k3_loop_start:
 
         load_polys aa, bb, a0_ptr, b0_ptr, b0_cache_ptr
         pmull res, aa, bb
         load_polys aa, bb, a1_ptr, b1_ptr, b1_cache_ptr
+        pmlal res, aa, bb
+        load_polys aa, bb, a2_ptr, b2_ptr, b2_cache_ptr
         pmlal res, aa, bb
 
         montgomery_reduce_long out0, res0
@@ -172,7 +176,7 @@ k2_loop_start:
         st2_wrap out, out
 
         subs count, count, #1
-        cbnz count, k2_loop_start
+        cbnz count, k3_loop_start
 
         pop_stack
         ret
@@ -213,7 +217,6 @@ k2_loop_start:
     .unreq t0
 
 /* simpasm: footer-start */
-
 #endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
-          (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2) */
+          (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3) */

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -141,9 +141,9 @@
         t0   .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
+        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
         .balign 4
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp

--- a/dev/aarch64_clean/src/rej_uniform_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm.S
@@ -4,7 +4,7 @@
  */
 
 /*************************************************
- * Name:        mlk_rej_uniform_asm_clean
+ * Name:        mlk_rej_uniform_asm
  *
  * Description: Run rejection sampling on uniform random bytes to generate
  *              uniform random integers mod q
@@ -19,9 +19,8 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) || \
-        defined(MLK_ARITH_BACKEND_AARCH64_OPT))  \
-    && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
+#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+    !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
 // We save the output on the stack first, and copy to the actual
@@ -115,9 +114,9 @@
     bits                        .req v31
 
     .text
-    .global MLK_ASM_NAMESPACE(rej_uniform_asm_clean)
+    .global MLK_ASM_NAMESPACE(rej_uniform_asm)
     .balign 4
-MLK_ASM_FN_SYMBOL(rej_uniform_asm_clean)
+MLK_ASM_FN_SYMBOL(rej_uniform_asm)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80
@@ -405,6 +404,5 @@ return:
     .unreq bits
 
 /* simpasm: footer-start */
-#endif /* (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) ||
-           defined(MLK_ARITH_BACKEND_AARCH64_OPT))
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+          !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -29,43 +29,48 @@ extern const int16_t mlk_aarch64_zetas_mulcache_native[];
 extern const int16_t mlk_aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t mlk_rej_uniform_table[];
 
-#define mlk_ntt_asm_opt MLK_NAMESPACE(ntt_asm_opt)
-void mlk_ntt_asm_opt(int16_t *, const int16_t *, const int16_t *);
+#define mlk_ntt_asm MLK_NAMESPACE(ntt_asm)
+void mlk_ntt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_intt_asm_opt MLK_NAMESPACE(intt_asm_opt)
-void mlk_intt_asm_opt(int16_t *, const int16_t *, const int16_t *);
+#define mlk_intt_asm MLK_NAMESPACE(intt_asm)
+void mlk_intt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_poly_reduce_asm_opt MLK_NAMESPACE(poly_reduce_asm_opt)
-void mlk_poly_reduce_asm_opt(int16_t *);
+#define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
+void mlk_poly_reduce_asm(int16_t *);
 
-#define mlk_poly_tomont_asm_opt MLK_NAMESPACE(poly_tomont_asm_opt)
-void mlk_poly_tomont_asm_opt(int16_t *);
+#define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
+void mlk_poly_tomont_asm(int16_t *);
 
-#define mlk_poly_mulcache_compute_asm_opt \
-  MLK_NAMESPACE(poly_mulcache_compute_asm_opt)
-void mlk_poly_mulcache_compute_asm_opt(int16_t *, const int16_t *,
-                                       const int16_t *, const int16_t *);
+#define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
+void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
+                                   const int16_t *);
 
-#define mlk_poly_tobytes_asm_opt MLK_NAMESPACE(poly_tobytes_asm_opt)
-void mlk_poly_tobytes_asm_opt(uint8_t *r, const int16_t *a);
+#define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
+void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_rej_uniform_asm_clean MLK_NAMESPACE(rej_uniform_asm_clean)
-unsigned mlk_rej_uniform_asm_clean(int16_t *r, const uint8_t *buf,
-                                   unsigned buflen, const uint8_t *table);
+#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
+unsigned mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
+                             const uint8_t *table);
 
 #endif /* MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H */

--- a/dev/aarch64_opt/src/intt.S
+++ b/dev/aarch64_opt/src/intt.S
@@ -194,9 +194,9 @@
         ninv_tw          .req v30
 
         .text
-        .global MLK_ASM_NAMESPACE(intt_asm_opt)
+        .global MLK_ASM_NAMESPACE(intt_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(intt_asm_opt)
+MLK_ASM_FN_SYMBOL(intt_asm)
         push_stack
 
         // Setup constants

--- a/dev/aarch64_opt/src/ntt.S
+++ b/dev/aarch64_opt/src/ntt.S
@@ -167,9 +167,9 @@
         t3  .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(ntt_asm_opt)
+        .global MLK_ASM_NAMESPACE(ntt_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(ntt_asm_opt)
+MLK_ASM_FN_SYMBOL(ntt_asm)
         push_stack
 
         mov wtmp, #3329
@@ -236,7 +236,7 @@ MLK_ASM_FN_SYMBOL(ntt_asm_opt)
         // mul v15.8H, v11.8H, v0.H[0]      // ...............*...............
 
         sub count, count, #1
-ntt_opt_loop0:
+ntt_loop0:
                                                 // Instructions:    76
                                                 // Expected cycles: 84
                                                 // Expected IPC:    0.90
@@ -408,7 +408,7 @@ ntt_opt_loop0:
         // str q15, [x0, #(-16 + 7*(512/8))]          // .....................~.....'.............................................................................*
 
         sub count, count, 1
-        cbnz count, ntt_opt_loop0
+        cbnz count, ntt_loop0
                                                 // Instructions:    66
                                                 // Expected cycles: 67
                                                 // Expected IPC:    0.99
@@ -631,7 +631,7 @@ ntt_opt_loop0:
         // ldr q13, [x2, #-16]                   // ..............................*
 
         sub count, count, #1
-ntt_opt_loop1:
+ntt_loop1:
                                                 // Instructions:    71
                                                 // Expected cycles: 82
                                                 // Expected IPC:    0.87
@@ -793,7 +793,7 @@ ntt_opt_loop1:
         // str q11, [x0, #(-16*1)]                    // .................................................................................~'................................................................................*
 
         sub count, count, 1
-        cbnz count, ntt_opt_loop1
+        cbnz count, ntt_loop1
                                                // Instructions:    47
                                                // Expected cycles: 52
                                                // Expected IPC:    0.90

--- a/dev/aarch64_opt/src/opt_impl.h
+++ b/dev/aarch64_opt/src/opt_impl.h
@@ -25,58 +25,58 @@
 
 static MLK_INLINE void mlk_ntt_native(int16_t data[MLKEM_N])
 {
-  mlk_ntt_asm_opt(data, mlk_aarch64_ntt_zetas_layer12345,
-                  mlk_aarch64_ntt_zetas_layer67);
+  mlk_ntt_asm(data, mlk_aarch64_ntt_zetas_layer12345,
+              mlk_aarch64_ntt_zetas_layer67);
 }
 
 static MLK_INLINE void mlk_intt_native(int16_t data[MLKEM_N])
 {
-  mlk_intt_asm_opt(data, mlk_aarch64_invntt_zetas_layer12345,
-                   mlk_aarch64_invntt_zetas_layer67);
+  mlk_intt_asm(data, mlk_aarch64_invntt_zetas_layer12345,
+               mlk_aarch64_invntt_zetas_layer67);
 }
 
 static MLK_INLINE void mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
-  mlk_poly_reduce_asm_opt(data);
+  mlk_poly_reduce_asm(data);
 }
 
 static MLK_INLINE void mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
-  mlk_poly_tomont_asm_opt(data);
+  mlk_poly_tomont_asm(data);
 }
 
 static MLK_INLINE void mlk_poly_mulcache_compute_native(
     int16_t x[MLKEM_N / 2], const int16_t y[MLKEM_N])
 {
-  mlk_poly_mulcache_compute_asm_opt(x, y, mlk_aarch64_zetas_mulcache_native,
-                                    mlk_aarch64_zetas_mulcache_twisted_native);
+  mlk_poly_mulcache_compute_asm(x, y, mlk_aarch64_zetas_mulcache_native,
+                                mlk_aarch64_zetas_mulcache_twisted_native);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
                                                const int16_t a[MLKEM_N])
 {
-  mlk_poly_tobytes_asm_opt(r, a);
+  mlk_poly_tobytes_asm(r, a);
 }
 
 static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
@@ -87,7 +87,7 @@ static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
   {
     return -1;
   }
-  return (int)mlk_rej_uniform_asm_clean(r, buf, buflen, mlk_rej_uniform_table);
+  return (int)mlk_rej_uniform_asm(r, buf, buflen, mlk_rej_uniform_table);
 }
 
 #endif /* MLK_ARITH_PROFILE_IMPL_H */

--- a/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
@@ -45,9 +45,9 @@
         modulus_twisted   .req v7
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_opt)
+        .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_opt)
+MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm)
         mov wtmp, #3329
         dup modulus.8h, wtmp
 
@@ -88,7 +88,7 @@ MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_opt)
         // sqrdmulh v27.8H, v28.8H, v7.8H       // ...........*...................
 
         sub count, count, #1
-poly_mulcache_compute_asm_opt_loop:
+poly_mulcache_compute_asm_loop:
                                               // Instructions:    9
                                               // Expected cycles: 13
                                               // Expected IPC:    0.69
@@ -126,7 +126,7 @@ poly_mulcache_compute_asm_opt_loop:
         // str q5, [x0], #16                       // ..........~..'.........*..'....
 
         sub count, count, 1
-        cbnz count, poly_mulcache_compute_asm_opt_loop
+        cbnz count, poly_mulcache_compute_asm_loop
                                           // Instructions:    2
                                           // Expected cycles: 5
                                           // Expected IPC:    0.40

--- a/dev/aarch64_opt/src/poly_reduce_asm.S
+++ b/dev/aarch64_opt/src/poly_reduce_asm.S
@@ -42,9 +42,9 @@
         modulus_twisted   .req v4
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_reduce_asm_opt)
+        .global MLK_ASM_NAMESPACE(poly_reduce_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_reduce_asm_opt)
+MLK_ASM_FN_SYMBOL(poly_reduce_asm)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp
@@ -102,7 +102,7 @@ MLK_ASM_FN_SYMBOL(poly_reduce_asm_opt)
         // add v16.8H, v2.8H, v27.8H              // .....................*.........
 
         sub count, count, #1
-poly_reduce_asm_opt_loop:
+poly_reduce_asm_loop:
                                                // Instructions:    32
                                                // Expected cycles: 36
                                                // Expected IPC:    0.89
@@ -186,7 +186,7 @@ poly_reduce_asm_opt_loop:
         // str q0, [x0, #-16]                     // .....~............................'......*..........................
 
         sub count, count, 1
-        cbnz count, poly_reduce_asm_opt_loop
+        cbnz count, poly_reduce_asm_loop
                                                // Instructions:    17
                                                // Expected cycles: 23
                                                // Expected IPC:    0.74

--- a/dev/aarch64_opt/src/poly_tobytes_asm.S
+++ b/dev/aarch64_opt/src/poly_tobytes_asm.S
@@ -24,12 +24,12 @@
         count .req x2
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_tobytes_asm_opt)
+        .global MLK_ASM_NAMESPACE(poly_tobytes_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_tobytes_asm_opt)
+MLK_ASM_FN_SYMBOL(poly_tobytes_asm)
 
         mov count, #16
-poly_tobytes_asm_opt_asm_loop_start:
+poly_tobytes_asm_asm_loop_start:
         ld2 {data0.8h, data1.8h}, [src], #32
 
         // r[3 * i + 0] = (t0 >> 0);
@@ -47,7 +47,7 @@ poly_tobytes_asm_opt_asm_loop_start:
         st3 {out0.8b, out1.8b, out2.8b}, [dst], #24
 
         subs count, count, #1
-        cbnz count, poly_tobytes_asm_opt_asm_loop_start
+        cbnz count, poly_tobytes_asm_asm_loop_start
         ret
 
         .unreq data0

--- a/dev/aarch64_opt/src/poly_tomont_asm.S
+++ b/dev/aarch64_opt/src/poly_tomont_asm.S
@@ -38,9 +38,9 @@
 
 
         .text
-        .global MLK_ASM_NAMESPACE(poly_tomont_asm_opt)
+        .global MLK_ASM_NAMESPACE(poly_tomont_asm)
         .balign 4
-MLK_ASM_FN_SYMBOL(poly_tomont_asm_opt)
+MLK_ASM_FN_SYMBOL(poly_tomont_asm)
 
         mov wtmp, #3329 // ML-KEM modulus
         dup modulus.8h, wtmp
@@ -84,7 +84,7 @@ MLK_ASM_FN_SYMBOL(poly_tomont_asm_opt)
         // ldr q27, [x0, #32]                // ......*........................
 
         sub count, count, #1
-poly_tomont_asm_opt_loop:
+poly_tomont_asm_loop:
                                               // Instructions:    20
                                               // Expected cycles: 24
                                               // Expected IPC:    0.83
@@ -144,7 +144,7 @@ poly_tomont_asm_opt_loop:
         // str q1, [x0, #-16]                     // ..............'...*...................
 
         sub count, count, 1
-        cbnz count, poly_tomont_asm_opt_loop
+        cbnz count, poly_tomont_asm_loop
                                               // Instructions:    15
                                               // Expected cycles: 18
                                               // Expected IPC:    0.83

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -141,9 +141,9 @@
         t0   .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
+        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
         .balign 4
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2)
         push_stack
 
         mov wtmp, #3329
@@ -328,7 +328,7 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
         // smlal2 v11.4S, v14.8H, v0.8H         // .........................................................................*.
 
         sub count, count, #2
-polyvec_basemul_acc_montgomery_cached_asm_k2_opt_loop:
+polyvec_basemul_acc_montgomery_cached_asm_k2_loop:
                                              // Instructions:    48
                                              // Expected cycles: 58
                                              // Expected IPC:    0.83
@@ -444,7 +444,7 @@ polyvec_basemul_acc_montgomery_cached_asm_k2_opt_loop:
         // str q13, [x0, #-16]                 // .....~.........................................'.....~.........................................'.....l............
 
         sub count, count, #1
-        cbnz count, polyvec_basemul_acc_montgomery_cached_asm_k2_opt_loop
+        cbnz count, polyvec_basemul_acc_montgomery_cached_asm_k2_loop
                                             // Instructions:    21
                                             // Expected cycles: 35
                                             // Expected IPC:    0.60

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -141,9 +141,9 @@
         t0   .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
+        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
         .balign 4
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp
@@ -330,7 +330,7 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
         // ld1 {v25.8H}, [x9], #16             // ..........................................................................*
 
         sub count, count, #2
-polyvec_basemul_acc_montgomery_cached_asm_k3_opt_loop:
+polyvec_basemul_acc_montgomery_cached_asm_k3_loop:
                                              // Instructions:    65
                                              // Expected cycles: 80
                                              // Expected IPC:    0.81
@@ -480,7 +480,7 @@ polyvec_basemul_acc_montgomery_cached_asm_k3_opt_loop:
         // str q13, [x0, #-16]                // .............~..............'.................................................~..............'.................................................l
 
         sub count, count, #1
-        cbnz count, polyvec_basemul_acc_montgomery_cached_asm_k3_opt_loop
+        cbnz count, polyvec_basemul_acc_montgomery_cached_asm_k3_loop
                                              // Instructions:    55
                                              // Expected cycles: 61
                                              // Expected IPC:    0.90

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -141,9 +141,9 @@
         t0   .req v28
 
         .text
-        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
+        .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
         .balign 4
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4)
         push_stack
         mov wtmp, #3329
         dup modulus.8h, wtmp
@@ -416,7 +416,7 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
         // zip1 v5.8H, v7.8H, v15.8H          // ........................................................................................*.........................
 
         sub count, count, #2
-polyvec_basemul_acc_montgomery_cached_asm_k4_opt_loop:
+polyvec_basemul_acc_montgomery_cached_asm_k4_loop:
                                              // Instructions:    82
                                              // Expected cycles: 102
                                              // Expected IPC:    0.80
@@ -600,7 +600,7 @@ polyvec_basemul_acc_montgomery_cached_asm_k4_opt_loop:
         // str q13, [x0, #-16]               // ...................................................~...........................'.....................................................~...........................'.....................................................l..........................
 
         sub count, count, #1
-        cbnz count, polyvec_basemul_acc_montgomery_cached_asm_k4_opt_loop
+        cbnz count, polyvec_basemul_acc_montgomery_cached_asm_k4_loop
 
                                              // Instructions:    50
                                              // Expected cycles: 56

--- a/dev/aarch64_opt/src/rej_uniform_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm.S
@@ -4,7 +4,7 @@
  */
 
 /*************************************************
- * Name:        mlk_rej_uniform_asm_clean
+ * Name:        mlk_rej_uniform_asm
  *
  * Description: Run rejection sampling on uniform random bytes to generate
  *              uniform random integers mod q
@@ -19,8 +19,9 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
-    !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
+#if (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) || \
+        defined(MLK_ARITH_BACKEND_AARCH64_OPT))  \
+    && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
 // We save the output on the stack first, and copy to the actual
@@ -114,9 +115,9 @@
     bits                        .req v31
 
     .text
-    .global MLK_ASM_NAMESPACE(rej_uniform_asm_clean)
+    .global MLK_ASM_NAMESPACE(rej_uniform_asm)
     .balign 4
-MLK_ASM_FN_SYMBOL(rej_uniform_asm_clean)
+MLK_ASM_FN_SYMBOL(rej_uniform_asm)
     push_stack
 
     // Load 0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80
@@ -404,5 +405,6 @@ return:
     .unreq bits
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
-          !MLK_MULTILEVEL_BUILD_NO_SHARED */
+#endif /* (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) ||
+           defined(MLK_ARITH_BACKEND_AARCH64_OPT))
+          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -405,16 +405,16 @@
 #undef mlk_aarch64_ntt_zetas_layer67
 #undef mlk_aarch64_zetas_mulcache_native
 #undef mlk_aarch64_zetas_mulcache_twisted_native
-#undef mlk_intt_asm_opt
-#undef mlk_ntt_asm_opt
-#undef mlk_poly_mulcache_compute_asm_opt
-#undef mlk_poly_reduce_asm_opt
-#undef mlk_poly_tobytes_asm_opt
-#undef mlk_poly_tomont_asm_opt
-#undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt
-#undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt
-#undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt
-#undef mlk_rej_uniform_asm_clean
+#undef mlk_intt_asm
+#undef mlk_ntt_asm
+#undef mlk_poly_mulcache_compute_asm
+#undef mlk_poly_reduce_asm
+#undef mlk_poly_tobytes_asm
+#undef mlk_poly_tomont_asm
+#undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k2
+#undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k3
+#undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k4
+#undef mlk_rej_uniform_asm
 #undef mlk_rej_uniform_table
 /* mlkem/native/aarch64/src/consts.h */
 #undef MLK_NATIVE_AARCH64_SRC_CONSTS_H

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -29,43 +29,48 @@ extern const int16_t mlk_aarch64_zetas_mulcache_native[];
 extern const int16_t mlk_aarch64_zetas_mulcache_twisted_native[];
 extern const uint8_t mlk_rej_uniform_table[];
 
-#define mlk_ntt_asm_opt MLK_NAMESPACE(ntt_asm_opt)
-void mlk_ntt_asm_opt(int16_t *, const int16_t *, const int16_t *);
+#define mlk_ntt_asm MLK_NAMESPACE(ntt_asm)
+void mlk_ntt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_intt_asm_opt MLK_NAMESPACE(intt_asm_opt)
-void mlk_intt_asm_opt(int16_t *, const int16_t *, const int16_t *);
+#define mlk_intt_asm MLK_NAMESPACE(intt_asm)
+void mlk_intt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_poly_reduce_asm_opt MLK_NAMESPACE(poly_reduce_asm_opt)
-void mlk_poly_reduce_asm_opt(int16_t *);
+#define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
+void mlk_poly_reduce_asm(int16_t *);
 
-#define mlk_poly_tomont_asm_opt MLK_NAMESPACE(poly_tomont_asm_opt)
-void mlk_poly_tomont_asm_opt(int16_t *);
+#define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
+void mlk_poly_tomont_asm(int16_t *);
 
-#define mlk_poly_mulcache_compute_asm_opt \
-  MLK_NAMESPACE(poly_mulcache_compute_asm_opt)
-void mlk_poly_mulcache_compute_asm_opt(int16_t *, const int16_t *,
-                                       const int16_t *, const int16_t *);
+#define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
+void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
+                                   const int16_t *);
 
-#define mlk_poly_tobytes_asm_opt MLK_NAMESPACE(poly_tobytes_asm_opt)
-void mlk_poly_tobytes_asm_opt(uint8_t *r, const int16_t *a);
+#define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
+void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt \
-  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
-void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+#define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
+  MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
+void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
-#define mlk_rej_uniform_asm_clean MLK_NAMESPACE(rej_uniform_asm_clean)
-unsigned mlk_rej_uniform_asm_clean(int16_t *r, const uint8_t *buf,
-                                   unsigned buflen, const uint8_t *table);
+#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
+unsigned mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
+                             const uint8_t *table);
 
 #endif /* MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H */

--- a/mlkem/native/aarch64/src/intt.S
+++ b/mlkem/native/aarch64/src/intt.S
@@ -29,14 +29,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/intt_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/intt.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(intt_asm_opt)
-MLK_ASM_FN_SYMBOL(intt_asm_opt)
+.global MLK_ASM_NAMESPACE(intt_asm)
+MLK_ASM_FN_SYMBOL(intt_asm)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]

--- a/mlkem/native/aarch64/src/ntt.S
+++ b/mlkem/native/aarch64/src/ntt.S
@@ -30,14 +30,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/ntt_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/ntt.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(ntt_asm_opt)
-MLK_ASM_FN_SYMBOL(ntt_asm_opt)
+.global MLK_ASM_NAMESPACE(ntt_asm)
+MLK_ASM_FN_SYMBOL(ntt_asm)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -64,7 +64,7 @@ MLK_ASM_FN_SYMBOL(ntt_asm_opt)
         ldr	q13, [x0, #0x180]
         sub	x4, x4, #0x1
 
-ntt_opt_loop0:
+ntt_loop0:
         sqrdmulh	v14.8h, v23.8h, v0.h[1]
         sqrdmulh	v23.8h, v17.8h, v0.h[1]
         mul	v17.8h, v17.8h, v0.h[0]
@@ -142,7 +142,7 @@ ntt_opt_loop0:
         ldr	q13, [x0, #0x180]
         mul	v15.8h, v11.8h, v0.h[0]
         sub	x4, x4, #0x1
-        cbnz	x4, ntt_opt_loop0
+        cbnz	x4, ntt_loop0
         sqrdmulh	v27.8h, v11.8h, v0.h[1]
         mul	v8.8h, v13.8h, v0.h[0]
         sqrdmulh	v22.8h, v13.8h, v0.h[1]
@@ -237,7 +237,7 @@ ntt_opt_loop0:
         ldur	q13, [x2, #-0x10]
         sub	x4, x4, #0x1
 
-ntt_opt_loop1:
+ntt_loop1:
         ldr	q19, [x0, #0x70]
         ldr	q1, [x1], #0x10
         mls	v23.8h, v21.8h, v7.h[0]
@@ -310,7 +310,7 @@ ntt_opt_loop1:
         ldur	q13, [x2, #-0x10]
         stur	q9, [x0, #-0x10]
         sub	x4, x4, #0x1
-        cbnz	x4, ntt_opt_loop1
+        cbnz	x4, ntt_loop1
         mls	v23.8h, v21.8h, v7.h[0]
         add	v14.8h, v27.8h, v8.8h
         ldur	q1, [x2, #-0x20]

--- a/mlkem/native/aarch64/src/opt_impl.h
+++ b/mlkem/native/aarch64/src/opt_impl.h
@@ -25,58 +25,58 @@
 
 static MLK_INLINE void mlk_ntt_native(int16_t data[MLKEM_N])
 {
-  mlk_ntt_asm_opt(data, mlk_aarch64_ntt_zetas_layer12345,
-                  mlk_aarch64_ntt_zetas_layer67);
+  mlk_ntt_asm(data, mlk_aarch64_ntt_zetas_layer12345,
+              mlk_aarch64_ntt_zetas_layer67);
 }
 
 static MLK_INLINE void mlk_intt_native(int16_t data[MLKEM_N])
 {
-  mlk_intt_asm_opt(data, mlk_aarch64_invntt_zetas_layer12345,
-                   mlk_aarch64_invntt_zetas_layer67);
+  mlk_intt_asm(data, mlk_aarch64_invntt_zetas_layer12345,
+               mlk_aarch64_invntt_zetas_layer67);
 }
 
 static MLK_INLINE void mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
-  mlk_poly_reduce_asm_opt(data);
+  mlk_poly_reduce_asm(data);
 }
 
 static MLK_INLINE void mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
-  mlk_poly_tomont_asm_opt(data);
+  mlk_poly_tomont_asm(data);
 }
 
 static MLK_INLINE void mlk_poly_mulcache_compute_native(
     int16_t x[MLKEM_N / 2], const int16_t y[MLKEM_N])
 {
-  mlk_poly_mulcache_compute_asm_opt(x, y, mlk_aarch64_zetas_mulcache_native,
-                                    mlk_aarch64_zetas_mulcache_twisted_native);
+  mlk_poly_mulcache_compute_asm(x, y, mlk_aarch64_zetas_mulcache_native,
+                                mlk_aarch64_zetas_mulcache_twisted_native);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
-  mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt(r, a, b, b_cache);
+  mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(r, a, b, b_cache);
 }
 
 static MLK_INLINE void mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
                                                const int16_t a[MLKEM_N])
 {
-  mlk_poly_tobytes_asm_opt(r, a);
+  mlk_poly_tobytes_asm(r, a);
 }
 
 static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
@@ -87,7 +87,7 @@ static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
   {
     return -1;
   }
-  return (int)mlk_rej_uniform_asm_clean(r, buf, buflen, mlk_rej_uniform_table);
+  return (int)mlk_rej_uniform_asm(r, buf, buflen, mlk_rej_uniform_table);
 }
 
 #endif /* MLK_ARITH_PROFILE_IMPL_H */

--- a/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
+++ b/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -9,14 +9,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/poly_mulcache_compute_asm_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/poly_mulcache_compute_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm_opt)
-MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_opt)
+.global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm)
+MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm)
 
         mov	w5, #0xd01              // =3329
         dup	v6.8h, w5
@@ -32,7 +32,7 @@ MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm_opt)
         sqrdmulh	v27.8h, v27.8h, v1.8h
         sub	x4, x4, #0x1
 
-poly_mulcache_compute_asm_opt_loop:
+poly_mulcache_compute_asm_loop:
         ldr	q29, [x1, #0x10]
         ldr	q21, [x2], #0x10
         mls	v2.8h, v27.8h, v6.h[0]
@@ -43,7 +43,7 @@ poly_mulcache_compute_asm_opt_loop:
         mul	v2.8h, v28.8h, v21.8h
         sqrdmulh	v27.8h, v28.8h, v7.8h
         sub	x4, x4, #0x1
-        cbnz	x4, poly_mulcache_compute_asm_opt_loop
+        cbnz	x4, poly_mulcache_compute_asm_loop
         mls	v2.8h, v27.8h, v6.h[0]
         str	q2, [x0], #0x10
         ret

--- a/mlkem/native/aarch64/src/poly_reduce_asm.S
+++ b/mlkem/native/aarch64/src/poly_reduce_asm.S
@@ -9,14 +9,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/poly_reduce_asm_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/poly_reduce_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(poly_reduce_asm_opt)
-MLK_ASM_FN_SYMBOL(poly_reduce_asm_opt)
+.global MLK_ASM_NAMESPACE(poly_reduce_asm)
+MLK_ASM_FN_SYMBOL(poly_reduce_asm)
 
         mov	w2, #0xd01              // =3329
         dup	v3.8h, w2
@@ -40,7 +40,7 @@ MLK_ASM_FN_SYMBOL(poly_reduce_asm_opt)
         add	v16.8h, v23.8h, v7.8h
         sub	x1, x1, #0x1
 
-poly_reduce_asm_opt_loop:
+poly_reduce_asm_loop:
         ldr	q6, [x0], #0x40
         ldr	q30, [x0, #0x20]
         sqdmulh	v31.8h, v6.8h, v4.h[0]
@@ -74,7 +74,7 @@ poly_reduce_asm_opt_loop:
         and	v27.16b, v3.16b, v18.16b
         add	v16.8h, v2.8h, v27.8h
         sub	x1, x1, #0x1
-        cbnz	x1, poly_reduce_asm_opt_loop
+        cbnz	x1, poly_reduce_asm_loop
         sqdmulh	v20.8h, v5.8h, v4.h[0]
         ldr	q24, [x0], #0x40
         stur	q21, [x0, #-0x20]

--- a/mlkem/native/aarch64/src/poly_tobytes_asm.S
+++ b/mlkem/native/aarch64/src/poly_tobytes_asm.S
@@ -9,18 +9,18 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/poly_tobytes_asm_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/poly_tobytes_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(poly_tobytes_asm_opt)
-MLK_ASM_FN_SYMBOL(poly_tobytes_asm_opt)
+.global MLK_ASM_NAMESPACE(poly_tobytes_asm)
+MLK_ASM_FN_SYMBOL(poly_tobytes_asm)
 
         mov	x2, #0x10               // =16
 
-poly_tobytes_asm_opt_asm_loop_start:
+poly_tobytes_asm_asm_loop_start:
         ld2	{ v0.8h, v1.8h }, [x1], #32
         xtn	v2.8b, v0.8h
         shrn	v3.8b, v0.8h, #0x8
@@ -29,7 +29,7 @@ poly_tobytes_asm_opt_asm_loop_start:
         shrn	v4.8b, v1.8h, #0x4
         st3	{ v2.8b, v3.8b, v4.8b }, [x0], #24
         subs	x2, x2, #0x1
-        cbnz	x2, poly_tobytes_asm_opt_asm_loop_start
+        cbnz	x2, poly_tobytes_asm_asm_loop_start
         ret
 
 #endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&

--- a/mlkem/native/aarch64/src/poly_tomont_asm.S
+++ b/mlkem/native/aarch64/src/poly_tomont_asm.S
@@ -9,14 +9,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/poly_tomont_asm_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/poly_tomont_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(poly_tomont_asm_opt)
-MLK_ASM_FN_SYMBOL(poly_tomont_asm_opt)
+.global MLK_ASM_NAMESPACE(poly_tomont_asm)
+MLK_ASM_FN_SYMBOL(poly_tomont_asm)
 
         mov	w2, #0xd01              // =3329
         dup	v4.8h, w2
@@ -34,7 +34,7 @@ MLK_ASM_FN_SYMBOL(poly_tomont_asm_opt)
         ldr	q27, [x0, #0x20]
         sub	x1, x1, #0x1
 
-poly_tomont_asm_opt_loop:
+poly_tomont_asm_loop:
         mls	v17.8h, v7.8h, v4.h[0]
         sqrdmulh	v5.8h, v23.8h, v3.8h
         ldr	q7, [x0], #0x40
@@ -56,7 +56,7 @@ poly_tomont_asm_opt_loop:
         ldr	q27, [x0, #0x20]
         stur	q26, [x0, #-0x20]
         sub	x1, x1, #0x1
-        cbnz	x1, poly_tomont_asm_opt_loop
+        cbnz	x1, poly_tomont_asm_loop
         mls	v17.8h, v7.8h, v4.h[0]
         sqrdmulh	v7.8h, v23.8h, v3.8h
         mul	v26.8h, v23.8h, v2.8h

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -16,14 +16,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
+.global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -115,7 +115,7 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
         ld1	{ v4.8h }, [x3], #16
         sub	x13, x13, #0x2
 
-polyvec_basemul_acc_montgomery_cached_asm_k2_opt_loop:
+polyvec_basemul_acc_montgomery_cached_asm_k2_loop:
         smull2	v20.4s, v3.8h, v17.8h
         ldr	q18, [x4], #0x20
         ldr	q30, [x5], #0x20
@@ -165,7 +165,7 @@ polyvec_basemul_acc_montgomery_cached_asm_k2_opt_loop:
         ld1	{ v4.8h }, [x3], #16
         smlal2	v11.4s, v14.8h, v0.8h
         sub	x13, x13, #0x1
-        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k2_opt_loop
+        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k2_loop
         smull2	v5.4s, v3.8h, v17.8h
         smlal	v12.4s, v14.4h, v0.4h
         smlal	v23.4s, v10.4h, v4.4h

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -16,14 +16,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
+.global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -118,7 +118,7 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
         ld1	{ v25.8h }, [x9], #16
         sub	x13, x13, #0x2
 
-polyvec_basemul_acc_montgomery_cached_asm_k3_opt_loop:
+polyvec_basemul_acc_montgomery_cached_asm_k3_loop:
         ldr	q20, [x1], #0x20
         uzp1	v7.8h, v15.8h, v16.8h
         uzp2	v15.8h, v15.8h, v16.8h
@@ -185,7 +185,7 @@ polyvec_basemul_acc_montgomery_cached_asm_k3_opt_loop:
         ldur	q18, [x8, #-0x10]
         ld1	{ v25.8h }, [x9], #16
         sub	x13, x13, #0x1
-        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k3_opt_loop
+        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k3_loop
         ldr	q7, [x1], #0x20
         uzp1	v20.8h, v15.8h, v16.8h
         uzp2	v15.8h, v15.8h, v16.8h

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -16,14 +16,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
-MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
+.global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
+MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4)
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -160,7 +160,7 @@ MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
         ld1	{ v23.8h }, [x3], #16
         sub	x13, x13, #0x2
 
-polyvec_basemul_acc_montgomery_cached_asm_k4_opt_loop:
+polyvec_basemul_acc_montgomery_cached_asm_k4_loop:
         smlal2	v24.4s, v26.8h, v28.8h
         uzp2	v4.8h, v4.8h, v3.8h
         smull2	v13.4s, v31.8h, v19.8h
@@ -244,7 +244,7 @@ polyvec_basemul_acc_montgomery_cached_asm_k4_opt_loop:
         str	q5, [x0], #0x20
         zip1	v5.8h, v7.8h, v15.8h
         sub	x13, x13, #0x1
-        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k4_opt_loop
+        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k4_loop
         smull2	v17.4s, v31.8h, v19.8h
         uzp2	v1.8h, v14.8h, v6.8h
         smull	v18.4s, v31.4h, v21.4h

--- a/mlkem/native/aarch64/src/rej_uniform_asm.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm.S
@@ -4,7 +4,7 @@
  */
 
 /*************************************************
- * Name:        mlk_rej_uniform_asm_clean
+ * Name:        mlk_rej_uniform_asm
  *
  * Description: Run rejection sampling on uniform random bytes to generate
  *              uniform random integers mod q
@@ -25,14 +25,14 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/rej_uniform_asm_clean.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/rej_uniform_asm.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(rej_uniform_asm_clean)
-MLK_ASM_FN_SYMBOL(rej_uniform_asm_clean)
+.global MLK_ASM_NAMESPACE(rej_uniform_asm)
+MLK_ASM_FN_SYMBOL(rej_uniform_asm)
 
         sub	sp, sp, #0x240
         mov	x7, #0x1                // =1

--- a/proofs/hol_light/arm/mlkem/mlkem_intt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_intt.S
@@ -26,18 +26,18 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/intt_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/intt.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_intt_asm_opt
-_PQCP_MLKEM_NATIVE_MLKEM768_intt_asm_opt:
+.global _PQCP_MLKEM_NATIVE_MLKEM768_intt_asm
+_PQCP_MLKEM_NATIVE_MLKEM768_intt_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_intt_asm_opt
-PQCP_MLKEM_NATIVE_MLKEM768_intt_asm_opt:
+.global PQCP_MLKEM_NATIVE_MLKEM768_intt_asm
+PQCP_MLKEM_NATIVE_MLKEM768_intt_asm:
 #endif
 
         sub	sp, sp, #0x40

--- a/proofs/hol_light/arm/mlkem/mlkem_ntt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_ntt.S
@@ -27,18 +27,18 @@
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
- *   dev/aarch64_opt/src/ntt_opt.S using scripts/simpasm. Do not modify it directly.
+ *   dev/aarch64_opt/src/ntt.S using scripts/simpasm. Do not modify it directly.
  */
 
 
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm_opt
-_PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm_opt:
+.global _PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm
+_PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm_opt
-PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm_opt:
+.global PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm
+PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm:
 #endif
 
         sub	sp, sp, #0x40
@@ -66,7 +66,7 @@ PQCP_MLKEM_NATIVE_MLKEM768_ntt_asm_opt:
         ldr	q13, [x0, #0x180]
         sub	x4, x4, #0x1
 
-ntt_opt_loop0:
+ntt_loop0:
         sqrdmulh	v14.8h, v23.8h, v0.h[1]
         sqrdmulh	v23.8h, v17.8h, v0.h[1]
         mul	v17.8h, v17.8h, v0.h[0]
@@ -144,7 +144,7 @@ ntt_opt_loop0:
         ldr	q13, [x0, #0x180]
         mul	v15.8h, v11.8h, v0.h[0]
         sub	x4, x4, #0x1
-        cbnz	x4, ntt_opt_loop0
+        cbnz	x4, ntt_loop0
         sqrdmulh	v27.8h, v11.8h, v0.h[1]
         mul	v8.8h, v13.8h, v0.h[0]
         sqrdmulh	v22.8h, v13.8h, v0.h[1]
@@ -239,7 +239,7 @@ ntt_opt_loop0:
         ldur	q13, [x2, #-0x10]
         sub	x4, x4, #0x1
 
-ntt_opt_loop1:
+ntt_loop1:
         ldr	q19, [x0, #0x70]
         ldr	q1, [x1], #0x10
         mls	v23.8h, v21.8h, v7.h[0]
@@ -312,7 +312,7 @@ ntt_opt_loop1:
         ldur	q13, [x2, #-0x10]
         stur	q9, [x0, #-0x10]
         sub	x4, x4, #0x1
-        cbnz	x4, ntt_opt_loop1
+        cbnz	x4, ntt_loop1
         mls	v23.8h, v21.8h, v7.h[0]
         add	v14.8h, v27.8h, v8.8h
         ldur	q1, [x2, #-0x20]

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -955,8 +955,8 @@ def gen_hol_light_asm(dry_run=False):
             dry_run=dry_run,
         )
 
-    gen_hol_light_asm_file("ntt_opt.S", "mlkem_ntt.S")
-    gen_hol_light_asm_file("intt_opt.S", "mlkem_intt.S")
+    gen_hol_light_asm_file("ntt.S", "mlkem_ntt.S")
+    gen_hol_light_asm_file("intt.S", "mlkem_intt.S")
 
 
 def update_via_copy(infile_full, outfile_full, dry_run=False, transform=None):

--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -201,31 +201,30 @@ static int bench(void)
 
 
 #if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN)
-  BENCH("ntt-clean", mlk_ntt_asm_clean((int16_t *)data0, (int16_t *)data1,
-                                       (int16_t *)data2));
-  BENCH("intt-clean", mlk_intt_asm_clean((int16_t *)data0, (int16_t *)data1,
-                                         (int16_t *)data2));
-  BENCH("mlk_poly-reduce-clean", mlk_poly_reduce_asm_clean((int16_t *)data0));
-  BENCH("mlk_poly-tomont-clean", mlk_poly_tomont_asm_clean((int16_t *)data0));
+  BENCH("ntt-clean",
+        mlk_ntt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
+  BENCH("intt-clean",
+        mlk_intt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
+  BENCH("mlk_poly-reduce-clean", mlk_poly_reduce_asm((int16_t *)data0));
+  BENCH("mlk_poly-tomont-clean", mlk_poly_tomont_asm((int16_t *)data0));
   BENCH("mlk_poly-tobytes-clean",
-        mlk_poly_tobytes_asm_clean((uint8_t *)data0, (int16_t *)data1));
-  BENCH(
-      "mlk_poly-mulcache-compute-clean",
-      mlk_poly_mulcache_compute_asm_clean((int16_t *)data0, (int16_t *)data1,
-                                          (int16_t *)data2, (int16_t *)data3));
+        mlk_poly_tobytes_asm((uint8_t *)data0, (int16_t *)data1));
+  BENCH("mlk_poly-mulcache-compute-clean",
+        mlk_poly_mulcache_compute_asm((int16_t *)data0, (int16_t *)data1,
+                                      (int16_t *)data2, (int16_t *)data3));
 #if MLKEM_K == 2
   BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-clean",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_clean(
+        mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #elif MLKEM_K == 3
   BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-clean",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_clean(
+        mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #elif MLKEM_K == 4
   BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-clean",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_clean(
+        mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #endif
@@ -233,27 +232,27 @@ static int bench(void)
 
 #if defined(MLK_ARITH_BACKEND_AARCH64_OPT)
   BENCH("ntt-opt",
-        mlk_ntt_asm_opt((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
+        mlk_ntt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
   BENCH("intt-opt",
-        mlk_intt_asm_opt((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
-  BENCH("mlk_poly-reduce-opt", mlk_poly_reduce_asm_opt((int16_t *)data0));
-  BENCH("mlk_poly-tomont-opt", mlk_poly_tomont_asm_opt((int16_t *)data0));
+        mlk_intt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
+  BENCH("mlk_poly-reduce-opt", mlk_poly_reduce_asm((int16_t *)data0));
+  BENCH("mlk_poly-tomont-opt", mlk_poly_tomont_asm((int16_t *)data0));
   BENCH("mlk_poly-mulcache-compute-opt",
-        mlk_poly_mulcache_compute_asm_opt((int16_t *)data0, (int16_t *)data1,
-                                          (int16_t *)data2, (int16_t *)data3));
+        mlk_poly_mulcache_compute_asm((int16_t *)data0, (int16_t *)data1,
+                                      (int16_t *)data2, (int16_t *)data3));
 #if MLKEM_K == 2
   BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-opt",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k2_opt(
+        mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #elif MLKEM_K == 3
   BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-opt",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k3_opt(
+        mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #elif MLKEM_K == 4
   BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-opt",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k4_opt(
+        mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #endif


### PR DESCRIPTION
Fixes #793 

This PR removes the "_opt" and "_clean" suffix from filename, function names, and symbols in the AArch64 back-end.

The "autogen" script is also updated to correctly copy, move and generate these files as appropriate.
