### PR TITLE
CI: Run CBMC on c7g.4xlarge instead of c7g.2xlarge

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-512)
-      ec2_instance_type: c7g.2xlarge
+      ec2_instance_type: c7g.4xlarge
       ec2_ami: ubuntu-latest (custom AMI)
       ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
       compile_mode: native
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-768)
-      ec2_instance_type: c7g.2xlarge
+      ec2_instance_type: c7g.4xlarge
       ec2_ami: ubuntu-latest (custom AMI)
       ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
       compile_mode: native
@@ -63,7 +63,7 @@ jobs:
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-1024)
-      ec2_instance_type: c7g.2xlarge
+      ec2_instance_type: c7g.4xlarge
       ec2_ami: ubuntu-latest (custom AMI)
       ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
       compile_mode: native


### PR DESCRIPTION
We have seen spurious failures in CBMC which we suspect to be related to the available RAM on the CBMC runners. This commit increases the amount of RAM on the CBMC runners to validate this theory.
