### PR TITLE
Fix running of ACVP tests in `tests all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@
 	func_768 kat_768 nistkat_768 acvp_768 \
 	func_1024 kat_1024 nistkat_1024 acvp_1024 \
 	run_func run_kat run_nistkat run_acvp \
-	run_func_512 run_kat_512 run_nistkat_512 run_acvp_512 \
-	run_func_768 run_kat_768 run_nistkat_768 run_acvp_768 \
-	run_func_1024 run_kat_1024 run_nistkat_1024 run_acvp_1024 \
+	run_func_512 run_kat_512 run_nistkat_512 \
+	run_func_768 run_kat_768 run_nistkat_768 \
+	run_func_1024 run_kat_1024 run_nistkat_1024 \
 	bench_512 bench_768 bench_1024 bench \
 	run_bench_512 run_bench_768 run_bench_1024 run_bench \
 	bench_components_512 bench_components_768 bench_components_1024 bench_components \

--- a/scripts/tests
+++ b/scripts/tests
@@ -686,7 +686,7 @@ class Tests:
             if nistkat is True:
                 self._run_schemes(TEST_TYPES.NISTKAT, opt)
             if acvp is True:
-                self._run_schemes(TEST_TYPES.ACVP, opt)
+                self._run_scheme(TEST_TYPES.ACVP, opt, None)
 
         if self.do_no_opt():
             _all(False)


### PR DESCRIPTION
* Resolves #924 

`tests all` is intended to run all available tests, including ACVP.

Most tests are parametrized by security level and available as separate targets in the Makefile, which `tests` invokes. For example, `make run_func_512` will run functionality tests for ML-KEM-512.

The ACVP tests are currently not parametrized by the level, but monolithic. They are invoked by `make run_acvp`, not `make run_acvp_{512,768,1024}`.

While `tests acvp` got the invocation of ACVP tests via `make` right, the `tests all` variant did not: It would invoke `make run_acvp_XXX`, which would do nothing.

This commit fixes `tests all` to invoke the ACVP tests via `make run_acvp`.
