### PR TITLE
Document MLK_NAMESPACE and MLK_NAMESPACE_K macros

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -118,6 +118,8 @@
 #undef MLK_MULTILEVEL_BUILD
 #undef MLK_NAMESPACE
 #undef MLK_NAMESPACE_K
+#undef MLK_NAMESPACE_PREFIX
+#undef MLK_NAMESPACE_PREFIX_K
 /* mlkem/indcpa.h */
 #undef MLK_INDCPA_H
 #undef mlk_gen_matrix

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -42,10 +42,20 @@
 #define MLK_ADD_PARAM_SET(s) s
 #endif
 
-#define MLK_NAMESPACE(s) \
-  MLK_CONCAT(MLK_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _), s)
-#define MLK_NAMESPACE_K(s) \
-  MLK_CONCAT(MLK_CONCAT(MLK_ADD_PARAM_SET(MLK_CONFIG_NAMESPACE_PREFIX), _), s)
+#define MLK_NAMESPACE_PREFIX MLK_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _)
+#define MLK_NAMESPACE_PREFIX_K \
+  MLK_CONCAT(MLK_ADD_PARAM_SET(MLK_CONFIG_NAMESPACE_PREFIX), _)
+
+/* Functions are prefixed by MLK_CONFIG_NAMESPACE.
+ *
+ * If multiple parameter sets are used, functions depending on the parameter
+ * set are additionally prefixed with 512/768/1024. See config.h.
+ *
+ * Example: If MLK_CONFIG_NAMESPACE_PREFIX is mlkem, then
+ * MLK_NAMESPACE_K(enc) becomes mlkem512_enc/mlkem768_enc/mlkem1024_enc.
+ */
+#define MLK_NAMESPACE(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX, s)
+#define MLK_NAMESPACE_K(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX_K, s)
 
 /* On Apple platforms, we need to emit leading underscore
  * in front of assembly symbols. We thus introducee a separate


### PR DESCRIPTION
For readers trying to see through the naming indirection using MLK_NAMESPACE(...) and MLK_NAMESPACE_K(...), the previous definitions

```c
 #define MLK_NAMESPACE(s) \
   MLK_CONCAT(MLK_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _), s)
 #define MLK_NAMESPACE_K(s) \
   MLK_CONCAT(MLK_CONCAT(MLK_ADD_PARAM_SET(MLK_CONFIG_NAMESPACE_PREFIX), _), s)
```

are a handful.

This commit keeps the functionality as-is, but introduces internal abbreviations for the level'ed and underscore'ed prefix, so that the toplevel definitions for MLK_NAMESPACE[_K] turn into the more expectable

```c
 #define MLK_NAMESPACE(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX, s)
 #define MLK_NAMESPACE_K(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX_K, s)
```

Also, a comment is added with an example.
