### PR TITLE
Make CI and CBMC workflows depend on Base workflow

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -5,14 +5,12 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
-    types: [ "opened", "synchronize" ]
+  workflow_run:
+    workflows: [ "Base tests" ]
+    types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,12 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
-    types: [ "opened", "synchronize" ]
+  workflow_run:
+    workflows: [ "Base tests" ]
+    types: [ completed ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
Using workflow_run to make CI and CBMC depend on the completeness of Base workflow
But this can only work after the PR is merged into main

**Steps**:

**Performed local tests**:
 - [ ] `lint` passing
 - [ ] `tests all` passing
 - [ ] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
