### PR TITLE
Switch mlkem_poly_basemul_acc_montgomery_cached_k2 proof to integer spec

### DIFF
--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
@@ -184,45 +184,29 @@ let poly_basemul_acc_montgomery_cached_k2_mc = define_assert_from_elf
     ];;
 
 let pmull = define
-  `pmull (x0: 16 word) (x1 : 16 word) (y0 : 16 word) (y1 : 16 word) =
-      word_add (word_mul ((word_sx x1) : 32 word) (word_sx y1))
-               (word_mul ((word_sx x0) : 32 word) (word_sx y0))`;;
+  `pmull (x0: int) (x1 : int) (y0 : int) (y1 : int) = x1 * y1 + x0 * y0`;;
 
 let pmull_acc2 = define
-    `pmull_acc2 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
-          (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word) =
-      word_add (pmull x10 x11 y10 y11) (pmull x00 x01 y00 y01)`;;
-
-let montred = define
-   `montred (x : 32 word) =
-      word_subword (
-         word_add (
-           word_mul (
-             (word_sx : 16 word -> 32 word) (
-               word_mul (
-                 word_subword x (0,16)
-               ) (word 3327)
-             )
-           )
-           (word 3329)
-         ) x
-      ) (16, 16)`;;
+    `pmull_acc2 (x00: int) (x01 : int) (y00 : int) (y01 : int)
+          (x10: int) (x11 : int) (y10 : int) (y11 : int) =
+      pmull x10 x11 y10 y11 + pmull x00 x01 y00 y01`;;
 
 let pmul_acc2 = define
-    `pmul_acc2 (x00: 16 word) (x01 : 16 word) (y00 : 16 word) (y01 : 16 word)
-          (x10: 16 word) (x11 : 16 word) (y10 : 16 word) (y11 : 16 word) =
-      montred (pmull_acc2 x00 x01 y00 y01 x10 x11 y10 y11)`;;
+    `pmul_acc2 (x00: int) (x01 : int) (y00 : int) (y01 : int)
+          (x10: int) (x11 : int) (y10 : int) (y11 : int) =
+     (&(inverse_mod 3329 65536) *
+      pmull_acc2 x00 x01 y00 y01 x10 x11 y10 y11) rem &3329`;;
 
-let basemul2_even_raw = define
-   `basemul2_even_raw x0 y0 y0t x1 y1 y1t = \i.
+let basemul2_even = define
+   `basemul2_even x0 y0 y0t x1 y1 y1t = \i.
       pmul_acc2 (x0 (2 * i)) (x0 (2 * i + 1))
                 (y0 (2 * i)) (y0t i)
                 (x1 (2 * i)) (x1 (2 * i + 1))
                 (y1 (2 * i)) (y1t i)
    `;;
 
-let basemul2_odd_raw = define
- `basemul2_odd_raw x0 y0 x1 y1 = \i.
+let basemul2_odd = define
+ `basemul2_odd x0 y0 x1 y1 = \i.
     pmul_acc2 (x0 (2 * i)) (x0 (2 * i + 1))
               (y0 (2 * i + 1)) (y0 (2 * i))
               (x1 (2 * i)) (x1 (2 * i + 1))
@@ -244,12 +228,14 @@ let poly_basemul_acc_montgomery_cached_k2_GOAL = `forall srcA srcB srcBt dst x0 
             (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i)      /\
             (!i. i < 256 ==> read(memory :> bytes16(word_add srcA  (word (512 + 2 * i)))) s = x1 i) /\
             (!i. i < 256 ==> read(memory :> bytes16(word_add srcB  (word (512 + 2 * i)))) s = y1 i) /\
