### PR TITLE
Add and apply "InsertBraces" option for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,6 +16,7 @@ IncludeBlocks: Preserve
 # Designate CBMC contracts/macros that appear in .h files
 # as "attributes" so they don't get increasingly indented line after line
 BreakBeforeBraces: Allman
+InsertBraces: true
 WhitespaceSensitiveMacros: ['__contract__', '__loop__' ]
 Macros:
  # Make this artifically long to avoid function bodies after short contracts

--- a/dev/x86_64/src/rej_uniform_avx2.c
+++ b/dev/x86_64/src/rej_uniform_avx2.c
@@ -118,9 +118,13 @@ unsigned mlk_rej_uniform_avx2(int16_t *MLK_RESTRICT r, const uint8_t *buf)
     pos += 3;
 
     if (val0 < MLKEM_Q)
+    {
       r[ctr++] = val0;
+    }
     if (val1 < MLKEM_Q && ctr < MLKEM_N)
+    {
       r[ctr++] = val1;
+    }
   }
 
   return ctr;

--- a/examples/bring_your_own_fips202/custom_fips202/tiny_sha3/sha3.c
+++ b/examples/bring_your_own_fips202/custom_fips202/tiny_sha3/sha3.c
@@ -50,13 +50,17 @@ void sha3_keccakf(uint64_t st[25])
   {
     /* Theta */
     for (i = 0; i < 5; i++)
+    {
       bc[i] = st[i] ^ st[i + 5] ^ st[i + 10] ^ st[i + 15] ^ st[i + 20];
+    }
 
     for (i = 0; i < 5; i++)
     {
       t = bc[(i + 4) % 5] ^ ROTL64(bc[(i + 1) % 5], 1);
       for (j = 0; j < 25; j += 5)
+      {
         st[j + i] ^= t;
+      }
     }
 
     /* Rho Pi */
@@ -73,9 +77,13 @@ void sha3_keccakf(uint64_t st[25])
     for (j = 0; j < 25; j += 5)
     {
       for (i = 0; i < 5; i++)
+      {
         bc[i] = st[j + i];
+      }
       for (i = 0; i < 5; i++)
+      {
         st[j + i] ^= (~bc[(i + 1) % 5]) & bc[(i + 2) % 5];
+      }
     }
 
     /*  Iota */
@@ -107,7 +115,9 @@ int sha3_init(sha3_ctx_t *c, int mdlen)
   int i;
 
   for (i = 0; i < 25; i++)
+  {
     c->st.q[i] = 0;
+  }
   c->mdlen = mdlen;
   c->rsiz = 200 - 2 * mdlen;
   c->pt = 0;

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -92,7 +92,9 @@ int main(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -92,7 +92,9 @@ int main(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/src/sha3.c
+++ b/examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/src/sha3.c
@@ -56,13 +56,17 @@ void tiny_sha3_keccakf(uint64_t st[25])
   {
     /* Theta */
     for (i = 0; i < 5; i++)
+    {
       bc[i] = st[i] ^ st[i + 5] ^ st[i + 10] ^ st[i + 15] ^ st[i + 20];
+    }
 
     for (i = 0; i < 5; i++)
     {
       t = bc[(i + 4) % 5] ^ ROTL64(bc[(i + 1) % 5], 1);
       for (j = 0; j < 25; j += 5)
+      {
         st[j + i] ^= t;
+      }
     }
 
     /* Rho Pi */
@@ -79,9 +83,13 @@ void tiny_sha3_keccakf(uint64_t st[25])
     for (j = 0; j < 25; j += 5)
     {
       for (i = 0; i < 5; i++)
+      {
         bc[i] = st[j + i];
+      }
       for (i = 0; i < 5; i++)
+      {
         st[j + i] ^= (~bc[(i + 1) % 5]) & bc[(i + 2) % 5];
+      }
     }
 
     /*  Iota */
@@ -119,7 +127,9 @@ int tiny_sha3_init(sha3_ctx_t *c, int mdlen)
   int i;
 
   for (i = 0; i < 25; i++)
+  {
     c->st.q[i] = 0;
+  }
   c->mdlen = mdlen;
   c->rsiz = 200 - 2 * mdlen;
   c->pt = 0;

--- a/examples/mlkem_native_as_code_package/main.c
+++ b/examples/mlkem_native_as_code_package/main.c
@@ -88,7 +88,9 @@ int main(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -78,7 +78,9 @@ static int test_keys_mlkem(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/monolithic_build_multilevel/main.c
+++ b/examples/monolithic_build_multilevel/main.c
@@ -58,7 +58,9 @@ static int test_keys_mlkem512(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -111,7 +113,9 @@ static int test_keys_mlkem768(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -165,7 +169,9 @@ static int test_keys_mlkem1024(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/monolithic_build_multilevel_native/main.c
+++ b/examples/monolithic_build_multilevel_native/main.c
@@ -62,7 +62,9 @@ static int test_keys_mlkem512(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -115,7 +117,9 @@ static int test_keys_mlkem768(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -169,7 +173,9 @@ static int test_keys_mlkem1024(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/multilevel_build/main.c
+++ b/examples/multilevel_build/main.c
@@ -58,7 +58,9 @@ static int test_keys_mlkem512(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -111,7 +113,9 @@ static int test_keys_mlkem768(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -164,7 +168,9 @@ static int test_keys_mlkem1024(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/examples/multilevel_build_native/main.c
+++ b/examples/multilevel_build_native/main.c
@@ -58,7 +58,9 @@ static int test_keys_mlkem512(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -111,7 +113,9 @@ static int test_keys_mlkem768(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 
@@ -165,7 +169,9 @@ static int test_keys_mlkem1024(void)
   {
     size_t i;
     for (i = 0; i < sizeof(key_a); i++)
+    {
       printf("%02x", key_a[i]);
+    }
   }
   printf("\n");
 

--- a/mlkem/debug.c
+++ b/mlkem/debug.c
@@ -48,7 +48,9 @@ void mlk_debug_check_bounds(const char *file, int line, const int16_t *ptr,
   }
 
   if (err == 1)
+  {
     exit(1);
+  }
 }
 
 #else /* !MLK_CONFIG_MULTILEVEL_NO_SHARED && MLKEM_DEBUG */

--- a/mlkem/native/x86_64/src/rej_uniform_avx2.c
+++ b/mlkem/native/x86_64/src/rej_uniform_avx2.c
@@ -118,9 +118,13 @@ unsigned mlk_rej_uniform_avx2(int16_t *MLK_RESTRICT r, const uint8_t *buf)
     pos += 3;
 
     if (val0 < MLKEM_Q)
+    {
       r[ctr++] = val0;
+    }
     if (val1 < MLKEM_Q && ctr < MLKEM_N)
+    {
       r[ctr++] = val1;
+    }
   }
 
   return ctr;

--- a/test/bench_mlkem.c
+++ b/test/bench_mlkem.c
@@ -45,7 +45,9 @@ static void print_percentile_legend(void)
   unsigned i;
   printf("%21s", "percentile");
   for (i = 0; i < sizeof(percentiles) / sizeof(percentiles[0]); i++)
+  {
     printf("%7d", percentiles[i]);
+  }
   printf("\n");
 }
 
@@ -54,7 +56,9 @@ static void print_percentiles(const char *txt, uint64_t cyc[NTESTS])
   unsigned i;
   printf("%10s percentiles:", txt);
   for (i = 0; i < sizeof(percentiles) / sizeof(percentiles[0]); i++)
+  {
     printf("%7" PRIu64, (cyc)[NTESTS * percentiles[i] / 100] / NITERATIONS);
+  }
   printf("\n");
 }
 


### PR DESCRIPTION
Fixes #946 

1. Adds "InsertBraces: true" to .clang-format file
2. autogen
3. format
4. lint

All tests OK.

