### PR TITLE
Remove CLEAN and OPT suffixes from MLK_ARITH_BACKEND_AARCH64 macro

### DIFF
--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -17,7 +17,7 @@
 #define MLK_USE_NATIVE_REJ_UNIFORM
 
 /* Guard for AArch64 assembly files */
-#define MLK_ARITH_BACKEND_AARCH64_CLEAN
+#define MLK_ARITH_BACKEND_AARCH64
 
 #if !defined(__ASSEMBLER__)
 #include "src/arith_native_aarch64.h"

--- a/dev/aarch64_clean/src/aarch64_zetas.c
+++ b/dev/aarch64_clean/src/aarch64_zetas.c
@@ -10,7 +10,7 @@
 
 #include "../../../common.h"
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 #include <stdint.h>
@@ -167,11 +167,11 @@ MLK_ALIGN const int16_t mlk_aarch64_zetas_mulcache_twisted_native[] = {
     -11566, 11566,
 };
 
-#else /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) \
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#else /* defined(MLK_ARITH_BACKEND_AARCH64) \
+         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
 
 MLK_EMPTY_CU(aarch64_zetas)
 
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) \
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/dev/aarch64_clean/src/intt.S
+++ b/dev/aarch64_clean/src/intt.S
@@ -24,7 +24,7 @@
 ///
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -388,5 +388,5 @@ layer123_start:
     .unreq ninv_tw
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/ntt.S
+++ b/dev/aarch64_clean/src/ntt.S
@@ -25,7 +25,7 @@
 ///
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -316,5 +316,5 @@ layer4567_start:
     .unreq t3
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -97,5 +97,5 @@ mulcache_compute_loop_start:
         .unreq modulus_twisted
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/poly_reduce_asm.S
+++ b/dev/aarch64_clean/src/poly_reduce_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -92,5 +92,5 @@ loop_start:
         .unreq modulus_twisted
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/poly_tobytes_asm.S
+++ b/dev/aarch64_clean/src/poly_tobytes_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -61,5 +61,5 @@ poly_tobytes_asm_asm_loop_start:
         .unreq count
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/poly_tomont_asm.S
+++ b/dev/aarch64_clean/src/poly_tomont_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -94,5 +94,5 @@ poly_tomont_asm_loop:
         .unreq tmp0
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2)
 /* simpasm: header-end */
@@ -214,6 +214,6 @@ k2_loop_start:
 
 /* simpasm: footer-start */
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2) */

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3)
 /* simpasm: header-end */
@@ -217,6 +217,6 @@ k3_loop_start:
     .unreq t0
 
 /* simpasm: footer-start */
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3) */

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4)
 /* simpasm: header-end */
@@ -227,6 +227,6 @@ k4_loop_start:
     .unreq t0
 
 /* simpasm: footer-start */
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2) */

--- a/dev/aarch64_clean/src/rej_uniform_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm.S
@@ -19,7 +19,7 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -404,5 +404,5 @@ return:
     .unreq bits
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_clean/src/rej_uniform_table.c
+++ b/dev/aarch64_clean/src/rej_uniform_table.c
@@ -10,7 +10,7 @@
 
 #include "../../../common.h"
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 #include <stdint.h>
@@ -279,10 +279,10 @@ MLK_ALIGN const uint8_t mlk_rej_uniform_table[] = {
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15 /* 255 */,
 };
 
-#else /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) \
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#else /* defined(MLK_ARITH_BACKEND_AARCH64) \
+         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
 
 MLK_EMPTY_CU(aarch64_rej_uniform_table)
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) \
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -18,7 +18,7 @@
 
 /* Identifier for this backend so that source and assembly files
  * in the build can be appropriately guarded. */
-#define MLK_ARITH_BACKEND_AARCH64_OPT
+#define MLK_ARITH_BACKEND_AARCH64
 
 
 #if !defined(__ASSEMBLER__)

--- a/dev/aarch64_opt/src/aarch64_zetas.c
+++ b/dev/aarch64_opt/src/aarch64_zetas.c
@@ -10,7 +10,7 @@
 
 #include "../../../common.h"
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 #include <stdint.h>
@@ -167,11 +167,11 @@ MLK_ALIGN const int16_t mlk_aarch64_zetas_mulcache_twisted_native[] = {
     -11566, 11566,
 };
 
