### PR TITLE
Scripts: Make simpasm, autogen, tests callable from any subdirectory

### DIFF
--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1242,6 +1242,8 @@ def _main():
 
     args = parser.parse_args()
 
+    os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+
     check_asm_register_aliases()
 
     gen_c_zeta_file(args.dry_run)

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -345,6 +345,8 @@ def _main():
 
     args = parser.parse_args()
 
+    os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+
     if (
         args.cflags is not None
         and args.cflags.startswith('"')

--- a/scripts/tests
+++ b/scripts/tests
@@ -1075,6 +1075,8 @@ def cli():
     if not hasattr(args, "l"):
         args.l = None
 
+    os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+
     if args.cmd == "all":
         Tests(args).all()
     elif args.cmd == "examples":


### PR DESCRIPTION
Previously, those scripts would need to be called from the root directory of the repository. With this change, they can be called from anywhere within the repository.

* Resolves #847 