### PR TITLE
CBMC: Pull and test weakening is_fresh in contract applications

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -196,6 +196,7 @@
 #undef mlk_polyvec_tomont
 /* mlkem/sys.h */
 #undef MLK_ALIGN
+#undef MLK_ALIGN_UP
 #undef MLK_ALWAYS_INLINE
 #undef MLK_CET_ENDBR
 #undef MLK_CT_TESTING_DECLASSIFY

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
           pkgs-2405 = inputs.nixpkgs-2405.legacyPackages.${system};
           util = pkgs.callPackage ./nix/util.nix {
-            cbmc = pkgs-unstable.cbmc;
+            cbmc = pkgs.cbmc;
             bitwuzla = pkgs-unstable.bitwuzla;
             z3 = pkgs-unstable.z3;
           };
@@ -114,7 +114,7 @@
             pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.x86_64-linux;
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
-              cbmc = pkgs-unstable.cbmc;
+              cbmc = pkgs.cbmc;
               bitwuzla = pkgs-unstable.bitwuzla;
               z3 = pkgs-unstable.z3;
             };

--- a/mlkem/poly_k.c
+++ b/mlkem/poly_k.c
@@ -285,27 +285,21 @@ void mlk_poly_getnoise_eta1_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
                                uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
                                uint8_t nonce3)
 {
-  MLK_ALIGN uint8_t buf0[MLKEM_ETA1 * MLKEM_N / 4];
-  MLK_ALIGN uint8_t buf1[MLKEM_ETA1 * MLKEM_N / 4];
-  MLK_ALIGN uint8_t buf2[MLKEM_ETA1 * MLKEM_N / 4];
-  MLK_ALIGN uint8_t buf3[MLKEM_ETA1 * MLKEM_N / 4];
-  MLK_ALIGN uint8_t extkey0[MLKEM_SYMBYTES + 1];
-  MLK_ALIGN uint8_t extkey1[MLKEM_SYMBYTES + 1];
-  MLK_ALIGN uint8_t extkey2[MLKEM_SYMBYTES + 1];
-  MLK_ALIGN uint8_t extkey3[MLKEM_SYMBYTES + 1];
-  memcpy(extkey0, seed, MLKEM_SYMBYTES);
-  memcpy(extkey1, seed, MLKEM_SYMBYTES);
-  memcpy(extkey2, seed, MLKEM_SYMBYTES);
-  memcpy(extkey3, seed, MLKEM_SYMBYTES);
-  extkey0[MLKEM_SYMBYTES] = nonce0;
-  extkey1[MLKEM_SYMBYTES] = nonce1;
-  extkey2[MLKEM_SYMBYTES] = nonce2;
-  extkey3[MLKEM_SYMBYTES] = nonce3;
-  mlk_prf_eta1_x4(buf0, buf1, buf2, buf3, extkey0, extkey1, extkey2, extkey3);
-  mlk_poly_cbd_eta1(r0, buf0);
-  mlk_poly_cbd_eta1(r1, buf1);
-  mlk_poly_cbd_eta1(r2, buf2);
-  mlk_poly_cbd_eta1(r3, buf3);
+  MLK_ALIGN uint8_t buf[4][MLK_ALIGN_UP(MLKEM_ETA1 * MLKEM_N / 4)];
+  MLK_ALIGN uint8_t extkey[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 1)];
+  memcpy(extkey[0], seed, MLKEM_SYMBYTES);
+  memcpy(extkey[1], seed, MLKEM_SYMBYTES);
+  memcpy(extkey[2], seed, MLKEM_SYMBYTES);
+  memcpy(extkey[3], seed, MLKEM_SYMBYTES);
+  extkey[0][MLKEM_SYMBYTES] = nonce0;
+  extkey[1][MLKEM_SYMBYTES] = nonce1;
+  extkey[2][MLKEM_SYMBYTES] = nonce2;
+  extkey[3][MLKEM_SYMBYTES] = nonce3;
+  mlk_prf_eta1_x4(buf, extkey);
+  mlk_poly_cbd_eta1(r0, buf[0]);
+  mlk_poly_cbd_eta1(r1, buf[1]);
+  mlk_poly_cbd_eta1(r2, buf[2]);
+  mlk_poly_cbd_eta1(r3, buf[3]);
 
   mlk_assert_abs_bound(r0, MLKEM_N, MLKEM_ETA1 + 1);
   mlk_assert_abs_bound(r1, MLKEM_N, MLKEM_ETA1 + 1);
@@ -314,14 +308,8 @@ void mlk_poly_getnoise_eta1_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
 
   /* Specification: Partially implements
    * [FIPS 203, Section 3.3, Destruction of intermediate values] */