-#else /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#else /* defined(MLK_ARITH_BACKEND_AARCH64) \
+         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
 
 MLK_EMPTY_CU(aarch64_zetas)
 
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) \
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/dev/aarch64_opt/src/intt.S
+++ b/dev/aarch64_opt/src/intt.S
@@ -24,7 +24,7 @@
 ///
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -1044,5 +1044,5 @@ layer123_start:
     .unreq ninv_tw
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/ntt.S
+++ b/dev/aarch64_opt/src/ntt.S
@@ -25,7 +25,7 @@
 ///
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -954,5 +954,5 @@ ntt_loop1:
     .unreq t3
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -176,5 +176,5 @@ poly_mulcache_compute_asm_loop:
         .unreq modulus_twisted
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/poly_reduce_asm.S
+++ b/dev/aarch64_opt/src/poly_reduce_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -255,5 +255,5 @@ poly_reduce_asm_loop:
         .unreq modulus_twisted
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/poly_tobytes_asm.S
+++ b/dev/aarch64_opt/src/poly_tobytes_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -61,5 +61,5 @@ poly_tobytes_asm_asm_loop_start:
         .unreq count
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/poly_tomont_asm.S
+++ b/dev/aarch64_opt/src/poly_tomont_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -213,5 +213,5 @@ poly_tomont_asm_loop:
         .unreq tmp0
 
 /* simpasm: footer-start */
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2)
 /* simpasm: header-end */
@@ -545,6 +545,6 @@ polyvec_basemul_acc_montgomery_cached_asm_k2_loop:
     .unreq t0
 
 /* simpasm: footer-start */
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2) */

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3)
 /* simpasm: header-end */
@@ -649,6 +649,6 @@ polyvec_basemul_acc_montgomery_cached_asm_k3_loop:
     .unreq t0
 
 /* simpasm: footer-start */
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3) */

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4)
 /* simpasm: header-end */
@@ -760,6 +760,6 @@ polyvec_basemul_acc_montgomery_cached_asm_k4_loop:
     .unreq t0
 
 /* simpasm: footer-start */
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4) */

--- a/dev/aarch64_opt/src/rej_uniform_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm.S
@@ -19,8 +19,7 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) || \
-        defined(MLK_ARITH_BACKEND_AARCH64_OPT))  \
+#if defined(MLK_ARITH_BACKEND_AARCH64)  \
     && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 /* simpasm: header-end */
 
@@ -405,6 +404,5 @@ return:
     .unreq bits
 
 /* simpasm: footer-start */
-#endif /* (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) ||
-           defined(MLK_ARITH_BACKEND_AARCH64_OPT))
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64)
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/dev/aarch64_opt/src/rej_uniform_table.c
+++ b/dev/aarch64_opt/src/rej_uniform_table.c
@@ -10,7 +10,7 @@
 
 #include "../../../common.h"
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 #include <stdint.h>
@@ -279,10 +279,10 @@ MLK_ALIGN const uint8_t mlk_rej_uniform_table[] = {
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15 /* 255 */,
 };
 
-#else /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#else /* defined(MLK_ARITH_BACKEND_AARCH64) \
+         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
 
 MLK_EMPTY_CU(aarch64_rej_uniform_table)
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) \
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -382,7 +382,7 @@
  * Undefine macros from native code
  */
 /* mlkem/native/aarch64/meta.h */
-#undef MLK_ARITH_BACKEND_AARCH64_OPT
+#undef MLK_ARITH_BACKEND_AARCH64
 #undef MLK_NATIVE_AARCH64_META_H
 #undef MLK_USE_NATIVE_INTT
 #undef MLK_USE_NATIVE_NTT

--- a/mlkem/native/aarch64/meta.h
+++ b/mlkem/native/aarch64/meta.h
@@ -18,7 +18,7 @@
 
 /* Identifier for this backend so that source and assembly files
  * in the build can be appropriately guarded. */
