### PR TITLE
CBMC: Fix documentation of `array_abs_bound`

### DIFF
--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -129,8 +129,10 @@
 
 /* Wrapper around array_bound operating on absolute values.
  *
- * Note that since the absolute bound is inclusive, but the lower
- * bound in array_bound is inclusive, we have to raise it by 1.
+ * The absolute value bound `k` is exclusive.
+ *
+ * Note that since the lower bound in array_bound is inclusive, we have to
+ * raise it by 1 here.
  */
 #define array_abs_bound(arr, lb, ub, k) \
   array_bound((arr), (lb), (ub), -((int)(k)) + 1, (k))


### PR DESCRIPTION
The documentation previously wrongly stated that the absolute bound is inclusive. Instead, it's exclusive. This commit fixes the documentation accordingly.
