### PR TITLE
Benchmarking: Re-enable MacMini

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Functional tests
-description: Run functional tests for MLKEM-C_AArch64
+description: Run functional tests
 
 inputs:
   nix-shell:

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Lint
-description: Lint MLKEM-C_AArch64
+description: Lint
 
 inputs:
   nix-shell:

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Multiple Functional tests
-description: Run functional tests for MLKEM-C_AArch64
+description: Run functional tests
 
 inputs:
   nix-shell:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,12 +52,12 @@ jobs:
           cflags: "-static"
           bench_extra_args: -w exec-on-bpi
           cross_prefix: riscv64-unknown-linux-gnu-
-        # - system: m1-mac-mini
-        #   name: Mac Mini (M1, 2020) benchmarks
-        #   bench_pmu: MAC
-        #   archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
-        #   cflags: "-flto"
-        #   bench_extra_args: "-r"
+        - system: m1-mac-mini
+          name: Mac Mini (M1, 2020) benchmarks
+          bench_pmu: MAC
+          archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
+          cflags: "-flto"
+          bench_extra_args: "-r"
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
     runs-on: self-hosted-${{ matrix.target.system }}
     steps:


### PR DESCRIPTION
This reverts commit 46bac9aa05c4533c6b8400ff976ba2c73be24ee9.

The MacMini was temporarily unavailable yesterday and, hence, got removed. It seems to have recovered by itself. This commit re-adds it.