### PR TITLE
Add proof for AArch64+SHA3 Keccak-f1600-x1

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -23,7 +23,7 @@ jobs:
   hol_light_proofs:
     strategy:
       matrix:
-        proof: [mlkem_ntt,mlkem_intt,mlkem_keccak_f1600]
+        proof: [mlkem_ntt,mlkem_intt,mlkem_keccak_f1600,mlkem_keccak_f1600_alt]
     name: HOL Light proof for ${{ matrix.proof }}.S
     runs-on: pqcp-arm64
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -49,7 +49,6 @@
 
     input_addr    .req x0
     input_rc      .req x1
-    const_addr    .req x1
     count         .req x2
     cur_const     .req x3
 
@@ -210,7 +209,7 @@
     str Asud, [input_addr, #0xC0]
 .endm
 
-#define STACK_SIZE (16*4 + 16*6) /* VREGS (16*4) + GPRS (TODO: Remove) */
+#define STACK_SIZE (16*4) /* VREGS (16*4) */
 
 #define STACK_BASE_GPRS (16*4)
 .macro alloc_stack
@@ -219,7 +218,7 @@
 
 .macro free_stack
     add sp, sp, #(STACK_SIZE)
-	.endm
+.endm
 
 .macro save_vregs
     stp  d8,  d9, [sp, #(16*0)]
@@ -300,7 +299,7 @@
     xar_m0 Ame_, Aga, E0, 28
     xar_m0 Abe_, Age, E1, 20
 
-    ld1r {v31.2d}, [const_addr], #8
+    ld1r {v31.2d}, [input_rc], #8
 
     bcax_m0 Aga, Aga_, Agi_, Age_
     bcax_m0 Age, Age_, Ago_, Agi_
@@ -341,7 +340,6 @@
 MLK_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_asm_clean)
     alloc_stack
     save_vregs
-    mov const_addr, input_rc
     load_input
 
     mov count, #(KECCAK_F1600_ROUNDS)
@@ -358,7 +356,6 @@ keccak_f1600_x1_v84a_loop:
 /****************** REGISTER DEALLOCATIONS *******************/
     .unreq input_addr
     .unreq input_rc
-    .unreq const_addr
     .unreq count
     .unreq cur_const
     .unreq Aba

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S
@@ -55,12 +55,11 @@
 .global MLK_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
 MLK_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_asm_clean)
 
