### PR TITLE
Document relation to reference implementation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,20 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+Relation to reference implementation
+====================================
+
+mlkem-native is a fork of the ML-KEM [reference implementation](https://github.com/pq-crystals/kyber).
+
+The following gives an overview of the major changes:
+
+- CBMC and debug annotations, and minor code restructurings or signature changes to facilitate the CBMC proofs. For example, `poly_add(x,a)` only comes in a destructive variant to avoid specifying aliasing constraints; `poly_rej_uniform` has an additional `offset` parameter indicating the position in the sampling buffer, to avoid passing shifted pointers).
+- Introduction of 4x-batched versions of some functions from the reference implementation. This is to leverage 4x-batched Keccak-f1600 implementations if present. The batching happens at the C level even if no native backend for FIPS 202 is present.
+- FIPS 203 compliance: Introduced PK (FIPS 203, Section 7.2, 'modulus check') and SK (FIPS 203, Section 7.3, 'hash check') check, as well as optional PCT (FIPS 203, Section 7.1, Pairwise Consistency). Also, introduced zeroization of stack buffers as required by (FIPS 203, Section 3.3, Destruction of intermediate values).
+- Introduction of native backend implementations. With the exception of the native backend for `poly_rej_uniform()`, which may fail and fall back to the C implementation, those are drop-in replacements for the corresponding C functions and dispatched at compile-time.
+- Restructuring of files to separate level-specific from level-generic functionality. This is needed to enable a multi-level build of mlkem-native where level-generic code is shared between levels.
+- More pervasive use of value barriers to harden constant-time primitives, even when Link-Time-Optimization (LTO) is enabled. The use of LTO can lead to insecure compilation in case of the reference implementation.
+- Use of a multiplication cache ('mulcache') structure to simplify and speedup the base multiplication.
+- Different placement of modular reductions: We reduce to _unsigned_ canonical representatives in `poly_reduce()`, and _assume_ such in all polynomial compression functions. The reference implementation works with a _signed_ `poly_reduce()`, and embeds various signed->unsigned conversions in the compression functions.
+- More inlining: Modular multiplication and primitives are in a header rather than a separate compilation unit.
+
+For details, please see the source code: Functions in the mlkem-native source tree are annotated with `/* Reference: ... */` comments to outline how they relate to the reference implementation.

--- a/mlkem/compress.c
+++ b/mlkem/compress.c
@@ -15,6 +15,12 @@
 
 #if defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || (MLKEM_K == 2 || MLKEM_K == 3)
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D4)
+/* Reference: `poly_compress()` in the reference implementation,
+ *            for ML-KEM-{512,768}.
+ *            - In contrast to the reference implementation, we assume
+ *              unsigned canonical coefficients here.
+ *              The reference implementation works with coefficients
+ *              in the range (-MLKEM_Q+1,...,MLKEM_Q-1). */
 MLK_INTERNAL_API
 void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
                           const mlk_poly *a)
@@ -52,6 +58,12 @@ void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D4 */
 
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D10)
+/* Reference: Embedded into `polyvec_compress()` in the
+ *            reference implementation, for ML-KEM-{512,768}.
+ *            - In contrast to the reference implementation, we assume
+ *              unsigned canonical coefficients here.
+ *              The reference implementation works with coefficients
+ *              in the range (-MLKEM_Q+1,...,MLKEM_Q-1). */
 MLK_INTERNAL_API
 void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
                            const mlk_poly *a)
