### PR TITLE
TEST: clang20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,9 @@ jobs:
          - name: clang-19
            shell: ci_clang19
            darwin: True
+         - name: clang-20
+           shell: ci_clang20
+           darwin: False
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -28,6 +28,7 @@ jobs:
           - ci_valgrind-varlat_clang17
           - ci_valgrind-varlat_clang18
           - ci_valgrind-varlat_clang19
+          - ci_valgrind-varlat_clang20
           - ci_valgrind-varlat_gcc48
           - ci_valgrind-varlat_gcc49
           - ci_valgrind-varlat_gcc7
@@ -63,7 +64,7 @@ jobs:
           valgrind_flags: --variable-latency-errors=yes
       - name:  Build and run test (-Ofast)
         # -Ofast got deprecated in clang19; -O3 -ffast-math should be used instead
-        if: ${{ matrix.nix-shell !=  'ci_valgrind-varlat_clang19' }}
+        if: ${{ matrix.nix-shell != 'ci_valgrind-varlat_clang19' &&  matrix.nix-shell !=  'ci_valgrind-varlat_clang20' }}
         uses: ./.github/actions/ct-test
         with:
           cflags: -Ofast -DMLK_KEYGEN_PCT

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1738410390,
-        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
                 gcc48 = pkgs-2405.gcc48;
                 gcc49 = pkgs-2405.gcc49;
                 qemu = pkgs-unstable.qemu; # 9.2.0
+                clang_20 = pkgs-unstable.clang_20;
               })
             ];
           };
@@ -84,6 +85,8 @@
           devShells.ci_clang17 = util.mkShellWithCC' pkgs.clang_17;
           devShells.ci_clang18 = util.mkShellWithCC' pkgs.clang_18;
           devShells.ci_clang19 = util.mkShellWithCC' pkgs.clang_19;
+          devShells.ci_clang20 = util.mkShellWithCC' pkgs.clang_20;
+
           devShells.ci_gcc48 = util.mkShellWithCC' pkgs.gcc48;
           devShells.ci_gcc49 = util.mkShellWithCC' pkgs.gcc49;
           devShells.ci_gcc7 = util.mkShellWithCC' pkgs.gcc7;
@@ -99,6 +102,7 @@
           devShells.ci_valgrind-varlat_clang17 = util.mkShellWithCC_valgrind' pkgs.clang_17;
           devShells.ci_valgrind-varlat_clang18 = util.mkShellWithCC_valgrind' pkgs.clang_18;
           devShells.ci_valgrind-varlat_clang19 = util.mkShellWithCC_valgrind' pkgs.clang_19;
+          devShells.ci_valgrind-varlat_clang20 = util.mkShellWithCC_valgrind' pkgs.clang_20;
           devShells.ci_valgrind-varlat_gcc48 = util.mkShellWithCC_valgrind' pkgs.gcc48;
           devShells.ci_valgrind-varlat_gcc49 = util.mkShellWithCC_valgrind' pkgs.gcc49;
           devShells.ci_valgrind-varlat_gcc7 = util.mkShellWithCC_valgrind' pkgs.gcc7;


### PR DESCRIPTION
clang 20.1.0 is expected to be released next month.
This PR adds a nix shell with clang 20.1.0rc2 and runs the compiler tests and constant-time tests with it.

This is mostly intended to identify any issues early. We can merge it once clang 20 is released.