### PR TITLE
Add a Makefile and documentation for automatically running SLOTHY

### DIFF
--- a/dev/aarch64_opt/src/Makefile
+++ b/dev/aarch64_opt/src/Makefile
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+
+######
+# To run, see the README.md file
+######
+
+# ISA to optimize for
+TARGET_ISA=Arm_AArch64
+
+# MicroArch target to optimize for
+TARGET_MICROARCH=Arm_Cortex_A55
+
+SLOTHY_FLAGS=-c sw_pipelining.enabled=true \
+             -c inputs_are_outputs \
+             -c reserved_regs="[x18--x30,sp]" \
+             -c sw_pipelining.minimize_overlapping=False \
+             -c sw_pipelining.allow_post \
+             -c variable_size \
+             -c constraints.stalls_first_attempt=64
+
+COMMON_H=../../../mlkem/common.h
+
+all: ntt.S \
+     intt.S \
+     poly_tobytes_asm.S \
+     poly_tomont_asm.S \
+     poly_reduce_asm.S \
+     poly_mulcache_compute_asm.S \
+     polyvec_basemul_acc_montgomery_cached_asm_k2.S \
+     polyvec_basemul_acc_montgomery_cached_asm_k3.S \
+     polyvec_basemul_acc_montgomery_cached_asm_k4.S \
+     rej_uniform_asm.S
+
+ntt.S: ../../aarch64_clean/src/ntt.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l layer123_start -l layer4567_start $(SLOTHY_FLAGS)
+
+intt.S: ../../aarch64_clean/src/intt.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l layer123_start -l layer4567_start $(SLOTHY_FLAGS)
+
+poly_tomont_asm.S: ../../aarch64_clean/src/poly_tomont_asm.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l poly_tomont_asm_loop $(SLOTHY_FLAGS)
+
+poly_reduce_asm.S: ../../aarch64_clean/src/poly_reduce_asm.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l loop_start $(SLOTHY_FLAGS)
+
+polyvec_basemul_acc_montgomery_cached_asm_k2.S: ../../aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l k2_loop_start $(SLOTHY_FLAGS)
+
+polyvec_basemul_acc_montgomery_cached_asm_k3.S: ../../aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l k3_loop_start $(SLOTHY_FLAGS)
+
+polyvec_basemul_acc_montgomery_cached_asm_k4.S: ../../aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l k4_loop_start $(SLOTHY_FLAGS)
+
+poly_mulcache_compute_asm.S: ../../aarch64_clean/src/poly_mulcache_compute_asm.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l mulcache_compute_loop_start $(SLOTHY_FLAGS)
+
+poly_tobytes_asm.S: ../../aarch64_clean/src/poly_tobytes_asm.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l poly_tobytes_asm_asm_loop_start $(SLOTHY_FLAGS) -c sw_pipelining.unroll=4
+
+# At the moment, SLOTHY can't process rej_uniform_asm.S
+rej_uniform_asm.S: ../../aarch64_clean/src/rej_uniform_asm.S $(COMMON_H)
+	cp $< $@
+
+# Extra target to test SLOTHY on rej_uniform_asm.S in future
+rej_uniform_asm_with_slothy.S: ../../aarch64_clean/src/rej_uniform_asm.S $(COMMON_H)
+	slothy-cli $(TARGET_ISA) $(TARGET_MICROARCH) $< -o $@ -l loop48 $(SLOTHY_FLAGS)

--- a/dev/aarch64_opt/src/README.md
+++ b/dev/aarch64_opt/src/README.md
@@ -1,0 +1,57 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# mlkem-native AArch64 backend SLOTHY-optimized code
+
+This directory contains the AArch64 backend _after_ it has
+been optimized by SLOTHY.
+
+## Running SLOTHY from the Makefile
+
+If the "clean" backend sources in [`../../aarch64_clean/src/*.S`](../../aarch64_clean/src/) change,
+then the `Makefile` in this directory can be used to re-generate the
+optimized sources using SLOTHY.
+
+The Makefile requires you to have a working SLOTHY setup. Note that mlkem-native's nix shell does currently not include SLOTHY.
+See the [SLOTHY Readme](https://github.com/slothy-optimizer/slothy/) for more details.
+
+## Example set up on macOS
+
+On macOS, let's say we have SLOTHY installed below
+$SLOTHY_ROOT, the mlkem-native repo in $MLKEM_NATIVE_ROOT, and llvm-mc in /opt/homebrew/opt/llvm/bin,
+then
+
+```
+cd $SLOTHY_ROOT
+# Force Python 3.11
+pyenv local 3.11
+# Start the python venv
+source venv/bin/activate
+
+# Add slothy-cli and llvm-mc to PATH
+PATH=$SLOTHY_ROOT:/opt/homebrew/opt/llvm/bin:$PATH
+export PATH
+
+# Goto mlkem-native repo
+cd $MLKEM_NATIVE_ROOT
+cd dev/aarch64_opt/src
+make
+```
+
+should apply SLOTHY to whatever clean assembly sources require processing.
+
+Do
+```
+make -B all
+```
+to process all the sources.
+
+To transfer the newly optimized files into the main source tree [mlkem/native](../../../mlkem/native), run `autogen` from the `nix` shell.
+
+## Current exceptions - file not processed by SLOTHY
+
+At present, `rej_uniform_asm.S` is not passed through SLOTHY, owing to complexity
+in its control flow. The Makefile simply copies this file from the "clean" directory unmodified.
+
+An additional target in the Makefile called
+`rej_uniform_asm_with_slothy.S` can be used to force SLOTHY to run on these units. This
+can be used to test SLOTHY as and when SLOTHY can process it.

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1012,7 +1012,11 @@ def synchronize_backend(
     in_dir, out_dir, dry_run=False, delete=False, no_simplify=False, **kwargs
 ):
     copied = []
+    # Only synchronize sources, but not README.md, Makefile and so on
+    extensions = (".c", ".h", ".i", ".inc", ".S")
     for f in get_files(os.path.join(in_dir, "*")):
+        if not f.endswith(extensions):
+            continue
         copied.append(os.path.basename(f))
         if delete is True:
             continue


### PR DESCRIPTION
This PR adds a suitable Makefile and README.md that explains how to automatically run
SLOTHY on the "clean" AArch64 back-end to produce the "opt" back-end.

