### PR TITLE
Update liboqs to `bf515a3`

### DIFF
--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -36,7 +36,7 @@ jobs:
           packages: 'cmake python3-jinja2 python3-tabulate python3-git python3-pytest valgrind'
       - uses: ./.github/actions/setup-oqs
         with:
-          commit: 'a554b36dd321e94c276e85c025f350c70740f328'
+          commit: 'bf515a36091e2bd1dd0fbfe8ce1747a45371312e'
       - name: Apply patch
         run: |
           cd $LIBOQS_DIR
@@ -44,8 +44,6 @@ jobs:
           sed -i "/name: mlkem-native/,/preserve_folder_structure/s%git_url: .*%git_url: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY%" scripts/copy_from_upstream/copy_from_upstream.yml
           sed -i "/name: mlkem-native/,/preserve_folder_structure/s/git_branch: .*/git_branch: $GITHUB_SHA/" scripts/copy_from_upstream/copy_from_upstream.yml
           sed -i "/name: mlkem-native/,/preserve_folder_structure/s/git_commit: .*/git_commit: $GITHUB_SHA/" scripts/copy_from_upstream/copy_from_upstream.yml
-          # Remove patch
-          sed -i "/name: mlkem-native/,/preserve_folder_structure/{/patches:/d}" scripts/copy_from_upstream/copy_from_upstream.yml
           git diff >> $GITHUB_STEP_SUMMARY
       - name: Configure
         run: |


### PR DESCRIPTION
This updates liboqs to the current version in main https://github.com/open-quantum-safe/liboqs/tree/bf515a36091e2bd1dd0fbfe8ce1747a45371312e

As
https://github.com/open-quantum-safe/liboqs/pull/2092 was merged upstream (which removed all remaining patching), we no longer need to remove the patching in the liboqs integration test.

<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
Provide a brief summary of your changes.

**Steps**:
If your pull request consists of multiple sequential changes, please describe them here:

**Performed local tests**:
 - [ ] `lint` passing
 - [ ] `tests all` passing
 - [ ] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