-#define MLK_ARITH_BACKEND_AARCH64_OPT
+#define MLK_ARITH_BACKEND_AARCH64
 
 
 #if !defined(__ASSEMBLER__)

--- a/mlkem/native/aarch64/src/aarch64_zetas.c
+++ b/mlkem/native/aarch64/src/aarch64_zetas.c
@@ -10,7 +10,7 @@
 
 #include "../../../common.h"
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 #include <stdint.h>
@@ -167,11 +167,11 @@ MLK_ALIGN const int16_t mlk_aarch64_zetas_mulcache_twisted_native[] = {
     -11566, 11566,
 };
 
-#else /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#else /* defined(MLK_ARITH_BACKEND_AARCH64) \
+         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
 
 MLK_EMPTY_CU(aarch64_zetas)
 
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) \
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/mlkem/native/aarch64/src/intt.S
+++ b/mlkem/native/aarch64/src/intt.S
@@ -24,7 +24,7 @@
 ///
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -417,5 +417,5 @@ layer123_start:
         add	sp, sp, #0x40
         ret
 
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/mlkem/native/aarch64/src/ntt.S
+++ b/mlkem/native/aarch64/src/ntt.S
@@ -25,7 +25,7 @@
 ///
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -365,5 +365,5 @@ ntt_loop1:
         add	sp, sp, #0x40
         ret
 
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
+++ b/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -48,5 +48,5 @@ poly_mulcache_compute_asm_loop:
         str	q2, [x0], #0x10
         ret
 
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/mlkem/native/aarch64/src/poly_reduce_asm.S
+++ b/mlkem/native/aarch64/src/poly_reduce_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -94,5 +94,5 @@ poly_reduce_asm_loop:
         stur	q24, [x0, #-0x40]
         ret
 
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/mlkem/native/aarch64/src/poly_tobytes_asm.S
+++ b/mlkem/native/aarch64/src/poly_tobytes_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -32,5 +32,5 @@ poly_tobytes_asm_asm_loop_start:
         cbnz	x2, poly_tobytes_asm_asm_loop_start
         ret
 
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/mlkem/native/aarch64/src/poly_tomont_asm.S
+++ b/mlkem/native/aarch64/src/poly_tomont_asm.S
@@ -4,7 +4,7 @@
  */
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -74,5 +74,5 @@ poly_tomont_asm_loop:
         stur	q23, [x0, #-0x40]
         ret
 
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT &&
+#endif /* MLK_ARITH_BACKEND_AARCH64 &&
           !MLK_MULTILEVEL_BUILD_NO_SHARED */

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2)
 
@@ -194,6 +194,6 @@ polyvec_basemul_acc_montgomery_cached_asm_k2_loop:
         add	sp, sp, #0x40
         ret
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 2) */

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3)
 
@@ -248,6 +248,6 @@ polyvec_basemul_acc_montgomery_cached_asm_k3_loop:
         add	sp, sp, #0x40
         ret
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 3) */

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -10,7 +10,7 @@
 // https://github.com/neon-ntt/neon-ntt
 
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
     (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4)
 
@@ -302,6 +302,6 @@ polyvec_basemul_acc_montgomery_cached_asm_k4_loop:
         add	sp, sp, #0x40
         ret
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) && \
           !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) && \
           (defined(MLK_MULTILEVEL_BUILD_WITH_SHARED) || MLKEM_K == 4) */

--- a/mlkem/native/aarch64/src/rej_uniform_asm.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm.S
@@ -19,8 +19,7 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) || \
-        defined(MLK_ARITH_BACKEND_AARCH64_OPT))  \
+#if defined(MLK_ARITH_BACKEND_AARCH64)  \
     && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 /*
@@ -185,6 +184,5 @@ return:
         add	sp, sp, #0x240
         ret
 
-#endif /* (defined(MLK_ARITH_BACKEND_AARCH64_CLEAN) ||
-           defined(MLK_ARITH_BACKEND_AARCH64_OPT))
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64)
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/mlkem/native/aarch64/src/rej_uniform_table.c
+++ b/mlkem/native/aarch64/src/rej_uniform_table.c
@@ -10,7 +10,7 @@
 
 #include "../../../common.h"
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT) && \
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)
 
 #include <stdint.h>
@@ -279,10 +279,10 @@ MLK_ALIGN const uint8_t mlk_rej_uniform_table[] = {
     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15 /* 255 */,
 };
 
