### PR TITLE
Makefile: Remove duplicated symbol check

### DIFF
--- a/test/mk/rules.mk
+++ b/test/mk/rules.mk
@@ -20,31 +20,6 @@ $(BUILD_DIR)/%.a: $(CONFIG)
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)rm -f $@
 	$(Q)$(CC_AR) rcs $@ $(filter %.o,$^)
-# skip test when run in scan-build as it does not work
-ifneq ($(findstring ccc-analyzer,$(CC)),ccc-analyzer)
-        # $AR doesn't care about duplicated symbols, one can only find it out
-        # via actually linking. The easiest one to do this that one can think
-        # of is to create a dummy C file with empty main function on the fly,
-        # pipe it to $CC and link with the built library
-	$(eval _LIB := $(subst $(BUILD_DIR)/lib,,$(@:%.a=%)))
-	$(eval _CFLAGS := $(subst -static,,$(CFLAGS)))
-
-ifeq ($(findstring Darwin,$(HOST_PLATFORM))$(CROSS_PREFIX),Darwin) # if is on native macOS
-	$(Q)echo "int main(void) {return 0;}" \
-		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
-		 -all_load -Wl,-undefined,dynamic_lookup -l$(_LIB) \
-		 -Imlkem $(wildcard test/notrandombytes/*.c) -o $(@:%.a=%_tmp.a.out)
-	$(Q)rm -f $(@:%.a=%_tmp.a.out)
-else                                           # if not on macOS or cross compiling on macOS
-	$(Q)echo "int main(void) {return 0;}" \
-		| $(CC) -x c - -L$(BUILD_DIR) $(_CFLAGS) \
-		-Wl,--whole-archive,--unresolved-symbols=ignore-in-object-files -l$(_LIB) \
-		-Wl,--no-whole-archive \
-		-Imlkem $(wildcard test/notrandombytes/*.c) -o $(@:%.a=%_tmp.a.out)
-	$(Q)rm -f $(@:%.a=%_tmp.a.out)
-endif
-	$(Q)echo "  AR         Checked for duplicated symbols"
-endif
 
 $(BUILD_DIR)/mlkem512/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"


### PR DESCRIPTION
test/mk/rules.mk includes a check for duplicated symbols when building archive files.

The implementation of this check is specific to the toolchain: We already distinguish Darwin vs. non-Darwin, and exclude the check when running with scan-build.

It turns out that the check does also not work with zig, as it uses unsupported linker arguments.

Instead of attempting to make the check more portable, this commit removes it altogether. This is OK because we anyway build various test binaries based on the generated libraries, and the build for those binaries would fail if there were duplicated symbols.
