### PR TITLE
Keccak-F1600: Use d-form LDP/LDR instead of LD2

### DIFF
--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -81,6 +81,33 @@
     Aso     .req v23
     Asu     .req v24
 
+    /* d-form of the above mapping */
+    Abad     .req d0
+    Abed     .req d1
+    Abid     .req d2
+    Abod     .req d3
+    Abud     .req d4
+    Agad     .req d5
+    Aged     .req d6
+    Agid     .req d7
+    Agod     .req d8
+    Agud     .req d9
+    Akad     .req d10
+    Aked     .req d11
+    Akid     .req d12
+    Akod     .req d13
+    Akud     .req d14
+    Amad     .req d15
+    Amed     .req d16
+    Amid     .req d17
+    Amod     .req d18
+    Amud     .req d19
+    Asad     .req d20
+    Ased     .req d21
+    Asid     .req d22
+    Asod     .req d23
+    Asud     .req d24
+
     /* q-form of the above mapping */
     Abaq    .req q0
     Abeq    .req q1
@@ -152,37 +179,35 @@
 /************************ MACROS ****************************/
 
 .macro load_input
-    ld2 {Aba.d, Abe.d}[0], [input_addr], #16
-    ld2 {Abi.d, Abo.d}[0], [input_addr], #16
-    ld2 {Abu.d, Aga.d}[0], [input_addr], #16
-    ld2 {Age.d, Agi.d}[0], [input_addr], #16
-    ld2 {Ago.d, Agu.d}[0], [input_addr], #16
-    ld2 {Aka.d, Ake.d}[0], [input_addr], #16
-    ld2 {Aki.d, Ako.d}[0], [input_addr], #16
-    ld2 {Aku.d, Ama.d}[0], [input_addr], #16
-    ld2 {Ame.d, Ami.d}[0], [input_addr], #16
-    ld2 {Amo.d, Amu.d}[0], [input_addr], #16
-    ld2 {Asa.d, Ase.d}[0], [input_addr], #16
-    ld2 {Asi.d, Aso.d}[0], [input_addr], #16
-    ld1 {Asu.d}[0], [input_addr], #8
-
-    sub input_addr, input_addr, #(25*8)
+    ldp Abad, Abed, [input_addr, #0x00]
+    ldp Abid, Abod, [input_addr, #0x10]
+    ldp Abud, Agad, [input_addr, #0x20]
+    ldp Aged, Agid, [input_addr, #0x30]
+    ldp Agod, Agud, [input_addr, #0x40]
+    ldp Akad, Aked, [input_addr, #0x50]
+    ldp Akid, Akod, [input_addr, #0x60]
+    ldp Akud, Amad, [input_addr, #0x70]
+    ldp Amed, Amid, [input_addr, #0x80]
+    ldp Amod, Amud, [input_addr, #0x90]
+    ldp Asad, Ased, [input_addr, #0xA0]
+    ldp Asid, Asod, [input_addr, #0xB0]
+    ldr Asud, [input_addr, #0xC0]
 .endm
 
 .macro store_input
-    st2 {Aba.d, Abe.d}[0], [input_addr], #16
-    st2 {Abi.d, Abo.d}[0], [input_addr], #16
-    st2 {Abu.d, Aga.d}[0], [input_addr], #16
-    st2 {Age.d, Agi.d}[0], [input_addr], #16
-    st2 {Ago.d, Agu.d}[0], [input_addr], #16
-    st2 {Aka.d, Ake.d}[0], [input_addr], #16
-    st2 {Aki.d, Ako.d}[0], [input_addr], #16
-    st2 {Aku.d, Ama.d}[0], [input_addr], #16
-    st2 {Ame.d, Ami.d}[0], [input_addr], #16
-    st2 {Amo.d, Amu.d}[0], [input_addr], #16
-    st2 {Asa.d, Ase.d}[0], [input_addr], #16
-    st2 {Asi.d, Aso.d}[0], [input_addr], #16
-    st1 {Asu.d}[0], [input_addr], #8
+    stp Abad, Abed, [input_addr, #0x00]
+    stp Abid, Abod, [input_addr, #0x10]
+    stp Abud, Agad, [input_addr, #0x20]
+    stp Aged, Agid, [input_addr, #0x30]
+    stp Agod, Agud, [input_addr, #0x40]
+    stp Akad, Aked, [input_addr, #0x50]
+    stp Akid, Akod, [input_addr, #0x60]
+    stp Akud, Amad, [input_addr, #0x70]
+    stp Amed, Amid, [input_addr, #0x80]
+    stp Amod, Amud, [input_addr, #0x90]
+    stp Asad, Ased, [input_addr, #0xA0]
+    stp Asid, Asod, [input_addr, #0xB0]
+    str Asud, [input_addr, #0xC0]
 .endm
 
 #define STACK_SIZE (16*4 + 16*6) /* VREGS (16*4) + GPRS (TODO: Remove) */
@@ -386,6 +411,31 @@ keccak_f1600_x1_v84a_loop:
     .unreq Asiq
     .unreq Asoq
     .unreq Asuq
+    .unreq Abad
+    .unreq Abed
+    .unreq Abid
+    .unreq Abod
+    .unreq Abud
+    .unreq Agad
+    .unreq Aged
+    .unreq Agid
+    .unreq Agod
+    .unreq Agud
+    .unreq Akad
+    .unreq Aked
+    .unreq Akid
+    .unreq Akod
+    .unreq Akud
+    .unreq Amad
+    .unreq Amed
+    .unreq Amid
+    .unreq Amod
+    .unreq Amud
+    .unreq Asad
+    .unreq Ased
+    .unreq Asid
+    .unreq Asod
+    .unreq Asud
     .unreq C0
     .unreq C1
     .unreq C2

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -61,20 +61,19 @@ MLK_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_asm_clean)
         stp	d12, d13, [sp, #0x20]
         stp	d14, d15, [sp, #0x30]
         mov	x1, x1
-        ld2	{ v0.d, v1.d }[0], [x0], #16
-        ld2	{ v2.d, v3.d }[0], [x0], #16
-        ld2	{ v4.d, v5.d }[0], [x0], #16
-        ld2	{ v6.d, v7.d }[0], [x0], #16
-        ld2	{ v8.d, v9.d }[0], [x0], #16
-        ld2	{ v10.d, v11.d }[0], [x0], #16
-        ld2	{ v12.d, v13.d }[0], [x0], #16
-        ld2	{ v14.d, v15.d }[0], [x0], #16
-        ld2	{ v16.d, v17.d }[0], [x0], #16
-        ld2	{ v18.d, v19.d }[0], [x0], #16
-        ld2	{ v20.d, v21.d }[0], [x0], #16
-        ld2	{ v22.d, v23.d }[0], [x0], #16
-        ld1	{ v24.d }[0], [x0], #8
-        sub	x0, x0, #0xc8
+        ldp	d0, d1, [x0]
+        ldp	d2, d3, [x0, #0x10]
+        ldp	d4, d5, [x0, #0x20]
+        ldp	d6, d7, [x0, #0x30]
+        ldp	d8, d9, [x0, #0x40]
+        ldp	d10, d11, [x0, #0x50]
+        ldp	d12, d13, [x0, #0x60]
+        ldp	d14, d15, [x0, #0x70]
+        ldp	d16, d17, [x0, #0x80]
+        ldp	d18, d19, [x0, #0x90]
+        ldp	d20, d21, [x0, #0xa0]
+        ldp	d22, d23, [x0, #0xb0]
+        ldr	d24, [x0, #0xc0]
         mov	x2, #0x18               // =24
 
 keccak_f1600_x1_v84a_loop:
@@ -147,19 +146,19 @@ keccak_f1600_x1_v84a_loop:
         eor	v0.16b, v0.16b, v31.16b
         sub	x2, x2, #0x1
         cbnz	x2, keccak_f1600_x1_v84a_loop
-        st2	{ v0.d, v1.d }[0], [x0], #16
-        st2	{ v2.d, v3.d }[0], [x0], #16
-        st2	{ v4.d, v5.d }[0], [x0], #16
-        st2	{ v6.d, v7.d }[0], [x0], #16
-        st2	{ v8.d, v9.d }[0], [x0], #16
-        st2	{ v10.d, v11.d }[0], [x0], #16
-        st2	{ v12.d, v13.d }[0], [x0], #16
-        st2	{ v14.d, v15.d }[0], [x0], #16
-        st2	{ v16.d, v17.d }[0], [x0], #16
-        st2	{ v18.d, v19.d }[0], [x0], #16
-        st2	{ v20.d, v21.d }[0], [x0], #16
-        st2	{ v22.d, v23.d }[0], [x0], #16
-        st1	{ v24.d }[0], [x0], #8
+        stp	d0, d1, [x0]
+        stp	d2, d3, [x0, #0x10]
+        stp	d4, d5, [x0, #0x20]
+        stp	d6, d7, [x0, #0x30]
+        stp	d8, d9, [x0, #0x40]
+        stp	d10, d11, [x0, #0x50]
+        stp	d12, d13, [x0, #0x60]
+        stp	d14, d15, [x0, #0x70]
+        stp	d16, d17, [x0, #0x80]
+        stp	d18, d19, [x0, #0x90]
+        stp	d20, d21, [x0, #0xa0]
+        stp	d22, d23, [x0, #0xb0]
+        str	d24, [x0, #0xc0]
         ldp	d8, d9, [sp]
         ldp	d10, d11, [sp, #0x10]
         ldp	d12, d13, [sp, #0x20]


### PR DESCRIPTION
The 1-fold Keccak-F1600 implementation based on v8.4-A Neon instructions uses a 0-lane LD2/ST2 to load/store the Keccak-F1600 state from memory. The upper halves of the Neon registers are unused.

This commit simplifies this by instead using a LDP/LDR targeting the D-forms of the Neon registers.

This matches the version verified by @jargh 