-#else /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
-          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
+#else /* defined(MLK_ARITH_BACKEND_AARCH64) \
+         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */
 
 MLK_EMPTY_CU(aarch64_rej_uniform_table)
 
-#endif /* defined(MLK_ARITH_BACKEND_AARCH64_OPT) \
+#endif /* defined(MLK_ARITH_BACKEND_AARCH64) \
           && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -314,12 +314,12 @@ def gen_aarch64_mulcache_twiddles_twisted():
 
 
 def gen_aarch64_fwd_ntt_zeta_file(dry_run=False):
-    def gen(suffix):
+    def gen():
         yield from gen_header()
         yield '#include "../../../common.h"'
         yield ""
-        yield f"#if defined(MLK_ARITH_BACKEND_AARCH64_{suffix.upper()}) && \\"
-        yield "     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)"
+        yield "#if defined(MLK_ARITH_BACKEND_AARCH64) && \\"
+        yield "    !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)"
         yield ""
         yield "#include <stdint.h>"
         yield '#include "arith_native_aarch64.h"'
@@ -352,25 +352,25 @@ def gen_aarch64_fwd_ntt_zeta_file(dry_run=False):
         yield from map(lambda t: str(t) + ",", gen_aarch64_mulcache_twiddles_twisted())
         yield "};"
         yield ""
-        yield f"#else /* defined(MLK_ARITH_BACKEND_AARCH64_{suffix.upper()})"
-        yield "          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */"
+        yield "#else /* defined(MLK_ARITH_BACKEND_AARCH64)"
+        yield "         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */"
         yield ""
         yield "MLK_EMPTY_CU(aarch64_zetas)"
         yield ""
         yield ""
-        yield f"#endif /* defined(MLK_ARITH_BACKEND_AARCH64_{suffix.upper()})"
+        yield "#endif /* defined(MLK_ARITH_BACKEND_AARCH64)"
         yield "          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */"
         yield ""
 
     update_file(
         "dev/aarch64_opt/src/aarch64_zetas.c",
-        "\n".join(gen("opt")),
+        "\n".join(gen()),
         dry_run=dry_run,
     )
 
     update_file(
         "dev/aarch64_clean/src/aarch64_zetas.c",
-        "\n".join(gen("clean")),
+        "\n".join(gen()),
         dry_run=dry_run,
     )
 
@@ -395,12 +395,12 @@ def gen_aarch64_rej_uniform_table_rows():
 
 
 def gen_aarch64_rej_uniform_table(dry_run=False):
-    def gen(suffix):
+    def gen():
         yield from gen_header()
         yield '#include "../../../common.h"'
         yield ""
-        yield f"#if defined(MLK_ARITH_BACKEND_AARCH64_{suffix.upper()}) && \\"
-        yield "     !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)"
+        yield "#if defined(MLK_ARITH_BACKEND_AARCH64) && \\"
+        yield "    !defined(MLK_MULTILEVEL_BUILD_NO_SHARED)"
         yield ""
         yield "#include <stdint.h>"
         yield '#include "arith_native_aarch64.h"'
@@ -413,24 +413,24 @@ def gen_aarch64_rej_uniform_table(dry_run=False):
         yield from map(lambda t: str(t) + ",", gen_aarch64_rej_uniform_table_rows())
         yield "};"
         yield ""
-        yield f"#else /* defined(MLK_ARITH_BACKEND_AARCH64_{suffix.upper()})"
-        yield "          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */"
+        yield "#else /* defined(MLK_ARITH_BACKEND_AARCH64)"
+        yield "         && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */"
         yield ""
         yield "MLK_EMPTY_CU(aarch64_rej_uniform_table)"
         yield ""