-  mlk_zeroize(buf0, sizeof(buf0));
-  mlk_zeroize(buf1, sizeof(buf1));
-  mlk_zeroize(buf2, sizeof(buf2));
-  mlk_zeroize(buf3, sizeof(buf3));
-  mlk_zeroize(extkey0, sizeof(extkey0));
-  mlk_zeroize(extkey1, sizeof(extkey1));
-  mlk_zeroize(extkey2, sizeof(extkey2));
-  mlk_zeroize(extkey3, sizeof(extkey3));
+  mlk_zeroize(buf, sizeof(buf));
+  mlk_zeroize(extkey, sizeof(extkey));
 }
 
 #if MLKEM_K == 2 || MLKEM_K == 4
@@ -399,42 +387,34 @@ void mlk_poly_getnoise_eta1122_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
 #if MLKEM_ETA2 >= MLKEM_ETA1
 #error mlk_poly_getnoise_eta1122_4x assumes MLKEM_ETA1 > MLKEM_ETA2
 #endif
-  MLK_ALIGN uint8_t buf0[MLKEM_ETA1 * MLKEM_N / 4];
-  MLK_ALIGN uint8_t buf1[MLKEM_ETA1 * MLKEM_N / 4];
-  /* Pad to larger buffer */
-  MLK_ALIGN uint8_t buf2[MLKEM_ETA1 * MLKEM_N / 4];
-  MLK_ALIGN uint8_t buf3[MLKEM_ETA1 * MLKEM_N / 4];
+  MLK_ALIGN uint8_t buf[4][MLK_ALIGN_UP(MLKEM_ETA1 * MLKEM_N / 4)];
+  MLK_ALIGN uint8_t extkey[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 1)];
 
-  MLK_ALIGN uint8_t extkey0[MLKEM_SYMBYTES + 1];
-  MLK_ALIGN uint8_t extkey1[MLKEM_SYMBYTES + 1];
-  MLK_ALIGN uint8_t extkey2[MLKEM_SYMBYTES + 1];
-  MLK_ALIGN uint8_t extkey3[MLKEM_SYMBYTES + 1];
-
-  memcpy(extkey0, seed, MLKEM_SYMBYTES);
-  memcpy(extkey1, seed, MLKEM_SYMBYTES);
-  memcpy(extkey2, seed, MLKEM_SYMBYTES);
-  memcpy(extkey3, seed, MLKEM_SYMBYTES);
-  extkey0[MLKEM_SYMBYTES] = nonce0;
-  extkey1[MLKEM_SYMBYTES] = nonce1;
-  extkey2[MLKEM_SYMBYTES] = nonce2;
-  extkey3[MLKEM_SYMBYTES] = nonce3;
+  memcpy(extkey[0], seed, MLKEM_SYMBYTES);
+  memcpy(extkey[1], seed, MLKEM_SYMBYTES);
+  memcpy(extkey[2], seed, MLKEM_SYMBYTES);
+  memcpy(extkey[3], seed, MLKEM_SYMBYTES);
+  extkey[0][MLKEM_SYMBYTES] = nonce0;
+  extkey[1][MLKEM_SYMBYTES] = nonce1;
+  extkey[2][MLKEM_SYMBYTES] = nonce2;
+  extkey[3][MLKEM_SYMBYTES] = nonce3;
 
   /* On systems with fast batched Keccak, we use 4-fold batched PRF,
-   * even though that means generating more random data in buf2 and buf3
+   * even though that means generating more random data in buf[2] and buf[3]
    * than necessary. */
 #if !defined(FIPS202_X4_DEFAULT_IMPLEMENTATION)
-  mlk_prf_eta1_x4(buf0, buf1, buf2, buf3, extkey0, extkey1, extkey2, extkey3);
+  mlk_prf_eta1_x4(buf, extkey);
 #else  /* FIPS202_X4_DEFAULT_IMPLEMENTATION */
-  mlk_prf_eta1(buf0, extkey0);
-  mlk_prf_eta1(buf1, extkey1);
-  mlk_prf_eta2(buf2, extkey2);
-  mlk_prf_eta2(buf3, extkey3);
+  mlk_prf_eta1(buf[0], extkey[0]);
+  mlk_prf_eta1(buf[1], extkey[1]);
+  mlk_prf_eta2(buf[2], extkey[2]);
+  mlk_prf_eta2(buf[3], extkey[3]);
 #endif /* FIPS202_X4_DEFAULT_IMPLEMENTATION */
 
