### PR TITLE
Allow customization of randombytes function name 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,17 @@ jobs:
           kat: true
           acvp: true
           examples: false # Some examples use a custom config themselves
+      - name: "Custom randombytes"
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          cflags: "-std=c11 -D_GNU_SOURCE -DMLK_CONFIG_FILE=\\\\\\\"../test/custom_randombytes_config.h\\\\\\\" -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+          func: true
+          nistkat: true
+          kat: true
+          acvp: true
+          examples: false # Some examples use a custom config themselves
       - name: "MLKEM_GEN_MATRIX_NBLOCKS=1"
         uses: ./.github/actions/multi-functest
         with:

--- a/integration/liboqs/ML-KEM-1024_META.yml
+++ b/integration/liboqs/ML-KEM-1024_META.yml
@@ -30,7 +30,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_C_dec
-    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
+    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
   - name: x86_64
     version: FIPS203
     folder_name: .
@@ -38,7 +38,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_dec
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: x86_64
         operating_systems:
@@ -55,7 +55,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_dec
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: arm_8
         operating_systems:

--- a/integration/liboqs/ML-KEM-512_META.yml
+++ b/integration/liboqs/ML-KEM-512_META.yml
@@ -30,7 +30,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_C_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_C_dec
-    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
+    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
   - name: x86_64
     version: FIPS203
     folder_name: .
@@ -38,7 +38,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_dec
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: x86_64
         operating_systems:
@@ -55,7 +55,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_dec
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: arm_8
         operating_systems:

--- a/integration/liboqs/ML-KEM-768_META.yml
+++ b/integration/liboqs/ML-KEM-768_META.yml
@@ -30,7 +30,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_C_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_C_dec
-    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
+    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
   - name: x86_64
     version: FIPS203
     folder_name: .
@@ -38,7 +38,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_dec
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: x86_64
         operating_systems:
