### PR TITLE
Remove outdated CC0 notices

### DIFF
--- a/examples/bring_your_own_fips202/mlkem_native/LICENSE
+++ b/examples/bring_your_own_fips202/mlkem_native/LICENSE
@@ -1,1 +1,0 @@
-../../../mlkem/LICENSE

--- a/examples/custom_backend/mlkem_native/mlkem/LICENSE
+++ b/examples/custom_backend/mlkem_native/mlkem/LICENSE
@@ -1,1 +1,0 @@
-../../../../mlkem/LICENSE

--- a/examples/custom_backend/mlkem_native/mlkem/fips202/LICENSE
+++ b/examples/custom_backend/mlkem_native/mlkem/fips202/LICENSE
@@ -1,1 +1,0 @@
-../../../../../mlkem/fips202/LICENSE

--- a/integration/liboqs/ML-KEM-1024_META.yml
+++ b/integration/liboqs/ML-KEM-1024_META.yml
@@ -30,7 +30,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_C_dec
-    sources: mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
+    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
   - name: x86_64
     version: FIPS203
     folder_name: .
@@ -38,7 +38,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_dec
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: x86_64
         operating_systems:
@@ -55,7 +55,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_dec
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: arm_8
         operating_systems:

--- a/integration/liboqs/ML-KEM-512_META.yml
+++ b/integration/liboqs/ML-KEM-512_META.yml
@@ -30,7 +30,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_C_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_C_dec
-    sources: mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
+    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
   - name: x86_64
     version: FIPS203
     folder_name: .
@@ -38,7 +38,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_dec
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: x86_64
         operating_systems:
@@ -55,7 +55,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_dec
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: arm_8
         operating_systems:

--- a/integration/liboqs/ML-KEM-768_META.yml
+++ b/integration/liboqs/ML-KEM-768_META.yml
@@ -30,7 +30,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_C_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_C_dec
-    sources: mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
+    sources: mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc mlkem/native/api.h mlkem/native/meta.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h integration/liboqs/config_c.h
   - name: x86_64
     version: FIPS203
     folder_name: .
@@ -38,7 +38,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_dec
-    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/x86_64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: x86_64
         operating_systems:
@@ -55,7 +55,7 @@ implementations:
     signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_keypair
     signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_enc
     signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_dec
-    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/LICENSE mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
+    sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h mlkem/cbmc.h mlkem/common.h mlkem/compress.c mlkem/compress.h mlkem/debug.c mlkem/debug.h mlkem/indcpa.c mlkem/indcpa.h mlkem/kem.c mlkem/kem.h mlkem/mlkem_native.h mlkem/native/api.h mlkem/native/meta.h mlkem/native/aarch64 mlkem/params.h mlkem/poly.c mlkem/poly.h mlkem/poly_k.c mlkem/poly_k.h mlkem/sampling.c mlkem/sampling.h mlkem/symmetric.h mlkem/sys.h mlkem/verify.c mlkem/verify.h mlkem/zetas.inc
     supported_platforms:
       - architecture: arm_8
         operating_systems:

--- a/mlkem/LICENSE
+++ b/mlkem/LICENSE
@@ -1,6 +1,0 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
-or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
-
-For Keccak and AES we are using public-domain
-code from sources and by authors listed in
-comments on top of the respective files.

--- a/mlkem/fips202/LICENSE
+++ b/mlkem/fips202/LICENSE
@@ -1,7 +1,0 @@
-Based on the CC0 implementation in https://github.com/mupq/mupq and
-the public domain implementation in
-crypto_hash/keccakc512/simple/ from http://bench.cr.yp.to/supercop.html
-by Ronny Van Keer
-and the public domain "TweetFips202" implementation
-from https://twitter.com/tweetfips202
-by Gilles Van Assche, Daniel J. Bernstein, and Peter Schwabe


### PR DESCRIPTION

mlkem-native is Apache-2.0 licensed as indicated in the toplevel
LICENSE file. This commit removes multiple outdated CC0 license
notes from the initial import of the reference implementation.

The note on the origin of the FIPS-202 C implementation is still
present in mlkem/fips202/keccakf1600.c.