-  mlk_poly_cbd_eta1(r0, buf0);
-  mlk_poly_cbd_eta1(r1, buf1);
-  mlk_poly_cbd_eta2(r2, buf2);
-  mlk_poly_cbd_eta2(r3, buf3);
+  mlk_poly_cbd_eta1(r0, buf[0]);
+  mlk_poly_cbd_eta1(r1, buf[1]);
+  mlk_poly_cbd_eta2(r2, buf[2]);
+  mlk_poly_cbd_eta2(r3, buf[3]);
 
   mlk_assert_abs_bound(r0, MLKEM_N, MLKEM_ETA1 + 1);
   mlk_assert_abs_bound(r1, MLKEM_N, MLKEM_ETA1 + 1);
@@ -443,14 +423,8 @@ void mlk_poly_getnoise_eta1122_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
 
   /* Specification: Partially implements
    * [FIPS 203, Section 3.3, Destruction of intermediate values] */
-  mlk_zeroize(buf0, sizeof(buf0));
-  mlk_zeroize(buf1, sizeof(buf1));
-  mlk_zeroize(buf2, sizeof(buf2));
-  mlk_zeroize(buf3, sizeof(buf3));
-  mlk_zeroize(extkey0, sizeof(extkey0));
-  mlk_zeroize(extkey1, sizeof(extkey1));
-  mlk_zeroize(extkey2, sizeof(extkey2));
-  mlk_zeroize(extkey3, sizeof(extkey3));
+  mlk_zeroize(buf, sizeof(buf));
+  mlk_zeroize(extkey, sizeof(extkey));
 }
 #endif /* MLKEM_K == 2 */
 

--- a/mlkem/poly_k.h
+++ b/mlkem/poly_k.h
@@ -539,18 +539,12 @@ void mlk_poly_getnoise_eta1_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
                                mlk_poly *r3, const uint8_t seed[MLKEM_SYMBYTES],
                                uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
                                uint8_t nonce3)
-/* Depending on MLKEM_K, the pointers passed to this function belong
-   to the same objects, so we cannot use memory_no_alias for r0-r3.
-
-   NOTE: Somehow it is important to use memory_no_alias() first in the
-         conjunctions defining each case.
-*/
-#if MLKEM_K == 2
 __contract__(
   requires(memory_no_alias(seed, MLKEM_SYMBYTES))
-  requires( /* Case A: r0, r1 consecutive, r2, r3 consecutive */
-    (memory_no_alias(r0, 2 * sizeof(mlk_poly)) && memory_no_alias(r2, 2 * sizeof(mlk_poly)) &&
-     r1 == r0 + 1 && r3 == r2 + 1 && !same_object(r0, r2)))
+  requires(memory_no_alias(r0, sizeof(mlk_poly)))
+  requires(memory_no_alias(r1, sizeof(mlk_poly)))
+  requires(memory_no_alias(r2, sizeof(mlk_poly)))
+  requires(memory_no_alias(r3, sizeof(mlk_poly)))
   assigns(memory_slice(r0, sizeof(mlk_poly)))
   assigns(memory_slice(r1, sizeof(mlk_poly)))
   assigns(memory_slice(r2, sizeof(mlk_poly)))
@@ -561,38 +555,6 @@ __contract__(
     && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
     && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1));
 );
