### PR TITLE
Remove use of MLK_NAMESPACE_PREFIX_ADD_LEVEL

### DIFF
--- a/examples/multilevel_build/Makefile
+++ b/examples/multilevel_build/Makefile
@@ -85,7 +85,6 @@ CFLAGS := \
 	-Wno-unused-command-line-argument \
 	-fomit-frame-pointer \
         -DMLK_NAMESPACE_PREFIX=mlkem \
-	-DMLK_NAMESPACE_PREFIX_ADD_LEVEL\
 	-std=c99 \
 	-pedantic \
 	-MMD \

--- a/examples/multilevel_build/README.md
+++ b/examples/multilevel_build/README.md
@@ -10,8 +10,7 @@ The library is built 3 times in different build directories `build/mlkem{512,768
 `MLK_MULTILEVEL_BUILD_WITH_SHARED` to force the inclusion of all level-independent code in the
 MLKEM512-build. For MLKEM-768 and MLKEM-1024, we set `MLK_MULTILEVEL_BUILD_NO_SHARED` to not include any
 level-independent code. Finally, we use the common namespace prefix `mlkem` as `MLK_NAMESPACE_PREFIX` for all three
-builds, but set `MLK_NAMESPACE_PREFIX_ADD_LEVEL` to additionally suffix level-dependent functions with `512/768/1024`,
-while level-independent functions are named `mlkem_xxx`.
+builds; the suffix 512/768/1024 will be added to level-dependent functions automatically.
 
 ## Usage
 

--- a/examples/multilevel_build_native/Makefile
+++ b/examples/multilevel_build_native/Makefile
@@ -60,7 +60,6 @@ CFLAGS := \
 	-Wno-unused-command-line-argument \
 	-fomit-frame-pointer \
 	-DMLK_NAMESPACE_PREFIX=mlkem \
-	-DMLK_NAMESPACE_PREFIX_ADD_LEVEL \
 	-std=c99 \
 	-pedantic \
 	-MMD \

--- a/examples/multilevel_build_native/README.md
+++ b/examples/multilevel_build_native/README.md
@@ -9,8 +9,7 @@ The library is built 3 times in different build directories `build/mlkem{512,768
 `MLK_MULTILEVEL_BUILD_WITH_SHARED` to force the inclusion of all level-independent code in the
 MLKEM512-build. For MLKEM-768 and MLKEM-1024, we set `MLK_MULTILEVEL_BUILD_NO_SHARED` to not include any
 level-independent code. Finally, we use the common namespace prefix `mlkem` as `MLK_NAMESPACE_PREFIX` for all three
-builds, but set `MLK_NAMESPACE_PREFIX_ADD_LEVEL` to additionally suffix level-dependent functions with `512/768/1024`,
-while level-independent functions are named `mlkem_xxx`.
+builds; the suffix 512/768/1024 will be added to level-dependent functions automatically.
 
 ## Usage
 


### PR DESCRIPTION
This option was previously used to indicate that the security level (512/768/1024) should be added to the namespace prefix.

Now, the suffixing is automatic based on whether MLK_MULTI_LEVEL_XXX is set. Setting the MLK_NAMESPACE_PREFIX_ADD_LEVEL flag therefore has no effect.

This commit removes / adjusts all uses or documentation of MLK_NAMESPACE_PREFIX_ADD_LEVEL.