-        yield f"#endif /* defined(MLK_ARITH_BACKEND_AARCH64_{suffix.upper()})"
+        yield "#endif /* defined(MLK_ARITH_BACKEND_AARCH64)"
         yield "          && !defined(MLK_MULTILEVEL_BUILD_NO_SHARED) */"
         yield ""
 
     update_file(
         "dev/aarch64_opt/src/rej_uniform_table.c",
-        "\n".join(gen("opt")),
+        "\n".join(gen()),
         dry_run=dry_run,
     )
 
     update_file(
         "dev/aarch64_clean/src/rej_uniform_table.c",
-        "\n".join(gen("clean")),
+        "\n".join(gen()),
         dry_run=dry_run,
     )
 

--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -199,63 +199,39 @@ static int bench(void)
         mlk_gen_matrix((mlk_polyvec *)data0, (uint8_t *)data1, 0))
 
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_CLEAN)
-  BENCH("ntt-clean",
-        mlk_ntt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
-  BENCH("intt-clean",
-        mlk_intt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
-  BENCH("mlk_poly-reduce-clean", mlk_poly_reduce_asm((int16_t *)data0));
-  BENCH("mlk_poly-tomont-clean", mlk_poly_tomont_asm((int16_t *)data0));
-  BENCH("mlk_poly-tobytes-clean",
-        mlk_poly_tobytes_asm((uint8_t *)data0, (int16_t *)data1));
-  BENCH("mlk_poly-mulcache-compute-clean",
-        mlk_poly_mulcache_compute_asm((int16_t *)data0, (int16_t *)data1,
-                                      (int16_t *)data2, (int16_t *)data3));
-#if MLKEM_K == 2
-  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-clean",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(
-            (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
-            (int16_t *)data3));
-#elif MLKEM_K == 3
-  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-clean",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(
-            (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
-            (int16_t *)data3));
-#elif MLKEM_K == 4
-  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-clean",
-        mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(
-            (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
-            (int16_t *)data3));
-#endif
-#endif /* MLK_ARITH_BACKEND_AARCH64_CLEAN */
+#if defined(MLK_ARITH_BACKEND_AARCH64)
 
-#if defined(MLK_ARITH_BACKEND_AARCH64_OPT)
-  BENCH("ntt-opt",
+  printf("---AArch64 native backend components---\n");
+
+  BENCH("ntt-native",
         mlk_ntt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
-  BENCH("intt-opt",
+  BENCH("intt-native",
         mlk_intt_asm((int16_t *)data0, (int16_t *)data1, (int16_t *)data2));
-  BENCH("mlk_poly-reduce-opt", mlk_poly_reduce_asm((int16_t *)data0));
-  BENCH("mlk_poly-tomont-opt", mlk_poly_tomont_asm((int16_t *)data0));
-  BENCH("mlk_poly-mulcache-compute-opt",
+  BENCH("mlk_poly-reduce-native", mlk_poly_reduce_asm((int16_t *)data0));
+  BENCH("mlk_poly-tomont-native", mlk_poly_tomont_asm((int16_t *)data0));
+  BENCH("mlk_poly-tobytes-native",
+        mlk_poly_tobytes_asm((uint8_t *)data0, (int16_t *)data1));
+  BENCH("mlk_poly-mulcache-compute-native",
         mlk_poly_mulcache_compute_asm((int16_t *)data0, (int16_t *)data1,
                                       (int16_t *)data2, (int16_t *)data3));
 #if MLKEM_K == 2
-  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-opt",
+  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-k2-native",
         mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #elif MLKEM_K == 3
-  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-opt",
+  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-k3-native",
         mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #elif MLKEM_K == 4
-  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-opt",
+  BENCH("mlk_polyvec-basemul-acc-montgomery-cached-asm-k4-native",
         mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(
             (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
             (int16_t *)data3));
 #endif
-#endif /* MLK_ARITH_BACKEND_AARCH64_OPT */
+
+#endif /* MLK_ARITH_BACKEND_AARCH64 */
 
   return 0;
 }


### PR DESCRIPTION
Remove CLEAN and OPT suffixes from MLK_ARITH_BACKEND_AARCH64 macro.
Additionally, report native backend is being benchmarked in `tests bench --components`

