### PR TITLE
HOL-Light: Add low-level spec and proof for AArch64 basemul

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -40,6 +40,12 @@ jobs:
             needs: ["mlkem_specs.ml", "mlkem_utils.ml"]
           - name: mlkem_poly_reduce
             needs: ["mlkem_specs.ml", "mlkem_utils.ml"]
+          - name: mlkem_poly_basemul_acc_montgomery_cached_k2
+            needs: ["mlkem_specs.ml", "mlkem_utils.ml"]
+          - name: mlkem_poly_basemul_acc_montgomery_cached_k3
+            needs: ["mlkem_specs.ml", "mlkem_utils.ml"]
+          - name: mlkem_poly_basemul_acc_montgomery_cached_k4
+            needs: ["mlkem_specs.ml", "mlkem_utils.ml"]
           - name: keccak_f1600_x1_scalar
             needs: ["keccak_specs.ml"]
           - name: keccak_f1600_x1_v84a

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -2,12 +2,12 @@
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";
-  version = "ea86b7535c49425b149d7ae88809ed97e3697661";
+  version = "4ee6cb44e7aab3d48de72a461491b3a70494df35";
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "s2n-bignum";
     rev = "${version}";
-    hash = "sha256-R5x7UT1flnXtDhZssTH+24fHawFOI8KwFmAAQ+x+Nk0=";
+    hash = "sha256-ay69mWbA/oBffVtEvAU/XBKOajlzukHXUTKYawwn2Ik=";
   };
   setupHook = writeText "setup-hook.sh" ''
     export S2N_BIGNUM_DIR="$1"

--- a/proofs/hol_light/arm/Makefile
+++ b/proofs/hol_light/arm/Makefile
@@ -65,15 +65,18 @@ endif
 endif
 endif
 