@@ -55,7 +55,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_dec
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/randombytes.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: arm_8
         operating_systems:

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -114,18 +114,18 @@
 #define MLK_FIPS202X4_CUSTOM_HEADER "../integration/liboqs/fips202x4_glue.h"
 
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -138,15 +138,14 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-/* #define MLK_USE_ZEROIZE_NATIVE
+/* #define MLK_CUSTOM_ZEROIZE
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+   static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }
@@ -192,7 +191,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_USE_ZEROIZE_NATIVE and provide a custom zeroization
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -154,6 +154,32 @@
 */
 
 /******************************************************************************
+ * Name:        MLK_CUSTOM_RANDOMBYTES
+ *
+ * Description: mlkem-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLK_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <oqs/rand.h>
+#include <stdint.h>
+#include "../../mlkem/sys.h"
+static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
+{
+  OQS_randombytes(ptr, len);
+}
+#endif
+
+/******************************************************************************
  * Name:        MLK_NO_ASM
  *
  * Description: If this option is set, mlkem-native will be built without

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -116,6 +116,32 @@
 */
 
 /******************************************************************************
+ * Name:        MLK_CUSTOM_RANDOMBYTES
+ *
+ * Description: mlkem-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLK_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <oqs/rand.h>
+#include <stdint.h>
+#include "../../mlkem/sys.h"
+static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
+{
+  OQS_randombytes(ptr, len);
+}
+#endif
+
+/******************************************************************************
  * Name:        MLK_NO_ASM
  *
  * Description: If this option is set, mlkem-native will be built without

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -76,18 +76,18 @@
 #define MLK_FIPS202X4_CUSTOM_HEADER "../integration/liboqs/fips202x4_glue.h"
 
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -100,15 +100,14 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-/* #define MLK_USE_ZEROIZE_NATIVE
+/* #define MLK_CUSTOM_ZEROIZE
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+   static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }
@@ -154,7 +153,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_USE_ZEROIZE_NATIVE and provide a custom zeroization
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -114,18 +114,18 @@
 #define MLK_FIPS202X4_CUSTOM_HEADER "../integration/liboqs/fips202x4_glue.h"
 
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -138,15 +138,14 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-/* #define MLK_USE_ZEROIZE_NATIVE
+/* #define MLK_CUSTOM_ZEROIZE
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+   static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }
@@ -193,7 +192,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_USE_ZEROIZE_NATIVE and provide a custom zeroization
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -154,6 +154,33 @@
 */
 
 /******************************************************************************
+ * Name:        MLK_CUSTOM_RANDOMBYTES
+ *
+ * Description: mlkem-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLK_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <oqs/rand.h>
+#include <stdint.h>
+#include "../../mlkem/sys.h"
+static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
+{
+  OQS_randombytes(ptr, len);
+}
+#endif
+
+
+/******************************************************************************
  * Name:        MLK_NO_ASM
  *
  * Description: If this option is set, mlkem-native will be built without

--- a/integration/liboqs/liboqs-check-filelist.py
+++ b/integration/liboqs/liboqs-check-filelist.py
@@ -30,8 +30,6 @@ def get_shared_sources(backend):
         for f in os.listdir(f"{MLKEM_DIR}/native")
         if os.path.isfile(f"{MLKEM_DIR}/native/{f}")
     ]
-    # randombytes.h is provided by liboqs
-    sources.remove("mlkem/randombytes.h")
     # We use a custom config
     sources.remove("mlkem/config.h")
     # Add FIPS202 glue code

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -263,6 +263,32 @@
 */
 
 /******************************************************************************
+ * Name:        MLK_CUSTOM_RANDOMBYTES
+ *
+ * Description: mlkem-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLK_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "sys.h"
+   static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
  * Name:        MLK_NO_ASM
  *
  * Description: If this option is set, mlkem-native will be built without

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -223,18 +223,18 @@
 /* #define MLK_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
 
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -247,15 +247,14 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-/* #define MLK_USE_ZEROIZE_NATIVE
+/* #define MLK_CUSTOM_ZEROIZE
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+   static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }
@@ -301,7 +300,7 @@
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_USE_ZEROIZE_NATIVE and provide a custom zeroization
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -221,7 +221,7 @@ int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   MLK_ALIGN uint8_t coins[2 * MLKEM_SYMBYTES];
 
   /* Acquire necessary randomness, and mark it as secret. */
-  randombytes(coins, 2 * MLKEM_SYMBYTES);
+  mlk_randombytes(coins, 2 * MLKEM_SYMBYTES);
   MLK_CT_TESTING_SECRET(coins, sizeof(coins));
 
   res = crypto_kem_keypair_derand(pk, sk, coins);
@@ -280,7 +280,7 @@ int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   int res;
   MLK_ALIGN uint8_t coins[MLKEM_SYMBYTES];
 
-  randombytes(coins, MLKEM_SYMBYTES);
+  mlk_randombytes(coins, MLKEM_SYMBYTES);
   MLK_CT_TESTING_SECRET(coins, sizeof(coins));
 
   res = crypto_kem_enc_derand(ct, ss, pk, coins);

--- a/mlkem/randombytes.h
+++ b/mlkem/randombytes.h
@@ -9,11 +9,14 @@
 #include <stdint.h>
 
 #include "cbmc.h"
+#include "common.h"
 
-void randombytes(uint8_t *out, size_t outlen)
+#if !defined(MLK_CUSTOM_RANDOMBYTES)
+void randombytes(uint8_t *out, size_t outlen);
+static MLK_INLINE void mlk_randombytes(uint8_t *out, size_t outlen)
 __contract__(
   requires(memory_no_alias(out, outlen))
-  assigns(memory_slice(out, outlen))
-);
+  assigns(memory_slice(out, outlen))) { randombytes(out, outlen); }
+#endif /* MLK_CUSTOM_RANDOMBYTES */
 
 #endif /* MLK_RANDOMBYTES_H */

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -221,20 +221,19 @@
  *
  *****************************************************************************/
 /* #define MLK_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
-
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -247,20 +246,20 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-/* #define MLK_USE_ZEROIZE_NATIVE
+/* #define MLK_CUSTOM_ZEROIZE
    #if !defined(__ASSEMBLER__)
    #include <stdint.h>
    #include "sys.h"
-   static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+   static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
    {
        ... your implementation ...
    }
    #endif
 */
