### PR TITLE
HOL-Light: Update to `main` for support of `HOLLIGHT_LOAD_PATH`

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -9,11 +9,15 @@ on:
     paths:
      - 'proofs/hol_light/arm/**/*.S'
      - 'proofs/hol_light/arm/**/*.ml'
+     - 'nix/hol_light/*'
+     - 'nix/s2n_bignum/*'
   pull_request:
     branches: ["main"]
     paths:
       - 'proofs/hol_light/arm/**/*.S'
       - 'proofs/hol_light/arm/**/*.ml'
+      - 'nix/hol_light/*'
+      - 'nix/s2n_bignum/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,6 +74,12 @@ jobs:
                fi
             done
           done
+
+          # Always re-run upon change to nix files for HOL-Light
+          if [[ "$changed_files" == *"nix/"* ]]; then
+            run_needed=1
+          fi
+
           echo "run_needed=${run_needed}" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/setup-shell
         if: |

--- a/nix/hol_light/default.nix
+++ b/nix/hol_light/default.nix
@@ -10,8 +10,8 @@ hol_light.overrideAttrs (old: {
   src = fetchFromGitHub {
     owner = "jrh13";
     repo = "hol-light";
-    rev = "c5e165f85dfb340a786dabd1073a24aa421dd61b";
-    hash = "sha256-umKHUsVKBVZ9EZzu3Ry9harbslP9uWlo11YDxNLaYZY";
+    rev = "0e4b1bd8c7d400214d6fa6027f15a4221b54f8d4";
+    hash = "sha256-M6ddzqoAFyMBmaznuz31+o035xdEz4VXZMHhH4Dm4c8=";
   };
   patches = [ ./0005-Fix-hollight-path.patch ];
   propagatedBuildInputs = old.propagatedBuildInputs ++ old.nativeBuildInputs;


### PR DESCRIPTION
This commit updates the HOL-Light version in the nix shell
to the latest `main` after the merge of the patch

https://github.com/jrh13/hol-light/pull/131

adding support for the HOLLIGHT_LOAD_PATH environment variable.

This removes the need for an ad-hoc patching of inline_load.ml
in our adaptation of build-proof.sh.