@@ -93,6 +105,8 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D10 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D4)
+/* Reference: `poly_decompress()` in the reference implementation,
+ *            for ML-KEM-{512,768}. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d4(mlk_poly *r,
                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
@@ -120,6 +134,8 @@ void mlk_poly_decompress_d4(mlk_poly *r,
 #endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D4 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D10)
+/* Reference: Embedded into `polyvec_decompress()` in the
+ *            reference implementation, for ML-KEM-{512,768}. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d10(mlk_poly *r,
                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
@@ -164,6 +180,12 @@ void mlk_poly_decompress_d10(mlk_poly *r,
 
 #if defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D5)
+/* Reference: `poly_compress()` in the reference implementation,
+ *            for ML-KEM-1024.
+ *            - In contrast to the reference implementation, we assume
+ *              unsigned canonical coefficients here.
+ *              The reference implementation works with coefficients
+ *              in the range (-MLKEM_Q+1,...,MLKEM_Q-1). */
 MLK_INTERNAL_API
 void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
                           const mlk_poly *a)
@@ -207,6 +229,12 @@ void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D5 */
 
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D11)
+/* Reference: Embedded into `polyvec_compress()` in the
+ *            reference implementation, for ML-KEM-1024.
+ *            - In contrast to the reference implementation, we assume
+ *              unsigned canonical coefficients here.
+ *              The reference implementation works with coefficients
+ *              in the range (-MLKEM_Q+1,...,MLKEM_Q-1). */
 MLK_INTERNAL_API
 void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
                            const mlk_poly *a)
@@ -255,6 +283,8 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D11 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D5)
+/* Reference: `poly_decompress()` in the reference implementation,
+ *            for ML-KEM-1024. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d5(mlk_poly *r,
                             const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D5])
@@ -310,6 +340,8 @@ void mlk_poly_decompress_d5(mlk_poly *r,
 #endif /* MLK_USE_NATIVE_POLY_DECOMPRESS_D5 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D11)
+/* Reference: Embedded into `polyvec_decompress()` in the
+ *            reference implementation, for ML-KEM-1024. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d11(mlk_poly *r,
                              const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D11])
@@ -358,6 +390,11 @@ void mlk_poly_decompress_d11(mlk_poly *r,
 #endif /* MLK_MULTILEVEL_BUILD) || MLKEM_K == 4 */
 
 #if !defined(MLK_USE_NATIVE_POLY_TOBYTES)
+/* Reference: `poly_tobytes()` in the reference implementation.
+ *            - In contrast to the reference implementation, we assume
+ *              unsigned canonical coefficients here.
+ *              The reference implementation works with coefficients
+ *              in the range (-MLKEM_Q+1,...,MLKEM_Q-1). */
 MLK_INTERNAL_API
 void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
 {
@@ -399,6 +436,7 @@ void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
 #endif /* MLK_USE_NATIVE_POLY_TOBYTES */
 
 #if !defined(MLK_USE_NATIVE_POLY_FROMBYTES)
+/* Reference: `poly_frombytes()` in the reference implementation. */
 MLK_INTERNAL_API
 void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
@@ -426,6 +464,12 @@ void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 }
 #endif /* MLK_USE_NATIVE_POLY_FROMBYTES */
 