-OBJ = mlkem/mlkem_ntt.o                       \
-      mlkem/mlkem_intt.o                      \
-      mlkem/mlkem_poly_tomont.o               \
-      mlkem/mlkem_poly_mulcache_compute.o     \
-      mlkem/mlkem_poly_reduce.o               \
-      mlkem/keccak_f1600_x1_scalar.o          \
-      mlkem/keccak_f1600_x1_v84a.o            \
-      mlkem/keccak_f1600_x2_v84a.o            \
-      mlkem/keccak_f1600_x4_v8a_v84a_scalar.o \
+OBJ = mlkem/mlkem_ntt.o                                   \
+      mlkem/mlkem_intt.o                                  \
+      mlkem/mlkem_poly_tomont.o                           \
+      mlkem/mlkem_poly_mulcache_compute.o                 \
+      mlkem/mlkem_poly_reduce.o                           \
+      mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.o \
+      mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.o \
+      mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.o \
+      mlkem/keccak_f1600_x1_scalar.o                      \
+      mlkem/keccak_f1600_x1_v84a.o                        \
+      mlkem/keccak_f1600_x2_v84a.o                        \
+      mlkem/keccak_f1600_x4_v8a_v84a_scalar.o             \
       mlkem/keccak_f1600_x4_v8a_scalar.o
 
 # According to

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024-2025 The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// AArch64 re-implementation of the asymmetric base multiplication from:
+
+// Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1
+// https://eprint.iacr.org/2021/986
+// https://github.com/neon-ntt/neon-ntt
+
+
+/*
+ * WARNING: This file is auto-derived from the mlkem-native source file
+ *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S using scripts/simpasm. Do not modify it directly.
+ */
+
+
+.text
+.balign 4
+#ifdef __APPLE__
+.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k2
+_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k2:
+#else
+.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k2
+PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k2:
+#endif
+
+        sub	sp, sp, #0x40
+        stp	d8, d9, [sp]
+        stp	d10, d11, [sp, #0x10]
+        stp	d12, d13, [sp, #0x20]
+        stp	d14, d15, [sp, #0x30]
+        mov	w14, #0xd01             // =3329
+        dup	v0.8h, w14
+        mov	w14, #0xcff             // =3327
+        dup	v2.8h, w14
+        add	x4, x1, #0x200
+        add	x5, x2, #0x200
+        add	x6, x3, #0x100
+        mov	x13, #0x10              // =16
+        ldr	q9, [x4], #0x20
+        ldur	q5, [x4, #-0x10]
+        ldr	q11, [x5], #0x20
+        uzp1	v23.8h, v9.8h, v5.8h
+        uzp2	v9.8h, v9.8h, v5.8h
+        ldr	q5, [x2], #0x20
+        ldur	q7, [x5, #-0x10]
+        ldur	q21, [x2, #-0x10]
+        uzp2	v10.8h, v11.8h, v7.8h
+        uzp1	v11.8h, v11.8h, v7.8h
+        uzp1	v7.8h, v5.8h, v21.8h
+        uzp2	v5.8h, v5.8h, v21.8h
+        ldr	q21, [x1], #0x20
+        ldur	q25, [x1, #-0x10]
+        ld1	{ v6.8h }, [x3], #16
+        uzp1	v26.8h, v21.8h, v25.8h
+        uzp2	v21.8h, v21.8h, v25.8h
+        smull	v25.4s, v26.4h, v5.4h
+        smull2	v5.4s, v26.8h, v5.8h
+        smull	v19.4s, v26.4h, v7.4h
+        smull2	v26.4s, v26.8h, v7.8h
+        smlal	v25.4s, v21.4h, v7.4h
+        smlal2	v5.4s, v21.8h, v7.8h
+        smlal	v19.4s, v21.4h, v6.4h
+        smlal2	v26.4s, v21.8h, v6.8h
+        smlal	v25.4s, v23.4h, v10.4h
+        smlal2	v5.4s, v23.8h, v10.8h
+        smlal	v19.4s, v23.4h, v11.4h
+        smlal2	v26.4s, v23.8h, v11.8h
+        ld1	{ v23.8h }, [x6], #16
+        smlal	v25.4s, v9.4h, v11.4h
+        smlal2	v5.4s, v9.8h, v11.8h
+        smlal2	v26.4s, v9.8h, v23.8h
+        smlal	v19.4s, v9.4h, v23.4h
+        ldr	q9, [x4], #0x20
+        uzp1	v11.8h, v25.8h, v5.8h
+        uzp1	v23.8h, v19.8h, v26.8h
+        mul	v11.8h, v11.8h, v2.8h
+        mul	v23.8h, v23.8h, v2.8h
+        ldr	q7, [x5], #0x20
+        smlal2	v5.4s, v11.8h, v0.8h
+        smlal	v25.4s, v11.4h, v0.4h
+        ldr	q11, [x2], #0x20
+        ldur	q21, [x2, #-0x10]
+        ldur	q6, [x4, #-0x10]
+        uzp1	v17.8h, v11.8h, v21.8h
+        ldr	q10, [x1], #0x20
+        ldur	q29, [x1, #-0x10]
+        uzp2	v11.8h, v11.8h, v21.8h
+        uzp1	v13.8h, v9.8h, v6.8h
+        uzp1	v3.8h, v10.8h, v29.8h
+        uzp2	v10.8h, v10.8h, v29.8h
+        smull	v12.4s, v3.4h, v11.4h
+        smull2	v11.4s, v3.8h, v11.8h
+        ldur	q21, [x5, #-0x10]
+        smlal	v12.4s, v10.4h, v17.4h
+        smlal2	v11.4s, v10.8h, v17.8h
+        uzp2	v29.8h, v7.8h, v21.8h
+        uzp1	v15.8h, v7.8h, v21.8h
+        smlal	v12.4s, v13.4h, v29.4h
+        smlal2	v11.4s, v13.8h, v29.8h
+        uzp2	v28.8h, v9.8h, v6.8h
+        smlal2	v26.4s, v23.8h, v0.8h
+        smlal	v12.4s, v28.4h, v15.4h
+        smlal2	v11.4s, v28.8h, v15.8h
+        smlal	v19.4s, v23.4h, v0.4h
+        uzp2	v27.8h, v25.8h, v5.8h
+        smull	v23.4s, v3.4h, v17.4h
+        uzp1	v9.8h, v12.8h, v11.8h
+        uzp2	v19.8h, v19.8h, v26.8h
+        mul	v14.8h, v9.8h, v2.8h
+        ld1	{ v22.8h }, [x6], #16
+        zip2	v9.8h, v19.8h, v27.8h
+        smlal2	v11.4s, v14.8h, v0.8h
+        ld1	{ v4.8h }, [x3], #16
+        sub	x13, x13, #0x2
+
+polyvec_basemul_acc_montgomery_cached_asm_k2_loop:
+        smull2	v20.4s, v3.8h, v17.8h
+        ldr	q18, [x4], #0x20
+        ldr	q30, [x5], #0x20
+        smlal2	v20.4s, v10.8h, v4.8h
+        smlal	v12.4s, v14.4h, v0.4h
+        smlal	v23.4s, v10.4h, v4.4h
+        str	q9, [x0, #0x10]
+        smlal2	v20.4s, v13.8h, v15.8h
+        ldr	q8, [x2], #0x20
+        smlal	v23.4s, v13.4h, v15.4h
+        smlal2	v20.4s, v28.8h, v22.8h
+        zip1	v26.8h, v19.8h, v27.8h
+        ldur	q9, [x2, #-0x10]
+        smlal	v23.4s, v28.4h, v22.4h
+        uzp2	v27.8h, v12.8h, v11.8h
+        uzp1	v17.8h, v8.8h, v9.8h
+        uzp2	v4.8h, v8.8h, v9.8h
+        uzp1	v5.8h, v23.8h, v20.8h
+        str	q26, [x0], #0x20
+        mul	v31.8h, v5.8h, v2.8h
+        ldur	q19, [x4, #-0x10]
+        ldr	q29, [x1], #0x20
+        ldur	q12, [x1, #-0x10]
+        smlal2	v20.4s, v31.8h, v0.8h
+        uzp1	v13.8h, v18.8h, v19.8h
+        uzp1	v3.8h, v29.8h, v12.8h
+        uzp2	v10.8h, v29.8h, v12.8h
+        smull	v12.4s, v3.4h, v4.4h
+        smull2	v11.4s, v3.8h, v4.8h
+        ldur	q5, [x5, #-0x10]
+        smlal	v12.4s, v10.4h, v17.4h
+        smlal2	v11.4s, v10.8h, v17.8h
+        uzp2	v14.8h, v30.8h, v5.8h
+        uzp1	v15.8h, v30.8h, v5.8h
+        smlal	v12.4s, v13.4h, v14.4h
+        smlal2	v11.4s, v13.8h, v14.8h
+        uzp2	v28.8h, v18.8h, v19.8h
+        smlal	v23.4s, v31.4h, v0.4h
+        smlal	v12.4s, v28.4h, v15.4h
+        smlal2	v11.4s, v28.8h, v15.8h
+        ld1	{ v22.8h }, [x6], #16
+        uzp2	v19.8h, v23.8h, v20.8h
+        uzp1	v1.8h, v12.8h, v11.8h
+        smull	v23.4s, v3.4h, v17.4h
+        mul	v14.8h, v1.8h, v2.8h
+        zip2	v9.8h, v19.8h, v27.8h
+        ld1	{ v4.8h }, [x3], #16
+        smlal2	v11.4s, v14.8h, v0.8h
+        sub	x13, x13, #0x1
+        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k2_loop
+        smull2	v5.4s, v3.8h, v17.8h
+        smlal	v12.4s, v14.4h, v0.4h
+        smlal	v23.4s, v10.4h, v4.4h
+        str	q9, [x0, #0x10]
+        smlal2	v5.4s, v10.8h, v4.8h
+        uzp2	v11.8h, v12.8h, v11.8h
+        zip1	v9.8h, v19.8h, v27.8h
+        smlal	v23.4s, v13.4h, v15.4h
+        smlal2	v5.4s, v13.8h, v15.8h
+        str	q9, [x0], #0x20
+        smlal	v23.4s, v28.4h, v22.4h
+        smlal2	v5.4s, v28.8h, v22.8h
+        uzp1	v9.8h, v23.8h, v5.8h
+        mul	v9.8h, v9.8h, v2.8h
+        smlal2	v5.4s, v9.8h, v0.8h
+        smlal	v23.4s, v9.4h, v0.4h
+        uzp2	v9.8h, v23.8h, v5.8h
+        zip2	v5.8h, v9.8h, v11.8h
+        zip1	v9.8h, v9.8h, v11.8h
+        str	q5, [x0, #0x10]
+        str	q9, [x0], #0x20
+        ldp	d8, d9, [sp]
+        ldp	d10, d11, [sp, #0x10]
+        ldp	d12, d13, [sp, #0x20]
+        ldp	d14, d15, [sp, #0x30]
+        add	sp, sp, #0x40
+        ret

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2024-2025 The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// AArch64 re-implementation of the asymmetric base multiplication from:
+
+// Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1
+// https://eprint.iacr.org/2021/986
+// https://github.com/neon-ntt/neon-ntt
+
+
+/*
+ * WARNING: This file is auto-derived from the mlkem-native source file
+ *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S using scripts/simpasm. Do not modify it directly.
+ */
+
+
+.text
+.balign 4
+#ifdef __APPLE__
+.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k3
+_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k3:
+#else
+.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k3
+PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k3:
+#endif
+
+        sub	sp, sp, #0x40
+        stp	d8, d9, [sp]
+        stp	d10, d11, [sp, #0x10]
+        stp	d12, d13, [sp, #0x20]
+        stp	d14, d15, [sp, #0x30]
+        mov	w14, #0xd01             // =3329
+        dup	v0.8h, w14
+        mov	w14, #0xcff             // =3327
+        dup	v2.8h, w14
+        add	x4, x1, #0x200
+        add	x5, x2, #0x200
+        add	x6, x3, #0x100
+        add	x7, x1, #0x400
+        add	x8, x2, #0x400
+        add	x9, x3, #0x200
+        mov	x13, #0x10              // =16
+        ldr	q7, [x2, #0x10]
+        ldr	q20, [x2], #0x20
+        ldr	q15, [x1, #0x10]
+        uzp1	v8.8h, v20.8h, v7.8h
+        uzp2	v7.8h, v20.8h, v7.8h
+        ld1	{ v20.8h }, [x3], #16
+        ldr	q30, [x1], #0x20
+        ldr	q11, [x4], #0x20
+        uzp1	v16.8h, v30.8h, v15.8h
+        uzp2	v15.8h, v30.8h, v15.8h
+        smull	v30.4s, v16.4h, v7.4h
+        smull2	v7.4s, v16.8h, v7.8h
+        smull	v9.4s, v16.4h, v8.4h
+        smull2	v16.4s, v16.8h, v8.8h
+        smlal	v30.4s, v15.4h, v8.4h
+        smlal2	v7.4s, v15.8h, v8.8h
+        smlal	v9.4s, v15.4h, v20.4h
+        smlal2	v16.4s, v15.8h, v20.8h
+        ldur	q20, [x4, #-0x10]
+        ldr	q15, [x5], #0x20
+        uzp1	v8.8h, v11.8h, v20.8h
+        uzp2	v20.8h, v11.8h, v20.8h
+        ldur	q11, [x5, #-0x10]
+        ld1	{ v27.8h }, [x6], #16
+        uzp1	v10.8h, v15.8h, v11.8h
+        uzp2	v15.8h, v15.8h, v11.8h
+        smlal	v9.4s, v8.4h, v10.4h
+        smlal2	v16.4s, v8.8h, v10.8h
+        smlal	v30.4s, v8.4h, v15.4h
+        smlal2	v7.4s, v8.8h, v15.8h
+        smlal	v9.4s, v20.4h, v27.4h
+        smlal2	v16.4s, v20.8h, v27.8h
+        smlal	v30.4s, v20.4h, v10.4h
+        smlal2	v7.4s, v20.8h, v10.8h
+        ldr	q20, [x7], #0x20
+        ldur	q15, [x7, #-0x10]
+        ldr	q8, [x8], #0x20
+        uzp1	v11.8h, v20.8h, v15.8h
+        uzp2	v20.8h, v20.8h, v15.8h
+        ldur	q15, [x8, #-0x10]
+        ld1	{ v27.8h }, [x9], #16
+        uzp1	v10.8h, v8.8h, v15.8h
+        uzp2	v15.8h, v8.8h, v15.8h
+        smlal	v9.4s, v11.4h, v10.4h
+        smlal2	v16.4s, v11.8h, v10.8h
+        smlal	v30.4s, v11.4h, v15.4h
+        smlal2	v7.4s, v11.8h, v15.8h
+        smlal	v9.4s, v20.4h, v27.4h
+        smlal2	v16.4s, v20.8h, v27.8h
+        smlal	v30.4s, v20.4h, v10.4h
+        smlal2	v7.4s, v20.8h, v10.8h
+        ldr	q15, [x2], #0x20
+        uzp1	v20.8h, v9.8h, v16.8h
+        uzp1	v8.8h, v30.8h, v7.8h
+        mul	v20.8h, v20.8h, v2.8h
+        mul	v8.8h, v8.8h, v2.8h
+        ldr	q21, [x4], #0x20
+        smlal	v9.4s, v20.4h, v0.4h
+        smlal2	v16.4s, v20.8h, v0.8h
+        smlal	v30.4s, v8.4h, v0.4h
+        smlal2	v7.4s, v8.8h, v0.8h
+        ldur	q6, [x4, #-0x10]
+        uzp2	v27.8h, v9.8h, v16.8h
+        uzp2	v10.8h, v30.8h, v7.8h
+        ldur	q16, [x2, #-0x10]
+        ldr	q30, [x1, #0x10]
+        ld1	{ v9.8h }, [x3], #16
+        ldr	q1, [x5], #0x20
+        ldur	q12, [x5, #-0x10]
+        ld1	{ v24.8h }, [x6], #16
+        ldr	q19, [x7], #0x20
+        ldur	q31, [x7, #-0x10]
+        ldr	q17, [x8], #0x20
+        ldur	q18, [x8, #-0x10]
+        ld1	{ v25.8h }, [x9], #16
+        sub	x13, x13, #0x2
+
+polyvec_basemul_acc_montgomery_cached_asm_k3_loop:
+        ldr	q20, [x1], #0x20
+        uzp1	v7.8h, v15.8h, v16.8h
+        uzp2	v15.8h, v15.8h, v16.8h
+        uzp1	v8.8h, v20.8h, v30.8h
+        uzp2	v20.8h, v20.8h, v30.8h
+        smull	v30.4s, v8.4h, v15.4h
+        smull2	v15.4s, v8.8h, v15.8h
+        smull	v11.4s, v8.4h, v7.4h
+        smull2	v8.4s, v8.8h, v7.8h
+        smlal	v30.4s, v20.4h, v7.4h
+        smlal2	v15.4s, v20.8h, v7.8h
+        smlal	v11.4s, v20.4h, v9.4h
+        smlal2	v8.4s, v20.8h, v9.8h
+        uzp1	v7.8h, v21.8h, v6.8h
+        uzp2	v20.8h, v21.8h, v6.8h
+        uzp1	v16.8h, v1.8h, v12.8h
+        uzp2	v9.8h, v1.8h, v12.8h
+        smlal	v11.4s, v7.4h, v16.4h
+        smlal2	v8.4s, v7.8h, v16.8h
+        smlal	v30.4s, v7.4h, v9.4h
+        smlal2	v15.4s, v7.8h, v9.8h
+        smlal	v11.4s, v20.4h, v24.4h
+        smlal2	v8.4s, v20.8h, v24.8h
+        smlal	v30.4s, v20.4h, v16.4h
+        smlal2	v15.4s, v20.8h, v16.8h
+        uzp1	v7.8h, v19.8h, v31.8h
+        uzp2	v20.8h, v19.8h, v31.8h
+        uzp1	v16.8h, v17.8h, v18.8h
+        uzp2	v9.8h, v17.8h, v18.8h
+        smlal	v11.4s, v7.4h, v16.4h
+        smlal2	v8.4s, v7.8h, v16.8h
+        smlal	v30.4s, v7.4h, v9.4h
+        smlal2	v15.4s, v7.8h, v9.8h
+        smlal	v11.4s, v20.4h, v25.4h
+        smlal2	v8.4s, v20.8h, v25.8h
+        smlal	v30.4s, v20.4h, v16.4h
+        smlal2	v15.4s, v20.8h, v16.8h
+        ldr	q16, [x2, #0x10]
+        uzp1	v7.8h, v11.8h, v8.8h
+        uzp1	v20.8h, v30.8h, v15.8h
+        mul	v7.8h, v7.8h, v2.8h
+        mul	v20.8h, v20.8h, v2.8h
+        zip2	v9.8h, v27.8h, v10.8h
+        zip1	v27.8h, v27.8h, v10.8h
+        smlal	v11.4s, v7.4h, v0.4h
+        smlal2	v8.4s, v7.8h, v0.8h
+        smlal	v30.4s, v20.4h, v0.4h
+        smlal2	v15.4s, v20.8h, v0.8h
+        str	q27, [x0], #0x20
+        uzp2	v27.8h, v11.8h, v8.8h
+        stur	q9, [x0, #-0x10]
+        uzp2	v10.8h, v30.8h, v15.8h
+        ldr	q30, [x1, #0x10]
+        ldr	q15, [x2], #0x20
+        ld1	{ v9.8h }, [x3], #16
+        ldr	q21, [x4], #0x20
+        ldur	q6, [x4, #-0x10]
+        ldr	q1, [x5], #0x20
+        ldur	q12, [x5, #-0x10]
+        ld1	{ v24.8h }, [x6], #16
+        ldr	q19, [x7], #0x20
+        ldur	q31, [x7, #-0x10]
+        ldr	q17, [x8], #0x20
+        ldur	q18, [x8, #-0x10]
+        ld1	{ v25.8h }, [x9], #16
+        sub	x13, x13, #0x1
+        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k3_loop
+        ldr	q7, [x1], #0x20
+        uzp1	v20.8h, v15.8h, v16.8h
+        uzp2	v15.8h, v15.8h, v16.8h
+        uzp1	v23.8h, v7.8h, v30.8h
+        uzp2	v11.8h, v7.8h, v30.8h
+        smull2	v8.4s, v23.8h, v20.8h
+        smull	v5.4s, v23.4h, v20.4h
+        smull2	v30.4s, v23.8h, v15.8h
+        uzp1	v28.8h, v1.8h, v12.8h
+        smlal2	v8.4s, v11.8h, v9.8h
+        smlal	v5.4s, v11.4h, v9.4h
+        uzp1	v3.8h, v21.8h, v6.8h
+        smull	v16.4s, v23.4h, v15.4h
+        smlal2	v8.4s, v3.8h, v28.8h
+        smlal	v5.4s, v3.4h, v28.4h
+        uzp2	v29.8h, v21.8h, v6.8h
+        uzp1	v7.8h, v17.8h, v18.8h
+        smlal2	v8.4s, v29.8h, v24.8h
+        uzp1	v14.8h, v19.8h, v31.8h
+        smlal	v16.4s, v11.4h, v20.4h
+        smlal2	v30.4s, v11.8h, v20.8h
+        smlal2	v8.4s, v14.8h, v7.8h
+        uzp2	v20.8h, v1.8h, v12.8h
+        uzp2	v21.8h, v19.8h, v31.8h
+        smlal2	v30.4s, v3.8h, v20.8h
+        smlal	v16.4s, v3.4h, v20.4h
+        smlal	v5.4s, v29.4h, v24.4h
+        uzp2	v9.8h, v17.8h, v18.8h
+        smlal2	v30.4s, v29.8h, v28.8h
+        smlal	v16.4s, v29.4h, v28.4h
+        smlal	v5.4s, v14.4h, v7.4h
+        smlal2	v8.4s, v21.8h, v25.8h
+        smlal2	v30.4s, v14.8h, v9.8h
+        smlal	v16.4s, v14.4h, v9.4h
+        smlal	v5.4s, v21.4h, v25.4h
+        zip1	v20.8h, v27.8h, v10.8h
+        smlal2	v30.4s, v21.8h, v7.8h
+        smlal	v16.4s, v21.4h, v7.4h
+        uzp1	v7.8h, v5.8h, v8.8h
+        str	q20, [x0], #0x20
+        mul	v15.8h, v7.8h, v2.8h
+        uzp1	v7.8h, v16.8h, v30.8h
+        zip2	v31.8h, v27.8h, v10.8h
+        mul	v20.8h, v7.8h, v2.8h
+        smlal	v5.4s, v15.4h, v0.4h
+        smlal2	v8.4s, v15.8h, v0.8h
+        stur	q31, [x0, #-0x10]
+        smlal2	v30.4s, v20.8h, v0.8h
+        smlal	v16.4s, v20.4h, v0.4h
+        uzp2	v15.8h, v5.8h, v8.8h
+        uzp2	v20.8h, v16.8h, v30.8h
+        zip1	v7.8h, v15.8h, v20.8h
+        zip2	v20.8h, v15.8h, v20.8h
+        str	q7, [x0], #0x20
+        stur	q20, [x0, #-0x10]
+        ldp	d8, d9, [sp]
+        ldp	d10, d11, [sp, #0x10]
+        ldp	d12, d13, [sp, #0x20]
+        ldp	d14, d15, [sp, #0x30]
+        add	sp, sp, #0x40
+        ret

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2024-2025 The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// AArch64 re-implementation of the asymmetric base multiplication from:
+
+// Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1
+// https://eprint.iacr.org/2021/986
+// https://github.com/neon-ntt/neon-ntt
+
+
+/*
+ * WARNING: This file is auto-derived from the mlkem-native source file
+ *   dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S using scripts/simpasm. Do not modify it directly.
+ */
+
+
+.text
+.balign 4
+#ifdef __APPLE__
+.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k4
+_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k4:
+#else
+.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k4
+PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_asm_k4:
+#endif
+
+        sub	sp, sp, #0x40
+        stp	d8, d9, [sp]
+        stp	d10, d11, [sp, #0x10]
+        stp	d12, d13, [sp, #0x20]
+        stp	d14, d15, [sp, #0x30]
+        mov	w14, #0xd01             // =3329
+        dup	v0.8h, w14
+        mov	w14, #0xcff             // =3327
+        dup	v2.8h, w14
+        add	x4, x1, #0x200
+        add	x5, x2, #0x200
+        add	x6, x3, #0x100
+        add	x7, x1, #0x400
+        add	x8, x2, #0x400
+        add	x9, x3, #0x200
+        add	x10, x1, #0x600
+        add	x11, x2, #0x600
+        add	x12, x3, #0x300
+        mov	x13, #0x10              // =16
+        ldr	q23, [x2, #0x10]
+        ldr	q19, [x2], #0x20
+        ldr	q17, [x5], #0x20
+        uzp2	v13.8h, v19.8h, v23.8h
+        uzp1	v19.8h, v19.8h, v23.8h
+        ldur	q23, [x5, #-0x10]
+        ldr	q30, [x1, #0x10]
+        uzp2	v9.8h, v17.8h, v23.8h
+        uzp1	v23.8h, v17.8h, v23.8h
+        ldr	q17, [x1], #0x20
+        ldr	q10, [x7, #0x10]
+        uzp1	v12.8h, v17.8h, v30.8h
+        uzp2	v17.8h, v17.8h, v30.8h
+        smull2	v30.4s, v12.8h, v13.8h
+        smull	v13.4s, v12.4h, v13.4h
+        smull2	v22.4s, v12.8h, v19.8h
+        smull	v12.4s, v12.4h, v19.4h
+        smlal2	v30.4s, v17.8h, v19.8h
+        smlal	v13.4s, v17.4h, v19.4h
+        ldr	q19, [x4], #0x20
+        ldur	q16, [x4, #-0x10]
+        ld1	{ v8.8h }, [x3], #16
+        uzp1	v26.8h, v19.8h, v16.8h
+        uzp2	v19.8h, v19.8h, v16.8h
+        smlal2	v30.4s, v26.8h, v9.8h
+        smlal	v13.4s, v26.4h, v9.4h
+        smlal2	v22.4s, v17.8h, v8.8h
+        smlal	v12.4s, v17.4h, v8.4h
+        smlal2	v30.4s, v19.8h, v23.8h
+        smlal	v13.4s, v19.4h, v23.4h
+        smlal2	v22.4s, v26.8h, v23.8h
+        smlal	v12.4s, v26.4h, v23.4h
+        ldr	q23, [x7], #0x20
+        ldr	q17, [x8, #0x10]
+        uzp1	v9.8h, v23.8h, v10.8h
+        uzp2	v23.8h, v23.8h, v10.8h
+        ldr	q10, [x10], #0x20
+        ldur	q16, [x10, #-0x10]
+        ld1	{ v8.8h }, [x12], #16
+        uzp1	v26.8h, v10.8h, v16.8h
+        uzp2	v10.8h, v10.8h, v16.8h
+        ld1	{ v16.8h }, [x6], #16
+        ldr	q3, [x11, #0x10]
+        smlal2	v22.4s, v19.8h, v16.8h
+        smlal	v12.4s, v19.4h, v16.4h
+        ldr	q19, [x11], #0x20
+        ld1	{ v16.8h }, [x9], #16
+        uzp1	v4.8h, v19.8h, v3.8h
+        uzp2	v19.8h, v19.8h, v3.8h
+        ldr	q3, [x8], #0x20
+        ldr	q31, [x2], #0x20
+        uzp1	v6.8h, v3.8h, v17.8h
+        uzp2	v17.8h, v3.8h, v17.8h
+        smlal2	v22.4s, v9.8h, v6.8h
+        smlal2	v30.4s, v9.8h, v17.8h
+        smlal	v13.4s, v9.4h, v17.4h
+        smlal	v12.4s, v9.4h, v6.4h
+        smlal2	v22.4s, v23.8h, v16.8h
+        smlal2	v30.4s, v23.8h, v6.8h
+        smlal	v13.4s, v23.4h, v6.4h
+        smlal	v12.4s, v23.4h, v16.4h
+        smlal2	v22.4s, v26.8h, v4.8h
+        smlal2	v30.4s, v26.8h, v19.8h
+        smlal	v13.4s, v26.4h, v19.4h
+        smlal	v12.4s, v26.4h, v4.4h
+        smlal2	v22.4s, v10.8h, v8.8h
+        smlal2	v30.4s, v10.8h, v4.8h
+        smlal	v13.4s, v10.4h, v4.4h
+        smlal	v12.4s, v10.4h, v8.4h
+        ldur	q19, [x2, #-0x10]
+        uzp1	v23.8h, v13.8h, v30.8h
+        uzp1	v17.8h, v12.8h, v22.8h
+        mul	v23.8h, v23.8h, v2.8h
+        uzp2	v21.8h, v31.8h, v19.8h
+        uzp1	v19.8h, v31.8h, v19.8h
+        mul	v17.8h, v17.8h, v2.8h
+        smlal	v13.4s, v23.4h, v0.4h
+        smlal2	v30.4s, v23.8h, v0.8h
+        ldr	q23, [x5], #0x20
+        smlal2	v22.4s, v17.8h, v0.8h
+        uzp2	v15.8h, v13.8h, v30.8h
+        smlal	v12.4s, v17.4h, v0.4h
+        ldur	q17, [x5, #-0x10]
+        ldr	q13, [x1, #0x10]
+        uzp2	v27.8h, v23.8h, v17.8h
+        uzp1	v28.8h, v23.8h, v17.8h
+        uzp2	v7.8h, v12.8h, v22.8h
+        ldr	q23, [x1], #0x20
+        zip1	v5.8h, v7.8h, v15.8h
+        ldr	q3, [x7, #0x10]
+        uzp1	v31.8h, v23.8h, v13.8h
+        uzp2	v16.8h, v23.8h, v13.8h
+        smull2	v24.4s, v31.8h, v21.8h
+        ldr	q6, [x8, #0x10]
+        ldr	q23, [x10], #0x20
+        smlal2	v24.4s, v16.8h, v19.8h
+        ldur	q17, [x10, #-0x10]
+        ld1	{ v22.8h }, [x12], #16
+        uzp1	v30.8h, v23.8h, v17.8h
+        uzp2	v11.8h, v23.8h, v17.8h
+        ldr	q23, [x4], #0x20
+        ldur	q17, [x4, #-0x10]
+        ldr	q4, [x7], #0x20
+        uzp1	v20.8h, v23.8h, v17.8h
+        uzp2	v26.8h, v23.8h, v17.8h
+        uzp1	v9.8h, v4.8h, v3.8h
+        smlal2	v24.4s, v20.8h, v27.8h
+        ld1	{ v8.8h }, [x6], #16
+        ldr	q25, [x11, #0x10]
+        ldr	q29, [x11], #0x20
+        ld1	{ v12.8h }, [x9], #16
+        uzp1	v10.8h, v29.8h, v25.8h
+        ldr	q14, [x8], #0x20
+        ld1	{ v23.8h }, [x3], #16
+        sub	x13, x13, #0x2
+
+polyvec_basemul_acc_montgomery_cached_asm_k4_loop:
+        smlal2	v24.4s, v26.8h, v28.8h
+        uzp2	v4.8h, v4.8h, v3.8h
+        smull2	v13.4s, v31.8h, v19.8h
+        ldr	q3, [x2], #0x20
+        uzp2	v1.8h, v29.8h, v25.8h
+        smlal2	v13.4s, v16.8h, v23.8h
+        ldur	q17, [x2, #-0x10]
+        smull	v18.4s, v31.4h, v19.4h
+        smlal2	v13.4s, v20.8h, v28.8h
+        smull	v29.4s, v31.4h, v21.4h
+        ldr	q21, [x5], #0x20
+        smlal2	v13.4s, v26.8h, v8.8h
+        smlal	v29.4s, v16.4h, v19.4h
+        ldur	q19, [x5, #-0x10]
+        smlal	v18.4s, v16.4h, v23.4h
+        smlal	v29.4s, v20.4h, v27.4h
+        uzp1	v31.8h, v14.8h, v6.8h
+        uzp2	v27.8h, v21.8h, v19.8h
+        smlal	v18.4s, v20.4h, v28.4h
+        ldr	q25, [x1, #0x10]
+        smlal	v29.4s, v26.4h, v28.4h
+        smlal	v18.4s, v26.4h, v8.4h
+        uzp2	v26.8h, v14.8h, v6.8h
+        smlal2	v13.4s, v9.8h, v31.8h
+        smlal2	v24.4s, v9.8h, v26.8h
+        smlal	v29.4s, v9.4h, v26.4h
+        smlal	v18.4s, v9.4h, v31.4h
+        smlal2	v13.4s, v4.8h, v12.8h
+        smlal2	v24.4s, v4.8h, v31.8h
+        smlal	v29.4s, v4.4h, v31.4h
+        smlal	v18.4s, v4.4h, v12.4h
+        smlal2	v13.4s, v30.8h, v10.8h
+        smlal2	v24.4s, v30.8h, v1.8h
+        smlal	v29.4s, v30.4h, v1.4h
+        smlal	v18.4s, v30.4h, v10.4h
+        smlal2	v13.4s, v11.8h, v22.8h
+        smlal2	v24.4s, v11.8h, v10.8h
+        smlal	v29.4s, v11.4h, v10.4h
+        smlal	v18.4s, v11.4h, v22.4h
+        ldr	q22, [x1], #0x20
+        uzp1	v31.8h, v29.8h, v24.8h
+        uzp1	v28.8h, v21.8h, v19.8h
+        mul	v19.8h, v31.8h, v2.8h
+        uzp1	v31.8h, v22.8h, v25.8h
+        uzp2	v16.8h, v22.8h, v25.8h
+        uzp2	v21.8h, v3.8h, v17.8h
+        smlal	v29.4s, v19.4h, v0.4h
+        smlal2	v24.4s, v19.8h, v0.8h
+        uzp1	v19.8h, v3.8h, v17.8h
+        uzp1	v26.8h, v18.8h, v13.8h
+        zip2	v14.8h, v7.8h, v15.8h
+        mul	v23.8h, v26.8h, v2.8h
+        uzp2	v15.8h, v29.8h, v24.8h
+        smull2	v24.4s, v31.8h, v21.8h
+        str	q14, [x0, #0x10]
+        ldr	q3, [x7, #0x10]
+        ldr	q6, [x8, #0x10]
+        ldr	q8, [x10], #0x20
+        ldur	q26, [x10, #-0x10]
+        ld1	{ v22.8h }, [x12], #16
+        uzp1	v30.8h, v8.8h, v26.8h
+        uzp2	v11.8h, v8.8h, v26.8h
+        ldr	q8, [x4], #0x20
+        ldur	q26, [x4, #-0x10]
+        ldr	q4, [x7], #0x20
+        uzp1	v20.8h, v8.8h, v26.8h
+        uzp2	v26.8h, v8.8h, v26.8h
+        ld1	{ v8.8h }, [x6], #16
+        uzp1	v9.8h, v4.8h, v3.8h
+        ldr	q25, [x11, #0x10]
+        ldr	q29, [x11], #0x20
+        ld1	{ v12.8h }, [x9], #16
+        ldr	q14, [x8], #0x20
+        smlal2	v24.4s, v16.8h, v19.8h
+        smlal2	v13.4s, v23.8h, v0.8h
+        smlal	v18.4s, v23.4h, v0.4h
+        ld1	{ v23.8h }, [x3], #16
+        smlal2	v24.4s, v20.8h, v27.8h
+        uzp2	v7.8h, v18.8h, v13.8h
+        uzp1	v10.8h, v29.8h, v25.8h
+        str	q5, [x0], #0x20
+        zip1	v5.8h, v7.8h, v15.8h
+        sub	x13, x13, #0x1
+        cbnz	x13, polyvec_basemul_acc_montgomery_cached_asm_k4_loop
+        smull2	v17.4s, v31.8h, v19.8h
+        uzp2	v1.8h, v14.8h, v6.8h
+        smull	v18.4s, v31.4h, v21.4h
+        smlal2	v24.4s, v26.8h, v28.8h
+        smlal2	v17.4s, v16.8h, v23.8h
+        smull	v21.4s, v31.4h, v19.4h
+        smlal	v18.4s, v16.4h, v19.4h
+        uzp2	v31.8h, v4.8h, v3.8h
+        uzp1	v3.8h, v14.8h, v6.8h
+        smlal	v21.4s, v16.4h, v23.4h
+        smlal	v18.4s, v20.4h, v27.4h
+        uzp2	v14.8h, v29.8h, v25.8h
+        smlal2	v17.4s, v20.8h, v28.8h
+        smlal	v21.4s, v20.4h, v28.4h
+        smlal	v18.4s, v26.4h, v28.4h
+        smlal2	v24.4s, v9.8h, v1.8h
+        smlal2	v17.4s, v26.8h, v8.8h
+        smlal	v21.4s, v26.4h, v8.4h
+        smlal	v18.4s, v9.4h, v1.4h
+        smlal2	v24.4s, v31.8h, v3.8h
+        smlal2	v17.4s, v9.8h, v3.8h
+        smlal	v21.4s, v9.4h, v3.4h
+        smlal	v18.4s, v31.4h, v3.4h
+        smlal2	v24.4s, v30.8h, v14.8h
+        smlal2	v17.4s, v31.8h, v12.8h
+        smlal	v21.4s, v31.4h, v12.4h
+        smlal	v18.4s, v30.4h, v14.4h
+        smlal2	v24.4s, v11.8h, v10.8h
+        smlal2	v17.4s, v30.8h, v10.8h
+        smlal	v21.4s, v30.4h, v10.4h
+        smlal	v18.4s, v11.4h, v10.4h
+        zip2	v19.8h, v7.8h, v15.8h
+        smlal2	v17.4s, v11.8h, v22.8h
+        smlal	v21.4s, v11.4h, v22.4h
+        uzp1	v23.8h, v18.8h, v24.8h
+        str	q19, [x0, #0x10]
+        mul	v19.8h, v23.8h, v2.8h
+        uzp1	v23.8h, v21.8h, v17.8h
+        str	q5, [x0], #0x20
+        mul	v26.8h, v23.8h, v2.8h
+        smlal	v18.4s, v19.4h, v0.4h
+        smlal2	v24.4s, v19.8h, v0.8h
+        smlal	v21.4s, v26.4h, v0.4h
+        smlal2	v17.4s, v26.8h, v0.8h
+        uzp2	v13.8h, v18.8h, v24.8h
+        uzp2	v19.8h, v21.8h, v17.8h
+        zip1	v23.8h, v19.8h, v13.8h
+        zip2	v19.8h, v19.8h, v13.8h
+        str	q23, [x0], #0x20
+        stur	q19, [x0, #-0x10]
+        ldp	d8, d9, [sp]
+        ldp	d10, d11, [sp, #0x10]
+        ldp	d12, d13, [sp, #0x20]
+        ldp	d14, d15, [sp, #0x30]
+        add	sp, sp, #0x40
+        ret

--- a/proofs/hol_light/arm/proofs/mlkem_intt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_intt.ml
@@ -527,14 +527,15 @@ let MLKEM_INTT_CORRECT = prove
 
   (*** Simulate all the way to the end, in effect unrolling loops ***)
 
-  MAP_EVERY (fun n -> ARM_STEPS_TAC MLKEM_INTT_EXEC [n] THEN SIMD_SIMPLIFY_TAC)
+  MAP_EVERY (fun n -> ARM_STEPS_TAC MLKEM_INTT_EXEC [n] THEN
+            (SIMD_SIMPLIFY_TAC [barred; barmul]))
             (1--1181) THEN
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
   (*** Reverse the restructuring by splitting the 128-bit words up ***)
 
   REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
-   CONV_RULE SIMD_SIMPLIFY_CONV o
+   CONV_RULE (SIMD_SIMPLIFY_CONV []) o
    CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
    check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 

--- a/proofs/hol_light/arm/proofs/mlkem_ntt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_ntt.ml
@@ -478,14 +478,15 @@ let MLKEM_NTT_CORRECT = prove
 
   (*** Simulate all the way to the end, in effect unrolling loops ***)
 
-  MAP_EVERY (fun n -> ARM_STEPS_TAC MLKEM_NTT_EXEC [n] THEN SIMD_SIMPLIFY_TAC)
+  MAP_EVERY (fun n -> ARM_STEPS_TAC MLKEM_NTT_EXEC [n] THEN
+             (SIMD_SIMPLIFY_TAC [barmul]))
             (1--904) THEN
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
   (*** Reverse the restructuring by splitting the 128-bit words up ***)
 
   REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
-    CONV_RULE SIMD_SIMPLIFY_CONV o
+    CONV_RULE (SIMD_SIMPLIFY_CONV []) o
     CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
     check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
@@ -1,0 +1,369 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+needs "arm/proofs/base.ml";;
+
+needs "proofs/mlkem_specs.ml";;
+needs "proofs/mlkem_utils.ml";;
+
+(**** print_literal_from_elf "mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.o";;
+ ****)
+
+
+let poly_basemul_acc_montgomery_cached_k2_mc = define_assert_from_elf
+    "poly_basemul_acc_montgomery_cached_k2_mc" "mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.o"
+    [
+      0xd10103ff;       (* arm_SUB SP SP (rvalue (word 64)) *)
+      0x6d0027e8;       (* arm_STP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+      0x6d012fea;       (* arm_STP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+      0x6d0237ec;       (* arm_STP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+      0x6d033fee;       (* arm_STP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+      0x5281a02e;       (* arm_MOV W14 (rvalue (word 3329)) *)
+      0x4e020dc0;       (* arm_DUP_GEN Q0 X14 16 128 *)
+      0x52819fee;       (* arm_MOV W14 (rvalue (word 3327)) *)
+      0x4e020dc2;       (* arm_DUP_GEN Q2 X14 16 128 *)
+      0x91080024;       (* arm_ADD X4 X1 (rvalue (word 512)) *)
+      0x91080045;       (* arm_ADD X5 X2 (rvalue (word 512)) *)
+      0x91040066;       (* arm_ADD X6 X3 (rvalue (word 256)) *)
+      0xd280020d;       (* arm_MOV X13 (rvalue (word 16)) *)
+      0x3cc20489;       (* arm_LDR Q9 X4 (Postimmediate_Offset (word 32)) *)
+      0x3cdf0085;       (* arm_LDR Q5 X4 (Immediate_Offset (word 18446744073709551600)) *)
+      0x3cc204ab;       (* arm_LDR Q11 X5 (Postimmediate_Offset (word 32)) *)
+      0x4e451937;       (* arm_UZP1 Q23 Q9 Q5 16 *)
+      0x4e455929;       (* arm_UZP2 Q9 Q9 Q5 16 *)
+      0x3cc20445;       (* arm_LDR Q5 X2 (Postimmediate_Offset (word 32)) *)
+      0x3cdf00a7;       (* arm_LDR Q7 X5 (Immediate_Offset (word 18446744073709551600)) *)
+      0x3cdf0055;       (* arm_LDR Q21 X2 (Immediate_Offset (word 18446744073709551600)) *)
+      0x4e47596a;       (* arm_UZP2 Q10 Q11 Q7 16 *)
+      0x4e47196b;       (* arm_UZP1 Q11 Q11 Q7 16 *)
+      0x4e5518a7;       (* arm_UZP1 Q7 Q5 Q21 16 *)
+      0x4e5558a5;       (* arm_UZP2 Q5 Q5 Q21 16 *)
+      0x3cc20435;       (* arm_LDR Q21 X1 (Postimmediate_Offset (word 32)) *)
+      0x3cdf0039;       (* arm_LDR Q25 X1 (Immediate_Offset (word 18446744073709551600)) *)
+      0x4cdf7466;       (* arm_LDR Q6 X3 (Postimmediate_Offset (word 16)) *)
+      0x4e591aba;       (* arm_UZP1 Q26 Q21 Q25 16 *)
+      0x4e595ab5;       (* arm_UZP2 Q21 Q21 Q25 16 *)
+      0x0e65c359;       (* arm_SMULL_VEC Q25 Q26 Q5 16 *)
+      0x4e65c345;       (* arm_SMULL2_VEC Q5 Q26 Q5 16 *)
+      0x0e67c353;       (* arm_SMULL_VEC Q19 Q26 Q7 16 *)
+      0x4e67c35a;       (* arm_SMULL2_VEC Q26 Q26 Q7 16 *)
+      0x0e6782b9;       (* arm_SMLAL_VEC Q25 Q21 Q7 16 *)
+      0x4e6782a5;       (* arm_SMLAL2_VEC Q5 Q21 Q7 16 *)
+      0x0e6682b3;       (* arm_SMLAL_VEC Q19 Q21 Q6 16 *)
+      0x4e6682ba;       (* arm_SMLAL2_VEC Q26 Q21 Q6 16 *)
+      0x0e6a82f9;       (* arm_SMLAL_VEC Q25 Q23 Q10 16 *)
+      0x4e6a82e5;       (* arm_SMLAL2_VEC Q5 Q23 Q10 16 *)
+      0x0e6b82f3;       (* arm_SMLAL_VEC Q19 Q23 Q11 16 *)
+      0x4e6b82fa;       (* arm_SMLAL2_VEC Q26 Q23 Q11 16 *)
+      0x4cdf74d7;       (* arm_LDR Q23 X6 (Postimmediate_Offset (word 16)) *)
+      0x0e6b8139;       (* arm_SMLAL_VEC Q25 Q9 Q11 16 *)
+      0x4e6b8125;       (* arm_SMLAL2_VEC Q5 Q9 Q11 16 *)
+      0x4e77813a;       (* arm_SMLAL2_VEC Q26 Q9 Q23 16 *)
+      0x0e778133;       (* arm_SMLAL_VEC Q19 Q9 Q23 16 *)
+      0x3cc20489;       (* arm_LDR Q9 X4 (Postimmediate_Offset (word 32)) *)
+      0x4e451b2b;       (* arm_UZP1 Q11 Q25 Q5 16 *)
+      0x4e5a1a77;       (* arm_UZP1 Q23 Q19 Q26 16 *)
+      0x4e629d6b;       (* arm_MUL_VEC Q11 Q11 Q2 16 128 *)
+      0x4e629ef7;       (* arm_MUL_VEC Q23 Q23 Q2 16 128 *)
+      0x3cc204a7;       (* arm_LDR Q7 X5 (Postimmediate_Offset (word 32)) *)
+      0x4e608165;       (* arm_SMLAL2_VEC Q5 Q11 Q0 16 *)
+      0x0e608179;       (* arm_SMLAL_VEC Q25 Q11 Q0 16 *)
+      0x3cc2044b;       (* arm_LDR Q11 X2 (Postimmediate_Offset (word 32)) *)
+      0x3cdf0055;       (* arm_LDR Q21 X2 (Immediate_Offset (word 18446744073709551600)) *)
+      0x3cdf0086;       (* arm_LDR Q6 X4 (Immediate_Offset (word 18446744073709551600)) *)
+      0x4e551971;       (* arm_UZP1 Q17 Q11 Q21 16 *)
+      0x3cc2042a;       (* arm_LDR Q10 X1 (Postimmediate_Offset (word 32)) *)
+      0x3cdf003d;       (* arm_LDR Q29 X1 (Immediate_Offset (word 18446744073709551600)) *)
+      0x4e55596b;       (* arm_UZP2 Q11 Q11 Q21 16 *)
+      0x4e46192d;       (* arm_UZP1 Q13 Q9 Q6 16 *)
+      0x4e5d1943;       (* arm_UZP1 Q3 Q10 Q29 16 *)
+      0x4e5d594a;       (* arm_UZP2 Q10 Q10 Q29 16 *)
+      0x0e6bc06c;       (* arm_SMULL_VEC Q12 Q3 Q11 16 *)
+      0x4e6bc06b;       (* arm_SMULL2_VEC Q11 Q3 Q11 16 *)
+      0x3cdf00b5;       (* arm_LDR Q21 X5 (Immediate_Offset (word 18446744073709551600)) *)
+      0x0e71814c;       (* arm_SMLAL_VEC Q12 Q10 Q17 16 *)
+      0x4e71814b;       (* arm_SMLAL2_VEC Q11 Q10 Q17 16 *)
+      0x4e5558fd;       (* arm_UZP2 Q29 Q7 Q21 16 *)
+      0x4e5518ef;       (* arm_UZP1 Q15 Q7 Q21 16 *)
+      0x0e7d81ac;       (* arm_SMLAL_VEC Q12 Q13 Q29 16 *)
+      0x4e7d81ab;       (* arm_SMLAL2_VEC Q11 Q13 Q29 16 *)
+      0x4e46593c;       (* arm_UZP2 Q28 Q9 Q6 16 *)
+      0x4e6082fa;       (* arm_SMLAL2_VEC Q26 Q23 Q0 16 *)
+      0x0e6f838c;       (* arm_SMLAL_VEC Q12 Q28 Q15 16 *)
+      0x4e6f838b;       (* arm_SMLAL2_VEC Q11 Q28 Q15 16 *)
+      0x0e6082f3;       (* arm_SMLAL_VEC Q19 Q23 Q0 16 *)
+      0x4e455b3b;       (* arm_UZP2 Q27 Q25 Q5 16 *)
+      0x0e71c077;       (* arm_SMULL_VEC Q23 Q3 Q17 16 *)
+      0x4e4b1989;       (* arm_UZP1 Q9 Q12 Q11 16 *)
+      0x4e5a5a73;       (* arm_UZP2 Q19 Q19 Q26 16 *)
+      0x4e629d2e;       (* arm_MUL_VEC Q14 Q9 Q2 16 128 *)
+      0x4cdf74d6;       (* arm_LDR Q22 X6 (Postimmediate_Offset (word 16)) *)
+      0x4e5b7a69;       (* arm_ZIP2 Q9 Q19 Q27 16 128 *)
+      0x4e6081cb;       (* arm_SMLAL2_VEC Q11 Q14 Q0 16 *)
+      0x4cdf7464;       (* arm_LDR Q4 X3 (Postimmediate_Offset (word 16)) *)
+      0xd10009ad;       (* arm_SUB X13 X13 (rvalue (word 2)) *)
+      0x4e71c074;       (* arm_SMULL2_VEC Q20 Q3 Q17 16 *)
+      0x3cc20492;       (* arm_LDR Q18 X4 (Postimmediate_Offset (word 32)) *)
+      0x3cc204be;       (* arm_LDR Q30 X5 (Postimmediate_Offset (word 32)) *)
+      0x4e648154;       (* arm_SMLAL2_VEC Q20 Q10 Q4 16 *)
+      0x0e6081cc;       (* arm_SMLAL_VEC Q12 Q14 Q0 16 *)
+      0x0e648157;       (* arm_SMLAL_VEC Q23 Q10 Q4 16 *)
+      0x3d800409;       (* arm_STR Q9 X0 (Immediate_Offset (word 16)) *)
+      0x4e6f81b4;       (* arm_SMLAL2_VEC Q20 Q13 Q15 16 *)
+      0x3cc20448;       (* arm_LDR Q8 X2 (Postimmediate_Offset (word 32)) *)
+      0x0e6f81b7;       (* arm_SMLAL_VEC Q23 Q13 Q15 16 *)
+      0x4e768394;       (* arm_SMLAL2_VEC Q20 Q28 Q22 16 *)
+      0x4e5b3a7a;       (* arm_ZIP1 Q26 Q19 Q27 16 128 *)
+      0x3cdf0049;       (* arm_LDR Q9 X2 (Immediate_Offset (word 18446744073709551600)) *)
+      0x0e768397;       (* arm_SMLAL_VEC Q23 Q28 Q22 16 *)
+      0x4e4b599b;       (* arm_UZP2 Q27 Q12 Q11 16 *)
+      0x4e491911;       (* arm_UZP1 Q17 Q8 Q9 16 *)
+      0x4e495904;       (* arm_UZP2 Q4 Q8 Q9 16 *)
+      0x4e541ae5;       (* arm_UZP1 Q5 Q23 Q20 16 *)
+      0x3c82041a;       (* arm_STR Q26 X0 (Postimmediate_Offset (word 32)) *)
+      0x4e629cbf;       (* arm_MUL_VEC Q31 Q5 Q2 16 128 *)
+      0x3cdf0093;       (* arm_LDR Q19 X4 (Immediate_Offset (word 18446744073709551600)) *)
+      0x3cc2043d;       (* arm_LDR Q29 X1 (Postimmediate_Offset (word 32)) *)
+      0x3cdf002c;       (* arm_LDR Q12 X1 (Immediate_Offset (word 18446744073709551600)) *)
+      0x4e6083f4;       (* arm_SMLAL2_VEC Q20 Q31 Q0 16 *)
+      0x4e531a4d;       (* arm_UZP1 Q13 Q18 Q19 16 *)
+      0x4e4c1ba3;       (* arm_UZP1 Q3 Q29 Q12 16 *)
+      0x4e4c5baa;       (* arm_UZP2 Q10 Q29 Q12 16 *)
+      0x0e64c06c;       (* arm_SMULL_VEC Q12 Q3 Q4 16 *)
+      0x4e64c06b;       (* arm_SMULL2_VEC Q11 Q3 Q4 16 *)
+      0x3cdf00a5;       (* arm_LDR Q5 X5 (Immediate_Offset (word 18446744073709551600)) *)
+      0x0e71814c;       (* arm_SMLAL_VEC Q12 Q10 Q17 16 *)
+      0x4e71814b;       (* arm_SMLAL2_VEC Q11 Q10 Q17 16 *)
+      0x4e455bce;       (* arm_UZP2 Q14 Q30 Q5 16 *)
+      0x4e451bcf;       (* arm_UZP1 Q15 Q30 Q5 16 *)
+      0x0e6e81ac;       (* arm_SMLAL_VEC Q12 Q13 Q14 16 *)
+      0x4e6e81ab;       (* arm_SMLAL2_VEC Q11 Q13 Q14 16 *)
+      0x4e535a5c;       (* arm_UZP2 Q28 Q18 Q19 16 *)
+      0x0e6083f7;       (* arm_SMLAL_VEC Q23 Q31 Q0 16 *)
+      0x0e6f838c;       (* arm_SMLAL_VEC Q12 Q28 Q15 16 *)
+      0x4e6f838b;       (* arm_SMLAL2_VEC Q11 Q28 Q15 16 *)
+      0x4cdf74d6;       (* arm_LDR Q22 X6 (Postimmediate_Offset (word 16)) *)
+      0x4e545af3;       (* arm_UZP2 Q19 Q23 Q20 16 *)
+      0x4e4b1981;       (* arm_UZP1 Q1 Q12 Q11 16 *)
+      0x0e71c077;       (* arm_SMULL_VEC Q23 Q3 Q17 16 *)
+      0x4e629c2e;       (* arm_MUL_VEC Q14 Q1 Q2 16 128 *)
+      0x4e5b7a69;       (* arm_ZIP2 Q9 Q19 Q27 16 128 *)
+      0x4cdf7464;       (* arm_LDR Q4 X3 (Postimmediate_Offset (word 16)) *)
+      0x4e6081cb;       (* arm_SMLAL2_VEC Q11 Q14 Q0 16 *)
+      0xd10005ad;       (* arm_SUB X13 X13 (rvalue (word 1)) *)
+      0xb5fff9ed;       (* arm_CBNZ X13 (word 2096956) *)
+      0x4e71c065;       (* arm_SMULL2_VEC Q5 Q3 Q17 16 *)
+      0x0e6081cc;       (* arm_SMLAL_VEC Q12 Q14 Q0 16 *)
+      0x0e648157;       (* arm_SMLAL_VEC Q23 Q10 Q4 16 *)
+      0x3d800409;       (* arm_STR Q9 X0 (Immediate_Offset (word 16)) *)
+      0x4e648145;       (* arm_SMLAL2_VEC Q5 Q10 Q4 16 *)
+      0x4e4b598b;       (* arm_UZP2 Q11 Q12 Q11 16 *)
+      0x4e5b3a69;       (* arm_ZIP1 Q9 Q19 Q27 16 128 *)
+      0x0e6f81b7;       (* arm_SMLAL_VEC Q23 Q13 Q15 16 *)
+      0x4e6f81a5;       (* arm_SMLAL2_VEC Q5 Q13 Q15 16 *)
+      0x3c820409;       (* arm_STR Q9 X0 (Postimmediate_Offset (word 32)) *)
+      0x0e768397;       (* arm_SMLAL_VEC Q23 Q28 Q22 16 *)
+      0x4e768385;       (* arm_SMLAL2_VEC Q5 Q28 Q22 16 *)
+      0x4e451ae9;       (* arm_UZP1 Q9 Q23 Q5 16 *)
+      0x4e629d29;       (* arm_MUL_VEC Q9 Q9 Q2 16 128 *)
+      0x4e608125;       (* arm_SMLAL2_VEC Q5 Q9 Q0 16 *)
+      0x0e608137;       (* arm_SMLAL_VEC Q23 Q9 Q0 16 *)
+      0x4e455ae9;       (* arm_UZP2 Q9 Q23 Q5 16 *)
+      0x4e4b7925;       (* arm_ZIP2 Q5 Q9 Q11 16 128 *)
+      0x4e4b3929;       (* arm_ZIP1 Q9 Q9 Q11 16 128 *)
+      0x3d800405;       (* arm_STR Q5 X0 (Immediate_Offset (word 16)) *)
+      0x3c820409;       (* arm_STR Q9 X0 (Postimmediate_Offset (word 32)) *)
+      0x6d4027e8;       (* arm_LDP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+      0x6d412fea;       (* arm_LDP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+      0x6d4237ec;       (* arm_LDP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+      0x6d433fee;       (* arm_LDP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+      0x910103ff;       (* arm_ADD SP SP (rvalue (word 64)) *)
+      0xd65f03c0        (* arm_RET X30 *)
+    ];;
+
+let pmull = define
+  `pmull (x0: 16 word) (x1 : 16 word) (y0 : 16 word) (y1 : 16 word) =
+      word_add (word_mul ((word_sx x1) : 32 word) (word_sx y1))
+               (word_mul ((word_sx x0) : 32 word) (word_sx y0))`;;
+
+let pmull_acc2 = define
+    `pmull_acc2 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
+          (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word) =
+      word_add (pmull x10 x11 y10 y11) (pmull x00 x01 y00 y01)`;;
+
+let montred = define
+   `montred (x : 32 word) =
+      word_subword (
+         word_add (
+           word_mul (
+             (word_sx : 16 word -> 32 word) (
+               word_mul (
+                 word_subword x (0,16)
+               ) (word 3327)
+             )
+           )
+           (word 3329)
+         ) x
+      ) (16, 16)`;;
+
+let pmul_acc2 = define
+    `pmul_acc2 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
+          (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word) =
+      montred (pmull_acc2 x00 x01 y00 y01 x10 x11 y10 y11)`;;
+
+let basemul2_even_raw = define
+   `basemul2_even_raw x0 y0 y0t x1 y1 y1t = \i.
+      pmul_acc2 (x0 (2 * i)) (x0 (2 * i + 1))
+                (y0 (2 * i)) (y0t i)
+                (x1 (2 * i)) (x1 (2 * i + 1))
+                (y1 (2 * i)) (y1t i)
+   `;;
+
+let basemul2_odd_raw = define
+ `basemul2_odd_raw x0 y0 x1 y1 = \i.
+    pmul_acc2 (x0 (2 * i)) (x0 (2 * i + 1))
+              (y0 (2 * i + 1)) (y0 (2 * i))
+              (x1 (2 * i)) (x1 (2 * i + 1))
+              (y1 (2 * i + 1)) (y1 (2 * i))
+ `;;
+
+let poly_basemul_acc_montgomery_cached_k2_EXEC = ARM_MK_EXEC_RULE poly_basemul_acc_montgomery_cached_k2_mc;;
+
+let poly_basemul_acc_montgomery_cached_k2_GOAL = `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t pc.
+     ALL (nonoverlapping (dst, 512))
+         [(word pc, LENGTH poly_basemul_acc_montgomery_cached_k2_mc); (srcA, 1024); (srcB, 1024); (srcBt, 512)]
+     ==>
+     ensures arm
+       (\s. aligned_bytes_loaded s (word pc) poly_basemul_acc_montgomery_cached_k2_mc /\
+            read PC s = word (pc + 20)  /\
+            C_ARGUMENTS [dst; srcA; srcB; srcBt] s  /\
+            (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (2 * i)))) s = x0 i)       /\
+            (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (2 * i)))) s = y0 i)       /\
+            (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i)      /\
+            (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (512 + 2 * i)))) s = x1 i) /\
+            (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (512 + 2 * i)))) s = y1 i) /\
+            (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i))
+       (\s. read PC s = word (pc + 640) /\
+            (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
+                                  basemul2_even_raw x0 y0 y0t x1 y1 y1t i /\
+                             read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
+                                  basemul2_odd_raw x0 y0 x1 y1 i))
+       // Register and memory footprint
+       (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+        MAYCHANGE [Q8; Q9; Q10; Q11; Q12; Q13; Q14; Q15] ,,
+        MAYCHANGE [memory :> bytes(dst, 512)])
+   `;;
+
+ (* ------------------------------------------------------------------------- *)
+ (* Proof                                                                     *)
+ (* ------------------------------------------------------------------------- *)
+
+let poly_basemul_acc_montgomery_cached_k2_SPEC = prove(poly_basemul_acc_montgomery_cached_k2_GOAL,
+     REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI;
+       MODIFIABLE_SIMD_REGS;
+       NONOVERLAPPING_CLAUSES; ALL; C_ARGUMENTS; fst poly_basemul_acc_montgomery_cached_k2_EXEC] THEN
+     REPEAT STRIP_TAC THEN
+
+     (* Split quantified assumptions into separate cases *)
+     CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
+     CONV_TAC((ONCE_DEPTH_CONV NUM_MULT_CONV) THENC (ONCE_DEPTH_CONV NUM_ADD_CONV)) THEN
+
+     (* Initialize symbolic execution *)
+     ENSURES_INIT_TAC "s0" THEN
+
+     (* Rewrite memory-read assumptions from 16-bit granularity
+      * to 128-bit granularity. *)
+     MEMORY_128_FROM_16_TAC "srcA" 64 THEN
+     MEMORY_128_FROM_16_TAC "srcB" 64 THEN
+     MEMORY_128_FROM_16_TAC "srcBt" 32 THEN
+     ASM_REWRITE_TAC [WORD_ADD_0] THEN
+     (* Forget original shape of assumption *)
+     DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcA) s = x`] THEN
+     DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcB) s = x`] THEN
+     DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcBt) s = x`] THEN
+
+     (* Symbolic execution
+        Note that we simplify eagerly after every step.
+        This reduces the proof time *)
+     REPEAT STRIP_TAC THEN
+     MAP_EVERY (fun n -> ARM_STEPS_TAC poly_basemul_acc_montgomery_cached_k2_EXEC [n] THEN
+                (SIMD_SIMPLIFY_TAC [pmull; GSYM WORD_ADD_ASSOC; pmull_acc2; montred; pmul_acc2])) (1--805) THEN
+
+     ENSURES_FINAL_STATE_TAC THEN
+     REPEAT CONJ_TAC THEN
+     ASM_REWRITE_TAC [] THEN
+
+     (* Reverse restructuring *)
+     REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
+       CONV_RULE (SIMD_SIMPLIFY_CONV []) o
+       CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
+       check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
+
+     (* Split quantified post-condition into separate cases *)
+     CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV
+              THENC (TRY_CONV (ONCE_DEPTH_CONV NUM_ADD_CONV))) THEN
+     CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN
+     ASM_REWRITE_TAC [WORD_ADD_0] THEN
+
+     (* Forget all assumptions *)
+     POP_ASSUM_LIST (K ALL_TAC) THEN
+
+     (* Split into one congruence goals per index. *)
+     REPEAT CONJ_TAC THEN
+
+     REWRITE_TAC[basemul2_even_raw; basemul2_odd_raw] THEN
+     CONV_TAC(ONCE_DEPTH_CONV EL_CONV) THEN
+     CONV_TAC(REPEATC (CHANGED_CONV (ONCE_DEPTH_CONV (NUM_MULT_CONV ORELSEC NUM_ADD_CONV)))) THEN
+     REFL_TAC
+ );;
+
+ let TWEAK_CONV =
+  ONCE_DEPTH_CONV let_CONV THENC
+  ONCE_DEPTH_CONV EXPAND_CASES_CONV THENC
+  ONCE_DEPTH_CONV NUM_MULT_CONV THENC
+  ONCE_DEPTH_CONV NUM_ADD_CONV THENC
+  PURE_REWRITE_CONV [WORD_ADD_0];;
+
+let poly_basemul_acc_montgomery_cached_k2_SPEC' = prove(
+   `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t pc returnaddress stackpointer.
+      aligned 16 stackpointer /\
+      ALLPAIRS nonoverlapping
+        [(dst, 512); (word_sub stackpointer (word 64),64)]
+        [(word pc, LENGTH poly_basemul_acc_montgomery_cached_k2_mc); (srcA, 1024); (srcB, 1024); (srcBt, 512)] /\
+      nonoverlapping (dst,512) (word_sub stackpointer (word 64),64)
+      ==>
+      ensures arm
+      (\s. // Assert that poly_basemul_acc_montgomery_cached_k2 is loaded at PC
+        aligned_bytes_loaded s (word pc) poly_basemul_acc_montgomery_cached_k2_mc /\
+        read PC s = word pc /\
+        read SP s = stackpointer /\
+        read X30 s = returnaddress /\
+        C_ARGUMENTS [dst; srcA; srcB; srcBt] s  /\
+        // Give names to in-memory data to be
+        // able to refer to them in the post-condition
+        (!i. i < 256 ==> read(memory :> bytes16(word_add srcA (word (2 * i)))) s = x0 i) /\
+        (!i. i < 256 ==> read(memory :> bytes16(word_add srcB (word (2 * i)))) s = y0 i) /\
+        (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i) /\
+        (!i. i < 256 ==> read(memory :> bytes16(word_add srcA (word (512 + 2 * i)))) s = x1 i) /\
+        (!i. i < 256 ==> read(memory :> bytes16(word_add srcB (word (512 + 2 * i)))) s = y1 i) /\
+        (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i)
+      )
+      (\s. read PC s = returnaddress /\
+       (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
+                             basemul2_even_raw x0 y0 y0t x1 y1 y1t i /\
+                        read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
+                             basemul2_odd_raw x0 y0 x1 y1 i)
+      )
+      // Register and memory footprint
+      (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+      MAYCHANGE [memory :> bytes(dst, 512);
+                 memory :> bytes(word_sub stackpointer (word 64),64)])`,
+  REWRITE_TAC[fst poly_basemul_acc_montgomery_cached_k2_EXEC] THEN
+  CONV_TAC TWEAK_CONV THEN
+  ARM_ADD_RETURN_STACK_TAC ~pre_post_nsteps:(5,5) poly_basemul_acc_montgomery_cached_k2_EXEC
+     (REWRITE_RULE[fst poly_basemul_acc_montgomery_cached_k2_EXEC] (CONV_RULE TWEAK_CONV poly_basemul_acc_montgomery_cached_k2_SPEC))
+      `[D8; D9; D10; D11; D12; D13; D14; D15]` 64  THEN
+   WORD_ARITH_TAC)
+;;

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
@@ -1,0 +1,436 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+needs "arm/proofs/base.ml";;
+
+needs "proofs/mlkem_specs.ml";;
+needs "proofs/mlkem_utils.ml";;
+
+(**** print_literal_from_elf "mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.o";;
+ ****)
+
+
+let poly_basemul_acc_montgomery_cached_k3_mc = define_assert_from_elf
+    "poly_basemul_acc_montgomery_cached_k3_mc" "mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.o"
+ [
+   0xd10103ff;       (* arm_SUB SP SP (rvalue (word 64)) *)
+   0x6d0027e8;       (* arm_STP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+   0x6d012fea;       (* arm_STP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+   0x6d0237ec;       (* arm_STP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+   0x6d033fee;       (* arm_STP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+   0x5281a02e;       (* arm_MOV W14 (rvalue (word 3329)) *)
+   0x4e020dc0;       (* arm_DUP_GEN Q0 X14 16 128 *)
+   0x52819fee;       (* arm_MOV W14 (rvalue (word 3327)) *)
+   0x4e020dc2;       (* arm_DUP_GEN Q2 X14 16 128 *)
+   0x91080024;       (* arm_ADD X4 X1 (rvalue (word 512)) *)
+   0x91080045;       (* arm_ADD X5 X2 (rvalue (word 512)) *)
+   0x91040066;       (* arm_ADD X6 X3 (rvalue (word 256)) *)
+   0x91100027;       (* arm_ADD X7 X1 (rvalue (word 1024)) *)
+   0x91100048;       (* arm_ADD X8 X2 (rvalue (word 1024)) *)
+   0x91080069;       (* arm_ADD X9 X3 (rvalue (word 512)) *)
+   0xd280020d;       (* arm_MOV X13 (rvalue (word 16)) *)
+   0x3dc00447;       (* arm_LDR Q7 X2 (Immediate_Offset (word 16)) *)
+   0x3cc20454;       (* arm_LDR Q20 X2 (Postimmediate_Offset (word 32)) *)
+   0x3dc0042f;       (* arm_LDR Q15 X1 (Immediate_Offset (word 16)) *)
+   0x4e471a88;       (* arm_UZP1 Q8 Q20 Q7 16 *)
+   0x4e475a87;       (* arm_UZP2 Q7 Q20 Q7 16 *)
+   0x4cdf7474;       (* arm_LDR Q20 X3 (Postimmediate_Offset (word 16)) *)
+   0x3cc2043e;       (* arm_LDR Q30 X1 (Postimmediate_Offset (word 32)) *)
+   0x3cc2048b;       (* arm_LDR Q11 X4 (Postimmediate_Offset (word 32)) *)
+   0x4e4f1bd0;       (* arm_UZP1 Q16 Q30 Q15 16 *)
+   0x4e4f5bcf;       (* arm_UZP2 Q15 Q30 Q15 16 *)
+   0x0e67c21e;       (* arm_SMULL_VEC Q30 Q16 Q7 16 *)
+   0x4e67c207;       (* arm_SMULL2_VEC Q7 Q16 Q7 16 *)
+   0x0e68c209;       (* arm_SMULL_VEC Q9 Q16 Q8 16 *)
+   0x4e68c210;       (* arm_SMULL2_VEC Q16 Q16 Q8 16 *)
+   0x0e6881fe;       (* arm_SMLAL_VEC Q30 Q15 Q8 16 *)
+   0x4e6881e7;       (* arm_SMLAL2_VEC Q7 Q15 Q8 16 *)
+   0x0e7481e9;       (* arm_SMLAL_VEC Q9 Q15 Q20 16 *)
+   0x4e7481f0;       (* arm_SMLAL2_VEC Q16 Q15 Q20 16 *)
+   0x3cdf0094;       (* arm_LDR Q20 X4 (Immediate_Offset (word 18446744073709551600)) *)
+   0x3cc204af;       (* arm_LDR Q15 X5 (Postimmediate_Offset (word 32)) *)
+   0x4e541968;       (* arm_UZP1 Q8 Q11 Q20 16 *)
+   0x4e545974;       (* arm_UZP2 Q20 Q11 Q20 16 *)
+   0x3cdf00ab;       (* arm_LDR Q11 X5 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4cdf74db;       (* arm_LDR Q27 X6 (Postimmediate_Offset (word 16)) *)
+   0x4e4b19ea;       (* arm_UZP1 Q10 Q15 Q11 16 *)
+   0x4e4b59ef;       (* arm_UZP2 Q15 Q15 Q11 16 *)
+   0x0e6a8109;       (* arm_SMLAL_VEC Q9 Q8 Q10 16 *)
+   0x4e6a8110;       (* arm_SMLAL2_VEC Q16 Q8 Q10 16 *)
+   0x0e6f811e;       (* arm_SMLAL_VEC Q30 Q8 Q15 16 *)
+   0x4e6f8107;       (* arm_SMLAL2_VEC Q7 Q8 Q15 16 *)
+   0x0e7b8289;       (* arm_SMLAL_VEC Q9 Q20 Q27 16 *)
+   0x4e7b8290;       (* arm_SMLAL2_VEC Q16 Q20 Q27 16 *)
+   0x0e6a829e;       (* arm_SMLAL_VEC Q30 Q20 Q10 16 *)
+   0x4e6a8287;       (* arm_SMLAL2_VEC Q7 Q20 Q10 16 *)
+   0x3cc204f4;       (* arm_LDR Q20 X7 (Postimmediate_Offset (word 32)) *)
+   0x3cdf00ef;       (* arm_LDR Q15 X7 (Immediate_Offset (word 18446744073709551600)) *)
+   0x3cc20508;       (* arm_LDR Q8 X8 (Postimmediate_Offset (word 32)) *)
+   0x4e4f1a8b;       (* arm_UZP1 Q11 Q20 Q15 16 *)
+   0x4e4f5a94;       (* arm_UZP2 Q20 Q20 Q15 16 *)
+   0x3cdf010f;       (* arm_LDR Q15 X8 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4cdf753b;       (* arm_LDR Q27 X9 (Postimmediate_Offset (word 16)) *)
+   0x4e4f190a;       (* arm_UZP1 Q10 Q8 Q15 16 *)
+   0x4e4f590f;       (* arm_UZP2 Q15 Q8 Q15 16 *)
+   0x0e6a8169;       (* arm_SMLAL_VEC Q9 Q11 Q10 16 *)
+   0x4e6a8170;       (* arm_SMLAL2_VEC Q16 Q11 Q10 16 *)
+   0x0e6f817e;       (* arm_SMLAL_VEC Q30 Q11 Q15 16 *)
+   0x4e6f8167;       (* arm_SMLAL2_VEC Q7 Q11 Q15 16 *)
+   0x0e7b8289;       (* arm_SMLAL_VEC Q9 Q20 Q27 16 *)
+   0x4e7b8290;       (* arm_SMLAL2_VEC Q16 Q20 Q27 16 *)
+   0x0e6a829e;       (* arm_SMLAL_VEC Q30 Q20 Q10 16 *)
+   0x4e6a8287;       (* arm_SMLAL2_VEC Q7 Q20 Q10 16 *)
+   0x3cc2044f;       (* arm_LDR Q15 X2 (Postimmediate_Offset (word 32)) *)
+   0x4e501934;       (* arm_UZP1 Q20 Q9 Q16 16 *)
+   0x4e471bc8;       (* arm_UZP1 Q8 Q30 Q7 16 *)
+   0x4e629e94;       (* arm_MUL_VEC Q20 Q20 Q2 16 128 *)
+   0x4e629d08;       (* arm_MUL_VEC Q8 Q8 Q2 16 128 *)
+   0x3cc20495;       (* arm_LDR Q21 X4 (Postimmediate_Offset (word 32)) *)
+   0x0e608289;       (* arm_SMLAL_VEC Q9 Q20 Q0 16 *)
+   0x4e608290;       (* arm_SMLAL2_VEC Q16 Q20 Q0 16 *)
+   0x0e60811e;       (* arm_SMLAL_VEC Q30 Q8 Q0 16 *)
+   0x4e608107;       (* arm_SMLAL2_VEC Q7 Q8 Q0 16 *)
+   0x3cdf0086;       (* arm_LDR Q6 X4 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4e50593b;       (* arm_UZP2 Q27 Q9 Q16 16 *)
+   0x4e475bca;       (* arm_UZP2 Q10 Q30 Q7 16 *)
+   0x3cdf0050;       (* arm_LDR Q16 X2 (Immediate_Offset (word 18446744073709551600)) *)
+   0x3dc0043e;       (* arm_LDR Q30 X1 (Immediate_Offset (word 16)) *)
+   0x4cdf7469;       (* arm_LDR Q9 X3 (Postimmediate_Offset (word 16)) *)
+   0x3cc204a1;       (* arm_LDR Q1 X5 (Postimmediate_Offset (word 32)) *)
+   0x3cdf00ac;       (* arm_LDR Q12 X5 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4cdf74d8;       (* arm_LDR Q24 X6 (Postimmediate_Offset (word 16)) *)
+   0x3cc204f3;       (* arm_LDR Q19 X7 (Postimmediate_Offset (word 32)) *)
+   0x3cdf00ff;       (* arm_LDR Q31 X7 (Immediate_Offset (word 18446744073709551600)) *)
+   0x3cc20511;       (* arm_LDR Q17 X8 (Postimmediate_Offset (word 32)) *)
+   0x3cdf0112;       (* arm_LDR Q18 X8 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4cdf7539;       (* arm_LDR Q25 X9 (Postimmediate_Offset (word 16)) *)
+   0xd10009ad;       (* arm_SUB X13 X13 (rvalue (word 2)) *)
+   0x3cc20434;       (* arm_LDR Q20 X1 (Postimmediate_Offset (word 32)) *)
+   0x4e5019e7;       (* arm_UZP1 Q7 Q15 Q16 16 *)
+   0x4e5059ef;       (* arm_UZP2 Q15 Q15 Q16 16 *)
+   0x4e5e1a88;       (* arm_UZP1 Q8 Q20 Q30 16 *)
+   0x4e5e5a94;       (* arm_UZP2 Q20 Q20 Q30 16 *)
+   0x0e6fc11e;       (* arm_SMULL_VEC Q30 Q8 Q15 16 *)
+   0x4e6fc10f;       (* arm_SMULL2_VEC Q15 Q8 Q15 16 *)
+   0x0e67c10b;       (* arm_SMULL_VEC Q11 Q8 Q7 16 *)
+   0x4e67c108;       (* arm_SMULL2_VEC Q8 Q8 Q7 16 *)
+   0x0e67829e;       (* arm_SMLAL_VEC Q30 Q20 Q7 16 *)
+   0x4e67828f;       (* arm_SMLAL2_VEC Q15 Q20 Q7 16 *)
+   0x0e69828b;       (* arm_SMLAL_VEC Q11 Q20 Q9 16 *)
+   0x4e698288;       (* arm_SMLAL2_VEC Q8 Q20 Q9 16 *)
+   0x4e461aa7;       (* arm_UZP1 Q7 Q21 Q6 16 *)
+   0x4e465ab4;       (* arm_UZP2 Q20 Q21 Q6 16 *)
+   0x4e4c1830;       (* arm_UZP1 Q16 Q1 Q12 16 *)
+   0x4e4c5829;       (* arm_UZP2 Q9 Q1 Q12 16 *)
+   0x0e7080eb;       (* arm_SMLAL_VEC Q11 Q7 Q16 16 *)
+   0x4e7080e8;       (* arm_SMLAL2_VEC Q8 Q7 Q16 16 *)
+   0x0e6980fe;       (* arm_SMLAL_VEC Q30 Q7 Q9 16 *)
+   0x4e6980ef;       (* arm_SMLAL2_VEC Q15 Q7 Q9 16 *)
+   0x0e78828b;       (* arm_SMLAL_VEC Q11 Q20 Q24 16 *)
+   0x4e788288;       (* arm_SMLAL2_VEC Q8 Q20 Q24 16 *)
+   0x0e70829e;       (* arm_SMLAL_VEC Q30 Q20 Q16 16 *)
+   0x4e70828f;       (* arm_SMLAL2_VEC Q15 Q20 Q16 16 *)
+   0x4e5f1a67;       (* arm_UZP1 Q7 Q19 Q31 16 *)
+   0x4e5f5a74;       (* arm_UZP2 Q20 Q19 Q31 16 *)
+   0x4e521a30;       (* arm_UZP1 Q16 Q17 Q18 16 *)
+   0x4e525a29;       (* arm_UZP2 Q9 Q17 Q18 16 *)
+   0x0e7080eb;       (* arm_SMLAL_VEC Q11 Q7 Q16 16 *)
+   0x4e7080e8;       (* arm_SMLAL2_VEC Q8 Q7 Q16 16 *)
+   0x0e6980fe;       (* arm_SMLAL_VEC Q30 Q7 Q9 16 *)
+   0x4e6980ef;       (* arm_SMLAL2_VEC Q15 Q7 Q9 16 *)
+   0x0e79828b;       (* arm_SMLAL_VEC Q11 Q20 Q25 16 *)
+   0x4e798288;       (* arm_SMLAL2_VEC Q8 Q20 Q25 16 *)
+   0x0e70829e;       (* arm_SMLAL_VEC Q30 Q20 Q16 16 *)
+   0x4e70828f;       (* arm_SMLAL2_VEC Q15 Q20 Q16 16 *)
+   0x3dc00450;       (* arm_LDR Q16 X2 (Immediate_Offset (word 16)) *)
+   0x4e481967;       (* arm_UZP1 Q7 Q11 Q8 16 *)
+   0x4e4f1bd4;       (* arm_UZP1 Q20 Q30 Q15 16 *)
+   0x4e629ce7;       (* arm_MUL_VEC Q7 Q7 Q2 16 128 *)
+   0x4e629e94;       (* arm_MUL_VEC Q20 Q20 Q2 16 128 *)
+   0x4e4a7b69;       (* arm_ZIP2 Q9 Q27 Q10 16 128 *)
+   0x4e4a3b7b;       (* arm_ZIP1 Q27 Q27 Q10 16 128 *)
+   0x0e6080eb;       (* arm_SMLAL_VEC Q11 Q7 Q0 16 *)
+   0x4e6080e8;       (* arm_SMLAL2_VEC Q8 Q7 Q0 16 *)
+   0x0e60829e;       (* arm_SMLAL_VEC Q30 Q20 Q0 16 *)
+   0x4e60828f;       (* arm_SMLAL2_VEC Q15 Q20 Q0 16 *)
+   0x3c82041b;       (* arm_STR Q27 X0 (Postimmediate_Offset (word 32)) *)
+   0x4e48597b;       (* arm_UZP2 Q27 Q11 Q8 16 *)
+   0x3c9f0009;       (* arm_STR Q9 X0 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4e4f5bca;       (* arm_UZP2 Q10 Q30 Q15 16 *)
+   0x3dc0043e;       (* arm_LDR Q30 X1 (Immediate_Offset (word 16)) *)
+   0x3cc2044f;       (* arm_LDR Q15 X2 (Postimmediate_Offset (word 32)) *)
+   0x4cdf7469;       (* arm_LDR Q9 X3 (Postimmediate_Offset (word 16)) *)
+   0x3cc20495;       (* arm_LDR Q21 X4 (Postimmediate_Offset (word 32)) *)
+   0x3cdf0086;       (* arm_LDR Q6 X4 (Immediate_Offset (word 18446744073709551600)) *)
+   0x3cc204a1;       (* arm_LDR Q1 X5 (Postimmediate_Offset (word 32)) *)
+   0x3cdf00ac;       (* arm_LDR Q12 X5 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4cdf74d8;       (* arm_LDR Q24 X6 (Postimmediate_Offset (word 16)) *)
+   0x3cc204f3;       (* arm_LDR Q19 X7 (Postimmediate_Offset (word 32)) *)
+   0x3cdf00ff;       (* arm_LDR Q31 X7 (Immediate_Offset (word 18446744073709551600)) *)
+   0x3cc20511;       (* arm_LDR Q17 X8 (Postimmediate_Offset (word 32)) *)
+   0x3cdf0112;       (* arm_LDR Q18 X8 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4cdf7539;       (* arm_LDR Q25 X9 (Postimmediate_Offset (word 16)) *)
+   0xd10005ad;       (* arm_SUB X13 X13 (rvalue (word 1)) *)
+   0xb5fff7cd;       (* arm_CBNZ X13 (word 2096888) *)
+   0x3cc20427;       (* arm_LDR Q7 X1 (Postimmediate_Offset (word 32)) *)
+   0x4e5019f4;       (* arm_UZP1 Q20 Q15 Q16 16 *)
+   0x4e5059ef;       (* arm_UZP2 Q15 Q15 Q16 16 *)
+   0x4e5e18f7;       (* arm_UZP1 Q23 Q7 Q30 16 *)
+   0x4e5e58eb;       (* arm_UZP2 Q11 Q7 Q30 16 *)
+   0x4e74c2e8;       (* arm_SMULL2_VEC Q8 Q23 Q20 16 *)
+   0x0e74c2e5;       (* arm_SMULL_VEC Q5 Q23 Q20 16 *)
+   0x4e6fc2fe;       (* arm_SMULL2_VEC Q30 Q23 Q15 16 *)
+   0x4e4c183c;       (* arm_UZP1 Q28 Q1 Q12 16 *)
+   0x4e698168;       (* arm_SMLAL2_VEC Q8 Q11 Q9 16 *)
+   0x0e698165;       (* arm_SMLAL_VEC Q5 Q11 Q9 16 *)
+   0x4e461aa3;       (* arm_UZP1 Q3 Q21 Q6 16 *)
+   0x0e6fc2f0;       (* arm_SMULL_VEC Q16 Q23 Q15 16 *)
+   0x4e7c8068;       (* arm_SMLAL2_VEC Q8 Q3 Q28 16 *)
+   0x0e7c8065;       (* arm_SMLAL_VEC Q5 Q3 Q28 16 *)
+   0x4e465abd;       (* arm_UZP2 Q29 Q21 Q6 16 *)
+   0x4e521a27;       (* arm_UZP1 Q7 Q17 Q18 16 *)
+   0x4e7883a8;       (* arm_SMLAL2_VEC Q8 Q29 Q24 16 *)
+   0x4e5f1a6e;       (* arm_UZP1 Q14 Q19 Q31 16 *)
+   0x0e748170;       (* arm_SMLAL_VEC Q16 Q11 Q20 16 *)
+   0x4e74817e;       (* arm_SMLAL2_VEC Q30 Q11 Q20 16 *)
+   0x4e6781c8;       (* arm_SMLAL2_VEC Q8 Q14 Q7 16 *)
+   0x4e4c5834;       (* arm_UZP2 Q20 Q1 Q12 16 *)
+   0x4e5f5a75;       (* arm_UZP2 Q21 Q19 Q31 16 *)
+   0x4e74807e;       (* arm_SMLAL2_VEC Q30 Q3 Q20 16 *)
+   0x0e748070;       (* arm_SMLAL_VEC Q16 Q3 Q20 16 *)
+   0x0e7883a5;       (* arm_SMLAL_VEC Q5 Q29 Q24 16 *)
+   0x4e525a29;       (* arm_UZP2 Q9 Q17 Q18 16 *)
+   0x4e7c83be;       (* arm_SMLAL2_VEC Q30 Q29 Q28 16 *)
+   0x0e7c83b0;       (* arm_SMLAL_VEC Q16 Q29 Q28 16 *)
+   0x0e6781c5;       (* arm_SMLAL_VEC Q5 Q14 Q7 16 *)
+   0x4e7982a8;       (* arm_SMLAL2_VEC Q8 Q21 Q25 16 *)
+   0x4e6981de;       (* arm_SMLAL2_VEC Q30 Q14 Q9 16 *)
+   0x0e6981d0;       (* arm_SMLAL_VEC Q16 Q14 Q9 16 *)
+   0x0e7982a5;       (* arm_SMLAL_VEC Q5 Q21 Q25 16 *)
+   0x4e4a3b74;       (* arm_ZIP1 Q20 Q27 Q10 16 128 *)
+   0x4e6782be;       (* arm_SMLAL2_VEC Q30 Q21 Q7 16 *)
+   0x0e6782b0;       (* arm_SMLAL_VEC Q16 Q21 Q7 16 *)
+   0x4e4818a7;       (* arm_UZP1 Q7 Q5 Q8 16 *)
+   0x3c820414;       (* arm_STR Q20 X0 (Postimmediate_Offset (word 32)) *)
+   0x4e629cef;       (* arm_MUL_VEC Q15 Q7 Q2 16 128 *)
+   0x4e5e1a07;       (* arm_UZP1 Q7 Q16 Q30 16 *)
+   0x4e4a7b7f;       (* arm_ZIP2 Q31 Q27 Q10 16 128 *)
+   0x4e629cf4;       (* arm_MUL_VEC Q20 Q7 Q2 16 128 *)
+   0x0e6081e5;       (* arm_SMLAL_VEC Q5 Q15 Q0 16 *)
+   0x4e6081e8;       (* arm_SMLAL2_VEC Q8 Q15 Q0 16 *)
+   0x3c9f001f;       (* arm_STR Q31 X0 (Immediate_Offset (word 18446744073709551600)) *)
+   0x4e60829e;       (* arm_SMLAL2_VEC Q30 Q20 Q0 16 *)
+   0x0e608290;       (* arm_SMLAL_VEC Q16 Q20 Q0 16 *)
+   0x4e4858af;       (* arm_UZP2 Q15 Q5 Q8 16 *)
+   0x4e5e5a14;       (* arm_UZP2 Q20 Q16 Q30 16 *)
+   0x4e5439e7;       (* arm_ZIP1 Q7 Q15 Q20 16 128 *)
+   0x4e5479f4;       (* arm_ZIP2 Q20 Q15 Q20 16 128 *)
+   0x3c820407;       (* arm_STR Q7 X0 (Postimmediate_Offset (word 32)) *)
+   0x3c9f0014;       (* arm_STR Q20 X0 (Immediate_Offset (word 18446744073709551600)) *)
+   0x6d4027e8;       (* arm_LDP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+   0x6d412fea;       (* arm_LDP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+   0x6d4237ec;       (* arm_LDP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+   0x6d433fee;       (* arm_LDP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+   0x910103ff;       (* arm_ADD SP SP (rvalue (word 64)) *)
+   0xd65f03c0        (* arm_RET X30 *)
+ ];;
+
+ let pmull = define
+   `pmull (x0: 16 word) (x1 : 16 word) (y0 : 16 word) (y1 : 16 word) =
+       word_add (word_mul ((word_sx x1) : 32 word) (word_sx y1))
+                (word_mul ((word_sx x0) : 32 word) (word_sx y0))`;;
+
+ let pmull_acc3 = define
+ `pmull_acc3 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
+             (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word)
+             (x20: 16 word) (x21 : 16 word) (y20 : 16 word) (y21 : 16 word) =
+   word_add (word_add (pmull x20 x21 y20 y21) (pmull x10 x11 y10 y11)) (pmull x00 x01 y00 y01)`;;
+
+ let montred = define
+    `montred (x : 32 word) =
+       word_subword (
+          word_add (
+            word_mul (
+              (word_sx : 16 word -> 32 word) (
+                word_mul (
+                  word_subword x (0,16)
+                ) (word 3327)
+              )
+            )
+            (word 3329)
+          ) x
+       ) (16, 16)`;;
+
+ let pmul_acc3 = define
+     `pmul_acc3 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
+                (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word)
+                (x20: 16 word) (x21 : 16 word) (y20 : 16 word) (y21 : 16 word) =
+       montred (pmull_acc3 x00 x01 y00 y01 x10 x11 y10 y11 x20 x21 y20 y21)`;;
+
+ let basemul3_even_raw = define
+    `basemul3_even_raw x0 y0 y0t x1 y1 y1t x2 y2 y2t = \i.
+       pmul_acc3 (x0 (2 * i)) (x0 (2 * i + 1))
+                 (y0 (2 * i)) (y0t i)
+                 (x1 (2 * i)) (x1 (2 * i + 1))
+                 (y1 (2 * i)) (y1t i)
+                 (x2 (2 * i)) (x2 (2 * i + 1))
+                 (y2 (2 * i)) (y2t i)
+    `;;
+
+ let basemul3_odd_raw = define
+  `basemul3_odd_raw x0 y0 x1 y1 x2 y2 = \i.
+     pmul_acc3 (x0 (2 * i)) (x0 (2 * i + 1))
+               (y0 (2 * i + 1)) (y0 (2 * i))
+               (x1 (2 * i)) (x1 (2 * i + 1))
+               (y1 (2 * i + 1)) (y1 (2 * i))
+               (x2 (2 * i)) (x2 (2 * i + 1))
+               (y2 (2 * i + 1)) (y2 (2 * i))
+  `;;
+
+ let poly_basemul_acc_montgomery_cached_k3_EXEC = ARM_MK_EXEC_RULE poly_basemul_acc_montgomery_cached_k3_mc;;
+
+ let poly_basemul_acc_montgomery_cached_k3_GOAL = `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t pc.
+      ALL (nonoverlapping (dst, 512))
+          [(word pc, LENGTH poly_basemul_acc_montgomery_cached_k3_mc); (srcA, 1536); (srcB, 1536); (srcBt, 768)]
+      ==>
+      ensures arm
+        (\s. aligned_bytes_loaded s (word pc) poly_basemul_acc_montgomery_cached_k3_mc /\
+             read PC s = word (pc + 20)  /\
+             C_ARGUMENTS [dst; srcA; srcB; srcBt] s  /\
+             (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (2 * i)))) s = x0 i)        /\
+             (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (2 * i)))) s = y0 i)        /\
+             (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i)       /\
+             (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (512 + 2 * i)))) s = x1 i)  /\
+             (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (512 + 2 * i)))) s = y1 i)  /\
+             (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i) /\
+             (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (1024 + 2 * i)))) s = x2 i)  /\
+             (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (1024 + 2 * i)))) s = y2 i)  /\
+             (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (512  + 2 * i)))) s = y2t i)
+        )
+        (\s. read PC s = word (pc + 856) /\
+             (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
+                                   basemul3_even_raw x0 y0 y0t x1 y1 y1t x2 y2 y2t i /\
+                              read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
+                                   basemul3_odd_raw x0 y0 x1 y1 x2 y2 i))
+        // Register and memory footprint
+        (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+         MAYCHANGE [Q8; Q9; Q10; Q11; Q12; Q13; Q14; Q15] ,,
+         MAYCHANGE [memory :> bytes(dst, 512)])
+    `;;
+
+  (* ------------------------------------------------------------------------- *)
+  (* Proof                                                                     *)
+  (* ------------------------------------------------------------------------- *)
+
+ let poly_basemul_acc_montgomery_cached_k3_SPEC = prove(poly_basemul_acc_montgomery_cached_k3_GOAL,
+       REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI;
+        MODIFIABLE_SIMD_REGS;
+        NONOVERLAPPING_CLAUSES; ALL; C_ARGUMENTS; fst poly_basemul_acc_montgomery_cached_k3_EXEC] THEN
+      REPEAT STRIP_TAC THEN
+
+      (* Split quantified assumptions into separate cases *)
+      CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
+      CONV_TAC((ONCE_DEPTH_CONV NUM_MULT_CONV) THENC (ONCE_DEPTH_CONV NUM_ADD_CONV)) THEN
+
+      (* Initialize symbolic execution *)
+      ENSURES_INIT_TAC "s0" THEN
+
+      (* Rewrite memory-read assumptions from 16-bit granularity
+       * to 128-bit granularity. *)
+      MEMORY_128_FROM_16_TAC "srcA" 96 THEN
+      MEMORY_128_FROM_16_TAC "srcB" 96 THEN
+      MEMORY_128_FROM_16_TAC "srcBt" 48 THEN
+      ASM_REWRITE_TAC [WORD_ADD_0] THEN
+      (* Forget original shape of assumption *)
+      DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcA) s = x`] THEN
+      DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcB) s = x`] THEN
+      DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcBt) s = x`] THEN
+
+      (* Symbolic execution
+         Note that we simplify eagerly after every step.
+         This reduces the proof time *)
+      REPEAT STRIP_TAC THEN
+      MAP_EVERY (fun n -> ARM_STEPS_TAC poly_basemul_acc_montgomery_cached_k3_EXEC [n] THEN
+                 (SIMD_SIMPLIFY_TAC [pmull; GSYM WORD_ADD_ASSOC; pmull_acc3; montred; pmul_acc3])) (1--1080) THEN
+
+      ENSURES_FINAL_STATE_TAC THEN
+      REPEAT CONJ_TAC THEN
+      ASM_REWRITE_TAC [] THEN
+
+      (* Reverse restructuring *)
+      REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
+        CONV_RULE (SIMD_SIMPLIFY_CONV []) o
+        CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
+        check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
+
+      (* Split quantified post-condition into separate cases *)
+      CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV
+               THENC (TRY_CONV (ONCE_DEPTH_CONV NUM_ADD_CONV))) THEN
+      CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN
+      ASM_REWRITE_TAC [WORD_ADD_0] THEN
+
+      (* Forget all assumptions *)
+      POP_ASSUM_LIST (K ALL_TAC) THEN
+
+      (* Split into one congruence goals per index. *)
+      REPEAT CONJ_TAC THEN
+
+      REWRITE_TAC[basemul3_even_raw; basemul3_odd_raw] THEN
+      CONV_TAC(ONCE_DEPTH_CONV EL_CONV) THEN
+      CONV_TAC(REPEATC (CHANGED_CONV (ONCE_DEPTH_CONV (NUM_MULT_CONV ORELSEC NUM_ADD_CONV)))) THEN
+      REFL_TAC
+  );;
+
+  let TWEAK_CONV =
+   ONCE_DEPTH_CONV let_CONV THENC
+   ONCE_DEPTH_CONV EXPAND_CASES_CONV THENC
+   ONCE_DEPTH_CONV NUM_MULT_CONV THENC
+   ONCE_DEPTH_CONV NUM_ADD_CONV THENC
+   PURE_REWRITE_CONV [WORD_ADD_0];;
+
+ let poly_basemul_acc_montgomery_cached_k3_SPEC' = prove(
+    `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t pc returnaddress stackpointer.
+       aligned 16 stackpointer /\
+       ALLPAIRS nonoverlapping
+         [(dst, 512); (word_sub stackpointer (word 64),64)]
+         [(word pc, LENGTH poly_basemul_acc_montgomery_cached_k3_mc); (srcA, 1536); (srcB, 1536); (srcBt, 768)] /\
+       nonoverlapping (dst,512) (word_sub stackpointer (word 64),64)
+       ==>
+       ensures arm
+       (\s. // Assert that poly_basemul_acc_montgomery_cached_k3 is loaded at PC
+         aligned_bytes_loaded s (word pc) poly_basemul_acc_montgomery_cached_k3_mc /\
+         read PC s = word pc /\
+         read SP s = stackpointer /\
+         read X30 s = returnaddress /\
+         C_ARGUMENTS [dst; srcA; srcB; srcBt] s  /\
+         // Give names to in-memory data to be
+         // able to refer to them in the post-condition
+         (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (2 * i)))) s = x0 i) /\
+         (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (2 * i)))) s = y0 i) /\
+         (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i) /\
+         (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (512 + 2 * i)))) s = x1 i) /\
+         (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (512 + 2 * i)))) s = y1 i) /\
+         (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i) /\
+         (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (1024 + 2 * i)))) s = x2 i) /\
+         (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (1024 + 2 * i)))) s = y2 i) /\
+         (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (512  + 2 * i)))) s = y2t i)
+       )
+       (\s. read PC s = returnaddress /\
+        (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
+                              basemul3_even_raw x0 y0 y0t x1 y1 y1t x2 y2 y2t i /\
+                         read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
+                              basemul3_odd_raw x0 y0 x1 y1 x2 y2 i)
+       )
+       // Register and memory footprint
+       (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+       MAYCHANGE [memory :> bytes(dst, 512);
+                  memory :> bytes(word_sub stackpointer (word 64),64)])`,
+   REWRITE_TAC[fst poly_basemul_acc_montgomery_cached_k3_EXEC] THEN
+   CONV_TAC TWEAK_CONV THEN
+   ARM_ADD_RETURN_STACK_TAC ~pre_post_nsteps:(5,5) poly_basemul_acc_montgomery_cached_k3_EXEC
+      (REWRITE_RULE[fst poly_basemul_acc_montgomery_cached_k3_EXEC] (CONV_RULE TWEAK_CONV poly_basemul_acc_montgomery_cached_k3_SPEC))
+       `[D8; D9; D10; D11; D12; D13; D14; D15]` 64  THEN
+    WORD_ARITH_TAC)
+ ;;

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
@@ -1,0 +1,501 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+needs "arm/proofs/base.ml";;
+
+needs "proofs/mlkem_specs.ml";;
+needs "proofs/mlkem_utils.ml";;
+
+(**** print_literal_from_elf "mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.o";;
+ ****)
+
+let poly_basemul_acc_montgomery_cached_k4_mc = define_assert_from_elf
+  "poly_basemul_acc_montgomery_cached_k4_mc" "mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.o"
+     [
+        0xd10103ff;       (* arm_SUB SP SP (rvalue (word 64)) *)
+        0x6d0027e8;       (* arm_STP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+        0x6d012fea;       (* arm_STP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+        0x6d0237ec;       (* arm_STP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+        0x6d033fee;       (* arm_STP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+        0x5281a02e;       (* arm_MOV W14 (rvalue (word 3329)) *)
+        0x4e020dc0;       (* arm_DUP_GEN Q0 X14 16 128 *)
+        0x52819fee;       (* arm_MOV W14 (rvalue (word 3327)) *)
+        0x4e020dc2;       (* arm_DUP_GEN Q2 X14 16 128 *)
+        0x91080024;       (* arm_ADD X4 X1 (rvalue (word 512)) *)
+        0x91080045;       (* arm_ADD X5 X2 (rvalue (word 512)) *)
+        0x91040066;       (* arm_ADD X6 X3 (rvalue (word 256)) *)
+        0x91100027;       (* arm_ADD X7 X1 (rvalue (word 1024)) *)
+        0x91100048;       (* arm_ADD X8 X2 (rvalue (word 1024)) *)
+        0x91080069;       (* arm_ADD X9 X3 (rvalue (word 512)) *)
+        0x9118002a;       (* arm_ADD X10 X1 (rvalue (word 1536)) *)
+        0x9118004b;       (* arm_ADD X11 X2 (rvalue (word 1536)) *)
+        0x910c006c;       (* arm_ADD X12 X3 (rvalue (word 768)) *)
+        0xd280020d;       (* arm_MOV X13 (rvalue (word 16)) *)
+        0x3dc00457;       (* arm_LDR Q23 X2 (Immediate_Offset (word 16)) *)
+        0x3cc20453;       (* arm_LDR Q19 X2 (Postimmediate_Offset (word 32)) *)
+        0x3cc204b1;       (* arm_LDR Q17 X5 (Postimmediate_Offset (word 32)) *)
+        0x4e575a6d;       (* arm_UZP2 Q13 Q19 Q23 16 *)
+        0x4e571a73;       (* arm_UZP1 Q19 Q19 Q23 16 *)
+        0x3cdf00b7;       (* arm_LDR Q23 X5 (Immediate_Offset (word 18446744073709551600)) *)
+        0x3dc0043e;       (* arm_LDR Q30 X1 (Immediate_Offset (word 16)) *)
+        0x4e575a29;       (* arm_UZP2 Q9 Q17 Q23 16 *)
+        0x4e571a37;       (* arm_UZP1 Q23 Q17 Q23 16 *)
+        0x3cc20431;       (* arm_LDR Q17 X1 (Postimmediate_Offset (word 32)) *)
+        0x3dc004ea;       (* arm_LDR Q10 X7 (Immediate_Offset (word 16)) *)
+        0x4e5e1a2c;       (* arm_UZP1 Q12 Q17 Q30 16 *)
+        0x4e5e5a31;       (* arm_UZP2 Q17 Q17 Q30 16 *)
+        0x4e6dc19e;       (* arm_SMULL2_VEC Q30 Q12 Q13 16 *)
+        0x0e6dc18d;       (* arm_SMULL_VEC Q13 Q12 Q13 16 *)
+        0x4e73c196;       (* arm_SMULL2_VEC Q22 Q12 Q19 16 *)
+        0x0e73c18c;       (* arm_SMULL_VEC Q12 Q12 Q19 16 *)
+        0x4e73823e;       (* arm_SMLAL2_VEC Q30 Q17 Q19 16 *)
+        0x0e73822d;       (* arm_SMLAL_VEC Q13 Q17 Q19 16 *)
+        0x3cc20493;       (* arm_LDR Q19 X4 (Postimmediate_Offset (word 32)) *)
+        0x3cdf0090;       (* arm_LDR Q16 X4 (Immediate_Offset (word 18446744073709551600)) *)
+        0x4cdf7468;       (* arm_LDR Q8 X3 (Postimmediate_Offset (word 16)) *)
+        0x4e501a7a;       (* arm_UZP1 Q26 Q19 Q16 16 *)
+        0x4e505a73;       (* arm_UZP2 Q19 Q19 Q16 16 *)
+        0x4e69835e;       (* arm_SMLAL2_VEC Q30 Q26 Q9 16 *)
+        0x0e69834d;       (* arm_SMLAL_VEC Q13 Q26 Q9 16 *)
+        0x4e688236;       (* arm_SMLAL2_VEC Q22 Q17 Q8 16 *)
+        0x0e68822c;       (* arm_SMLAL_VEC Q12 Q17 Q8 16 *)
+        0x4e77827e;       (* arm_SMLAL2_VEC Q30 Q19 Q23 16 *)
+        0x0e77826d;       (* arm_SMLAL_VEC Q13 Q19 Q23 16 *)
+        0x4e778356;       (* arm_SMLAL2_VEC Q22 Q26 Q23 16 *)
+        0x0e77834c;       (* arm_SMLAL_VEC Q12 Q26 Q23 16 *)
+        0x3cc204f7;       (* arm_LDR Q23 X7 (Postimmediate_Offset (word 32)) *)
+        0x3dc00511;       (* arm_LDR Q17 X8 (Immediate_Offset (word 16)) *)
+        0x4e4a1ae9;       (* arm_UZP1 Q9 Q23 Q10 16 *)
+        0x4e4a5af7;       (* arm_UZP2 Q23 Q23 Q10 16 *)
+        0x3cc2054a;       (* arm_LDR Q10 X10 (Postimmediate_Offset (word 32)) *)
+        0x3cdf0150;       (* arm_LDR Q16 X10 (Immediate_Offset (word 18446744073709551600)) *)
+        0x4cdf7588;       (* arm_LDR Q8 X12 (Postimmediate_Offset (word 16)) *)
+        0x4e50195a;       (* arm_UZP1 Q26 Q10 Q16 16 *)
+        0x4e50594a;       (* arm_UZP2 Q10 Q10 Q16 16 *)
+        0x4cdf74d0;       (* arm_LDR Q16 X6 (Postimmediate_Offset (word 16)) *)
+        0x3dc00563;       (* arm_LDR Q3 X11 (Immediate_Offset (word 16)) *)
+        0x4e708276;       (* arm_SMLAL2_VEC Q22 Q19 Q16 16 *)
+        0x0e70826c;       (* arm_SMLAL_VEC Q12 Q19 Q16 16 *)
+        0x3cc20573;       (* arm_LDR Q19 X11 (Postimmediate_Offset (word 32)) *)
+        0x4cdf7530;       (* arm_LDR Q16 X9 (Postimmediate_Offset (word 16)) *)
+        0x4e431a64;       (* arm_UZP1 Q4 Q19 Q3 16 *)
+        0x4e435a73;       (* arm_UZP2 Q19 Q19 Q3 16 *)
+        0x3cc20503;       (* arm_LDR Q3 X8 (Postimmediate_Offset (word 32)) *)
+        0x3cc2045f;       (* arm_LDR Q31 X2 (Postimmediate_Offset (word 32)) *)
+        0x4e511866;       (* arm_UZP1 Q6 Q3 Q17 16 *)
+        0x4e515871;       (* arm_UZP2 Q17 Q3 Q17 16 *)
+        0x4e668136;       (* arm_SMLAL2_VEC Q22 Q9 Q6 16 *)
+        0x4e71813e;       (* arm_SMLAL2_VEC Q30 Q9 Q17 16 *)
+        0x0e71812d;       (* arm_SMLAL_VEC Q13 Q9 Q17 16 *)
+        0x0e66812c;       (* arm_SMLAL_VEC Q12 Q9 Q6 16 *)
+        0x4e7082f6;       (* arm_SMLAL2_VEC Q22 Q23 Q16 16 *)
+        0x4e6682fe;       (* arm_SMLAL2_VEC Q30 Q23 Q6 16 *)
+        0x0e6682ed;       (* arm_SMLAL_VEC Q13 Q23 Q6 16 *)
+        0x0e7082ec;       (* arm_SMLAL_VEC Q12 Q23 Q16 16 *)
+        0x4e648356;       (* arm_SMLAL2_VEC Q22 Q26 Q4 16 *)
+        0x4e73835e;       (* arm_SMLAL2_VEC Q30 Q26 Q19 16 *)
+        0x0e73834d;       (* arm_SMLAL_VEC Q13 Q26 Q19 16 *)
+        0x0e64834c;       (* arm_SMLAL_VEC Q12 Q26 Q4 16 *)
+        0x4e688156;       (* arm_SMLAL2_VEC Q22 Q10 Q8 16 *)
+        0x4e64815e;       (* arm_SMLAL2_VEC Q30 Q10 Q4 16 *)
+        0x0e64814d;       (* arm_SMLAL_VEC Q13 Q10 Q4 16 *)
+        0x0e68814c;       (* arm_SMLAL_VEC Q12 Q10 Q8 16 *)
+        0x3cdf0053;       (* arm_LDR Q19 X2 (Immediate_Offset (word 18446744073709551600)) *)
+        0x4e5e19b7;       (* arm_UZP1 Q23 Q13 Q30 16 *)
+        0x4e561991;       (* arm_UZP1 Q17 Q12 Q22 16 *)
+        0x4e629ef7;       (* arm_MUL_VEC Q23 Q23 Q2 16 128 *)
+        0x4e535bf5;       (* arm_UZP2 Q21 Q31 Q19 16 *)
+        0x4e531bf3;       (* arm_UZP1 Q19 Q31 Q19 16 *)
+        0x4e629e31;       (* arm_MUL_VEC Q17 Q17 Q2 16 128 *)
+        0x0e6082ed;       (* arm_SMLAL_VEC Q13 Q23 Q0 16 *)
+        0x4e6082fe;       (* arm_SMLAL2_VEC Q30 Q23 Q0 16 *)
+        0x3cc204b7;       (* arm_LDR Q23 X5 (Postimmediate_Offset (word 32)) *)
+        0x4e608236;       (* arm_SMLAL2_VEC Q22 Q17 Q0 16 *)
+        0x4e5e59af;       (* arm_UZP2 Q15 Q13 Q30 16 *)
+        0x0e60822c;       (* arm_SMLAL_VEC Q12 Q17 Q0 16 *)
+        0x3cdf00b1;       (* arm_LDR Q17 X5 (Immediate_Offset (word 18446744073709551600)) *)
+        0x3dc0042d;       (* arm_LDR Q13 X1 (Immediate_Offset (word 16)) *)
+        0x4e515afb;       (* arm_UZP2 Q27 Q23 Q17 16 *)
+        0x4e511afc;       (* arm_UZP1 Q28 Q23 Q17 16 *)
+        0x4e565987;       (* arm_UZP2 Q7 Q12 Q22 16 *)
+        0x3cc20437;       (* arm_LDR Q23 X1 (Postimmediate_Offset (word 32)) *)
+        0x4e4f38e5;       (* arm_ZIP1 Q5 Q7 Q15 16 128 *)
+        0x3dc004e3;       (* arm_LDR Q3 X7 (Immediate_Offset (word 16)) *)
+        0x4e4d1aff;       (* arm_UZP1 Q31 Q23 Q13 16 *)
+        0x4e4d5af0;       (* arm_UZP2 Q16 Q23 Q13 16 *)
+        0x4e75c3f8;       (* arm_SMULL2_VEC Q24 Q31 Q21 16 *)
+        0x3dc00506;       (* arm_LDR Q6 X8 (Immediate_Offset (word 16)) *)
+        0x3cc20557;       (* arm_LDR Q23 X10 (Postimmediate_Offset (word 32)) *)
+        0x4e738218;       (* arm_SMLAL2_VEC Q24 Q16 Q19 16 *)
+        0x3cdf0151;       (* arm_LDR Q17 X10 (Immediate_Offset (word 18446744073709551600)) *)
+        0x4cdf7596;       (* arm_LDR Q22 X12 (Postimmediate_Offset (word 16)) *)
+        0x4e511afe;       (* arm_UZP1 Q30 Q23 Q17 16 *)
+        0x4e515aeb;       (* arm_UZP2 Q11 Q23 Q17 16 *)
+        0x3cc20497;       (* arm_LDR Q23 X4 (Postimmediate_Offset (word 32)) *)
+        0x3cdf0091;       (* arm_LDR Q17 X4 (Immediate_Offset (word 18446744073709551600)) *)
+        0x3cc204e4;       (* arm_LDR Q4 X7 (Postimmediate_Offset (word 32)) *)
+        0x4e511af4;       (* arm_UZP1 Q20 Q23 Q17 16 *)
+        0x4e515afa;       (* arm_UZP2 Q26 Q23 Q17 16 *)
+        0x4e431889;       (* arm_UZP1 Q9 Q4 Q3 16 *)
+        0x4e7b8298;       (* arm_SMLAL2_VEC Q24 Q20 Q27 16 *)
+        0x4cdf74c8;       (* arm_LDR Q8 X6 (Postimmediate_Offset (word 16)) *)
+        0x3dc00579;       (* arm_LDR Q25 X11 (Immediate_Offset (word 16)) *)
+        0x3cc2057d;       (* arm_LDR Q29 X11 (Postimmediate_Offset (word 32)) *)
+        0x4cdf752c;       (* arm_LDR Q12 X9 (Postimmediate_Offset (word 16)) *)
+        0x4e591baa;       (* arm_UZP1 Q10 Q29 Q25 16 *)
+        0x3cc2050e;       (* arm_LDR Q14 X8 (Postimmediate_Offset (word 32)) *)
+        0x4cdf7477;       (* arm_LDR Q23 X3 (Postimmediate_Offset (word 16)) *)
+        0xd10009ad;       (* arm_SUB X13 X13 (rvalue (word 2)) *)
+        0x4e7c8358;       (* arm_SMLAL2_VEC Q24 Q26 Q28 16 *)
+        0x4e435884;       (* arm_UZP2 Q4 Q4 Q3 16 *)
+        0x4e73c3ed;       (* arm_SMULL2_VEC Q13 Q31 Q19 16 *)
+        0x3cc20443;       (* arm_LDR Q3 X2 (Postimmediate_Offset (word 32)) *)
+        0x4e595ba1;       (* arm_UZP2 Q1 Q29 Q25 16 *)
+        0x4e77820d;       (* arm_SMLAL2_VEC Q13 Q16 Q23 16 *)
+        0x3cdf0051;       (* arm_LDR Q17 X2 (Immediate_Offset (word 18446744073709551600)) *)
+        0x0e73c3f2;       (* arm_SMULL_VEC Q18 Q31 Q19 16 *)
+        0x4e7c828d;       (* arm_SMLAL2_VEC Q13 Q20 Q28 16 *)
+        0x0e75c3fd;       (* arm_SMULL_VEC Q29 Q31 Q21 16 *)
+        0x3cc204b5;       (* arm_LDR Q21 X5 (Postimmediate_Offset (word 32)) *)
+        0x4e68834d;       (* arm_SMLAL2_VEC Q13 Q26 Q8 16 *)
+        0x0e73821d;       (* arm_SMLAL_VEC Q29 Q16 Q19 16 *)
+        0x3cdf00b3;       (* arm_LDR Q19 X5 (Immediate_Offset (word 18446744073709551600)) *)
+        0x0e778212;       (* arm_SMLAL_VEC Q18 Q16 Q23 16 *)
+        0x0e7b829d;       (* arm_SMLAL_VEC Q29 Q20 Q27 16 *)
+        0x4e4619df;       (* arm_UZP1 Q31 Q14 Q6 16 *)
+        0x4e535abb;       (* arm_UZP2 Q27 Q21 Q19 16 *)
+        0x0e7c8292;       (* arm_SMLAL_VEC Q18 Q20 Q28 16 *)
+        0x3dc00439;       (* arm_LDR Q25 X1 (Immediate_Offset (word 16)) *)
+        0x0e7c835d;       (* arm_SMLAL_VEC Q29 Q26 Q28 16 *)
+        0x0e688352;       (* arm_SMLAL_VEC Q18 Q26 Q8 16 *)
+        0x4e4659da;       (* arm_UZP2 Q26 Q14 Q6 16 *)
+        0x4e7f812d;       (* arm_SMLAL2_VEC Q13 Q9 Q31 16 *)
+        0x4e7a8138;       (* arm_SMLAL2_VEC Q24 Q9 Q26 16 *)
+        0x0e7a813d;       (* arm_SMLAL_VEC Q29 Q9 Q26 16 *)
+        0x0e7f8132;       (* arm_SMLAL_VEC Q18 Q9 Q31 16 *)
+        0x4e6c808d;       (* arm_SMLAL2_VEC Q13 Q4 Q12 16 *)
+        0x4e7f8098;       (* arm_SMLAL2_VEC Q24 Q4 Q31 16 *)
+        0x0e7f809d;       (* arm_SMLAL_VEC Q29 Q4 Q31 16 *)
+        0x0e6c8092;       (* arm_SMLAL_VEC Q18 Q4 Q12 16 *)
+        0x4e6a83cd;       (* arm_SMLAL2_VEC Q13 Q30 Q10 16 *)
+        0x4e6183d8;       (* arm_SMLAL2_VEC Q24 Q30 Q1 16 *)
+        0x0e6183dd;       (* arm_SMLAL_VEC Q29 Q30 Q1 16 *)
+        0x0e6a83d2;       (* arm_SMLAL_VEC Q18 Q30 Q10 16 *)
+        0x4e76816d;       (* arm_SMLAL2_VEC Q13 Q11 Q22 16 *)
+        0x4e6a8178;       (* arm_SMLAL2_VEC Q24 Q11 Q10 16 *)
+        0x0e6a817d;       (* arm_SMLAL_VEC Q29 Q11 Q10 16 *)
+        0x0e768172;       (* arm_SMLAL_VEC Q18 Q11 Q22 16 *)
+        0x3cc20436;       (* arm_LDR Q22 X1 (Postimmediate_Offset (word 32)) *)
+        0x4e581bbf;       (* arm_UZP1 Q31 Q29 Q24 16 *)
+        0x4e531abc;       (* arm_UZP1 Q28 Q21 Q19 16 *)
+        0x4e629ff3;       (* arm_MUL_VEC Q19 Q31 Q2 16 128 *)
+        0x4e591adf;       (* arm_UZP1 Q31 Q22 Q25 16 *)
+        0x4e595ad0;       (* arm_UZP2 Q16 Q22 Q25 16 *)
+        0x4e515875;       (* arm_UZP2 Q21 Q3 Q17 16 *)
+        0x0e60827d;       (* arm_SMLAL_VEC Q29 Q19 Q0 16 *)
+        0x4e608278;       (* arm_SMLAL2_VEC Q24 Q19 Q0 16 *)
+        0x4e511873;       (* arm_UZP1 Q19 Q3 Q17 16 *)
+        0x4e4d1a5a;       (* arm_UZP1 Q26 Q18 Q13 16 *)
+        0x4e4f78ee;       (* arm_ZIP2 Q14 Q7 Q15 16 128 *)
+        0x4e629f57;       (* arm_MUL_VEC Q23 Q26 Q2 16 128 *)
+        0x4e585baf;       (* arm_UZP2 Q15 Q29 Q24 16 *)
+        0x4e75c3f8;       (* arm_SMULL2_VEC Q24 Q31 Q21 16 *)
+        0x3d80040e;       (* arm_STR Q14 X0 (Immediate_Offset (word 16)) *)
+        0x3dc004e3;       (* arm_LDR Q3 X7 (Immediate_Offset (word 16)) *)
+        0x3dc00506;       (* arm_LDR Q6 X8 (Immediate_Offset (word 16)) *)
+        0x3cc20548;       (* arm_LDR Q8 X10 (Postimmediate_Offset (word 32)) *)
+        0x3cdf015a;       (* arm_LDR Q26 X10 (Immediate_Offset (word 18446744073709551600)) *)
+        0x4cdf7596;       (* arm_LDR Q22 X12 (Postimmediate_Offset (word 16)) *)
+        0x4e5a191e;       (* arm_UZP1 Q30 Q8 Q26 16 *)
+        0x4e5a590b;       (* arm_UZP2 Q11 Q8 Q26 16 *)
+        0x3cc20488;       (* arm_LDR Q8 X4 (Postimmediate_Offset (word 32)) *)
+        0x3cdf009a;       (* arm_LDR Q26 X4 (Immediate_Offset (word 18446744073709551600)) *)
+        0x3cc204e4;       (* arm_LDR Q4 X7 (Postimmediate_Offset (word 32)) *)
+        0x4e5a1914;       (* arm_UZP1 Q20 Q8 Q26 16 *)
+        0x4e5a591a;       (* arm_UZP2 Q26 Q8 Q26 16 *)
+        0x4cdf74c8;       (* arm_LDR Q8 X6 (Postimmediate_Offset (word 16)) *)
+        0x4e431889;       (* arm_UZP1 Q9 Q4 Q3 16 *)
+        0x3dc00579;       (* arm_LDR Q25 X11 (Immediate_Offset (word 16)) *)
+        0x3cc2057d;       (* arm_LDR Q29 X11 (Postimmediate_Offset (word 32)) *)
+        0x4cdf752c;       (* arm_LDR Q12 X9 (Postimmediate_Offset (word 16)) *)
+        0x3cc2050e;       (* arm_LDR Q14 X8 (Postimmediate_Offset (word 32)) *)
+        0x4e738218;       (* arm_SMLAL2_VEC Q24 Q16 Q19 16 *)
+        0x4e6082ed;       (* arm_SMLAL2_VEC Q13 Q23 Q0 16 *)
+        0x0e6082f2;       (* arm_SMLAL_VEC Q18 Q23 Q0 16 *)
+        0x4cdf7477;       (* arm_LDR Q23 X3 (Postimmediate_Offset (word 16)) *)
+        0x4e7b8298;       (* arm_SMLAL2_VEC Q24 Q20 Q27 16 *)
+        0x4e4d5a47;       (* arm_UZP2 Q7 Q18 Q13 16 *)
+        0x4e591baa;       (* arm_UZP1 Q10 Q29 Q25 16 *)
+        0x3c820405;       (* arm_STR Q5 X0 (Postimmediate_Offset (word 32)) *)
+        0x4e4f38e5;       (* arm_ZIP1 Q5 Q7 Q15 16 128 *)
+        0xd10005ad;       (* arm_SUB X13 X13 (rvalue (word 1)) *)
+        0xb5fff5ad;       (* arm_CBNZ X13 (word 2096820) *)
+        0x4e73c3f1;       (* arm_SMULL2_VEC Q17 Q31 Q19 16 *)
+        0x4e4659c1;       (* arm_UZP2 Q1 Q14 Q6 16 *)
+        0x0e75c3f2;       (* arm_SMULL_VEC Q18 Q31 Q21 16 *)
+        0x4e7c8358;       (* arm_SMLAL2_VEC Q24 Q26 Q28 16 *)
+        0x4e778211;       (* arm_SMLAL2_VEC Q17 Q16 Q23 16 *)
+        0x0e73c3f5;       (* arm_SMULL_VEC Q21 Q31 Q19 16 *)
+        0x0e738212;       (* arm_SMLAL_VEC Q18 Q16 Q19 16 *)
+        0x4e43589f;       (* arm_UZP2 Q31 Q4 Q3 16 *)
+        0x4e4619c3;       (* arm_UZP1 Q3 Q14 Q6 16 *)
+        0x0e778215;       (* arm_SMLAL_VEC Q21 Q16 Q23 16 *)
+        0x0e7b8292;       (* arm_SMLAL_VEC Q18 Q20 Q27 16 *)
+        0x4e595bae;       (* arm_UZP2 Q14 Q29 Q25 16 *)
+        0x4e7c8291;       (* arm_SMLAL2_VEC Q17 Q20 Q28 16 *)
+        0x0e7c8295;       (* arm_SMLAL_VEC Q21 Q20 Q28 16 *)
+        0x0e7c8352;       (* arm_SMLAL_VEC Q18 Q26 Q28 16 *)
+        0x4e618138;       (* arm_SMLAL2_VEC Q24 Q9 Q1 16 *)
+        0x4e688351;       (* arm_SMLAL2_VEC Q17 Q26 Q8 16 *)
+        0x0e688355;       (* arm_SMLAL_VEC Q21 Q26 Q8 16 *)
+        0x0e618132;       (* arm_SMLAL_VEC Q18 Q9 Q1 16 *)
+        0x4e6383f8;       (* arm_SMLAL2_VEC Q24 Q31 Q3 16 *)
+        0x4e638131;       (* arm_SMLAL2_VEC Q17 Q9 Q3 16 *)
+        0x0e638135;       (* arm_SMLAL_VEC Q21 Q9 Q3 16 *)
+        0x0e6383f2;       (* arm_SMLAL_VEC Q18 Q31 Q3 16 *)
+        0x4e6e83d8;       (* arm_SMLAL2_VEC Q24 Q30 Q14 16 *)
+        0x4e6c83f1;       (* arm_SMLAL2_VEC Q17 Q31 Q12 16 *)
+        0x0e6c83f5;       (* arm_SMLAL_VEC Q21 Q31 Q12 16 *)
+        0x0e6e83d2;       (* arm_SMLAL_VEC Q18 Q30 Q14 16 *)
+        0x4e6a8178;       (* arm_SMLAL2_VEC Q24 Q11 Q10 16 *)
+        0x4e6a83d1;       (* arm_SMLAL2_VEC Q17 Q30 Q10 16 *)
+        0x0e6a83d5;       (* arm_SMLAL_VEC Q21 Q30 Q10 16 *)
+        0x0e6a8172;       (* arm_SMLAL_VEC Q18 Q11 Q10 16 *)
+        0x4e4f78f3;       (* arm_ZIP2 Q19 Q7 Q15 16 128 *)
+        0x4e768171;       (* arm_SMLAL2_VEC Q17 Q11 Q22 16 *)
+        0x0e768175;       (* arm_SMLAL_VEC Q21 Q11 Q22 16 *)
+        0x4e581a57;       (* arm_UZP1 Q23 Q18 Q24 16 *)
+        0x3d800413;       (* arm_STR Q19 X0 (Immediate_Offset (word 16)) *)
+        0x4e629ef3;       (* arm_MUL_VEC Q19 Q23 Q2 16 128 *)
+        0x4e511ab7;       (* arm_UZP1 Q23 Q21 Q17 16 *)
+        0x3c820405;       (* arm_STR Q5 X0 (Postimmediate_Offset (word 32)) *)
+        0x4e629efa;       (* arm_MUL_VEC Q26 Q23 Q2 16 128 *)
+        0x0e608272;       (* arm_SMLAL_VEC Q18 Q19 Q0 16 *)
+        0x4e608278;       (* arm_SMLAL2_VEC Q24 Q19 Q0 16 *)
+        0x0e608355;       (* arm_SMLAL_VEC Q21 Q26 Q0 16 *)
+        0x4e608351;       (* arm_SMLAL2_VEC Q17 Q26 Q0 16 *)
+        0x4e585a4d;       (* arm_UZP2 Q13 Q18 Q24 16 *)
+        0x4e515ab3;       (* arm_UZP2 Q19 Q21 Q17 16 *)
+        0x4e4d3a77;       (* arm_ZIP1 Q23 Q19 Q13 16 128 *)
+        0x4e4d7a73;       (* arm_ZIP2 Q19 Q19 Q13 16 128 *)
+        0x3c820417;       (* arm_STR Q23 X0 (Postimmediate_Offset (word 32)) *)
+        0x3c9f0013;       (* arm_STR Q19 X0 (Immediate_Offset (word 18446744073709551600)) *)
+        0x6d4027e8;       (* arm_LDP D8 D9 SP (Immediate_Offset (iword (&0))) *)
+        0x6d412fea;       (* arm_LDP D10 D11 SP (Immediate_Offset (iword (&16))) *)
+        0x6d4237ec;       (* arm_LDP D12 D13 SP (Immediate_Offset (iword (&32))) *)
+        0x6d433fee;       (* arm_LDP D14 D15 SP (Immediate_Offset (iword (&48))) *)
+        0x910103ff;       (* arm_ADD SP SP (rvalue (word 64)) *)
+        0xd65f03c0        (* arm_RET X30 *)
+      ];;
+
+  let pmull = define
+    `pmull (x0: 16 word) (x1 : 16 word) (y0 : 16 word) (y1 : 16 word) =
+        word_add (word_mul ((word_sx x1) : 32 word) (word_sx y1))
+                 (word_mul ((word_sx x0) : 32 word) (word_sx y0))`;;
+
+  let pmull_acc4 = define
+  `pmull_acc4 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
+              (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word)
+              (x20: 16 word) (x21 : 16 word) (y20 : 16 word) (y21 : 16 word)
+              (x30: 16 word) (x31 : 16 word) (y30 : 16 word) (y31 : 16 word) =
+    word_add (word_add (word_add (pmull x30 x31 y30 y31) (pmull x20 x21 y20 y21)) (pmull x10 x11 y10 y11)) (pmull x00 x01 y00 y01)`;;
+
+  let montred = define
+     `montred (x : 32 word) =
+        word_subword (
+           word_add (
+             word_mul (
+               (word_sx : 16 word -> 32 word) (
+                 word_mul (
+                   word_subword x (0,16)
+                 ) (word 3327)
+               )
+             )
+             (word 3329)
+           ) x
+        ) (16, 16)`;;
+
+  let pmul_acc4 = define
+      `pmul_acc4 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
+                 (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word)
+                 (x20: 16 word) (x21 : 16 word) (y20 : 16 word) (y21 : 16 word)
+                 (x30: 16 word) (x31 : 16 word) (y30 : 16 word) (y31 : 16 word) =
+        montred (pmull_acc4 x00 x01 y00 y01 x10 x11 y10 y11 x20 x21 y20 y21 x30 x31 y30 y31)`;;
+
+  let basemul4_even_raw = define
+     `basemul4_even_raw x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t = \i.
+        pmul_acc4 (x0 (2 * i)) (x0 (2 * i + 1))
+                  (y0 (2 * i)) (y0t i)
+                  (x1 (2 * i)) (x1 (2 * i + 1))
+                  (y1 (2 * i)) (y1t i)
+                  (x2 (2 * i)) (x2 (2 * i + 1))
+                  (y2 (2 * i)) (y2t i)
+                  (x3 (2 * i)) (x3 (2 * i + 1))
+                  (y3 (2 * i)) (y3t i)
+     `;;
+
+  let basemul4_odd_raw = define
+   `basemul4_odd_raw x0 y0 x1 y1 x2 y2 x3 y3 = \i.
+      pmul_acc4 (x0 (2 * i)) (x0 (2 * i + 1))
+                (y0 (2 * i + 1)) (y0 (2 * i))
+                (x1 (2 * i)) (x1 (2 * i + 1))
+                (y1 (2 * i + 1)) (y1 (2 * i))
+                (x2 (2 * i)) (x2 (2 * i + 1))
+                (y2 (2 * i + 1)) (y2 (2 * i))
+                (x3 (2 * i)) (x3 (2 * i + 1))
+                (y3 (2 * i + 1)) (y3 (2 * i))
+   `;;
+
+  let poly_basemul_acc_montgomery_cached_k4_EXEC = ARM_MK_EXEC_RULE poly_basemul_acc_montgomery_cached_k4_mc;;
+
+  let poly_basemul_acc_montgomery_cached_k4_GOAL = `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t pc.
+       ALL (nonoverlapping (dst, 512))
+           [(word pc, LENGTH poly_basemul_acc_montgomery_cached_k4_mc); (srcA, 2048); (srcB, 2048); (srcBt, 1024)]
+       ==>
+       ensures arm
+         (\s. aligned_bytes_loaded s (word pc) poly_basemul_acc_montgomery_cached_k4_mc /\
+              read PC s = word (pc + 20)  /\
+              C_ARGUMENTS [dst; srcA; srcB; srcBt] s  /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (2 * i)))) s = x0 i)        /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (2 * i)))) s = y0 i)        /\
+              (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i)       /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (512 + 2 * i)))) s = x1 i)  /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (512 + 2 * i)))) s = y1 i)  /\
+              (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i) /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (1024 + 2 * i)))) s = x2 i)  /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (1024 + 2 * i)))) s = y2 i)  /\
+              (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (512  + 2 * i)))) s = y2t i) /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (1536 + 2 * i)))) s = x3 i)  /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (1536 + 2 * i)))) s = y3 i)  /\
+              (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (768  + 2 * i)))) s = y3t i)
+         )
+         (\s. read PC s = word (pc + 1072) /\
+              (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
+                                    basemul4_even_raw x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t i /\
+                               read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
+                                    basemul4_odd_raw x0 y0 x1 y1 x2 y2 x3 y3 i))
+         // Register and memory footprint
+         (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+          MAYCHANGE [Q8; Q9; Q10; Q11; Q12; Q13; Q14; Q15] ,,
+          MAYCHANGE [memory :> bytes(dst, 512)])
+     `;;
+
+   (* ------------------------------------------------------------------------- *)
+   (* Proof                                                                     *)
+   (* ------------------------------------------------------------------------- *)
+
+  let poly_basemul_acc_montgomery_cached_k4_SPEC = prove(poly_basemul_acc_montgomery_cached_k4_GOAL,
+        REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI;
+         MODIFIABLE_SIMD_REGS;
+         NONOVERLAPPING_CLAUSES; ALL; C_ARGUMENTS; fst poly_basemul_acc_montgomery_cached_k4_EXEC] THEN
+       REPEAT STRIP_TAC THEN
+
+       (* Split quantified assumptions into separate cases *)
+       CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
+       CONV_TAC((ONCE_DEPTH_CONV NUM_MULT_CONV) THENC (ONCE_DEPTH_CONV NUM_ADD_CONV)) THEN
+
+       (* Initialize symbolic execution *)
+       ENSURES_INIT_TAC "s0" THEN
+
+       (* Rewrite memory-read assumptions from 16-bit granularity
+        * to 128-bit granularity. *)
+       MEMORY_128_FROM_16_TAC "srcA" 128 THEN
+       MEMORY_128_FROM_16_TAC "srcB" 128 THEN
+       MEMORY_128_FROM_16_TAC "srcBt" 64 THEN
+       ASM_REWRITE_TAC [WORD_ADD_0] THEN
+       (* Forget original shape of assumption *)
+       DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcA) s = x`] THEN
+       DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcB) s = x`] THEN
+       DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 srcBt) s = x`] THEN
+
+       (* Symbolic execution
+          Note that we simplify eagerly after every step.
+          This reduces the proof time *)
+       REPEAT STRIP_TAC THEN
+       MAP_EVERY (fun n -> ARM_STEPS_TAC poly_basemul_acc_montgomery_cached_k4_EXEC [n] THEN
+                  (SIMD_SIMPLIFY_TAC [pmull; GSYM WORD_ADD_ASSOC; pmull_acc4; montred; pmul_acc4])) (1--1355) THEN
+
+       ENSURES_FINAL_STATE_TAC THEN
+       REPEAT CONJ_TAC THEN
+       ASM_REWRITE_TAC [] THEN
+
+       (* Reverse restructuring *)
+       REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
+         CONV_RULE (SIMD_SIMPLIFY_CONV []) o
+         CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
+         check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
+
+       (* Split quantified post-condition into separate cases *)
+       CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV
+                THENC (TRY_CONV (ONCE_DEPTH_CONV NUM_ADD_CONV))) THEN
+       CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN
+       ASM_REWRITE_TAC [WORD_ADD_0] THEN
+
+       (* Forget all assumptions *)
+       POP_ASSUM_LIST (K ALL_TAC) THEN
+
+       (* Split into one congruence goals per index. *)
+       REPEAT CONJ_TAC THEN
+
+       REWRITE_TAC[basemul4_even_raw; basemul4_odd_raw] THEN
+       CONV_TAC(ONCE_DEPTH_CONV EL_CONV) THEN
+       CONV_TAC(REPEATC (CHANGED_CONV (ONCE_DEPTH_CONV (NUM_MULT_CONV ORELSEC NUM_ADD_CONV)))) THEN
+       REFL_TAC
+   );;
+
+   let TWEAK_CONV =
+    ONCE_DEPTH_CONV let_CONV THENC
+    ONCE_DEPTH_CONV EXPAND_CASES_CONV THENC
+    ONCE_DEPTH_CONV NUM_MULT_CONV THENC
+    ONCE_DEPTH_CONV NUM_ADD_CONV THENC
+    PURE_REWRITE_CONV [WORD_ADD_0];;
+
+  let poly_basemul_acc_montgomery_cached_k4_SPEC' = prove(
+     `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t pc returnaddress stackpointer.
+        aligned 16 stackpointer /\
+        ALLPAIRS nonoverlapping
+          [(dst, 512); (word_sub stackpointer (word 64),64)]
+          [(word pc, LENGTH poly_basemul_acc_montgomery_cached_k4_mc); (srcA, 2048); (srcB, 2048); (srcBt, 1024)] /\
+        nonoverlapping (dst,512) (word_sub stackpointer (word 64),64)
+        ==>
+        ensures arm
+        (\s. // Assert that poly_basemul_acc_montgomery_cached_k4 is loaded at PC
+          aligned_bytes_loaded s (word pc) poly_basemul_acc_montgomery_cached_k4_mc /\
+          read PC s = word pc /\
+          read SP s = stackpointer /\
+          read X30 s = returnaddress /\
+          C_ARGUMENTS [dst; srcA; srcB; srcBt] s  /\
+          // Give names to in-memory data to be
+          // able to refer to them in the post-condition
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (2 * i)))) s = x0 i) /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (2 * i)))) s = y0 i) /\
+          (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i) /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (512 + 2 * i)))) s = x1 i) /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (512 + 2 * i)))) s = y1 i) /\
+          (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i) /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (1024 + 2 * i)))) s = x2 i) /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (1024 + 2 * i)))) s = y2 i) /\
+          (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (512  + 2 * i)))) s = y2t i) /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (1536 + 2 * i)))) s = x3 i)  /\
+          (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (1536 + 2 * i)))) s = y3 i)  /\
+          (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (768  + 2 * i)))) s = y3t i)
+        )
+        (\s. read PC s = returnaddress /\
+         (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
+                               basemul4_even_raw x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t i /\
+                          read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
+                               basemul4_odd_raw x0 y0 x1 y1 x2 y2 x3 y3 i)
+        )
+        // Register and memory footprint
+        (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+        MAYCHANGE [memory :> bytes(dst, 512);
+                   memory :> bytes(word_sub stackpointer (word 64),64)])`,
+    REWRITE_TAC[fst poly_basemul_acc_montgomery_cached_k4_EXEC] THEN
+    CONV_TAC TWEAK_CONV THEN
+    ARM_ADD_RETURN_STACK_TAC ~pre_post_nsteps:(5,5) poly_basemul_acc_montgomery_cached_k4_EXEC
+       (REWRITE_RULE[fst poly_basemul_acc_montgomery_cached_k4_EXEC] (CONV_RULE TWEAK_CONV poly_basemul_acc_montgomery_cached_k4_SPEC))
+        `[D8; D9; D10; D11; D12; D13; D14; D15]` 64  THEN
+     WORD_ARITH_TAC)
+  ;;

--- a/proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml
@@ -156,7 +156,8 @@ let poly_mulcache_compute_SPEC = prove(poly_mulcache_compute_GOAL,
        Note that we simplify eagerly after every step.
        This reduces the proof time *)
     REPEAT STRIP_TAC THEN
-    MAP_EVERY (fun n -> ARM_STEPS_TAC poly_mulcache_compute_EXEC [n] THEN SIMD_SIMPLIFY_TAC)
+    MAP_EVERY (fun n -> ARM_STEPS_TAC poly_mulcache_compute_EXEC [n] THEN
+               (SIMD_SIMPLIFY_TAC [barmul]))
               (1--181) THEN
     ENSURES_FINAL_STATE_TAC THEN
     REPEAT CONJ_TAC THEN
@@ -164,7 +165,7 @@ let poly_mulcache_compute_SPEC = prove(poly_mulcache_compute_GOAL,
 
     (* Reverse restructuring *)
     REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
-      CONV_RULE SIMD_SIMPLIFY_CONV o
+      CONV_RULE (SIMD_SIMPLIFY_CONV []) o
       CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
       check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 

--- a/proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml
@@ -163,14 +163,14 @@ let MLKEM_POLY_REDUCE_CORRECT = prove
   (*** Do a full simulation with no breakpoints, unrolling the loop ***)
 
   MAP_EVERY (fun n ->
-   ARM_STEPS_TAC MLKEM_POLY_REDUCE_EXEC [n] THEN SIMD_SIMPLIFY_TAC)
+   ARM_STEPS_TAC MLKEM_POLY_REDUCE_EXEC [n] THEN (SIMD_SIMPLIFY_TAC [barred]))
   (1--276) THEN
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
   (*** Reverse the restructuring by splitting the 128-bit words up ***)
 
   REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
-   CONV_RULE SIMD_SIMPLIFY_CONV o
+   CONV_RULE (SIMD_SIMPLIFY_CONV []) o
    CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
    check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 

--- a/proofs/hol_light/arm/proofs/mlkem_poly_tomont.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_tomont.ml
@@ -130,7 +130,8 @@ let POLY_TOMONT_SPEC = prove(POLY_TOMONT_GOAL,
        Note that we simplify eagerly after every step.
        This reduces the proof time *)
     STRIP_TAC THEN
-    MAP_EVERY (fun n -> ARM_STEPS_TAC POLY_TOMONT_EXEC [n] THEN SIMD_SIMPLIFY_TAC)
+    MAP_EVERY (fun n -> ARM_STEPS_TAC POLY_TOMONT_EXEC [n] THEN
+               (SIMD_SIMPLIFY_TAC [barmul]))
               (1--185) THEN
     ENSURES_FINAL_STATE_TAC THEN
     REPEAT CONJ_TAC THEN
@@ -138,7 +139,7 @@ let POLY_TOMONT_SPEC = prove(POLY_TOMONT_GOAL,
 
     (* Reverse restructuring *)
     REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
-      CONV_RULE SIMD_SIMPLIFY_CONV o
+      CONV_RULE (SIMD_SIMPLIFY_CONV []) o
       CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
       check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 

--- a/proofs/hol_light/arm/proofs/mlkem_utils.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_utils.ml
@@ -29,17 +29,17 @@ let READ_MEMORY_SPLIT_CONV =
     (baseconv THENC BINOP_CONV (conv(n - 1))) tm in
   conv;;
 
-let SIMD_SIMPLIFY_CONV =
+let SIMD_SIMPLIFY_CONV unfold_defs =
   TOP_DEPTH_CONV
    (REWR_CONV WORD_SUBWORD_AND ORELSEC WORD_SIMPLE_SUBWORD_CONV) THENC
   DEPTH_CONV WORD_NUM_RED_CONV THENC
-  REWRITE_CONV[GSYM barred; GSYM barmul];;
+  REWRITE_CONV (map GSYM unfold_defs);;
 
-let SIMD_SIMPLIFY_TAC =
+let SIMD_SIMPLIFY_TAC unfold_defs =
   let simdable = can (term_match [] `read X (s:armstate):int128 = whatever`) in
   TRY(FIRST_X_ASSUM
    (ASSUME_TAC o
-    CONV_RULE(RAND_CONV SIMD_SIMPLIFY_CONV) o
+    CONV_RULE(RAND_CONV (SIMD_SIMPLIFY_CONV unfold_defs)) o
     check (simdable o concl)));;
 
 let MEMORY_128_FROM_16_TAC =

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -960,6 +960,18 @@ def gen_hol_light_asm(dry_run=False):
     gen_hol_light_arith_asm_file(
         "poly_mulcache_compute_asm.S", "mlkem_poly_mulcache_compute.S"
     )
+    gen_hol_light_arith_asm_file(
+        "polyvec_basemul_acc_montgomery_cached_asm_k2.S",
+        "mlkem_poly_basemul_acc_montgomery_cached_k2.S",
+    )
+    gen_hol_light_arith_asm_file(
+        "polyvec_basemul_acc_montgomery_cached_asm_k3.S",
+        "mlkem_poly_basemul_acc_montgomery_cached_k3.S",
+    )
+    gen_hol_light_arith_asm_file(
+        "polyvec_basemul_acc_montgomery_cached_asm_k4.S",
+        "mlkem_poly_basemul_acc_montgomery_cached_k4.S",
+    )
 
     def gen_hol_light_fips202_asm_file(infile, outfile):
         update_via_simpasm(


### PR DESCRIPTION
This commit adds low-level specifications and functional correctness proofs for the AArch64 polynomial base multiplication routines

- poly_basemul_acc_montgomery_cached_k2
- poly_basemul_acc_montgomery_cached_k3
- poly_basemul_acc_montgomery_cached_k4

The specs are 'low-level' in the sense that they do only provide a description in HOL of what is being computed on raw words; they do, however, not yet give a high-level description of what the computation does mod-3329: A scalar product in `Prod_i F_q[X]/(X^2-zeta_i)`.

The addition of a high-level spec and the connection of low-level and high level spec will be in a future commit.

s2n-bignum is updated to incorporate the recent addition of various long multiplication instructions.

The other ML-KEM arithmetic proofs needed updating since a core tactic SIMD_SIMPLIFY_TAC for the simplification of SIMD expressions was generalized to allow for a parametrized list of definitions to fold. Previously, this was hardcoded to the definitions used by the NTT and invNTT.