-            (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i))
+            (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i) /\
+            (!i. i < 256 ==> abs(ival(x0 i)) <= &2 pow 12 /\  abs(ival(x1 i)) <= &2 pow 12))
        (\s. read PC s = word (pc + 640) /\
-            (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
-                                  basemul2_even_raw x0 y0 y0t x1 y1 y1t i /\
-                             read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
-                                  basemul2_odd_raw x0 y0 x1 y1 i))
+            (!i. i < 128 ==> (ival(read(memory :> bytes16(word_add dst (word (4 * i)))) s) ==
+                              basemul2_even (ival o x0) (ival o y0) (ival o y0t)
+                                                (ival o x1) (ival o y1) (ival o y1t) i) (mod &3329) /\
+                             (ival(read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s) ==
+                              basemul2_odd (ival o x0) (ival o y0) (ival o x1) (ival o y1) i) (mod &3329)))
        // Register and memory footprint
        (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
         MAYCHANGE [Q8; Q9; Q10; Q11; Q12; Q13; Q14; Q15] ,,
@@ -289,7 +275,7 @@ let poly_basemul_acc_montgomery_cached_k2_SPEC = prove(poly_basemul_acc_montgome
         This reduces the proof time *)
      REPEAT STRIP_TAC THEN
      MAP_EVERY (fun n -> ARM_STEPS_TAC poly_basemul_acc_montgomery_cached_k2_EXEC [n] THEN
-                (SIMD_SIMPLIFY_TAC [pmull; GSYM WORD_ADD_ASSOC; pmull_acc2; montred; pmul_acc2])) (1--805) THEN
+                (SIMD_SIMPLIFY_TAC [montred])) (1--805) THEN
 
      ENSURES_FINAL_STATE_TAC THEN
      REPEAT CONJ_TAC THEN
@@ -307,16 +293,23 @@ let poly_basemul_acc_montgomery_cached_k2_SPEC = prove(poly_basemul_acc_montgome
      CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN
      ASM_REWRITE_TAC [WORD_ADD_0] THEN
 
-     (* Forget all assumptions *)
-     POP_ASSUM_LIST (K ALL_TAC) THEN
+     (* Forget all state-related assumptions, but keep bounds at least *)
+     DISCARD_STATE_TAC "s805" THEN
 
      (* Split into one congruence goals per index. *)
      REPEAT CONJ_TAC THEN
-
-     REWRITE_TAC[basemul2_even_raw; basemul2_odd_raw] THEN
+     REWRITE_TAC[basemul2_even; basemul2_odd;
+                 pmul_acc2; pmull_acc2; pmull; o_THM] THEN
      CONV_TAC(ONCE_DEPTH_CONV EL_CONV) THEN
-     CONV_TAC(REPEATC (CHANGED_CONV (ONCE_DEPTH_CONV (NUM_MULT_CONV ORELSEC NUM_ADD_CONV)))) THEN
-     REFL_TAC
+     CONV_TAC NUM_REDUCE_CONV THEN
+
+     (* Solve the congruence goals *)
+
+    ASSUM_LIST((fun ths -> W(MP_TAC o CONJUNCT1 o GEN_CONGBOUND_RULE ths o
+      rand o lhand o rator o snd))) THEN
+    REWRITE_TAC[GSYM INT_REM_EQ] THEN CONV_TAC INT_REM_DOWN_CONV THEN
+    MATCH_MP_TAC EQ_IMP THEN AP_TERM_TAC THEN AP_THM_TAC THEN AP_TERM_TAC THEN
+    CONV_TAC INT_RING
  );;
 
  let TWEAK_CONV =
@@ -348,13 +341,15 @@ let poly_basemul_acc_montgomery_cached_k2_SPEC' = prove(
         (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (2 * i)))) s = y0t i) /\
         (!i. i < 256 ==> read(memory :> bytes16(word_add srcA (word (512 + 2 * i)))) s = x1 i) /\
         (!i. i < 256 ==> read(memory :> bytes16(word_add srcB (word (512 + 2 * i)))) s = y1 i) /\
