### PR TITLE
Rename -c M1 option to -c MAC

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -104,11 +104,11 @@ jobs:
         run: |
           make clean
           ./scripts/tests bench -c PERF --no-run
-      - name: "tests bench (build only, cycles: M1)"
+      - name: "tests bench (build only, cycles: MAC)"
         if: ${{ matrix.target.name == 'macos (aarch64)' || matrix.target.name == 'macos (x86_64)' }}
         run: |
           make clean
-          ./scripts/tests bench -c M1 --no-run
+          ./scripts/tests bench -c MAC --no-run
       - name: tests bench components
         run: |
           make clean

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -35,13 +35,16 @@ make run_acvp
 
 The resulting binaries can be found in `test/build` (their full path is printed by `make`).
 
-For benchmarking, specify the cycle counting method. Currently, **mlkem-native** is supporting PERF, PMU (AArch64 and
-x86 only), M1 (Apple Silicon only):
+For benchmarking, specify the cycle counting method. Currently, **mlkem-native** is supporting NO, PERF, PMU, and MAC:
+* `NO` means that no cycle counting will be used; this can be used to confirm that benchmarks compile fine.
+* `PERF` uses the `perf` kernel module for cycle counting. Does not work on Apple platforms.
+* `PMU` uses direct PMU access if available. On AArch64, this may require you to load a kernel module first, see [here](https://github.com/mupq/pqax?tab=readme-ov-file#enable-access-to-performance-counters). Does not work on Apple platforms.
+* `MAC` is `perf`-based and works on some Apple platforms, at least Apple M1.
 
 ```
-# CYCLES has to be on of PERF, PMU, M1, NO
-make run_bench CYCLES=PERF
-make run_bench_components CYCLES=PERF
+# CYCLES has to be one of PERF, PMU, MAC, NO
+sudo make run_bench CYCLES=PERF
+sudo make run_bench_components CYCLES=PERF
 ```
 
 ### Using `tests` script
@@ -53,7 +56,15 @@ example,
 ./scripts/tests func
 ```
 
-will compile and run functionality tests. For detailed information on how to use the script, please refer to
+will compile and run functionality tests. Similarly,
+
+```bash
+./scripts/tests bench -c PERF -r
+```
+
+will compile and run benchmarks, using PERF for cycle counting (`-c PERF`) and running as root (`-r`).
+
+For detailed information on how to use the script, please refer to
 `./scripts/tests --help`.
 
 ### Windows

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ lib: $(BUILD_DIR)/libmlkem.a $(BUILD_DIR)/libmlkem512.a $(BUILD_DIR)/libmlkem768
 # building benchmarking binaries
 check_defined = $(if $(value $1),, $(error $2))
 check-defined-CYCLES:
-	@:$(call check_defined,CYCLES,CYCLES undefined. Benchmarking requires setting one of NO PMU PERF M1)
+	@:$(call check_defined,CYCLES,CYCLES undefined. Benchmarking requires setting one of NO PMU PERF MAC)
 
 bench_512: check-defined-CYCLES \
 	$(MLKEM512_DIR)/bin/bench_mlkem512

--- a/scripts/tests
+++ b/scripts/tests
@@ -967,8 +967,8 @@ def cli():
     bench_parser.add_argument(
         "-c",
         "--cycles",
-        help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silicon.",
-        choices=["NO", "PMU", "PERF", "M1"],
+        help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. MAC works on some Apple platforms, at least Apple M1.",
+        choices=["NO", "PMU", "PERF", "MAC"],
         type=str.upper,
         required=True,
     )

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -143,7 +143,7 @@ uint64_t get_cyclecounter(void)
   ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
   return cpu_cycles;
 }
-#elif defined(M1_CYCLES)
+#elif defined(MAC_CYCLES)
 /*
  * based on
  * https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155#file-m1_robsize-c-L390

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -68,8 +68,8 @@ ifeq ($(CYCLES),PERF)
 	CFLAGS += -DPERF_CYCLES
 endif
 
-ifeq ($(CYCLES),M1)
-	CFLAGS += -DM1_CYCLES
+ifeq ($(CYCLES),MAC)
+	CFLAGS += -DMAC_CYCLES
 endif
 
 ##############################


### PR DESCRIPTION
It has been reported that the -c M1 cycle counting option does seem to work on some Intel Macs as well. This commit renames it to -c MAC and adjusts the documentation accordingly.

* Resolves #810 