+
 
 /******************************************************************************
  * Name:        MLK_KEYGEN_PCT

--- a/test/custom_randombytes_config.h
+++ b/test/custom_randombytes_config.h
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2024-2025 The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MLK_CONFIG_H
+#define MLK_CONFIG_H
+
+/******************************************************************************
+ * Name:        MLKEM_K
+ *
+ * Description: Determines the security level for ML-KEM
+ *              - MLKEM_K=2 corresponds to ML-KEM-512
+ *              - MLKEM_K=3 corresponds to ML-KEM-768
+ *              - MLKEM_K=4 corresponds to ML-KEM-1024
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#ifndef MLKEM_K
+#define MLKEM_K 3 /* Change this for different security strengths */
+#endif
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_FILE
+ *
+ * Description: If defined, this is a header that will be included instead
+ *              of this default configuration file mlkem/config.h.
+ *
+ *              When you need to build mlkem-native in multiple configurations,
+ *              using varying MLK_CONFIG_FILE can be more convenient
+ *              then configuring everything through CFLAGS.
+ *
+ *              To use, MLK_CONFIG_FILE _must_ be defined prior
+ *              to the inclusion of any mlkem-native headers. For example,
+ *              it can be set by passing `-DMLK_CONFIG_FILE="..."`
+ *              on the command line.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_FILE "config.h" */
+
+/******************************************************************************
+ * Name:        MLK_NAMESPACE_PREFIX
+ *
+ * Description: The prefix to use to namespace global symbols from mlkem/.
+ *
+ *              In a multi-level build (that is, if either
+ *              - MLK_MULTILEVEL_BUILD_WITH_SHARED, or
+ *              - MLK_MULTILEVEL_BUILD_NO_SHARED,
+ *              are set, level-dependent symbols will additionally be prefixed
+ *              with the security level.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if !defined(MLK_NAMESPACE_PREFIX)
+#define MLK_NAMESPACE_PREFIX MLK_DEFAULT_NAMESPACE_PREFIX
+#endif
+
+/******************************************************************************
+ * Name:        MLK_MULTILEVEL_BUILD_WITH_SHARED
+ *
+ * Description: This is for multi-level builds of mlkem-native only. If you
+ *              need only a single security level build of mlkem-native,
+ *              keep this unset.
+ *
+ *              If this is set, all MLKEM_K-independent code will be included
+ *              in the build, including code needed only for other security
+ *              levels.
+ *
+ *              Example: mlk_poly_cbd3 is only needed for MLKEM_K == 2. Yet, if
+ *              this option is set for a build with MLKEM_K==3/4, it would
+ *              be included.
+ *
+ *              To build mlkem-native with support for all security levels,
+ *              build it three times -- once per level -- and set the option
+ *              MLK_MULTILEVEL_BUILD_WITH_SHARED for exactly one of
+ *              them, and MLK_MULTILEVEL_BUILD_NO_SHARED for the
+ *              others.
+ *
+ *              See examples/multilevel_build for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_MULTILEVEL_BUILD_WITH_SHARED */
+
+/******************************************************************************
+ * Name:        MLK_MULTILEVEL_BUILD_NO_SHARED
+ *
+ * Description: This is for multi-level builds of mlkem-native only. If you
+ *              need only a single security level build of mlkem-native,
+ *              keep this unset.
+ *
+ *              If this is set, no MLKEM_K-independent code will be included
+ *              in the build.
+ *
+ *              To build mlkem-native with support for all security levels,
+ *              build it three times -- once per level -- and set the option
+ *              MLK_MULTILEVEL_BUILD_WITH_SHARED for exactly one of
+ *              them, and MLK_MULTILEVEL_BUILD_NO_SHARED for the
+ *              others.
+ *
+ *              See examples/multilevel_build for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_MULTILEVEL_BUILD_NO_SHARED */
+
+/******************************************************************************
+ * Name:        MLK_USE_NATIVE_BACKEND_ARITH
+ *
+ * Description: Determines whether an native arithmetic backend should be used.
+ *
+ *              The arithmetic backend covers performance critical functions
+ *              such as the number-theoretic transform (NTT).
+ *
+ *              If this option is unset, the C backend will be used.
+ *
+ *              If this option is set, the arithmetic backend to be use is
+ *              determined by MLK_ARITH_BACKEND: If the latter is
+ *              unset, the default backend for your the target architecture
+ *              will be used. If set, it must be the name of a backend metadata
+ *              file.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if !defined(MLK_USE_NATIVE_BACKEND_ARITH)
+/* #define MLK_USE_NATIVE_BACKEND_ARITH */
+#endif
+
+/******************************************************************************
+ * Name:        MLK_ARITH_BACKEND_FILE
+ *
+ * Description: The arithmetic backend to use.
+ *
+ *              If MLK_USE_NATIVE_BACKEND_ARITH is unset, this option
+ *              is ignored.
+ *
+ *              If MLK_USE_NATIVE_BACKEND_ARITH is set, this option must
+ *              either be undefined or the filename of an arithmetic backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if defined(MLK_USE_NATIVE_BACKEND_ARITH) && !defined(MLK_ARITH_BACKEND_FILE)
+#define MLK_ARITH_BACKEND_FILE "native/meta.h"
+#endif
+
+/******************************************************************************
+ * Name:        MLK_USE_NATIVE_BACKEND_FIPS202
+ *
+ * Description: Determines whether an native FIPS202 backend should be used.
+ *
+ *              The FIPS202 backend covers 1x/2x/4x-fold Keccak-f1600, which is
+ *              the performance bottleneck of SHA3 and SHAKE.
+ *
+ *              If this option is unset, the C backend will be used.
+ *
+ *              If this option is set, the FIPS202 backend to be use is
+ *              determined by MLK_FIPS202_BACKEND: If the latter is
+ *              unset, the default backend for your the target architecture
+ *              will be used. If set, it must be the name of a backend metadata
+ *              file.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if !defined(MLK_USE_NATIVE_BACKEND_FIPS202)
+/* #define MLK_USE_NATIVE_BACKEND_FIPS202 */
+#endif
+
+/******************************************************************************
+ * Name:        MLK_FIPS202_BACKEND_FILE
+ *
+ * Description: The FIPS-202 backend to use.
+ *
+ *              If MLK_USE_NATIVE_BACKEND_FIPS202 is set, this option must
+ *              either be undefined or the filename of a FIPS202 backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if defined(MLK_USE_NATIVE_BACKEND_FIPS202) && \
+    !defined(MLK_FIPS202_BACKEND_FILE)
+#define MLK_FIPS202_BACKEND_FILE "fips202/native/auto.h"
+#endif
+
+/******************************************************************************
+ * Name:        MLK_FIPS202_CUSTOM_HEADER
+ *
+ * Description: Custom header to use for FIPS-202
+ *
+ *              This should only be set if you intend to use a custom
+ *              FIPS-202 implementation, different from the one shipped
+ *              with mlkem-native.
+ *
+ *              If set, it must be the name of a file serving as the
+ *              replacement for mlkem/fips202/fips202.h, and exposing
+ *              the same API (see FIPS202.md).
+ *
+ *****************************************************************************/
+/* #define MLK_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
+/******************************************************************************
+ * Name:        MLK_FIPS202X4_CUSTOM_HEADER
+ *
+ * Description: Custom header to use for FIPS-202-X4
+ *
+ *              This should only be set if you intend to use a custom
+ *              FIPS-202 implementation, different from the one shipped
+ *              with mlkem-native.
+ *
+ *              If set, it must be the name of a file serving as the
+ *              replacement for mlkem/fips202/fips202x4.h, and exposing
+ *              the same API (see FIPS202.md).
+ *
+ *****************************************************************************/
+/* #define MLK_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
+/******************************************************************************
+ * Name:        MLK_CUSTOM_ZEROIZE
+ *
+ * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
+ *              intermediate stack buffers before returning from function calls.
+ *
+ *              Set this option and define `mlk_zeroize` if you want to
+ *              use a custom method to zeroize intermediate stack buffers.
+ *              The default implementation uses SecureZeroMemory on Windows
+ *              and a memset + compiler barrier otherwise. If neither of those
+ *              is available on the target platform, compilation will fail,
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
+ *
+ *              WARNING:
+ *              The explicit stack zeroization conducted by mlkem-native
+ *              reduces the likelihood of data leaking on the stack, but
+ *              does not eliminate it! The C standard makes no guarantee about
+ *              where a compiler allocates structures and whether/where it makes
+ *              copies of them. Also, in addition to entire structures, there
+ *              may also be potentially exploitable leakage of individual values
+ *              on the stack.
+ *
+ *              If you need bullet-proof zeroization of the stack, you need to
+ *              consider additional measures instead of of what this feature
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
+ *
+ *****************************************************************************/
+/*
+#define MLK_CUSTOM_ZEROIZE
+#if !defined(__ASSEMBLER__)
+#include <stdint.h>
+#include <string.h>
+#include "../mlkem/sys.h"
+static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
+{
+  explicit_bzero(ptr, len);
+}
+#endif
+*/
+
+/******************************************************************************
+ * Name:        MLK_CUSTOM_RANDOMBYTES
+ *
+ * Description: mlkem-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+#define MLK_CUSTOM_RANDOMBYTES
+#if !defined(__ASSEMBLER__)
+#include <stdint.h>
+#include "../mlkem/sys.h"
+#include "notrandombytes/notrandombytes.h"
+static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
+{
+  randombytes(ptr, len);
+}
+#endif
+
+
+
+/******************************************************************************
+ * Name:        MLK_NO_ASM
+ *
+ * Description: If this option is set, mlkem-native will be built without
+ *              use of native code or inline assembly.
+ *
+ *              By default, inline assembly is used to implement value barriers.
+ *              Without inline assembly, mlkem-native will use a global volatile
+ *              'opt blocker' instead; see verify.h.
+ *
+ *              Inline assembly is also used to implement a secure zeroization
+ *              function on non-Windows platforms. If this option is set and
+ *              the target platform is not Windows, you MUST set
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
+ *              function.
+ *
+ *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and
+ *              and MLK_USE_NATIVE_BACKEND_ARITH will be ignored, and no native
+ *              backends will be used.
+ *
+ *****************************************************************************/
+/* #define MLK_NO_ASM */
+
+/******************************************************************************
+ * Name:        MLK_KEYGEN_PCT
+ *
+ * Description: Compliance with [FIPS 140-3
+ *IG](https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf)
+ *              requires a Pairwise Consistency Test (PCT) to be carried out
+ *              on a freshly generated keypair before it can be exported.
+ *
+ *              Set this option if such a check should be implemented.
+ *              In this case, crypto_kem_keypair_derand and crypto_kem_keypair
+ *              will return a non-zero error code if the PCT failed.
+ *
+ *              NOTE: This feature will drastically lower the performance of
+ *              key generation.
+ *
+ *****************************************************************************/
+/* #define MLK_KEYGEN_PCT */
+
+/******************************************************************************
+ * Name:        MLK_KEYGEN_PCT_BREAKAGE_TEST
+ *
+ * Description: If this option is set, the user must provide a runtime
+ *              function `static inline int mlk_break_pct() { ... }` to
+ *              indicate whether the PCT should be made fail.
+ *
+ *              This option only has an effect if MLK_KEYGEN_PCT is set.
+ *
+ *****************************************************************************/
+/* #define MLK_KEYGEN_PCT_BREAKAGE_TEST
+   #if !defined(__ASSEMBLER__)
+   #include "sys.h"
+   static MLK_INLINE int mlk_break_pct(void)
+   {
+       ... return 0/1 depending on whether PCT should be broken ...
+   }
+   #endif
+*/
+
+/*************************  Config internals  ********************************/
+
+/* Default namespace
+ *
+ * Don't change this. If you need a different namespace, re-define
+ * MLK_NAMESPACE_PREFIX above instead, and remove the following.
+ *
+ * The default MLKEM namespace is
+ *
+ *   PQCP_MLKEM_NATIVE_MLKEM<LEVEL>_
+ *
+ * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
+ */
+
+#if MLKEM_K == 2
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
+#elif MLKEM_K == 3
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768
+#elif MLKEM_K == 4
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM1024
+#endif
+
+#endif /* MLK_CONFIG_H */