+/* Reference: `poly_frommsg()` in the reference implementation.
+ *            - We use a value barrier around the bit-selection mask to
+ *              reduce the risk of compiler-introduced branches.
+ *              The reference implementation contains the expression
+ *              `(msg[i] >> j) & 1` which the compiler can reason must
+ *              be either 0 or 1. */
 MLK_INTERNAL_API
 void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
 {
@@ -456,6 +500,12 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
   mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 
+/* Reference: `poly_tomsg()` in the reference implementation.
+ *            - In contrast to the reference implementation, we assume
+ *              unsigned canonical coefficients here.
+ *              The reference implementation works with coefficients
+ *              in the range (-MLKEM_Q+1,...,MLKEM_Q-1).
+ */
 MLK_INTERNAL_API
 void mlk_poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const mlk_poly *a)
 {

--- a/mlkem/compress.h
+++ b/mlkem/compress.h
@@ -24,6 +24,7 @@
  * Specification: Compress_1 from [FIPS 203, Eq (4.7)].
  *
  ************************************************************/
+
 /*
  * The multiplication in this routine will exceed UINT32_MAX
  * and wrap around for large values of u. This is expected and required.
@@ -32,6 +33,8 @@
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
+
+/* Reference: Embedded in poly_tomsg() in the reference implementation. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d1(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -72,6 +75,9 @@ __contract__(
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
+
+/* Reference: Embedded into `poly_compress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d4(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -104,6 +110,9 @@ __contract__(
  * Specification: Decompress_4 from [FIPS 203, Eq (4.8)].
  *
  ************************************************************/
+
+/* Reference: Embedded into `poly_decompress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d4(uint32_t u)
 __contract__(
   requires(0 <= u && u < 16)
@@ -129,6 +138,9 @@ __contract__(
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
+
+/* Reference: Embedded into `poly_compress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d5(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -161,6 +173,9 @@ __contract__(
  * Specification: Decompress_5 from [FIPS 203, Eq (4.8)].
  *
  ************************************************************/
+
+/* Reference: Embedded into `poly_decompress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d5(uint32_t u)
 __contract__(
   requires(0 <= u && u < 32)
@@ -186,6 +201,9 @@ __contract__(
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
+
+/* Reference: Embedded into `polyvec_compress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d10(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -219,6 +237,9 @@ __contract__(
  * Specification: Decompress_10 from [FIPS 203, Eq (4.8)].
  *
  ************************************************************/
+
+/* Reference: Embedded into `polyvec_decompress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d10(uint32_t u)
 __contract__(
   requires(0 <= u && u < 1024)
@@ -244,6 +265,9 @@ __contract__(
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
+
+/* Reference: Embedded into `polyvec_compress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d11(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -277,6 +301,9 @@ __contract__(
  * Specification: Decompress_11 from [FIPS 203, Eq (4.8)].
  *
  ************************************************************/
+
+/* Reference: Embedded into `polyvec_decompress()` in the
+ *            reference implementation. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d11(uint32_t u)
 __contract__(
   requires(0 <= u && u < 2048)

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -46,6 +46,8 @@ __contract__(
  * Specification: Implements [FIPS 203, Section 7.2, 'modulus check']
  *
  **************************************************/
+
+/* Reference: Not implemented in the reference implementation. */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
 {
@@ -85,6 +87,8 @@ static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
  * Specification: Implements [FIPS 203, Section 7.3, 'hash check']
  *
  **************************************************/
+
+/* Reference: Not implemented in the reference implementation. */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
@@ -125,8 +129,9 @@ __contract__(
 #if defined(MLK_KEYGEN_PCT)
 /* Specification:
  * Partially implements 'Pairwise Consistency Test' [FIPS 140-3 IG] and
- * [FIPS 203, Section 7.1, Pairwise Consistency].
- */
+ * [FIPS 203, Section 7.1, Pairwise Consistency]. */
+
+/* Reference: Not implemented in the reference implementation. */
 static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                          uint8_t const sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
@@ -178,6 +183,9 @@ static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
 }
 #endif /* MLKEM_KEYGEN_PCT */
 
+/* Reference: `crypto_kem_keypair_derand()` in the reference implementation
+ *            - We optionally include PCT which is not present in
+ *              the reference code. */
 MLK_EXTERNAL_API
 int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                               uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES],
@@ -203,6 +211,8 @@ int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   return 0;
 }
 
+/* Reference: `crypto_kem_keypair()` in the reference implementation
+ *            - We zeroize the stack buffer */
 MLK_EXTERNAL_API
 int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                        uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
@@ -222,6 +232,9 @@ int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   return res;
 }
 
