### PR TITLE
Contributor's agreement to relicensing mlkem-native under `Apache-2.0 OR ISC OR MIT`

### DIFF
--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -18,3 +18,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Thing Han, Lim <potsrevenmil@gmail.com>
 - Spencer Wilson <spencer.wilson@uwaterloo.ca>
 - Basil Hess <bhe@zurich.ibm.com>
+- Mila Anastasova <manastasova2017@fau.edu>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -16,3 +16,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - John Harrison <jargh@amazon.com>
 - Matthias J. Kannwischer <matthias@kannwischer.eu>
 - Thing Han, Lim <potsrevenmil@gmail.com>
+- Spencer Wilson <spencer.wilson@uwaterloo.ca>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -12,3 +12,4 @@ By adding my name to the list below, I agree to relicense all my contributions
 in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 
 - Hanno Becker <beckphan@amazon.co.uk>
+- Duc Tri Nguyen <cothannguyen@gmail.com>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -19,3 +19,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Spencer Wilson <spencer.wilson@uwaterloo.ca>
 - Basil Hess <bhe@zurich.ibm.com>
 - Mila Anastasova <manastasova2017@fau.edu>
+- Ry Jones <ry@linux.com>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -1,0 +1,12 @@
+# Relicensing mlkem-native
+
+This document gathers consent by mlkem-native contributors to relicense
+mlkem-native from `Apache-2.0` to `Apache-2.0 OR ISC OR MIT`.
+
+The relicensing itself is intended to be carried out once all contributors
+have given consent to the relicensing.
+
+## Contributors agreeing to relicensing
+
+By adding my name to the list below, I agree to relicense all my contributions
+in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -20,3 +20,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Basil Hess <bhe@zurich.ibm.com>
 - Mila Anastasova <manastasova2017@fau.edu>
 - Ry Jones <ry@linux.com>
+- Rod Chapman <rodchap@amazon.co.uk>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -14,3 +14,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Hanno Becker <beckphan@amazon.co.uk>
 - Duc Tri Nguyen <cothannguyen@gmail.com>
 - John Harrison <jargh@amazon.com>
+- Matthias J. Kannwischer <matthias@kannwischer.eu>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -10,3 +10,5 @@ have given consent to the relicensing.
 
 By adding my name to the list below, I agree to relicense all my contributions
 in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
+
+- Hanno Becker <beckphan@amazon.co.uk>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -17,3 +17,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Matthias J. Kannwischer <matthias@kannwischer.eu>
 - Thing Han, Lim <potsrevenmil@gmail.com>
 - Spencer Wilson <spencer.wilson@uwaterloo.ca>
+- Basil Hess <bhe@zurich.ibm.com>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -15,3 +15,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Duc Tri Nguyen <cothannguyen@gmail.com>
 - John Harrison <jargh@amazon.com>
 - Matthias J. Kannwischer <matthias@kannwischer.eu>
+- Thing Han, Lim <potsrevenmil@gmail.com>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -13,3 +13,4 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 
 - Hanno Becker <beckphan@amazon.co.uk>
 - Duc Tri Nguyen <cothannguyen@gmail.com>
+- John Harrison <jargh@amazon.com>


### PR DESCRIPTION
This PR adds a RELICENSE file. The purpose of this file is to gather consent from mlkem-native contributors that their contributions may be relicensed as `Apache-2.0 OR MIT OR ISC`.

The relicensing itself is planned to be carried out once all contributors have added their names to that file.

Contributors agreeing to the relicensing should push a separate commit adding their name to `RELICENSE`.
