### PR TITLE
Add `tests hol_light` command

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches: ["main"]
     paths:
+     - '.github/workflows/hol_light.yml'
+     - 'proofs/hol_light/arm/Makefile'
      - 'proofs/hol_light/arm/**/*.S'
      - 'proofs/hol_light/arm/**/*.ml'
      - 'nix/hol_light/*'
@@ -14,6 +16,8 @@ on:
   pull_request:
     branches: ["main"]
     paths:
+      - '.github/workflows/hol_light.yml'
+      - 'proofs/hol_light/arm/Makefile'
       - 'proofs/hol_light/arm/**/*.S'
       - 'proofs/hol_light/arm/**/*.ml'
       - 'nix/hol_light/*'
@@ -82,7 +86,7 @@ jobs:
           done
 
           # Always re-run upon change to nix files for HOL-Light
-          if [[ "$changed_files" == *"nix/"* ]]; then
+          if [[ "$changed_files" == *"nix/"* ]] || [[ "$changed_files" == *"hol_light.yml"* ]] || [[ "$changed_files" == *"proofs/hol_light/arm/Makefile"* ]]; then
             run_needed=1
           fi
 
@@ -94,4 +98,4 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           nix-shell: 'hol_light'
           script: |
-            make -C proofs/hol_light/arm mlkem/${{ matrix.proof.name }}.correct
+            tests hol_light -p ${{ matrix.proof.name }}

--- a/proofs/hol_light/arm/Makefile
+++ b/proofs/hol_light/arm/Makefile
@@ -82,7 +82,6 @@ OBJ = mlkem/mlkem_ntt.o                                   \
 # According to
 # https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms,
 # x18 should not be used for Apple platforms. Check this using grep.
-ifneq ($(OSTYPE_RESULT),Darwin)
 $(OBJ): %.o : %.S
 	@echo "Preparing $@ ..."
 	@echo "AS: `$(ASSEMBLE) --version`"
@@ -91,24 +90,6 @@ $(OBJ): %.o : %.S
 	cat $< | $(PREPROCESS) | $(SPLIT) | grep -v -E '^\s+.quad\s+0x[0-9a-f]+$$' | $(ASSEMBLE) -o $@ -
 	$(OBJDUMP) $@ | ( ( ! grep --ignore-case -E 'w18|[^0]x18' ) || ( rm $@ ; exit 1 ) )
 	cat $< | $(PREPROCESS) | $(SPLIT) | $(ASSEMBLE) -o $@ -
