### PR TITLE
Revert using workflow_run

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -4,6 +4,7 @@ name: CBMC
 permissions:
   contents: read
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: ["main"]

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -5,12 +5,14 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [ "Base tests" ]
-    types: [ completed ]
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [ "opened", "synchronize" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [ "Base tests" ]
-    types: [ completed ]
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [ "opened", "synchronize" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: Extended tests
 permissions:
   contents: read
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: ["main"]


### PR DESCRIPTION
<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
workflow triggered by workflow_run wont be rendered in a PR, which is not ideal.
We should probably go with resuing workflows instead

**Steps**:
If your pull request consists of multiple sequential changes, please describe them here:

**Performed local tests**:
 - [ ] `lint` passing
 - [ ] `tests all` passing
 - [ ] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