-        (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i)
+        (!i. i < 128 ==> read(memory :> bytes16(word_add srcBt (word (256 + 2 * i)))) s = y1t i) /\
+        (!i. i < 256 ==> abs(ival(x0 i)) <= &2 pow 12 /\  abs(ival(x1 i)) <= &2 pow 12)
       )
       (\s. read PC s = returnaddress /\
-       (!i. i < 128 ==> read(memory :> bytes16(word_add dst (word (4 * i)))) s =
-                             basemul2_even_raw x0 y0 y0t x1 y1 y1t i /\
-                        read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s =
-                             basemul2_odd_raw x0 y0 x1 y1 i)
+           (!i. i < 128 ==> (ival(read(memory :> bytes16(word_add dst (word (4 * i)))) s) ==
+                              basemul2_even (ival o x0) (ival o y0) (ival o y0t)
+                                                (ival o x1) (ival o y1) (ival o y1t) i) (mod &3329) /\
+                             (ival(read(memory :> bytes16(word_add dst (word (4 * i + 2)))) s) ==
+                              basemul2_odd (ival o x0) (ival o y0) (ival o x1) (ival o y1) i) (mod &3329))
       )
       // Register and memory footprint
       (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
@@ -249,7 +249,7 @@ let poly_basemul_acc_montgomery_cached_k3_mc = define_assert_from_elf
    word_add (word_add (pmull x20 x21 y20 y21) (pmull x10 x11 y10 y11)) (pmull x00 x01 y00 y01)`;;
 
  let montred = define
-    `montred (x : 32 word) =
+    `(montred:int32->int16) x =
        word_subword (
           word_add (
             word_mul (

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
@@ -303,7 +303,7 @@ let poly_basemul_acc_montgomery_cached_k4_mc = define_assert_from_elf
     word_add (word_add (word_add (pmull x30 x31 y30 y31) (pmull x20 x21 y20 y21)) (pmull x10 x11 y10 y11)) (pmull x00 x01 y00 y01)`;;
 
   let montred = define
-     `montred (x : 32 word) =
+     `(montred:int32->int16) x =
         word_subword (
            word_add (
              word_mul (

--- a/proofs/hol_light/arm/proofs/mlkem_specs.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_specs.ml
@@ -152,7 +152,8 @@ let INVERSE_NTT_CONV =
   ONCE_DEPTH_CONV EXP_MOD_CONV THENC INT_REDUCE_CONV;;
 
 (* ------------------------------------------------------------------------- *)
-(* Abbreviate the Barrett reduction and multiplication patterns in the code. *)
+(* Abbreviate the Barrett reduction and multiplication and Montgomery        *)
+(* reduction patterns in the code.                                           *)
 (* ------------------------------------------------------------------------- *)
 
 let barred = define
@@ -171,53 +172,105 @@ let barmul = define
            (word_mul (iword_saturate((&2 * ival a * k + &32768) div &65536))
                      (word 3329))`;;
 
+let montred = define
+   `(montred:int32->int16) x =
+    word_subword
+     (word_add
+       (word_mul ((word_sx:int16->int32)
+                    (word_mul (word_subword x (0,16)) (word 3327)))
+                 (word 3329))
+       x)
+     (16,16)`;;
+
 (* ------------------------------------------------------------------------- *)
 (* Congruence-and-bound propagation, just recursion on the expression tree.  *)
 (* ------------------------------------------------------------------------- *)
 
 let CONGBOUND_ATOM = prove
- (`!x:int16. (ival x == ival x) (mod &3329) /\
-             -- &32768 <= ival x /\ ival x <= &32767`,
-  GEN_TAC THEN CONJ_TAC THENL [CONV_TAC INTEGER_RULE; BOUNDER_TAC[]]);;
+ (`!x:N word. (ival x == ival x) (mod &3329) /\
+              --(&2 pow (dimindex(:N) - 1)) <= ival x /\
+              ival x <= &2 pow (dimindex(:N) - 1) - &1`,
+  GEN_TAC THEN REWRITE_TAC[INT_ARITH `x:int <= y - &1 <=> x < y`] THEN
+  REWRITE_TAC[IVAL_BOUND] THEN INTEGER_TAC);;
 
 let CONGBOUND_ATOM_GEN = prove
- (`!x:int16. abs(ival x) <= n
-           ==> (ival x == ival x) (mod &3329) /\ --n <= ival x /\ ival x <= n`,
+ (`!x:N word. abs(ival x) <= n
+              ==> (ival x == ival x) (mod &3329) /\ --n <= ival x /\ ival x <= n`,
   REWRITE_TAC[INTEGER_RULE `(x:int == x) (mod n)`] THEN INT_ARITH_TAC);;
 
+let CONGBOUND_IWORD = prove
+ (`!x. ((x == x') (mod &3329) /\ l <= x /\ x <= u)
+       ==> --(&2 pow (dimindex(:N) - 1)) <= l /\ u <= &2 pow (dimindex(:N) - 1) - &1
+           ==> (ival(iword x:N word) == x') (mod &3329) /\
+               l <= ival(iword x:N word) /\ ival(iword x:N word) <= u`,
+  GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN REWRITE_TAC[word_sx] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) IVAL_IWORD o lhand o rand o rand o snd) THEN
+  ANTS_TAC THENL [ASM_INT_ARITH_TAC; DISCH_THEN SUBST1_TAC] THEN
+  ASM_REWRITE_TAC[]);;
+
+let CONGBOUND_WORD_SX = prove
+ (`!x:M word.
+        ((ival x == x') (mod &3329) /\ l <= ival x /\ ival x <= u)
+        ==> --(&2 pow (dimindex(:N) - 1)) <= l /\ u <= &2 pow (dimindex(:N) - 1) - &1
+            ==> (ival(word_sx x:N word) == x') (mod &3329) /\
+                l <= ival(word_sx x:N word) /\ ival(word_sx x:N word) <= u`,
+  REWRITE_TAC[word_sx; CONGBOUND_IWORD]);;
+
 let CONGBOUND_WORD_ADD = prove
- (`!x y:int16.
+ (`!x y:N word.
         ((ival x == x') (mod &3329) /\ lx <= ival x /\ ival x <= ux) /\
         ((ival y == y') (mod &3329) /\ ly <= ival y /\ ival y <= uy)
-        ==> -- &32768 <= lx + ly /\ ux + uy <= &32767
+        ==> --(&2 pow (dimindex(:N) - 1)) <= lx + ly /\
+            ux + uy <= &2 pow (dimindex(:N) - 1) - &1
             ==> (ival(word_add x y) == x' + y') (mod &3329) /\
                 lx + ly <= ival(word_add x y) /\
                 ival(word_add x y) <= ux + uy`,
-  REPEAT GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN
-  SUBGOAL_THEN `ival(word_add x y:int16) = ival x + ival y` SUBST_ALL_TAC THENL
-   [MATCH_MP_TAC INT_CONG_IMP_EQ THEN
-    EXISTS_TAC `(&2:int) pow dimindex(:16)` THEN
-    REWRITE_TAC[ICONG_WORD_ADD] THEN
-    MP_TAC(ISPEC `word_add x y:int16` IVAL_BOUND) THEN
-    REWRITE_TAC[DIMINDEX_16; ARITH] THEN ASM_INT_ARITH_TAC;
-    ASM_SIMP_TAC[INT_CONG_ADD] THEN ASM_INT_ARITH_TAC]);;
+  REPEAT GEN_TAC THEN REWRITE_TAC[WORD_ADD_IMODULAR; imodular] THEN
+  STRIP_TAC THEN STRIP_TAC THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_IMP] CONGBOUND_IWORD) THEN
+  ASM_SIMP_TAC[INT_CONG_ADD] THEN ASM_INT_ARITH_TAC);;
 
 let CONGBOUND_WORD_SUB = prove
- (`!x y:int16.
+ (`!x y:N word.
         ((ival x == x') (mod &3329) /\ lx <= ival x /\ ival x <= ux) /\
         ((ival y == y') (mod &3329) /\ ly <= ival y /\ ival y <= uy)
-        ==> -- &32768 <= lx - uy /\ ux - ly <= &32767
+        ==> --(&2 pow (dimindex(:N) - 1)) <= lx - uy /\
+            ux - ly <= &2 pow (dimindex(:N) - 1) - &1
             ==> (ival(word_sub x y) == x' - y') (mod &3329) /\
                 lx - uy <= ival(word_sub x y) /\
                 ival(word_sub x y) <= ux - ly`,
-  REPEAT GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN
-  SUBGOAL_THEN `ival(word_sub x y:int16) = ival x - ival y` SUBST_ALL_TAC THENL
-   [MATCH_MP_TAC INT_CONG_IMP_EQ THEN
-    EXISTS_TAC `(&2:int) pow dimindex(:16)` THEN
-    REWRITE_TAC[ICONG_WORD_SUB] THEN
-    MP_TAC(ISPEC `word_sub x y:int16` IVAL_BOUND) THEN
-    REWRITE_TAC[DIMINDEX_16; ARITH] THEN ASM_INT_ARITH_TAC;
-    ASM_SIMP_TAC[INT_CONG_SUB] THEN ASM_INT_ARITH_TAC]);;
+  REPEAT GEN_TAC THEN REWRITE_TAC[WORD_SUB_IMODULAR; imodular] THEN
+  STRIP_TAC THEN STRIP_TAC THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_IMP] CONGBOUND_IWORD) THEN
+  ASM_SIMP_TAC[INT_CONG_SUB] THEN ASM_INT_ARITH_TAC);;
+
+let CONGBOUND_WORD_MUL = prove
+ (`!x y:N word.
+        ((ival x == x') (mod &3329) /\ lx <= ival x /\ ival x <= ux) /\
+        ((ival y == y') (mod &3329) /\ ly <= ival y /\ ival y <= uy)
+        ==> --(&2 pow (dimindex(:N) - 1))
+            <= min (lx * ly) (min (lx * uy) (min (ux * ly) (ux * uy))) /\
+            max (lx * ly) (max (lx * uy) (max (ux * ly) (ux * uy)))
+            <= &2 pow (dimindex(:N) - 1) - &1
+            ==> (ival(word_mul x y) == x' * y') (mod &3329) /\
+                min (lx * ly) (min (lx * uy) (min (ux * ly) (ux * uy)))
+                <= ival(word_mul x y) /\
+                ival(word_mul x y)
+                <= max (lx * ly) (max (lx * uy) (max (ux * ly) (ux * uy)))`,
+  let lemma = prove
+     (`l:int <= x /\ x <= u
+       ==> !a. a * l <= a * x /\ a * x <= a * u \/
+               a * u <= a * x /\ a * x <= a * l`,
+      MESON_TAC[INT_LE_NEGTOTAL; INT_LE_LMUL;
+                INT_ARITH `a * x:int <= a * y <=> --a * y <= --a * x`]) in
+  REPEAT GEN_TAC THEN
+  DISCH_THEN(CONJUNCTS_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
+  DISCH_THEN(ASSUME_TAC o SPEC `ival(x:N word)` o MATCH_MP lemma) THEN
+  DISCH_THEN(MP_TAC o MATCH_MP lemma) THEN DISCH_THEN(fun th ->
+        ASSUME_TAC(SPEC `ly:int` th) THEN ASSUME_TAC(SPEC `uy:int` th)) THEN
+  REWRITE_TAC[WORD_MUL_IMODULAR; imodular] THEN STRIP_TAC THEN
+  MATCH_MP_TAC(REWRITE_RULE[IMP_IMP] CONGBOUND_IWORD) THEN
+  ASM_SIMP_TAC[INT_CONG_MUL] THEN ASM_INT_ARITH_TAC);;
 
 let CONGBOUND_BARRED = prove
  (`!a a' l u.
@@ -306,39 +359,112 @@ let CONGBOUND_BARMUL = prove
    `l:int <= x /\ x <= u ==> abs x <= max (abs l) (abs u)`] THEN
   CONV_TAC INT_ARITH);;
 
+let MONTRED_LEMMA = prove
+ (`!x. &2 pow 16 * ival(montred x) =
+       ival(word_add
+         (word_mul (word_sx(iword(ival x * &3327):int16)) (word 3329)) x)`,
+  GEN_TAC THEN REWRITE_TAC[montred] THEN REWRITE_TAC[WORD_BLAST
+   `word_subword (x:int32) (0,16):int16 = word_sx x`] THEN
+  REWRITE_TAC[IWORD_INT_MUL; GSYM word_sx; GSYM WORD_IWORD] THEN
+  REWRITE_TAC[WORD_BLAST `(word_sx:int32->int16) x = word_zx x`] THEN
+  CONV_TAC INT_REDUCE_CONV THEN MATCH_MP_TAC(BITBLAST_RULE
+   `word_and x (word 65535):int32 = word 0
+    ==> &65536 * ival(word_subword x (16,16):int16) = ival x`) THEN
+  REWRITE_TAC[BITBLAST_RULE
+   `word_and x (word 65535):int32 = word 0 <=> word_zx x:int16 = word 0`] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) WORD_ZX_ADD o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_16; DIMINDEX_32; ARITH] THEN DISCH_THEN SUBST1_TAC THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) WORD_ZX_MUL o lhand o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_16; DIMINDEX_32; ARITH] THEN DISCH_THEN SUBST1_TAC THEN
+  REWRITE_TAC[WORD_BLAST `word_zx(word_sx (x:int16):int32) = x`] THEN
+  REWRITE_TAC[GSYM VAL_EQ_0; VAL_WORD_ADD; VAL_WORD_MUL; VAL_WORD] THEN
+  CONV_TAC MOD_DOWN_CONV THEN REWRITE_TAC[GSYM DIVIDES_MOD; DIMINDEX_16] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN MATCH_MP_TAC(NUMBER_RULE
+   `(a * b + 1 == 0) (mod d) ==> d divides ((x * a) * b + x)`) THEN
+  REWRITE_TAC[CONG] THEN ARITH_TAC);;
+
+let CONGBOUND_MONTRED = prove
+ (`!a a' l u.
+      (ival a == a') (mod &3329) /\ l <= ival a /\ ival a <= u
+      ==> --(&2038398976) <= l /\ u <= &2038402304
+          ==> (ival(montred a) == &(inverse_mod 3329 65536) * a') (mod &3329) /\
+              (l - &109084672) div &2 pow 16 <= ival(montred a) /\
+              ival(montred a) <= &1 + (u + &109081343) div &2 pow 16`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN STRIP_TAC THEN
+  CONV_TAC NUM_REDUCE_CONV THEN CONV_TAC(ONCE_DEPTH_CONV INVERSE_MOD_CONV) THEN
+  MP_TAC(SPECL [`&169:int`; `(&2:int) pow 16`; `&3329:int`] (INTEGER_RULE
+ `!d e n:int. (e * d == &1) (mod n)
+              ==> !x y. ((x == d * y) (mod n) <=> (e * x == y) (mod n))`)) THEN
+  ANTS_TAC THENL
+   [REWRITE_TAC[GSYM INT_REM_EQ] THEN INT_ARITH_TAC;
+    DISCH_THEN(fun th -> REWRITE_TAC[th])] THEN
+  ONCE_REWRITE_TAC[INT_ARITH
+   `l:int <= x <=> &2 pow 16 * l <= &2 pow 16 * x`] THEN
+  REWRITE_TAC[MONTRED_LEMMA] THEN
+  REWRITE_TAC[WORD_RULE
+   `word_add (word_mul a b) c = iword(ival a * ival b + ival c)`] THEN
+  ASM_SIMP_TAC[IVAL_WORD_SX; DIMINDEX_16; DIMINDEX_32; ARITH] THEN
+  W(MP_TAC o PART_MATCH (lhand o rand) IVAL_IWORD o
+   lhand o rator o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_32] THEN CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN
+  W(MP_TAC o C ISPEC IVAL_BOUND o
+    rand o funpow 3 lhand o rand o lhand o lhand o snd) THEN
+  REWRITE_TAC[DIMINDEX_16; ARITH] THEN STRIP_TAC THEN
+  ANTS_TAC THENL [ASM_INT_ARITH_TAC; DISCH_THEN SUBST1_TAC] THEN
+  ASM_REWRITE_TAC[INTEGER_RULE
+   `(a * p + x:int == y) (mod p) <=> (x == y) (mod p)`] THEN
+  ASM_INT_ARITH_TAC);;
+
+let DIMINDEX_INT_REDUCE_CONV =
+  DEPTH_CONV(WORD_NUM_RED_CONV ORELSEC DIMINDEX_CONV) THENC
+  INT_REDUCE_CONV;;
+
+let CONCL_BOUNDS_RULE =
+  CONV_RULE(BINOP2_CONV
+          (LAND_CONV(RAND_CONV DIMINDEX_INT_REDUCE_CONV))
+          (BINOP2_CONV
+           (LAND_CONV DIMINDEX_INT_REDUCE_CONV)
+           (RAND_CONV DIMINDEX_INT_REDUCE_CONV)));;
+
+let SIDE_ELIM_RULE th =
+  MP th (EQT_ELIM(DIMINDEX_INT_REDUCE_CONV(lhand(concl th))));;
+
 let rec GEN_CONGBOUND_RULE aboths tm =
   match tm with
     Comb(Comb(Const("barmul",_),kb),t) ->
         let ktm,btm = dest_pair kb and th0 = GEN_CONGBOUND_RULE aboths t in
         let th1 = SPECL [ktm;btm] (MATCH_MP CONGBOUND_BARMUL th0) in
-        let th2 = DEPTH_CONV WORD_NUM_RED_CONV (lhand(concl th1)) in
-        let th3 = MP th1 (EQT_ELIM th2) in
-        CONV_RULE(BINOP2_CONV
-          (LAND_CONV(RAND_CONV(DEPTH_CONV WORD_NUM_RED_CONV)))
-          (BINOP2_CONV
-           (LAND_CONV(DEPTH_CONV WORD_NUM_RED_CONV))
-           (RAND_CONV(DEPTH_CONV WORD_NUM_RED_CONV)))) th3
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
   | Comb(Const("barred",_),t) ->
         let th1 = GEN_CONGBOUND_RULE aboths t in
         MATCH_MP CONGBOUND_BARRED th1
+  | Comb(Const("montred",_),t) ->
+        let th1 = GEN_CONGBOUND_RULE aboths t in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE(MATCH_MP CONGBOUND_MONTRED th1))
+  | Comb(Const("word_sx",_),t) ->
+        let th0 = GEN_CONGBOUND_RULE aboths t in
+        let tyin = type_match
+         (type_of(rator(rand(lhand(funpow 4 rand (snd(dest_forall
+            (concl CONGBOUND_WORD_SX)))))))) (type_of(rator tm)) [] in
+        let th1 = MATCH_MP (INST_TYPE tyin CONGBOUND_WORD_SX) th0 in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
   | Comb(Comb(Const("word_add",_),ltm),rtm) ->
         let lth = GEN_CONGBOUND_RULE aboths ltm
         and rth = GEN_CONGBOUND_RULE aboths rtm in
         let th1 = MATCH_MP CONGBOUND_WORD_ADD (CONJ lth rth) in
-        let th2 = DEPTH_CONV WORD_NUM_RED_CONV (lhand(concl th1)) in
-        let th3 = MP th1 (EQT_ELIM th2) in
-        CONV_RULE(RAND_CONV (BINOP2_CONV
-           (LAND_CONV INT_ADD_CONV) (RAND_CONV INT_ADD_CONV))) th3
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
   | Comb(Comb(Const("word_sub",_),ltm),rtm) ->
         let lth = GEN_CONGBOUND_RULE aboths ltm
         and rth = GEN_CONGBOUND_RULE aboths rtm in
         let th1 = MATCH_MP CONGBOUND_WORD_SUB (CONJ lth rth) in
-        let th2 = DEPTH_CONV WORD_NUM_RED_CONV (lhand(concl th1)) in
-        let th3 = MP th1 (EQT_ELIM th2) in
-        CONV_RULE(RAND_CONV (BINOP2_CONV
-           (LAND_CONV INT_SUB_CONV) (RAND_CONV INT_SUB_CONV))) th3
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
+  | Comb(Comb(Const("word_mul",_),ltm),rtm) ->
+        let lth = GEN_CONGBOUND_RULE aboths ltm
+        and rth = GEN_CONGBOUND_RULE aboths rtm in
+        let th1 = MATCH_MP CONGBOUND_WORD_MUL (CONJ lth rth) in
+        CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
   | _ -> (try MATCH_MP CONGBOUND_ATOM_GEN
                (find ((=) tm o rand o rand o lhand o concl) aboths)
-          with Failure _ -> ISPEC tm CONGBOUND_ATOM);;
+          with Failure _ -> CONCL_BOUNDS_RULE(ISPEC tm CONGBOUND_ATOM));;
 
 let CONGBOUND_RULE = GEN_CONGBOUND_RULE [];;


### PR DESCRIPTION
This changes the specification style used in this proof from raw word operations to integer congruences, under some additional input bound assumptions |x0_i|, |x1_i| <= 2^12.

This relies on some improvements to the underlying automation for congruences and bounds, which are updated in line with some similar changes in s2n-bignum.

  https://github.com/jargh/s2n-bignum-dev/commit/50e617bce53a737ef11a605b7660dfe2bb97f01d

So far mlkem_poly_basemul_acc_montgomery_cached_k[34] are left as they are, except that the definition of "montred" is further type-constrained to match the definition used in the updated automation, which is in any case the type instance used in the specifications.

<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
Provide a brief summary of your changes.

**Steps**:
If your pull request consists of multiple sequential changes, please describe them here:

**Performed local tests**:
 - [ ] `lint` passing
 - [ ] `tests all` passing
 - [ ] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