--- a/test/custom_zeroize_config.h
+++ b/test/custom_zeroize_config.h
@@ -223,18 +223,18 @@
 /* #define MLK_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
 
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -247,16 +247,16 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-#define MLK_USE_ZEROIZE_NATIVE
+
+#define MLK_CUSTOM_ZEROIZE
 #if !defined(__ASSEMBLER__)
 #include <stdint.h>
 #include <string.h>
 #include "../mlkem/sys.h"
-static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
 {
   explicit_bzero(ptr, len);
 }
@@ -275,7 +275,7 @@ static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_USE_ZEROIZE_NATIVE and provide a custom zeroization
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and

--- a/test/no_asm_config.h
+++ b/test/no_asm_config.h
@@ -224,18 +224,18 @@
 /* #define MLK_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
 
 /******************************************************************************
- * Name:        MLK_USE_ZEROIZE_NATIVE
+ * Name:        MLK_CUSTOM_ZEROIZE
  *
  * Description: In compliance with FIPS 203 Section 3.3, mlkem-native zeroizes
  *              intermediate stack buffers before returning from function calls.
  *
- *              Set this option and define `mlk_zeroize_native` if you want to
+ *              Set this option and define `mlk_zeroize` if you want to
  *              use a custom method to zeroize intermediate stack buffers.
  *              The default implementation uses SecureZeroMemory on Windows
  *              and a memset + compiler barrier otherwise. If neither of those
  *              is available on the target platform, compilation will fail,
- *              and you will need to use MLK_USE_ZEROIZE_NATIVE to provide
- *              a custom implementation of `mlk_zeroize_native()`.
+ *              and you will need to use MLK_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
  *
  *              WARNING:
  *              The explicit stack zeroization conducted by mlkem-native
@@ -248,16 +248,15 @@
  *
  *              If you need bullet-proof zeroization of the stack, you need to
  *              consider additional measures instead of of what this feature
- *              provides. In this case, you can set mlk_zeroize_native to a
- *              no-op.
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
-#define MLK_USE_ZEROIZE_NATIVE
+#define MLK_CUSTOM_ZEROIZE
 #if !defined(__ASSEMBLER__)
 #include <stdint.h>
 #include <string.h>
 #include "../mlkem/sys.h"
-static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
+static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
 {
   explicit_bzero(ptr, len);
 }
@@ -276,7 +275,7 @@ static MLK_INLINE void mlk_zeroize_native(void *ptr, size_t len)
  *              Inline assembly is also used to implement a secure zeroization
  *              function on non-Windows platforms. If this option is set and
  *              the target platform is not Windows, you MUST set
- *              MLK_USE_ZEROIZE_NATIVE and provide a custom zeroization
+ *              MLK_CUSTOM_ZEROIZE and provide a custom zeroization
  *              function.
  *
  *              If this option is set, MLK_USE_NATIVE_BACKEND_FIPS202 and


### PR DESCRIPTION
Resolves https://github.com/pq-code-package/mlkem-native/issues/640

This commit makes the name of the randombytes function configurable through
the config.h. Thus far, we have been assuming the function to be called
randombytes.