+/* Reference: `crypto_kem_enc_derand()` in the reference implementation
+ *            - We include public key check
+ *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
 int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
                           uint8_t ss[MLKEM_SSBYTES],
@@ -257,6 +270,8 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   return 0;
 }
 
+/* Reference: `crypto_kem_enc()` in the reference implementation
+ *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
 int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
                    uint8_t ss[MLKEM_SSBYTES],
@@ -276,6 +291,9 @@ int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   return res;
 }
 
+/* Reference: `crypto_kem_dec()` in the reference implementation
+ *            - We include secret key check
+ *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
 int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
                    const uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],

--- a/mlkem/sampling.c
+++ b/mlkem/sampling.c
@@ -10,6 +10,11 @@
 #include "sampling.h"
 #include "symmetric.h"
 
+/* Reference: `rej_uniform()` in the reference implementation.
+ *            - Our signature differs from the reference implementation
+ *              in that it adds the offset and always expects the base of the
+ *              target buffer. This avoids shifting the buffer base in the
+ *              caller, which appears tricky to reason about. */
 static unsigned mlk_rej_uniform_scalar(int16_t *r, unsigned target,
                                        unsigned offset, const uint8_t *buf,
                                        unsigned buflen)
@@ -84,12 +89,12 @@ __contract__(
  * is provided on how many bytes of the input buffer have been consumed.
  **************************************************/
 
-/*
- * NOTE: The signature differs from the Kyber reference implementation
- * in that it adds the offset and always expects the base of the target
- * buffer. This avoids shifting the buffer base in the caller, which appears
- * tricky to reason about.
- */
+/* Reference: `rej_uniform()` in the reference implementation.
+ *            - Our signature differs from the reference implementation
+ *              in that it adds the offset and always expects the base of the
+ *              target buffer. This avoids shifting the buffer base in the
+ *              caller, which appears tricky to reason about.
+ *            - Optional fallback to native implementation. */
 static unsigned mlk_rej_uniform(int16_t *r, unsigned target, unsigned offset,
                                 const uint8_t *buf, unsigned buflen)
 __contract__(
@@ -123,6 +128,9 @@ __contract__(
   ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + MLK_XOF_RATE) / MLK_XOF_RATE)
 #endif
 
+/* Reference: Does not exist in reference implementation.
+ *            - x4-batched version of `rej_uniform()` from the
+ *              reference implementation, leveraging x4-batched Keccak-f1600. */
 MLK_INTERNAL_API
 void mlk_poly_rej_uniform_x4(mlk_poly *vec, uint8_t *seed[4])
 {
@@ -233,7 +241,10 @@ void mlk_poly_rej_uniform(mlk_poly *entry, uint8_t seed[MLKEM_SYMBYTES + 2])
  * Arguments:   - const uint8_t *x: pointer to input byte array
  *
  * Returns 32-bit unsigned integer loaded from x
+ *
  **************************************************/
+
+/* Reference: `load32_littleendian()` in the reference implementation. */
 static uint32_t mlk_load32_littleendian(const uint8_t x[4])
 {
   uint32_t r;
@@ -244,6 +255,7 @@ static uint32_t mlk_load32_littleendian(const uint8_t x[4])
   return r;
 }
 
+/* Reference: `cbd2()` in the reference implementationo. */
 MLK_INTERNAL_API
 void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
 {
@@ -281,7 +293,10 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
  * Arguments:   - const uint8_t *x: pointer to input byte array
  *
  * Returns 32-bit unsigned integer loaded from x (most significant byte is zero)
+ *
  **************************************************/
+
+/* Reference: `load24_littleendian()` in the reference implementation. */
 static uint32_t mlk_load24_littleendian(const uint8_t x[3])
 {
   uint32_t r;
@@ -291,6 +306,7 @@ static uint32_t mlk_load24_littleendian(const uint8_t x[3])
   return r;
 }
 
+/* Reference: `cbd3()` in the reference implementationo. */
 MLK_INTERNAL_API
 void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4])
 {


### PR DESCRIPTION
* Resolves https://github.com/pq-code-package/mlkem-native/issues/785

This commit adds `/* Reference: ... */` annotations for the
mlkem-native source code, outlining on a per-function basis
the connection to the reference implementation.

It also adds a REFERENCE.md file summarizing the deviations.

Signed-off-by: Hanno Becker <beckphan@amazon.co.uk>