### PR TITLE
tests: Integrate namespace check into `tests func`

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -96,12 +96,7 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ./scripts/tests all --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} -v
-      - name: Check namespacing ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }}, ${{ env.EXAMPLES }})
-        if: ${{ inputs.check_namespace == 'true' }}
-        shell: ${{ env.SHELL }}
-        run: |
-          ./scripts/check-namespace
+          ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} -v
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -60,10 +60,7 @@ jobs:
       - uses: ./.github/actions/setup-os
       - name: tests func
         run: |
-          ./scripts/tests func
-      - name: check namespacing
-        run: |
-          ./scripts/check-namespace
+          ./scripts/tests func --check-namespace
   quickcheck_bench:
     strategy:
       fail-fast: false
@@ -142,16 +139,13 @@ jobs:
       - uses: ./.github/actions/setup-apt
       - name: tests func
         run: |
-          ./scripts/tests func --cflags="-std=c90"
+          ./scripts/tests func --cflags="-std=c90" --check-namespace
       - name: tests bench
         run: |
           ./scripts/tests bench -c NO --cflags="-std=c90"
       - name: tests bench components
         run: |
           ./scripts/tests bench --components -c NO --cflags="-std=c90"
-      - name: check namespacing
-        run: |
-          ./scripts/check-namespace
   quickcheck-windows:
     strategy:
       fail-fast: false

--- a/scripts/check-namespace
+++ b/scripts/check-namespace
@@ -18,9 +18,6 @@ import os
 
 
 def check_file(file_path, namespaces):
-    if file_path.endswith("debug.c.o"):
-        print("skipping namespacing: {}".format(file_path))
-        return
     print("checking namespacing: {}".format(file_path))
     command = ["nm", "-g", file_path]
 
@@ -76,4 +73,5 @@ def run():
 
 
 if __name__ == "__main__":
+    os.chdir(os.path.join(os.path.dirname(__file__), ".."))
     run()

--- a/scripts/tests
+++ b/scripts/tests
@@ -540,6 +540,14 @@ class Tests:
     def func(self):
         def _func(opt):
             self._compile_schemes(TEST_TYPES.FUNC, opt)
+            if self.args.check_namespace is True:
+                p = subprocess.run(
+                    ["python3", "check-namespace"],
+                    stdout=subprocess.DEVNULL if not self.args.verbose else None,
+                    cwd="scripts",
+                )
+                if p.returncode != 0:
+                    self.fail(f"Namespacing failed for opt={opt}")
             if self.args.run:
                 self._run_schemes(TEST_TYPES.FUNC, opt)
 
@@ -934,6 +942,13 @@ def cli():
         "all", help="Run all tests (except benchmark for now)", parents=[common_parser]
     )
 
+    all_parser.add_argument(
+        "--check-namespace",
+        help="Check namespacing of binaries",
+        action="store_true",
+        default=False,
+    )
+
     func_group = all_parser.add_mutually_exclusive_group()
     func_group.add_argument(
         "--func", action="store_true", dest="func", help="Run func test", default=True
@@ -1134,6 +1149,12 @@ def cli():
         "func",
         help="Run the functional tests for all parameter sets",
         parents=[common_parser],
+    )
+    func_parser.add_argument(
+        "--check-namespace",
+        help="Check namespacing of binaries",
+        action="store_true",
+        default=False,
     )
 
     # kat arguments


### PR DESCRIPTION
* Resolves #372 

This commit adds the parameter --check-namespace to `tests func`. It is false by default. If true, `scripts/check-namespace` is called after both the C and the native build to check namespacing.

Previously, a call to `check-namespace` after `tests func` would only apply to the final binary produced by `tests func`, which was the native one.
