### PR TITLE
keypair_derand: *coins -> coins[2 * MLKEM_SYMBYTES] 

### DIFF
--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -189,7 +189,7 @@ static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
 MLK_EXTERNAL_API
 int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                               uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES],
-                              const uint8_t *coins)
+                              const uint8_t coins[2 * MLKEM_SYMBYTES])
 {
   mlk_indcpa_keypair_derand(pk, sk, coins);
   memcpy(sk + MLKEM_INDCPA_SECRETKEYBYTES, pk, MLKEM_INDCCA_PUBLICKEYBYTES);

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -63,7 +63,7 @@ MLK_EXTERNAL_API
 MLK_MUST_CHECK_RETURN_VALUE
 int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                               uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES],
-                              const uint8_t *coins)
+                              const uint8_t coins[2 * MLKEM_SYMBYTES])
 __contract__(
   requires(memory_no_alias(pk, MLKEM_INDCCA_PUBLICKEYBYTES))
   requires(memory_no_alias(sk, MLKEM_INDCCA_SECRETKEYBYTES))

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -137,7 +137,7 @@ MLK_API_MUST_CHECK_RETURN_VALUE
 int MLK_API_NAMESPACE(keypair_derand)(
     uint8_t pk[MLKEM_PUBLICKEYBYTES(MLK_CONFIG_API_PARAMETER_SET)],
     uint8_t sk[MLKEM_SECRETKEYBYTES(MLK_CONFIG_API_PARAMETER_SET)],
-    const uint8_t *coins);
+    const uint8_t coins[2 * MLKEM_SYMBYTES]);
 
 /*************************************************
  * Name:        crypto_kem_keypair


### PR DESCRIPTION
* Resolves #944 

keypair_derand requires 2 * MLKEM_SYMBYTES bytes of randomness. So far the function
signature took a const uint8_t *coins.
This commit changfes the function signature to make the size explicit:
const uint8_t coins[2 * MLKEM_SYMBYTES].
This is in line with the enc_derand function and should reduce the risk of
misuse.


Based on #942. 