### PR TITLE
CBMC: Simplify rej_uniform_scalar proof

### DIFF
--- a/mlkem/sampling.c
+++ b/mlkem/sampling.c
@@ -38,7 +38,7 @@ __contract__(
   while (ctr < target && pos + 3 <= buflen)
   __loop__(
     invariant(offset <= ctr && ctr <= target && pos <= buflen)
-    invariant(ctr > 0 ==> array_bound(r, 0, ctr, 0, MLKEM_Q)))
+    invariant(array_bound(r, 0, ctr, 0, MLKEM_Q)))
   {
     val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
     val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;


### PR DESCRIPTION
It was observed in https://github.com/pq-code-package/mldsa-native/pull/86 that
invariant(ctr > 0 ==> array_bound(r, 0, ctr, 0, MLKEM_Q))) can be simplified to
invariant(array_bound(r, 0, ctr, 0, MLKEM_Q)))
as
invariant(array_bound(r, 0, 0, 0, MLKEM_Q))) is just true.

This commit simplifies the one place in mlkem-native where we had a similar implicatation.

<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
Provide a brief summary of your changes.

**Steps**:
If your pull request consists of multiple sequential changes, please describe them here:

**Performed local tests**:
 - [ ] `lint` passing
 - [ ] `tests all` passing
 - [ ] `tests bench` passing
 - [ ] `tests cbmc` passing

**Do you expect this change to impact performance**: Yes/No

If yes, please provide local benchmarking results.