-else
-GOBJCOPY?=/opt/homebrew/opt/binutils/bin/gobjcopy
-$(OBJ): %.o : %.S
-	@echo "Preparing $@ ..."
-	@echo "AS: `$(ASSEMBLE) --version`"
-	@echo "OBJDUMP: `$(OBJDUMP) --version`"
-	@if ! (which $(GOBJCOPY) >/dev/null); then \
-	  echo "gobjcopy not found. Consider installing it via 'brew install binutils'. If you have, and if it is in a different location than $(GOBJCOPY), please set the GOBJCOPY environment variable accordingly.";\
-	  exit 1; \
-	fi
-	@echo "GOBJCOPY: `$(GOBJCOPY) --version`"
-	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	cat $< | $(PREPROCESS) | $(SPLIT) | grep -v -E '^\s+.quad\s+0x[0-9a-f]+$$' | $(ASSEMBLE) -o $@ -
-	$(OBJDUMP) $@ | ( ( ! grep --ignore-case -E 'w18|[^0]x18' ) || ( rm $@ ; exit 1 ) )
-	cat $< | $(PREPROCESS) | $(SPLIT) | $(ASSEMBLE) -o $@ -
-        # On Darwin, we need to explicitly convert Mach-O to ELF
-	$(GOBJCOPY) -I mach-o-arm64 -O elf64-littleaarch64 $@ $@
-endif
 
 clean:; rm -f */*.o */*/*.o */*.correct */*.native
 

--- a/proofs/hol_light/arm/README.md
+++ b/proofs/hol_light/arm/README.md
@@ -48,6 +48,8 @@ make -C proofs/hol_light/arm
 
 will build and run the proofs. Note that this make take hours even on powerful machines.
 
+For convenience, you can also use `tests hol_light` which wraps the `make` invocation above; see `tests hol_light --help`.
+
 ### macOS (AArch64)
 
 If you want run the proofs from an AArch64 Apple machine, you need to manually install `gobjcopy` via

--- a/proofs/hol_light/arm/README.md
+++ b/proofs/hol_light/arm/README.md
@@ -50,14 +50,3 @@ will build and run the proofs. Note that this make take hours even on powerful m
 
 For convenience, you can also use `tests hol_light` which wraps the `make` invocation above; see `tests hol_light --help`.
 
-### macOS (AArch64)
-
-If you want run the proofs from an AArch64 Apple machine, you need to manually install `gobjcopy` via
-
-```
-brew install binutils
-```
-
-and put its parent directory (typically `/opt/homebrew/opt/binutils/bin`) into your `PATH`.
-This is needed to convert Mach-O object files to ELF (if you know a way to install a suitable version
-of `objcopy` through `nix`, please let us know!).

--- a/proofs/hol_light/arm/list_proofs.sh
+++ b/proofs/hol_light/arm/list_proofs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This tiny script just lists the names of source files for which
+# we have a spec and proof in HOL-Light.
+
+ROOT=$(git rev-parse --show-toplevel)
+cd $ROOT
+ls -1 proofs/hol_light/arm/mlkem/*.S | cut -d '/' -f 5 | sed 's/\.S//'

--- a/scripts/tests
+++ b/scripts/tests
@@ -793,6 +793,62 @@ class Tests:
 
         self.check_fail()
 
+    def hol_light(self):
+
+        def list_proofs():
+            cmd_str = ["./proofs/hol_light/arm/list_proofs.sh"]
+            p = subprocess.run(cmd_str, capture_output=True, universal_newlines=False)
+            proofs = filter(lambda s: s.strip() != "", p.stdout.decode().split("\n"))
+            return list(proofs)
+
+        if self.args.list_functions:
+            for p in list_proofs():
+                print(p)
+            exit(0)
+
+        def run_hol_light_single_step(proofs):
+            num_proofs = len(proofs)
+            for i, func in enumerate(proofs):
+                log = logger(f"HOL_LIGHT ({i+1}/{num_proofs})", None, None, None)
+                log.info(f"Starting HOL-Light proof for {func}")
+                start = time.time()
+                proof_bin = f"mlkem/{func}.native"
+                proof_target = f"mlkem/{func}.correct"
+                proof_dir = "proofs/hol_light/arm"
+                # Remove intermediate proof files to force-rerun
+                try:
+                    os.remove(os.path.join(proof_dir, proof_bin))
+                    os.remove(os.path.join(proof_dir, proof_target))
+                except FileNotFoundError:
+                    pass
+                p = subprocess.run(
+                    [
+                        "make",
+                        f"mlkem/{func}.correct",
+                    ]
+                    + self.make_j(),
+                    cwd="proofs/hol_light/arm",
+                    env=os.environ.copy(),
+                    capture_output=(self.args.verbose is False),
+                )
+
+                end = time.time()
+                dur = int(end - start)
+                if p.returncode != 0:
+                    log.error(f"   FAILED (after {dur}s)")
+                    if p.stderr is not None:
+                        log.error(p.stderr.decode())
+                    self.fail(f"HOL-Light proof for {func}")
+                else:
+                    log.info(f"   SUCCESS (after {dur}s)")
+
+        proofs = list_proofs()
+        if self.args.proof is not None:
+            proofs = self.args.proof
+
+        run_hol_light_single_step(proofs)
+        self.check_fail()
+
 
 #
 # Command line interface
@@ -1043,6 +1099,29 @@ def cli():
         default=False,
     )
 
+    # hol_light arguments
+    hol_light_parser = cmd_subparsers.add_parser(
+        "hol_light",
+        help="Run the HOL_LIGHT proofs for all parameter sets",
+        parents=[common_parser],
+    )
+
+    hol_light_parser.add_argument(
+        "-p",
+        "--proof",
+        nargs="+",
+        help="Space separated list of functions for which to run the HOL_LIGHT proofs.",
+        default=None,
+    )
+
+    hol_light_parser.add_argument(
+        "-l",
+        "--list-functions",
+        help="Don't run any proofs, but list all functions for which HOL_LIGHT proofs are available",
+        action="store_true",
+        default=False,
+    )
+
     # func arguments
     func_parser = cmd_subparsers.add_parser(
         "func",
@@ -1081,6 +1160,8 @@ def cli():
         Tests(args).bench()
     elif args.cmd == "cbmc":
         Tests(args).cbmc()
+    elif args.cmd == "hol_light":
+        Tests(args).hol_light()
     elif args.cmd == "func":
         Tests(args).func()
     elif args.cmd == "kat":

--- a/scripts/tests
+++ b/scripts/tests
@@ -718,13 +718,6 @@ class Tests:
                 log = logger(f"CBMC ({i+1}/{num_proofs})", scheme, None, None)
                 log.info(f"Starting CBMC proof for {func}")
                 start = time.time()
-                if self.args.verbose is False:
-                    extra_args = {
-                        "stdout": subprocess.DEVNULL,
-                        "stderr": subprocess.DEVNULL,
-                    }
-                else:
-                    extra_args = {}
                 try:
                     p = subprocess.run(
                         [
@@ -738,12 +731,12 @@ class Tests:
                         + self.make_j(),
                         cwd="proofs/cbmc",
                         env=os.environ.copy() | envvars,
-                        capture_output=True,
                         timeout=self.args.timeout,
+                        capture_output=(self.args.verbose is False),
                     )
-                except subprocess.TimeoutExpired:
+                except subprocess.TimeoutExpired as e:
                     log.error(f"   TIMEOUT (after {self.args.timeout}s)")
-                    log.error(p.stderr)
+                    log.error(e.stderr.decode())
                     self.fail(f"CBMC proof for {func}")
                     if self.args.fail_upon_error:
                         log.error(
@@ -756,7 +749,8 @@ class Tests:
                 dur = int(end - start)
                 if p.returncode != 0:
                     log.error(f"   FAILED (after {dur}s)")
-                    log.error(p.stderr.decode())
+                    if p.stderr is not None:
+                        log.error(p.stderr.decode())
                     self.fail(f"CBMC proof for {func}")
                 else:
                     log.info(f"   SUCCESS (after {dur}s)")


### PR DESCRIPTION
* Resolves #885 

Usage:
- `tests hol_light -p FUNCTION [--verbose]` runs the HOL-Light
  proof for FUNCTION
- `tests hol_light -l` lists all available function names for
  which a proof is present.

The use of `--verbose` is recommended since HOL-Light proofs
tend to run for a long time, and without `--verbose` one cannot
track progress.