### PR TITLE
Config: Document all configuration options

### DIFF
--- a/examples/monolithic_build_multilevel_native/mlkem_native_all.c
+++ b/examples/monolithic_build_multilevel_native/mlkem_native_all.c
@@ -4,7 +4,6 @@
  */
 
 #define MLK_MULTILEVEL_BUILD
-#define MLK_EXTERNAL_API static
 
 /* Three instances of mlkem-native for all security levels */
 
@@ -14,8 +13,6 @@
 #define MLK_MONOBUILD_WITH_NATIVE_ARITH
 #define MLK_MONOBUILD_WITH_NATIVE_FIPS202
 #define MLK_MONOBUILD_KEEP_SHARED_HEADERS
-/* Indicate that this is a monobuild */
-#define MLK_MONOBUILD
 
 #define MLKEM_K 2
 #define MLK_CONFIG_FILE "multilevel_config.h"

--- a/examples/monolithic_build_multilevel_native/multilevel_config.h
+++ b/examples/monolithic_build_multilevel_native/multilevel_config.h
@@ -126,4 +126,31 @@
 #define MLK_FIPS202_BACKEND_FILE "fips202/native/auto.h"
 #endif
 
+/******************************************************************************
+ * Name:        MLK_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+#define MLK_INTERNAL_API_QUALIFIER static
+
+/******************************************************************************
+ * Name:        MLK_EXTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of mlkem-native's
+ *              public API.
+ *
+ *              The primary use case for this option are single-CU builds
+ *              where the public API exposed by mlkem-native is wrapped by
+ *              another API in the consuming application. In this case,
+ *              even mlkem-native's public API can be marked `static`.
+ *
+ *****************************************************************************/
+#define MLK_EXTERNAL_API_QUALIFIER static
+
 #endif /* MLkEM_NATIVE_CONFIG_H */

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -14,19 +14,18 @@
 #include "params.h"
 #include "sys.h"
 
-/* For a monobuild (where all compilation units are merged into one), mark
- * all non-public API as static since they don't need external linkage. */
-#if !defined(MLK_MONOBUILD)
+/* Internal and public API have external linkage by default, but
+ * this can be overwritten by the user, e.g. for single-CU builds. */
+#if !defined(MLK_INTERNAL_API_QUALIFIER)
 #define MLK_INTERNAL_API
 #else
-#define MLK_INTERNAL_API static
+#define MLK_INTERNAL_API MLK_INTERNAL_API_QUALIFIER
 #endif
 
-/* Public API may have internal or external linkage, depending on how
- * mlkem-native is used in the monobuild. Keep it external by default,
- * but allow the user to overwrite this in the config. */
-#if !defined(MLK_EXTERNAL_API)
+#if !defined(MLK_EXTERNAL_API_QUALIFIER)
 #define MLK_EXTERNAL_API
+#else
+#define MLK_EXTERNAL_API MLK_EXTERNAL_API_QUALIFIER
 #endif
 
 #if defined(MLK_MULTILEVEL_BUILD_NO_SHARED) || \

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -288,6 +288,33 @@
 */
 
 /******************************************************************************
+ * Name:        MLK_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+/* #define MLK_INTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLK_EXTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of mlkem-native's
+ *              public API.
+ *
+ *              The primary use case for this option are single-CU builds
+ *              where the public API exposed by mlkem-native is wrapped by
+ *              another API in the consuming application. In this case,
+ *              even mlkem-native's public API can be marked `static`.
+ *
+ *****************************************************************************/
+/* #define MLK_EXTERNAL_API_QUALIFIER */
+
+/******************************************************************************
  * Name:        MLK_NO_ASM
  *
  * Description: If this option is set, mlkem-native will be built without

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -315,6 +315,18 @@
 /* #define MLK_EXTERNAL_API_QUALIFIER */
 
 /******************************************************************************
+ * Name:        MLK_CT_TESTING_ENABLED
+ *
+ * Description: If set, mlkem-native annotates data as secret / public using
+ *              valgrind's annotations VALGRIND_MAKE_MEM_UNDEFINED and
+ *              VALGRIND_MAKE_MEM_DEFINED, enabling various checks for secret-
+ *              dependent control flow of variable time execution (depending
+ *              on the exact version of valgrind installed).
+ *
+ *****************************************************************************/
+/* #define MLK_CT_TESTING_ENABLED */
+
+/******************************************************************************
  * Name:        MLK_NO_ASM
  *
  * Description: If this option is set, mlkem-native will be built without


### PR DESCRIPTION
* Resolves #926 

Previously, mlkem-native used undocumented configuration options

- MLK_MONOBUILD
- MLK_EXTERNAL_API

to control the qualifiers used for mlkem-native's internal and public API, respectively.

This commit renames those options to

- MLK_INTERNAL_API_QUALIFIER
- MLK_EXTERNAL_API_QUALIFIER

and documents them.

It also modifies the config for the `monolithic_build_multilevel_native` example to test the `static` public API qualifier.

Also, the PR extends `config.h` with documentation for `MLK_CT_TESTING_ENABLED`.