### PR TITLE
CBMC: Add a link to list of undefined behaviors caught by CBMC

### DIFF
--- a/proofs/cbmc/README.md
+++ b/proofs/cbmc/README.md
@@ -62,3 +62,5 @@ tests cbmc --help
 ## What is covered?
 
 Each proved function has an eponymous sub-directory of its own. Use [list_proofs.sh](list_proofs.sh) to see the list of functions covered.
+
+The classes of undefined behavior covered by CBMC are documented [here](https://github.com/diffblue/cbmc/blob/develop/doc/C/c11-undefined-behavior.html).


### PR DESCRIPTION
This commit adds a link to the list of undefined behaviors caught by CBMC to the CBMC README.

Unfortunately, the HTML page targetted by the link is not rendered, limiting its usefulness. The CBMC team is aware, and we can update the link once there is a rendered version.

* Resolves #891 