-#elif MLKEM_K == 4
-__contract__(
-  requires(memory_no_alias(seed, MLKEM_SYMBYTES))
-  requires( /* Case B: r0, r1, r2, r3 consecutive */
-    (memory_no_alias(r0, 4 * sizeof(mlk_poly)) && r1 == r0 + 1 && r2 == r0 + 2 && r3 == r0 + 3))
-  assigns(memory_slice(r0, sizeof(mlk_poly)))
-  assigns(memory_slice(r1, sizeof(mlk_poly)))
-  assigns(memory_slice(r2, sizeof(mlk_poly)))
-  assigns(memory_slice(r3, sizeof(mlk_poly)))
-  ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1));
-);
-#elif MLKEM_K == 3
-__contract__(
-  requires(memory_no_alias(seed, MLKEM_SYMBYTES))
-  requires( /* Case C: r0, r1, r2 consecutive */
- (memory_no_alias(r0, 3 * sizeof(mlk_poly)) && memory_no_alias(r3, 1 * sizeof(mlk_poly)) &&
-  r1 == r0 + 1 && r2 == r0 + 2 && !same_object(r3, r0)))
-  assigns(memory_slice(r0, sizeof(mlk_poly)))
-  assigns(memory_slice(r1, sizeof(mlk_poly)))
-  assigns(memory_slice(r2, sizeof(mlk_poly)))
-  assigns(memory_slice(r3, sizeof(mlk_poly)))
-  ensures(
-    array_abs_bound(r0->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
-    && array_abs_bound(r1->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
-    && array_abs_bound(r2->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1)
-    && array_abs_bound(r3->coeffs,0, MLKEM_N, MLKEM_ETA1 + 1));
-);
-#endif /* MLKEM_K */
 
 #if MLKEM_ETA1 == MLKEM_ETA2
 /*

--- a/mlkem/sampling.h
+++ b/mlkem/sampling.h
@@ -55,24 +55,21 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4]);
  * Description: Generate four polynomials using rejection sampling
  *              on (pseudo-)uniformly random bytes sampled from a seed.
  *
- * Arguments:   - mlk_poly *vec:           Pointer to an array of 4 polynomials
- *                                     to be sampled.
- *              - uint8_t *seed[4]:    Pointer to array of four pointers
- *                                     pointing to the seed buffers of size
- *                                     MLKEM_SYMBYTES + 2 each.
+ * Arguments:   - mlk_poly *vec:
+ *                Pointer to an array of 4 polynomials to be sampled.
+ *              - uint8_t seed[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)]:
+ *                Pointer consecutive array of seed buffers of size
+ *                MLKEM_SYMBYTES + 2 each, plus padding for alignment.
  *
  * Specification: Implements [FIPS 203, Algorithm 7, SampleNTT]
  *
  **************************************************/
 MLK_INTERNAL_API
-void mlk_poly_rej_uniform_x4(mlk_poly *vec, uint8_t *seed[4])
+void mlk_poly_rej_uniform_x4(mlk_poly *vec,
+                             uint8_t seed[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)])
 __contract__(
   requires(memory_no_alias(vec, sizeof(mlk_poly) * 4))
-  requires(memory_no_alias(seed, sizeof(uint8_t*) * 4))
-  requires(memory_no_alias(seed[0], MLKEM_SYMBYTES + 2))
-  requires(memory_no_alias(seed[1], MLKEM_SYMBYTES + 2))
-  requires(memory_no_alias(seed[2], MLKEM_SYMBYTES + 2))
-  requires(memory_no_alias(seed[3], MLKEM_SYMBYTES + 2))
+  requires(memory_no_alias(seed, 4 * MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)))
   assigns(memory_slice(vec, sizeof(mlk_poly) * 4))
   ensures(array_bound(vec[0].coeffs, 0, MLKEM_N, 0, MLKEM_Q))
   ensures(array_bound(vec[1].coeffs, 0, MLKEM_N, 0, MLKEM_Q))

--- a/mlkem/symmetric.h
+++ b/mlkem/symmetric.h
@@ -30,9 +30,10 @@
   mlk_shake256(OUT, (ETA) * MLKEM_N / 4, IN, MLKEM_SYMBYTES + 1)
 #define mlk_prf_eta1(OUT, IN) mlk_prf_eta(MLKEM_ETA1, OUT, IN)
 #define mlk_prf_eta2(OUT, IN) mlk_prf_eta(MLKEM_ETA2, OUT, IN)
-#define mlk_prf_eta1_x4(OUT0, OUT1, OUT2, OUT3, IN0, IN1, IN2, IN3)            \
-  mlk_shake256x4(OUT0, OUT1, OUT2, OUT3, (MLKEM_ETA1 * MLKEM_N / 4), IN0, IN1, \
-                 IN2, IN3, MLKEM_SYMBYTES + 1)
+#define mlk_prf_eta1_x4(OUT, IN)                                        \
+  mlk_shake256x4((OUT)[0], (OUT)[1], (OUT)[2], (OUT)[3],                \
+                 (MLKEM_ETA1 * MLKEM_N / 4), (IN)[0], (IN)[1], (IN)[2], \
+                 (IN)[3], MLKEM_SYMBYTES + 1)
 
 /* XOF function, FIPS 203 4.1 */
 #define mlk_xof_ctx mlk_shake128ctx
@@ -45,10 +46,12 @@
 #define mlk_xof_release(CTX) mlk_shake128_release((CTX))
 
 #define mlk_xof_x4_init(CTX) mlk_shake128x4_init((CTX))
-#define mlk_xof_x4_absorb(CTX, IN0, IN1, IN2, IN3, INBYTES) \
-  mlk_shake128x4_absorb_once((CTX), (IN0), (IN1), (IN2), (IN3), (INBYTES))
-#define mlk_xof_x4_squeezeblocks(BUF0, BUF1, BUF2, BUF3, NBLOCKS, CTX) \
-  mlk_shake128x4_squeezeblocks((BUF0), (BUF1), (BUF2), (BUF3), (NBLOCKS), (CTX))
+#define mlk_xof_x4_absorb(CTX, IN, INBYTES)                             \
+  mlk_shake128x4_absorb_once((CTX), (IN)[0], (IN)[1], (IN)[2], (IN)[3], \
+                             (INBYTES))
+#define mlk_xof_x4_squeezeblocks(BUF, NBLOCKS, CTX)                    \
+  mlk_shake128x4_squeezeblocks((BUF)[0], (BUF)[1], (BUF)[2], (BUF)[3], \
+                               (NBLOCKS), (CTX))
 #define mlk_xof_x4_release(CTX) mlk_shake128x4_release((CTX))
 
 #define MLK_XOF_RATE SHAKE128_RATE

--- a/mlkem/sys.h
+++ b/mlkem/sys.h
@@ -109,6 +109,8 @@
 #endif
 
 #define MLK_DEFAULT_ALIGN 32
+#define MLK_ALIGN_UP(N) \
+  ((((N) + (MLK_DEFAULT_ALIGN - 1)) / MLK_DEFAULT_ALIGN) * MLK_DEFAULT_ALIGN)
 #if defined(__GNUC__)
 #define MLK_ALIGN __attribute__((aligned(MLK_DEFAULT_ALIGN)))
 #elif defined(_MSC_VER)

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -14,12 +14,12 @@ buildEnv {
   paths =
     builtins.attrValues {
       cbmc = cbmc.overrideAttrs (old: rec {
-        version = "6.4.1"; # remember to adjust this in ../flake.nix too
+        version = "e033ba1f10121e5a913991ab6fc672d34a115ec1"; # remember to adjust this in ../flake.nix too
         src = fetchFromGitHub {
           owner = "diffblue";
-          repo = old.pname;
-          tag = "${old.pname}-${version}";
-          hash = "sha256-O8aZTW+Eylshl9bmm9GzbljWB0+cj2liZHs2uScERkM=";
+          repo = "cbmc";
+          rev = "e033ba1f10121e5a913991ab6fc672d34a115ec1";
+          hash = "sha256-m2LhpldzBSYP9caQ2RJBl++Cx5Fx97y8E2P2SKcsmMM=";
         };
       });
       litani = callPackage ./litani.nix { }; # 1.29.0

--- a/proofs/cbmc/poly_rej_uniform_x4/poly_rej_uniform_x4_harness.c
+++ b/proofs/cbmc/poly_rej_uniform_x4/poly_rej_uniform_x4_harness.c
@@ -8,6 +8,6 @@
 void harness(void)
 {
   mlk_poly out[4];
-  uint8_t *seed[4];
+  uint8_t seed[4][MLK_ALIGN_UP(MLKEM_SYMBYTES + 2)];
   mlk_poly_rej_uniform_x4(out, seed);
 }

--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -58,24 +58,18 @@ static int bench(void)
   MLK_ALIGN uint64_t data2[1024];
   MLK_ALIGN uint64_t data3[1024];
   MLK_ALIGN uint64_t data4[1024];
-  uint8_t *seed[4];
   uint8_t nonce0 = 0, nonce1 = 1, nonce2 = 2, nonce3 = 3;
   uint64_t cyc[NTESTS];
 
   unsigned i, j;
   uint64_t t0, t1;
 
-  seed[0] = (uint8_t *)data1;
-  seed[1] = (uint8_t *)data2;
-  seed[2] = (uint8_t *)data3;
-  seed[3] = (uint8_t *)data4;
-
   BENCH("keccak-f1600-x1", mlk_keccakf1600_permute(data0))
   BENCH("keccak-f1600-x4", mlk_keccakf1600x4_permute(data0))
   BENCH("mlk_poly_rej_uniform",
         mlk_poly_rej_uniform((mlk_poly *)data0, (uint8_t *)data1))
   BENCH("mlk_poly_rej_uniform_x4",
-        mlk_poly_rej_uniform_x4((mlk_poly *)data0, seed))
+        mlk_poly_rej_uniform_x4((mlk_poly *)data0, (uint8_t(*)[64])data1))
 
   /* mlk_poly */
   /* mlk_poly_compress_du */


### PR DESCRIPTION
* Resolves #764 

This PR updates CBMC to include the change from https://github.com/diffblue/cbmc/pull/8603 which weakens the interpretation of `memory_no_alias` (or `__CPROVER_is_fresh`) in function contract applications: Rather than asserting that every pointer featuring in a `memory_no_alis/__CPROVER_is_fresh` clause be in a separate object, pointers can now point to the same object, so long as the slices they represent are disjoint.

This allows us to undo some artificial splitting of 2D arrays into separate objects, which this PR also does.