-        sub	sp, sp, #0xa0
+        sub	sp, sp, #0x40
         stp	d8, d9, [sp]
         stp	d10, d11, [sp, #0x10]
         stp	d12, d13, [sp, #0x20]
         stp	d14, d15, [sp, #0x30]
-        mov	x1, x1
         ldp	d0, d1, [x0]
         ldp	d2, d3, [x0, #0x10]
         ldp	d4, d5, [x0, #0x20]
@@ -163,7 +162,7 @@ keccak_f1600_x1_v84a_loop:
         ldp	d10, d11, [sp, #0x10]
         ldp	d12, d13, [sp, #0x20]
         ldp	d14, d15, [sp, #0x30]
-        add	sp, sp, #0xa0
+        add	sp, sp, #0x40
         ret
 
 #endif /* __ARM_FEATURE_SHA3 */

--- a/proofs/hol_light/arm/Makefile
+++ b/proofs/hol_light/arm/Makefile
@@ -25,10 +25,11 @@ SRC_ARM ?= $(SRC)/arm
 # Some clang-based preprocessors seem to behave differently, and get confused
 # by single-quote characters in comments, so we eliminate // comments first.
 
+ARCHFLAGS=-march=armv8.4-a+sha3
 ifeq ($(OSTYPE_RESULT),Darwin)
 PREPROCESS=sed -e 's/\/\/.*//' | $(CC) -E -xassembler-with-cpp -
 else
-PREPROCESS=$(CC) -E -xassembler-with-cpp -
+PREPROCESS=$(CC) $(ARCHFLAGS) -E -xassembler-with-cpp -
 endif
 
 # Generally GNU-type assemblers are happy with multiple instructions on
@@ -47,24 +48,27 @@ SPLIT=tr ';' '\n'
 #  sudo apt-get install binutils-aarch64-linux-gnu
 
 ifeq ($(ARCHTYPE_RESULT),aarch64)
-ASSEMBLE=as
+ASSEMBLE=as $(ARCHFLAGS)
 OBJDUMP=objdump -d
 else
 ifeq ($(ARCHTYPE_RESULT),arm64)
-ASSEMBLE=as
+ASSEMBLE=as $(ARCHFLAGS)
 OBJDUMP=objdump -d
 else
 ifeq ($(OSTYPE_RESULT),Darwin)
 ASSEMBLE=as -arch arm64
 OBJDUMP=otool -tvV
 else
-ASSEMBLE=aarch64-linux-gnu-as
+ASSEMBLE=aarch64-linux-gnu-as $(ARCHFLAGS)
 OBJDUMP=aarch64-linux-gnu-objdump -d
 endif
 endif
 endif
 
-OBJ = mlkem/mlkem_ntt.o mlkem/mlkem_intt.o mlkem/mlkem_keccak_f1600.o
+OBJ = mlkem/mlkem_ntt.o                 \
+      mlkem/mlkem_intt.o                \
+      mlkem/mlkem_keccak_f1600.o        \
+      mlkem/mlkem_keccak_f1600_alt.o
 
 # According to
 # https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms,

--- a/proofs/hol_light/arm/mlkem/mlkem_keccak_f1600_alt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_keccak_f1600_alt.S
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) 2021-2022 Arm Limited
+ * Copyright (c) 2022 Matthias Kannwischer
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+//
+// Author: Hanno Becker <hanno.becker@arm.com>
+// Author: Matthias Kannwischer <matthias@kannwischer.eu>
+//
+// This implementation is essentially from the paper
+//
+//   Hybrid scalar/vector implementations of Keccak and SPHINCS+ on AArch64
+//   https://eprint.iacr.org/2022/1243
+//
+// The only difference is interleaving/deinterleaving of Keccak state
+// during load and store, so that the caller need not do this.
+//
+
+
+
+/*
+ * WARNING: This file is auto-derived from the mlkem-native source file
+ *   dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm_clean.S using scripts/simpasm. Do not modify it directly.
+ */
+
+
+.text
+.balign 4
+#ifdef __APPLE__
+.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_asm_clean
+_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_asm_clean:
+#else
+.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_asm_clean
+PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_asm_clean:
+#endif
+
+        sub	sp, sp, #0x40
+        stp	d8, d9, [sp]
+        stp	d10, d11, [sp, #0x10]
+        stp	d12, d13, [sp, #0x20]
+        stp	d14, d15, [sp, #0x30]
+        ldp	d0, d1, [x0]
+        ldp	d2, d3, [x0, #0x10]
+        ldp	d4, d5, [x0, #0x20]
+        ldp	d6, d7, [x0, #0x30]
+        ldp	d8, d9, [x0, #0x40]
+        ldp	d10, d11, [x0, #0x50]
+        ldp	d12, d13, [x0, #0x60]
+        ldp	d14, d15, [x0, #0x70]
+        ldp	d16, d17, [x0, #0x80]
+        ldp	d18, d19, [x0, #0x90]
+        ldp	d20, d21, [x0, #0xa0]
+        ldp	d22, d23, [x0, #0xb0]
+        ldr	d24, [x0, #0xc0]
+        mov	x2, #0x18               // =24
+
+keccak_f1600_x1_v84a_loop:
+        eor3	v30.16b, v0.16b, v5.16b, v10.16b
+        eor3	v29.16b, v1.16b, v6.16b, v11.16b
+        eor3	v28.16b, v2.16b, v7.16b, v12.16b
+        eor3	v27.16b, v3.16b, v8.16b, v13.16b
+        eor3	v26.16b, v4.16b, v9.16b, v14.16b
+        eor3	v30.16b, v30.16b, v15.16b, v20.16b
+        eor3	v29.16b, v29.16b, v16.16b, v21.16b
+        eor3	v28.16b, v28.16b, v17.16b, v22.16b
+        eor3	v27.16b, v27.16b, v18.16b, v23.16b
+        eor3	v26.16b, v26.16b, v19.16b, v24.16b
+        rax1	v25.2d, v30.2d, v28.2d
+        rax1	v28.2d, v28.2d, v26.2d
+        rax1	v26.2d, v26.2d, v29.2d
+        rax1	v29.2d, v29.2d, v27.2d
+        rax1	v27.2d, v27.2d, v30.2d
+        eor	v30.16b, v0.16b, v26.16b
+        xar	v0.2d, v2.2d, v29.2d, #0x2
+        xar	v2.2d, v12.2d, v29.2d, #0x15
+        xar	v12.2d, v13.2d, v28.2d, #0x27
+        xar	v13.2d, v19.2d, v27.2d, #0x38
+        xar	v19.2d, v23.2d, v28.2d, #0x8
+        xar	v23.2d, v15.2d, v26.2d, #0x17
+        xar	v15.2d, v1.2d, v25.2d, #0x3f
+        xar	v1.2d, v8.2d, v28.2d, #0x9
+        xar	v8.2d, v16.2d, v25.2d, #0x13
+        xar	v16.2d, v7.2d, v29.2d, #0x3a
+        xar	v7.2d, v10.2d, v26.2d, #0x3d
+        xar	v10.2d, v3.2d, v28.2d, #0x24
+        xar	v3.2d, v18.2d, v28.2d, #0x2b
+        xar	v18.2d, v17.2d, v29.2d, #0x31
+        xar	v17.2d, v11.2d, v25.2d, #0x36
+        xar	v11.2d, v9.2d, v27.2d, #0x2c
+        xar	v9.2d, v22.2d, v29.2d, #0x3
+        xar	v22.2d, v14.2d, v27.2d, #0x19
+        xar	v14.2d, v20.2d, v26.2d, #0x2e
+        xar	v20.2d, v4.2d, v27.2d, #0x25
+        xar	v4.2d, v24.2d, v27.2d, #0x32
+        xar	v24.2d, v21.2d, v25.2d, #0x3e
+        xar	v21.2d, v5.2d, v26.2d, #0x1c
+        xar	v27.2d, v6.2d, v25.2d, #0x14
+        ld1r	{ v31.2d }, [x1], #8
+        bcax	v5.16b, v10.16b, v7.16b, v11.16b
+        bcax	v6.16b, v11.16b, v8.16b, v7.16b
+        bcax	v7.16b, v7.16b, v9.16b, v8.16b
+        bcax	v8.16b, v8.16b, v10.16b, v9.16b
+        bcax	v9.16b, v9.16b, v11.16b, v10.16b
+        bcax	v10.16b, v15.16b, v12.16b, v16.16b
+        bcax	v11.16b, v16.16b, v13.16b, v12.16b
+        bcax	v12.16b, v12.16b, v14.16b, v13.16b
+        bcax	v13.16b, v13.16b, v15.16b, v14.16b
+        bcax	v14.16b, v14.16b, v16.16b, v15.16b
+        bcax	v15.16b, v20.16b, v17.16b, v21.16b
+        bcax	v16.16b, v21.16b, v18.16b, v17.16b
+        bcax	v17.16b, v17.16b, v19.16b, v18.16b
+        bcax	v18.16b, v18.16b, v20.16b, v19.16b
+        bcax	v19.16b, v19.16b, v21.16b, v20.16b
+        bcax	v20.16b, v0.16b, v22.16b, v1.16b
+        bcax	v21.16b, v1.16b, v23.16b, v22.16b
+        bcax	v22.16b, v22.16b, v24.16b, v23.16b
+        bcax	v23.16b, v23.16b, v0.16b, v24.16b
+        bcax	v24.16b, v24.16b, v1.16b, v0.16b
+        bcax	v0.16b, v30.16b, v2.16b, v27.16b
+        bcax	v1.16b, v27.16b, v3.16b, v2.16b
+        bcax	v2.16b, v2.16b, v4.16b, v3.16b
+        bcax	v3.16b, v3.16b, v30.16b, v4.16b
+        bcax	v4.16b, v4.16b, v27.16b, v30.16b
+        eor	v0.16b, v0.16b, v31.16b
+        sub	x2, x2, #0x1
+        cbnz	x2, keccak_f1600_x1_v84a_loop
+        stp	d0, d1, [x0]
+        stp	d2, d3, [x0, #0x10]
+        stp	d4, d5, [x0, #0x20]
+        stp	d6, d7, [x0, #0x30]
+        stp	d8, d9, [x0, #0x40]
+        stp	d10, d11, [x0, #0x50]
+        stp	d12, d13, [x0, #0x60]
+        stp	d14, d15, [x0, #0x70]
+        stp	d16, d17, [x0, #0x80]
+        stp	d18, d19, [x0, #0x90]
+        stp	d20, d21, [x0, #0xa0]
+        stp	d22, d23, [x0, #0xb0]
+        str	d24, [x0, #0xc0]
+        ldp	d8, d9, [sp]
+        ldp	d10, d11, [sp, #0x10]
+        ldp	d12, d13, [sp, #0x20]
+        ldp	d14, d15, [sp, #0x30]
+        add	sp, sp, #0x40
+        ret

--- a/proofs/hol_light/arm/proofs/mlkem_keccak_f1600_alt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_keccak_f1600_alt.ml
@@ -1,0 +1,301 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+(* ========================================================================= *)
+(* Keccak-f1600 vector code.                                                 *)
+(* ========================================================================= *)
+
+needs "arm/proofs/base.ml";;
+needs "arm/proofs/utils/keccak_spec.ml";;
+
+(**** print_literal_from_elf "arm/mlkem/mlkem_keccak_f1600_alt.o";;
+ ****)
+
+let mlkem_keccak_f1600_alt_mc = define_assert_from_elf
+  "mlkem_keccak_f1600_alt_mc" "mlkem/mlkem_keccak_f1600_alt.o"
+[
+  0xd10103ff;       (* arm_SUB SP SP (rvalue (word 64)) *)
+  0x6d0027e8;       (* arm_STP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+  0x6d012fea;       (* arm_STP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+  0x6d0237ec;       (* arm_STP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+  0x6d033fee;       (* arm_STP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+  0x6d400400;       (* arm_LDP D0 D1 X0 (Immediate_Offset (iword (&0))) *)
+  0x6d410c02;       (* arm_LDP D2 D3 X0 (Immediate_Offset (iword (&16))) *)
+  0x6d421404;       (* arm_LDP D4 D5 X0 (Immediate_Offset (iword (&32))) *)
+  0x6d431c06;       (* arm_LDP D6 D7 X0 (Immediate_Offset (iword (&48))) *)
+  0x6d442408;       (* arm_LDP D8 D9 X0 (Immediate_Offset (iword (&64))) *)
+  0x6d452c0a;       (* arm_LDP D10 D11 X0 (Immediate_Offset (iword (&80))) *)
+  0x6d46340c;       (* arm_LDP D12 D13 X0 (Immediate_Offset (iword (&96))) *)
+  0x6d473c0e;       (* arm_LDP D14 D15 X0 (Immediate_Offset (iword (&112))) *)
+  0x6d484410;       (* arm_LDP D16 D17 X0 (Immediate_Offset (iword (&128))) *)
+  0x6d494c12;       (* arm_LDP D18 D19 X0 (Immediate_Offset (iword (&144))) *)
+  0x6d4a5414;       (* arm_LDP D20 D21 X0 (Immediate_Offset (iword (&160))) *)
+  0x6d4b5c16;       (* arm_LDP D22 D23 X0 (Immediate_Offset (iword (&176))) *)
+  0xfd406018;       (* arm_LDR D24 X0 (Immediate_Offset (word 192)) *)
+  0xd2800302;       (* arm_MOV X2 (rvalue (word 24)) *)
+  0xce05281e;       (* arm_EOR3 Q30 Q0 Q5 Q10 *)
+  0xce062c3d;       (* arm_EOR3 Q29 Q1 Q6 Q11 *)
+  0xce07305c;       (* arm_EOR3 Q28 Q2 Q7 Q12 *)
+  0xce08347b;       (* arm_EOR3 Q27 Q3 Q8 Q13 *)
+  0xce09389a;       (* arm_EOR3 Q26 Q4 Q9 Q14 *)
+  0xce0f53de;       (* arm_EOR3 Q30 Q30 Q15 Q20 *)
+  0xce1057bd;       (* arm_EOR3 Q29 Q29 Q16 Q21 *)
+  0xce115b9c;       (* arm_EOR3 Q28 Q28 Q17 Q22 *)
+  0xce125f7b;       (* arm_EOR3 Q27 Q27 Q18 Q23 *)
+  0xce13635a;       (* arm_EOR3 Q26 Q26 Q19 Q24 *)
+  0xce7c8fd9;       (* arm_RAX1 Q25 Q30 Q28 *)
+  0xce7a8f9c;       (* arm_RAX1 Q28 Q28 Q26 *)
+  0xce7d8f5a;       (* arm_RAX1 Q26 Q26 Q29 *)
+  0xce7b8fbd;       (* arm_RAX1 Q29 Q29 Q27 *)
+  0xce7e8f7b;       (* arm_RAX1 Q27 Q27 Q30 *)
+  0x6e3a1c1e;       (* arm_EOR_VEC Q30 Q0 Q26 128 *)
+  0xce9d0840;       (* arm_XAR Q0 Q2 Q29 (word 2) *)
+  0xce9d5582;       (* arm_XAR Q2 Q12 Q29 (word 21) *)
+  0xce9c9dac;       (* arm_XAR Q12 Q13 Q28 (word 39) *)
+  0xce9be26d;       (* arm_XAR Q13 Q19 Q27 (word 56) *)
+  0xce9c22f3;       (* arm_XAR Q19 Q23 Q28 (word 8) *)
+  0xce9a5df7;       (* arm_XAR Q23 Q15 Q26 (word 23) *)
+  0xce99fc2f;       (* arm_XAR Q15 Q1 Q25 (word 63) *)
+  0xce9c2501;       (* arm_XAR Q1 Q8 Q28 (word 9) *)
+  0xce994e08;       (* arm_XAR Q8 Q16 Q25 (word 19) *)
+  0xce9de8f0;       (* arm_XAR Q16 Q7 Q29 (word 58) *)
+  0xce9af547;       (* arm_XAR Q7 Q10 Q26 (word 61) *)
+  0xce9c906a;       (* arm_XAR Q10 Q3 Q28 (word 36) *)
+  0xce9cae43;       (* arm_XAR Q3 Q18 Q28 (word 43) *)
+  0xce9dc632;       (* arm_XAR Q18 Q17 Q29 (word 49) *)
+  0xce99d971;       (* arm_XAR Q17 Q11 Q25 (word 54) *)
+  0xce9bb12b;       (* arm_XAR Q11 Q9 Q27 (word 44) *)
+  0xce9d0ec9;       (* arm_XAR Q9 Q22 Q29 (word 3) *)
+  0xce9b65d6;       (* arm_XAR Q22 Q14 Q27 (word 25) *)
+  0xce9aba8e;       (* arm_XAR Q14 Q20 Q26 (word 46) *)
+  0xce9b9494;       (* arm_XAR Q20 Q4 Q27 (word 37) *)
+  0xce9bcb04;       (* arm_XAR Q4 Q24 Q27 (word 50) *)
+  0xce99fab8;       (* arm_XAR Q24 Q21 Q25 (word 62) *)
+  0xce9a70b5;       (* arm_XAR Q21 Q5 Q26 (word 28) *)
+  0xce9950db;       (* arm_XAR Q27 Q6 Q25 (word 20) *)
+  0x4ddfcc3f;       (* arm_LD1R Q31 X1 (Postimmediate_Offset (word 8)) 64 128 *)
+  0xce272d45;       (* arm_BCAX Q5 Q10 Q7 Q11 *)
+  0xce281d66;       (* arm_BCAX Q6 Q11 Q8 Q7 *)
+  0xce2920e7;       (* arm_BCAX Q7 Q7 Q9 Q8 *)
+  0xce2a2508;       (* arm_BCAX Q8 Q8 Q10 Q9 *)
+  0xce2b2929;       (* arm_BCAX Q9 Q9 Q11 Q10 *)
+  0xce2c41ea;       (* arm_BCAX Q10 Q15 Q12 Q16 *)
+  0xce2d320b;       (* arm_BCAX Q11 Q16 Q13 Q12 *)
+  0xce2e358c;       (* arm_BCAX Q12 Q12 Q14 Q13 *)
+  0xce2f39ad;       (* arm_BCAX Q13 Q13 Q15 Q14 *)
+  0xce303dce;       (* arm_BCAX Q14 Q14 Q16 Q15 *)
+  0xce31568f;       (* arm_BCAX Q15 Q20 Q17 Q21 *)
+  0xce3246b0;       (* arm_BCAX Q16 Q21 Q18 Q17 *)
+  0xce334a31;       (* arm_BCAX Q17 Q17 Q19 Q18 *)
+  0xce344e52;       (* arm_BCAX Q18 Q18 Q20 Q19 *)
+  0xce355273;       (* arm_BCAX Q19 Q19 Q21 Q20 *)
+  0xce360414;       (* arm_BCAX Q20 Q0 Q22 Q1 *)
+  0xce375835;       (* arm_BCAX Q21 Q1 Q23 Q22 *)
+  0xce385ed6;       (* arm_BCAX Q22 Q22 Q24 Q23 *)
+  0xce2062f7;       (* arm_BCAX Q23 Q23 Q0 Q24 *)
+  0xce210318;       (* arm_BCAX Q24 Q24 Q1 Q0 *)
+  0xce226fc0;       (* arm_BCAX Q0 Q30 Q2 Q27 *)
+  0xce230b61;       (* arm_BCAX Q1 Q27 Q3 Q2 *)
+  0xce240c42;       (* arm_BCAX Q2 Q2 Q4 Q3 *)
+  0xce3e1063;       (* arm_BCAX Q3 Q3 Q30 Q4 *)
+  0xce3b7884;       (* arm_BCAX Q4 Q4 Q27 Q30 *)
+  0x6e3f1c00;       (* arm_EOR_VEC Q0 Q0 Q31 128 *)
+  0xd1000442;       (* arm_SUB X2 X2 (rvalue (word 1)) *)
+  0xb5fff782;       (* arm_CBNZ X2 (word 2096880) *)
+  0x6d000400;       (* arm_STP D0 D1 X0 (Immediate_Offset (iword (&0))) *)
+  0x6d010c02;       (* arm_STP D2 D3 X0 (Immediate_Offset (iword (&16))) *)
+  0x6d021404;       (* arm_STP D4 D5 X0 (Immediate_Offset (iword (&32))) *)
+  0x6d031c06;       (* arm_STP D6 D7 X0 (Immediate_Offset (iword (&48))) *)
+  0x6d042408;       (* arm_STP D8 D9 X0 (Immediate_Offset (iword (&64))) *)
+  0x6d052c0a;       (* arm_STP D10 D11 X0 (Immediate_Offset (iword (&80))) *)
+  0x6d06340c;       (* arm_STP D12 D13 X0 (Immediate_Offset (iword (&96))) *)
+  0x6d073c0e;       (* arm_STP D14 D15 X0 (Immediate_Offset (iword (&112))) *)
+  0x6d084410;       (* arm_STP D16 D17 X0 (Immediate_Offset (iword (&128))) *)
+  0x6d094c12;       (* arm_STP D18 D19 X0 (Immediate_Offset (iword (&144))) *)
+  0x6d0a5414;       (* arm_STP D20 D21 X0 (Immediate_Offset (iword (&160))) *)
+  0x6d0b5c16;       (* arm_STP D22 D23 X0 (Immediate_Offset (iword (&176))) *)
+  0xfd006018;       (* arm_STR D24 X0 (Immediate_Offset (word 192)) *)
+  0x6d4027e8;       (* arm_LDP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+  0x6d412fea;       (* arm_LDP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+  0x6d4237ec;       (* arm_LDP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+  0x6d433fee;       (* arm_LDP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+  0x910103ff;       (* arm_ADD SP SP (rvalue (word 64)) *)
+  0xd65f03c0        (* arm_RET X30 *)
+];;
+
+let MLKEM_KECCAK_F1600_ALT_EXEC = ARM_MK_EXEC_RULE mlkem_keccak_f1600_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Convenient constructs to state and prove correctness. Should possibly     *)
+(* introduce a full state component for word lists eventually.               *)
+(* ------------------------------------------------------------------------- *)
+
+let wordlist_from_memory = define
+ `wordlist_from_memory(a,0) s = [] /\
+  wordlist_from_memory(a,SUC n) s =
+  APPEND (wordlist_from_memory(a,n) s)
+         [read (memory :> bytes64(word_add a (word(8 * n)))) s]`;;
+
+(*** This is very naive and should be done more efficiently ***)
+
+let WORDLIST_FROM_MEMORY_CONV =
+  let uconv =
+    (LAND_CONV(RAND_CONV num_CONV) THENC
+     GEN_REWRITE_CONV I [CONJUNCT2 wordlist_from_memory]) ORELSEC
+     GEN_REWRITE_CONV I [CONJUNCT1 wordlist_from_memory] in
+  let conv =
+    TOP_DEPTH_CONV uconv THENC
+    ONCE_DEPTH_CONV NUM_MULT_CONV THENC
+    GEN_REWRITE_CONV ONCE_DEPTH_CONV [WORD_ADD_0] THENC
+    GEN_REWRITE_CONV TOP_DEPTH_CONV [APPEND]
+  and filt = can (term_match [] `wordlist_from_memory(a,NUMERAL n) s`) in
+  conv o check filt;;
+
+(*** Evaluate EL in concrete instances ***)
+
+let EL_CONV =
+  let conv0 = GEN_REWRITE_CONV I [CONJUNCT1 EL] THENC GEN_REWRITE_CONV I [HD]
+  and conv1 = GEN_REWRITE_CONV I [CONJUNCT2 EL]
+  and convt = GEN_REWRITE_CONV I [TL] in
+  let convs = LAND_CONV num_CONV THENC conv1 THENC RAND_CONV convt in
+  let rec conv tm = (conv0 ORELSEC (convs THENC conv)) tm in
+  conv;;
+
+(*** Introduce ghost variables for Qn given Dn register reads in a list ***)
+
+let GHOST_SUBREGLIST_TAC =
+  W(fun (asl,w) ->
+        let regreads = map (rator o rand) (dest_list(find_term is_list w)) in
+        let regnames = map ((^) "init_" o name_of o rand) regreads in
+        let ghostvars = map (C (curry mk_var) `:int128`) regnames in
+        EVERY(map2 GHOST_INTRO_TAC ghostvars regreads));;
+
+(* ------------------------------------------------------------------------- *)
+(* Correctness proof                                                         *)
+(* ------------------------------------------------------------------------- *)
+
+let MLKEM_KECCAK_F1600_ALT_CORRECT = prove
+ (`!a rc A pc.
+      ALL (nonoverlapping (a,200)) [(word pc,0x1ac); (rc,192)]
+      ==> ensures arm
+           (\s. aligned_bytes_loaded s (word pc) mlkem_keccak_f1600_alt_mc /\
+                read PC s = word (pc + 0x14) /\
+                C_ARGUMENTS [a; rc] s /\
+                wordlist_from_memory(a,25) s = A /\
+                wordlist_from_memory(rc,24) s = round_constants)
+           (\s. read PC s = word(pc + 0x194) /\
+                wordlist_from_memory(a,25) s = keccak 24 A)
+           (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+            MAYCHANGE [Q8; Q9; Q10; Q11; Q12; Q13; Q14; Q15] ,,
+            MAYCHANGE [memory :> bytes(a,200)])`,
+  MAP_EVERY X_GEN_TAC
+   [`a:int64`; `rc:int64`; `A:int64 list`; `pc:num`] THEN
+  REWRITE_TAC[fst MLKEM_KECCAK_F1600_ALT_EXEC] THEN
+  REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
+              ALL; ALLPAIRS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  (*** Set up the loop invariant ***)
+
+  ENSURES_WHILE_UP_TAC `24` `pc + 0x4c` `pc + 0x15c`
+   `\i s.
+      wordlist_from_memory(rc,24) s = round_constants /\
+      read X0 s = a /\
+      read X1 s = word_add rc (word(8 * i)) /\
+      read X2 s = word_sub (word 24) (word i) /\
+      [read D0 s; read D1 s; read D2 s; read D3 s; read D4 s;
+       read D5 s; read D6 s; read D7 s; read D8 s; read D9 s;
+       read D10 s; read D11 s; read D12 s; read D13 s; read D14 s;
+       read D15 s; read D16 s; read D17 s; read D18 s; read D19 s;
+       read D20 s; read D21 s; read D22 s; read D23 s; read D24 s] =
+      keccak i A` THEN
+  REWRITE_TAC[condition_semantics] THEN REPEAT CONJ_TAC THENL
+   [ARITH_TAC;
+
+    (*** Initial holding of the invariant ***)
+
+    REWRITE_TAC[round_constants; CONS_11; GSYM CONJ_ASSOC;
+                WORDLIST_FROM_MEMORY_CONV `wordlist_from_memory(rc,24) s`] THEN
+    ENSURES_INIT_TAC "s0" THEN
+    BIGNUM_DIGITIZE_TAC "A_" `read (memory :> bytes (a,8 * 25)) s0` THEN
+    FIRST_ASSUM(MP_TAC o CONV_RULE(LAND_CONV WORDLIST_FROM_MEMORY_CONV)) THEN
+    ASM_REWRITE_TAC[] THEN DISCH_TAC THEN
+    ARM_STEPS_TAC MLKEM_KECCAK_F1600_ALT_EXEC (1--14) THEN
+    ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+    REPEAT(CONJ_TAC THENL [CONV_TAC WORD_RULE; ALL_TAC]) THEN
+    ASM_REWRITE_TAC[DREG_EXPAND_CLAUSES; READ_ZEROTOP_64] THEN
+    EXPAND_TAC "A" THEN REWRITE_TAC[keccak; CONS_11] THEN
+    CONV_TAC WORD_BLAST;
+
+    (*** Preservation of the invariant including end condition code ***)
+
+    X_GEN_TAC `i:num` THEN STRIP_TAC THEN VAL_INT64_TAC `i:num` THEN
+    REWRITE_TAC[round_constants; CONS_11; GSYM CONJ_ASSOC;
+                WORDLIST_FROM_MEMORY_CONV `wordlist_from_memory(rc,24) s`] THEN
+    REWRITE_TAC[DREG_EXPAND_CLAUSES; READ_ZEROTOP_64] THEN
+    GHOST_SUBREGLIST_TAC THEN
+    ENSURES_INIT_TAC "s0" THEN
+    SUBGOAL_THEN
+     `read (memory :> bytes64(word_add rc (word(8 * i)))) s0 =
+      EL i round_constants`
+    ASSUME_TAC THENL
+     [UNDISCH_TAC `i < 24` THEN SPEC_TAC(`i:num`,`i:num`) THEN
+      CONV_TAC EXPAND_CASES_CONV THEN
+      CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN
+      ASM_REWRITE_TAC[round_constants; WORD_ADD_0] THEN
+      CONV_TAC(ONCE_DEPTH_CONV EL_CONV) THEN REWRITE_TAC[];
+      ALL_TAC] THEN
+    ARM_STEPS_TAC MLKEM_KECCAK_F1600_ALT_EXEC (1--68) THEN
+    ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+    REPEAT(CONJ_TAC THENL [CONV_TAC WORD_RULE; ALL_TAC]) THEN
+    REWRITE_TAC[keccak] THEN FIRST_X_ASSUM(fun th ->
+      GEN_REWRITE_TAC (RAND_CONV o RAND_CONV) [SYM th]) THEN
+    REWRITE_TAC[keccak_round] THEN CONV_TAC(ONCE_DEPTH_CONV EL_CONV) THEN
+    CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
+    REWRITE_TAC[CONS_11] THEN REPEAT CONJ_TAC THEN BITBLAST_TAC;
+
+    (*** The trivial loop-back goal ***)
+
+    X_GEN_TAC `i:num` THEN STRIP_TAC THEN
+    REWRITE_TAC[round_constants; CONS_11; GSYM CONJ_ASSOC;
+    WORDLIST_FROM_MEMORY_CONV `wordlist_from_memory(rc,24) s`] THEN
+    ARM_SIM_TAC MLKEM_KECCAK_F1600_ALT_EXEC [1] THEN
+    VAL_INT64_TAC `i:num` THEN
+    ASM_REWRITE_TAC[] THEN CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN
+    ASM_SIMP_TAC[LT_IMP_NE];
+
+    (*** The tail of deferred rotations and writeback ***)
+
+    REWRITE_TAC[DREG_EXPAND_CLAUSES; READ_ZEROTOP_64] THEN
+    GHOST_SUBREGLIST_TAC THEN
+    ARM_SIM_TAC MLKEM_KECCAK_F1600_ALT_EXEC (1--14) THEN
+    CONV_TAC(LAND_CONV WORDLIST_FROM_MEMORY_CONV) THEN
+    ASM_REWRITE_TAC[]]);;
+
+let MLKEM_KECCAK_F1600_ALT_SUBROUTINE_CORRECT = prove
+(`!a rc A pc stackpointer returnaddress.
+        aligned 16 stackpointer /\
+        nonoverlapping (a,200) (word_sub stackpointer (word 64),64) /\
+        ALLPAIRS nonoverlapping
+          [(a,200); (word_sub stackpointer (word 64),64)]
+          [(word pc,0x1ac); (rc,192)]
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) mlkem_keccak_f1600_alt_mc /\
+                  read PC s = word pc /\
+                  read SP s = stackpointer /\
+                  read X30 s = returnaddress /\
+                  C_ARGUMENTS [a; rc] s /\
+                  wordlist_from_memory(a,25) s = A /\
+                  wordlist_from_memory(rc,24) s = round_constants)
+             (\s. read PC s = returnaddress /\
+                  wordlist_from_memory(a,25) s = keccak 24 A)
+             (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+              MAYCHANGE [memory :> bytes(a,200);
+                  memory :> bytes(word_sub stackpointer (word 64),64)])`,
+  let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
+  CONV_TAC TWEAK_CONV THEN
+  ARM_ADD_RETURN_STACK_TAC ~pre_post_nsteps:(5,5) MLKEM_KECCAK_F1600_ALT_EXEC
+   (CONV_RULE TWEAK_CONV MLKEM_KECCAK_F1600_ALT_CORRECT)
+  `[D8; D9; D10; D11; D12; D13; D14; D15]` 64);;

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -950,7 +950,7 @@ def gen_hol_light_asm(dry_run=False):
             f"dev/aarch64_opt/src/{infile}",
             "proofs/hol_light/arm/mlkem",
             outfile=outfile,
-            cflags="-Imlkem/native/aarch64/src -DMLK_ARITH_BACKEND_AARCH64_OPT",
+            cflags="-march=armv8.4-a+sha3 -Imlkem/native/aarch64/src -DMLK_ARITH_BACKEND_AARCH64_OPT",
             preserve_header=False,
             dry_run=dry_run,
         )
@@ -963,13 +963,16 @@ def gen_hol_light_asm(dry_run=False):
             f"dev/fips202/aarch64/src/{infile}",
             "proofs/hol_light/arm/mlkem",
             outfile=outfile,
-            cflags="-Imlkem/fips202/native/aarch64/src/ -DMLK_FIPS202_BACKEND_AARCH64_DEFAULT",
+            cflags="-march=armv8.4-a+sha3 -Imlkem/fips202/native/aarch64/src/ -DMLK_FIPS202_BACKEND_AARCH64_DEFAULT",
             preserve_header=False,
             dry_run=dry_run,
         )
 
     gen_hol_light_fips202_asm_file(
         "keccak_f1600_x1_scalar_asm_opt.S", "mlkem_keccak_f1600.S"
+    )
+    gen_hol_light_fips202_asm_file(
+        "keccak_f1600_x1_v84a_asm_clean.S", "mlkem_keccak_f1600_alt.S"
     )
 
 


### PR DESCRIPTION
This commit integrates the functional correctness proof for
the AArch64+SHA3 based implementation of Keccak-f1600-x1,
contributed by John Harrison.