### PR TITLE
Relicense mlkem-native as `Apache-2.0 OR ISC OR MIT`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -16,7 +16,7 @@ forward and inverse NTT for ML-KEM, carries the MIT license.
 Copyright (c) 2022 Arm Limited
 Copyright (c) 2022 Hanno Becker
 Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
-Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) The mlkem-native project authors
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -42,7 +42,7 @@ Keccak-F1600 permutation, carries the MIT license.
 
 Copyright (c) 2021-2022 Arm Limited
 Copyright (c) 2022 Matthias Kannwischer
-Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) The mlkem-native project authors
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -105,7 +105,7 @@ The code in test/nistrng/aes.* is derived from code in BearSSL
 and carries the MIT license. It is only used for testing purposes.
 
 ```
-Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) The mlkem-native project authors
 Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
 
 SPDX-License-Identifier: MIT
@@ -140,7 +140,7 @@ The benchmarking code in test/hal/hal.c carries the
 MIT license. It is only used for testing purposes.
 
 ```
-Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) The mlkem-native project authors
 Copyright (c) 2022 Arm Limited
 Copyright (c) 2020 Dougall Johnson
 SPDX-License-Identifier: MIT
@@ -176,7 +176,7 @@ SPDX-License-Identifier: MIT
 ISC license for mlkem-native content
 ------------------------------------
 
-Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) The mlkem-native project authors
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice
@@ -194,7 +194,7 @@ THIS SOFTWARE.
 MIT license for mlkem-native content
 ------------------------------------
 
-Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) The mlkem-native project authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in
@@ -404,7 +404,7 @@ Apache-2.0 license for mlkem-native content
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2024-2025 The mlkem-native project authors
+   Copyright (c) The mlkem-native project authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,221 @@
+mlkem-native is a fork of the public domain Kyber reference implementation,
+available on https://github.com/pq-crystals/kyber.
+
+All new files and all files derived from the Kyber reference
+implementation are made available under the Apache-2.0 license OR
+the ISC license OR the MIT license. This covers the C code and
+AVX2 assembly in mlkem/* and dev/*. These licenses are
+reproduced at the bottom of this file.
+
+License for AArch64 assembly
+----------------------------
+
+The AArch64 assembly in dev/* and mlkem/* implementing the
+forward and inverse NTT for ML-KEM, carries the MIT license.
+
+Copyright (c) 2022 Arm Limited
+Copyright (c) 2022 Hanno Becker
+Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+Copyright (c) 2024-2025 The mlkem-native project authors
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The AArch64 assembly in dev/* and mlkem/* implementing the
+Keccak-F1600 permutation, carries the MIT license.
+
+Copyright (c) 2021-2022 Arm Limited
+Copyright (c) 2022 Matthias Kannwischer
+Copyright (c) 2024-2025 The mlkem-native project authors
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Licenses for support code
+-------------------------
+
+The code in test/nistrng/rng.c is derived from code provided by NIST
+and governed by the following terms of use:
+
+```
+NIST-developed software is provided by NIST as a public service. You may
+use, copy, and distribute copies of the software in any medium, provided
+that you keep intact this entire notice. You may improve, modify, and
+create derivative works of the software or any portion of the software, and
+you may copy and distribute such modifications or works. Modified works
+should carry a notice stating that you changed the software and should note
+the date and nature of any such change. Please explicitly acknowledge the
+National Institute of Standards and Technology as the source of the
+software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO
+WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF
+LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF
+THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL
+BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING
+THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED
+TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and
+distributing the software and you assume all risks associated with its use,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs or
+equipment, and the unavailability or interruption of operation. This
+software is not intended to be used in any situation where a failure could
+cause risk of injury or damage to property. The software developed by NIST
+employees is not subject to copyright protection within the United
+States.
+```
+
+The code in test/nistrng/aes.* is derived from code in BearSSL
+and carries the MIT license. It is only used for testing purposes.
+
+```
+Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
+
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+The code in test/notrandombytes/* is derived from
+https://cr.yp.to/papers.html#surf and licensed under
+LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT.
+It is only used for testing purposes.
+
+The benchmarking code in test/hal/hal.c carries the
+MIT license. It is only used for testing purposes.
+
+```
+Copyright (c) 2024-2025 The mlkem-native project authors
+Copyright (c) 2022 Arm Limited
+Copyright (c) 2020 Dougall Johnson
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+The tiny_sha3 implementation in examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/src/
+carries the MIT license. It is only used for testing purposes.
+
+```
+SPDX-License-Identifier: MIT
+
+19-Nov-11  Markku-Juhani O. Saarinen <mjos@iki.fi>
+```
+
+ISC license for mlkem-native content
+------------------------------------
+
+Copyright (c) 2024-2025 The mlkem-native project authors
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+
+MIT license for mlkem-native content
+------------------------------------
+
+Copyright (c) 2024-2025 The mlkem-native project authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Apache-2.0 license for mlkem-native content
+-------------------------------------------
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +404,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright (c) 2024-2025 The mlkem-native project authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -141,8 +141,8 @@ MIT license. It is only used for testing purposes.
 
 ```
 Copyright (c) The mlkem-native project authors
-Copyright (c) 2022 Arm Limited
 Copyright (c) 2020 Dougall Johnson
+Copyright (c) 2022 Arm Limited
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: func kat nistkat acvp \
 	func_512 kat_512 nistkat_512 acvp_512 \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: func kat nistkat acvp \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 ![Proof: HOL-Light](https://github.com/pq-code-package/mlkem-native/actions/workflows/hol_light.yml/badge.svg)
 ![Benchmarks](https://github.com/pq-code-package/mlkem-native/actions/workflows/bench.yml/badge.svg)
 ![C90](https://img.shields.io/badge/language-C90-blue.svg)
-[![Apache](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+[![License: Apache](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 mlkem-native is a secure, fast, and portable C90 implementation of ML-KEM[^FIPS203].
 It is a fork of the ML-KEM reference implementation[^REF].

--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_AARCH64_CLEAN_META_H

--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/aarch64_zetas.c
+++ b/dev/aarch64_clean/src/aarch64_zetas.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/aarch64_clean/src/aarch64_zetas.c
+++ b/dev/aarch64_clean/src/aarch64_zetas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H
 #define MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H

--- a/dev/aarch64_clean/src/consts.h
+++ b/dev/aarch64_clean/src/consts.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_AARCH64_CLEAN_SRC_CONSTS_H

--- a/dev/aarch64_clean/src/consts.h
+++ b/dev/aarch64_clean/src/consts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/intt.S
+++ b/dev/aarch64_clean/src/intt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_clean/src/intt.S
+++ b/dev/aarch64_clean/src/intt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_clean/src/ntt.S
+++ b/dev/aarch64_clean/src/ntt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_clean/src/ntt.S
+++ b/dev/aarch64_clean/src/ntt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_clean/src/poly_mulcache_compute_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_clean/src/poly_reduce_asm.S
+++ b/dev/aarch64_clean/src/poly_reduce_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/poly_reduce_asm.S
+++ b/dev/aarch64_clean/src/poly_reduce_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_clean/src/poly_tobytes_asm.S
+++ b/dev/aarch64_clean/src/poly_tobytes_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/poly_tobytes_asm.S
+++ b/dev/aarch64_clean/src/poly_tobytes_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_clean/src/poly_tomont_asm.S
+++ b/dev/aarch64_clean/src/poly_tomont_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/poly_tomont_asm.S
+++ b/dev/aarch64_clean/src/poly_tomont_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/rej_uniform_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*************************************************

--- a/dev/aarch64_clean/src/rej_uniform_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_clean/src/rej_uniform_table.c
+++ b/dev/aarch64_clean/src/rej_uniform_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/aarch64_clean/src/rej_uniform_table.c
+++ b/dev/aarch64_clean/src/rej_uniform_table.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_AARCH64_OPT_META_H

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/Makefile
+++ b/dev/aarch64_opt/src/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 ######
 # To run, see the README.md file

--- a/dev/aarch64_opt/src/Makefile
+++ b/dev/aarch64_opt/src/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 ######

--- a/dev/aarch64_opt/src/aarch64_zetas.c
+++ b/dev/aarch64_opt/src/aarch64_zetas.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/aarch64_opt/src/aarch64_zetas.c
+++ b/dev/aarch64_opt/src/aarch64_zetas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H
 #define MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H

--- a/dev/aarch64_opt/src/consts.h
+++ b/dev/aarch64_opt/src/consts.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_AARCH64_OPT_SRC_CONSTS_H

--- a/dev/aarch64_opt/src/consts.h
+++ b/dev/aarch64_opt/src/consts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/intt.S
+++ b/dev/aarch64_opt/src/intt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_opt/src/intt.S
+++ b/dev/aarch64_opt/src/intt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_opt/src/ntt.S
+++ b/dev/aarch64_opt/src/ntt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_opt/src/ntt.S
+++ b/dev/aarch64_opt/src/ntt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
+++ b/dev/aarch64_opt/src/poly_mulcache_compute_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_opt/src/poly_reduce_asm.S
+++ b/dev/aarch64_opt/src/poly_reduce_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/poly_reduce_asm.S
+++ b/dev/aarch64_opt/src/poly_reduce_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_opt/src/poly_tobytes_asm.S
+++ b/dev/aarch64_opt/src/poly_tobytes_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/poly_tobytes_asm.S
+++ b/dev/aarch64_opt/src/poly_tobytes_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_opt/src/poly_tomont_asm.S
+++ b/dev/aarch64_opt/src/poly_tomont_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/poly_tomont_asm.S
+++ b/dev/aarch64_opt/src/poly_tomont_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/rej_uniform_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*************************************************

--- a/dev/aarch64_opt/src/rej_uniform_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/aarch64_opt/src/rej_uniform_table.c
+++ b/dev/aarch64_opt/src/rej_uniform_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/aarch64_opt/src/rej_uniform_table.c
+++ b/dev/aarch64_opt/src/rej_uniform_table.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/auto.h
+++ b/dev/fips202/aarch64/auto.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/fips202/aarch64/auto.h
+++ b/dev/fips202/aarch64/auto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 #define MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_scalar_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_scalar_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/dev/fips202/aarch64/src/keccakf1600_round_constants.c
+++ b/dev/fips202/aarch64/src/keccakf1600_round_constants.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../../common.h"

--- a/dev/fips202/aarch64/src/keccakf1600_round_constants.c
+++ b/dev/fips202/aarch64/src/keccakf1600_round_constants.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/x1_scalar.h
+++ b/dev/fips202/aarch64/x1_scalar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_FIPS202_AARCH64_X1_SCALAR_H

--- a/dev/fips202/aarch64/x1_scalar.h
+++ b/dev/fips202/aarch64/x1_scalar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/x1_v84a.h
+++ b/dev/fips202/aarch64/x1_v84a.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_FIPS202_AARCH64_X1_V84A_H

--- a/dev/fips202/aarch64/x1_v84a.h
+++ b/dev/fips202/aarch64/x1_v84a.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/x2_v84a.h
+++ b/dev/fips202/aarch64/x2_v84a.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_FIPS202_AARCH64_X2_V84A_H

--- a/dev/fips202/aarch64/x2_v84a.h
+++ b/dev/fips202/aarch64/x2_v84a.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/x4_v8a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_scalar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_FIPS202_AARCH64_X4_V8A_SCALAR_H

--- a/dev/fips202/aarch64/x4_v8a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_scalar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_FIPS202_AARCH64_X4_V8A_V84A_SCALAR_H

--- a/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_DEV_X86_64_META_H

--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/align.h
+++ b/dev/x86_64/src/align.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/align.h
+++ b/dev/x86_64/src/align.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_X86_64_SRC_ARITH_NATIVE_X86_64_H

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEV_X86_64_SRC_ARITH_NATIVE_X86_64_H
 #define MLK_DEV_X86_64_SRC_ARITH_NATIVE_X86_64_H

--- a/dev/x86_64/src/basemul.S
+++ b/dev/x86_64/src/basemul.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/basemul.S
+++ b/dev/x86_64/src/basemul.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/basemul.c
+++ b/dev/x86_64/src/basemul.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/basemul.c
+++ b/dev/x86_64/src/basemul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/compress_avx2.c
+++ b/dev/x86_64/src/compress_avx2.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/compress_avx2.c
+++ b/dev/x86_64/src/compress_avx2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/consts.c
+++ b/dev/x86_64/src/consts.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/consts.c
+++ b/dev/x86_64/src/consts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/consts.h
+++ b/dev/x86_64/src/consts.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/consts.h
+++ b/dev/x86_64/src/consts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/fq.inc
+++ b/dev/x86_64/src/fq.inc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/x86_64/src/fq.inc
+++ b/dev/x86_64/src/fq.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/intt.S
+++ b/dev/x86_64/src/intt.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/intt.S
+++ b/dev/x86_64/src/intt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/ntt.S
+++ b/dev/x86_64/src/ntt.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/ntt.S
+++ b/dev/x86_64/src/ntt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/nttfrombytes.S
+++ b/dev/x86_64/src/nttfrombytes.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/nttfrombytes.S
+++ b/dev/x86_64/src/nttfrombytes.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/nttpack.S
+++ b/dev/x86_64/src/nttpack.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/nttpack.S
+++ b/dev/x86_64/src/nttpack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/ntttobytes.S
+++ b/dev/x86_64/src/ntttobytes.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/ntttobytes.S
+++ b/dev/x86_64/src/ntttobytes.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/nttunpack.S
+++ b/dev/x86_64/src/nttunpack.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/nttunpack.S
+++ b/dev/x86_64/src/nttunpack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/reduce.S
+++ b/dev/x86_64/src/reduce.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/reduce.S
+++ b/dev/x86_64/src/reduce.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/rej_uniform_avx2.c
+++ b/dev/x86_64/src/rej_uniform_avx2.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/rej_uniform_avx2.c
+++ b/dev/x86_64/src/rej_uniform_avx2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/rej_uniform_table.c
+++ b/dev/x86_64/src/rej_uniform_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/x86_64/src/rej_uniform_table.c
+++ b/dev/x86_64/src/rej_uniform_table.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/shuffle.inc
+++ b/dev/x86_64/src/shuffle.inc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/x86_64/src/shuffle.inc
+++ b/dev/x86_64/src/shuffle.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/tomont.S
+++ b/dev/x86_64/src/tomont.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/dev/x86_64/src/tomont.S
+++ b/dev/x86_64/src/tomont.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/dev/x86_64/src/x86_64_zetas.i
+++ b/dev/x86_64/src/x86_64_zetas.i
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/dev/x86_64/src/x86_64_zetas.i
+++ b/dev/x86_64/src/x86_64_zetas.i
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/bring_your_own_fips202/custom_fips202/fips202.h
+++ b/examples/bring_your_own_fips202/custom_fips202/fips202.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/examples/bring_your_own_fips202/custom_fips202/fips202.h
+++ b/examples/bring_your_own_fips202/custom_fips202/fips202.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
+++ b/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
+++ b/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/custom_backend/mlkem_native/custom_config.h
+++ b/examples/custom_backend/mlkem_native/custom_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/examples/custom_backend/mlkem_native/custom_config.h
+++ b/examples/custom_backend/mlkem_native/custom_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/custom.h
+++ b/examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/custom.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #if !defined(MLK_FIPS202_CUSTOM_TINY_SHA3_H)

--- a/examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/custom.h
+++ b/examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/custom.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/mlkem_native_as_code_package/main.c
+++ b/examples/mlkem_native_as_code_package/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/mlkem_native_as_code_package/main.c
+++ b/examples/mlkem_native_as_code_package/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/monolithic_build/config_1024.h
+++ b/examples/monolithic_build/config_1024.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/examples/monolithic_build/config_1024.h
+++ b/examples/monolithic_build/config_1024.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build/config_512.h
+++ b/examples/monolithic_build/config_512.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/examples/monolithic_build/config_512.h
+++ b/examples/monolithic_build/config_512.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build/config_768.h
+++ b/examples/monolithic_build/config_768.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/examples/monolithic_build/config_768.h
+++ b/examples/monolithic_build/config_768.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel/main.c
+++ b/examples/monolithic_build_multilevel/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel/main.c
+++ b/examples/monolithic_build_multilevel/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/monolithic_build_multilevel/mlkem_native_all.c
+++ b/examples/monolithic_build_multilevel/mlkem_native_all.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* Only include API to check consistency with mlkem/mlkem_native.h

--- a/examples/monolithic_build_multilevel/mlkem_native_all.c
+++ b/examples/monolithic_build_multilevel/mlkem_native_all.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel/mlkem_native_all.h
+++ b/examples/monolithic_build_multilevel/mlkem_native_all.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #if !defined(MLK_ALL_H)

--- a/examples/monolithic_build_multilevel/mlkem_native_all.h
+++ b/examples/monolithic_build_multilevel/mlkem_native_all.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel/multilevel_config.h
+++ b/examples/monolithic_build_multilevel/multilevel_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/examples/monolithic_build_multilevel/multilevel_config.h
+++ b/examples/monolithic_build_multilevel/multilevel_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel_native/main.c
+++ b/examples/monolithic_build_multilevel_native/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel_native/main.c
+++ b/examples/monolithic_build_multilevel_native/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/monolithic_build_multilevel_native/mlkem_native_all.c
+++ b/examples/monolithic_build_multilevel_native/mlkem_native_all.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* Three instances of mlkem-native for all security levels */

--- a/examples/monolithic_build_multilevel_native/mlkem_native_all.c
+++ b/examples/monolithic_build_multilevel_native/mlkem_native_all.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/monolithic_build_multilevel_native/multilevel_config.h
+++ b/examples/monolithic_build_multilevel_native/multilevel_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/examples/monolithic_build_multilevel_native/multilevel_config.h
+++ b/examples/monolithic_build_multilevel_native/multilevel_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/multilevel_build/main.c
+++ b/examples/multilevel_build/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/multilevel_build/main.c
+++ b/examples/multilevel_build/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/multilevel_build/mlkem_native_all.h
+++ b/examples/multilevel_build/mlkem_native_all.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #if !defined(MLK_ALL_H)

--- a/examples/multilevel_build/mlkem_native_all.h
+++ b/examples/multilevel_build/mlkem_native_all.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/multilevel_build_native/main.c
+++ b/examples/multilevel_build_native/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/examples/multilevel_build_native/main.c
+++ b/examples/multilevel_build_native/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/examples/multilevel_build_native/mlkem_native_all.h
+++ b/examples/multilevel_build_native/mlkem_native_all.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #if !defined(MLK_ALL_H)

--- a/examples/multilevel_build_native/mlkem_native_all.h
+++ b/examples/multilevel_build_native/mlkem_native_all.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/integration/liboqs/ML-KEM-1024_META.yml
+++ b/integration/liboqs/ML-KEM-1024_META.yml
@@ -1,5 +1,5 @@
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 name: ML-KEM-1024
 type: kem
 claimed-nist-level: 5

--- a/integration/liboqs/ML-KEM-1024_META.yml
+++ b/integration/liboqs/ML-KEM-1024_META.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 name: ML-KEM-1024
 type: kem

--- a/integration/liboqs/ML-KEM-512_META.yml
+++ b/integration/liboqs/ML-KEM-512_META.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 name: ML-KEM-512
 type: kem

--- a/integration/liboqs/ML-KEM-512_META.yml
+++ b/integration/liboqs/ML-KEM-512_META.yml
@@ -1,5 +1,5 @@
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 name: ML-KEM-512
 type: kem
 claimed-nist-level: 1

--- a/integration/liboqs/ML-KEM-768_META.yml
+++ b/integration/liboqs/ML-KEM-768_META.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 name: ML-KEM-768
 type: kem

--- a/integration/liboqs/ML-KEM-768_META.yml
+++ b/integration/liboqs/ML-KEM-768_META.yml
@@ -1,5 +1,5 @@
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 name: ML-KEM-768
 type: kem
 claimed-nist-level: 3

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/integration/liboqs/fips202_glue.h
+++ b/integration/liboqs/fips202_glue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_INTEGRATION_LIBOQS_FIPS202_GLUE_H

--- a/integration/liboqs/fips202_glue.h
+++ b/integration/liboqs/fips202_glue.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_INTEGRATION_LIBOQS_FIPS202_GLUE_H
 #define MLK_INTEGRATION_LIBOQS_FIPS202_GLUE_H

--- a/integration/liboqs/fips202x4_glue.h
+++ b/integration/liboqs/fips202x4_glue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_INTEGRATION_LIBOQS_FIPS202X4_GLUE_H

--- a/integration/liboqs/fips202x4_glue.h
+++ b/integration/liboqs/fips202x4_glue.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_INTEGRATION_LIBOQS_FIPS202X4_GLUE_H
 #define MLK_INTEGRATION_LIBOQS_FIPS202X4_GLUE_H

--- a/integration/liboqs/liboqs-check-filelist.py
+++ b/integration/liboqs/liboqs-check-filelist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # This script makes sure that the sources in the liboqs meta files
 # are kept up to date.

--- a/integration/liboqs/liboqs-check-filelist.py
+++ b/integration/liboqs/liboqs-check-filelist.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # This script makes sure that the sources in the liboqs meta files

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CBMC_H

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_COMMON_H
 #define MLK_COMMON_H

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_COMMON_H

--- a/mlkem/compress.c
+++ b/mlkem/compress.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/compress.c
+++ b/mlkem/compress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/compress.h
+++ b/mlkem/compress.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/compress.h
+++ b/mlkem/compress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/debug.c
+++ b/mlkem/debug.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* NOTE: You can remove this file unless you compile with MLKEM_DEBUG. */

--- a/mlkem/debug.c
+++ b/mlkem/debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/debug.h
+++ b/mlkem/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEBUG_H

--- a/mlkem/debug.h
+++ b/mlkem/debug.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_DEBUG_H
 #define MLK_DEBUG_H

--- a/mlkem/fips202/fips202.c
+++ b/mlkem/fips202/fips202.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/fips202/fips202.c
+++ b/mlkem/fips202/fips202.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/fips202.h
+++ b/mlkem/fips202/fips202.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_FIPS202_H

--- a/mlkem/fips202/fips202.h
+++ b/mlkem/fips202/fips202.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_FIPS202_H
 #define MLK_FIPS202_FIPS202_H

--- a/mlkem/fips202/fips202x4.c
+++ b/mlkem/fips202/fips202x4.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/fips202/fips202x4.c
+++ b/mlkem/fips202/fips202x4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/fips202x4.h
+++ b/mlkem/fips202/fips202x4.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_FIPS202X4_H
 #define MLK_FIPS202_FIPS202X4_H

--- a/mlkem/fips202/fips202x4.h
+++ b/mlkem/fips202/fips202x4.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_FIPS202X4_H

--- a/mlkem/fips202/keccakf1600.c
+++ b/mlkem/fips202/keccakf1600.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/fips202/keccakf1600.c
+++ b/mlkem/fips202/keccakf1600.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/keccakf1600.h
+++ b/mlkem/fips202/keccakf1600.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_KECCAKF1600_H

--- a/mlkem/fips202/keccakf1600.h
+++ b/mlkem/fips202/keccakf1600.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_KECCAKF1600_H
 #define MLK_FIPS202_KECCAKF1600_H

--- a/mlkem/fips202/native/aarch64/auto.h
+++ b/mlkem/fips202/native/aarch64/auto.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/fips202/native/aarch64/auto.h
+++ b/mlkem/fips202/native/aarch64/auto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 #define MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c
+++ b/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../../common.h"

--- a/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c
+++ b/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/aarch64/x1_scalar.h
+++ b/mlkem/fips202/native/aarch64/x1_scalar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_AARCH64_X1_SCALAR_H

--- a/mlkem/fips202/native/aarch64/x1_scalar.h
+++ b/mlkem/fips202/native/aarch64/x1_scalar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/aarch64/x1_v84a.h
+++ b/mlkem/fips202/native/aarch64/x1_v84a.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_AARCH64_X1_V84A_H

--- a/mlkem/fips202/native/aarch64/x1_v84a.h
+++ b/mlkem/fips202/native/aarch64/x1_v84a.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/aarch64/x2_v84a.h
+++ b/mlkem/fips202/native/aarch64/x2_v84a.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_AARCH64_X2_V84A_H

--- a/mlkem/fips202/native/aarch64/x2_v84a.h
+++ b/mlkem/fips202/native/aarch64/x2_v84a.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/aarch64/x4_v8a_scalar.h
+++ b/mlkem/fips202/native/aarch64/x4_v8a_scalar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_AARCH64_X4_V8A_SCALAR_H

--- a/mlkem/fips202/native/aarch64/x4_v8a_scalar.h
+++ b/mlkem/fips202/native/aarch64/x4_v8a_scalar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h
+++ b/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_AARCH64_X4_V8A_V84A_SCALAR_H

--- a/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h
+++ b/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/api.h
+++ b/mlkem/fips202/native/api.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_API_H

--- a/mlkem/fips202/native/api.h
+++ b/mlkem/fips202/native/api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/auto.h
+++ b/mlkem/fips202/native/auto.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_AUTO_H

--- a/mlkem/fips202/native/auto.h
+++ b/mlkem/fips202/native/auto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
+++ b/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
+++ b/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.h
+++ b/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.h
+++ b/mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_X86_64_SRC_KECCAKP_1600_TIMES4_SIMD256_H

--- a/mlkem/fips202/native/x86_64/xkcp.h
+++ b/mlkem/fips202/native/x86_64/xkcp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_FIPS202_NATIVE_X86_64_XKCP_H

--- a/mlkem/fips202/native/x86_64/xkcp.h
+++ b/mlkem/fips202/native/x86_64/xkcp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/meta.h
+++ b/mlkem/native/aarch64/meta.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_NATIVE_AARCH64_META_H

--- a/mlkem/native/aarch64/meta.h
+++ b/mlkem/native/aarch64/meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/aarch64_zetas.c
+++ b/mlkem/native/aarch64/src/aarch64_zetas.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/native/aarch64/src/aarch64_zetas.c
+++ b/mlkem/native/aarch64/src/aarch64_zetas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H
 #define MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H

--- a/mlkem/native/aarch64/src/consts.h
+++ b/mlkem/native/aarch64/src/consts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/consts.h
+++ b/mlkem/native/aarch64/src/consts.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_NATIVE_AARCH64_SRC_CONSTS_H

--- a/mlkem/native/aarch64/src/intt.S
+++ b/mlkem/native/aarch64/src/intt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/mlkem/native/aarch64/src/intt.S
+++ b/mlkem/native/aarch64/src/intt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/mlkem/native/aarch64/src/ntt.S
+++ b/mlkem/native/aarch64/src/ntt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/mlkem/native/aarch64/src/ntt.S
+++ b/mlkem/native/aarch64/src/ntt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
+++ b/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
+++ b/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/mlkem/native/aarch64/src/poly_reduce_asm.S
+++ b/mlkem/native/aarch64/src/poly_reduce_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/poly_reduce_asm.S
+++ b/mlkem/native/aarch64/src/poly_reduce_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/mlkem/native/aarch64/src/poly_tobytes_asm.S
+++ b/mlkem/native/aarch64/src/poly_tobytes_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/poly_tobytes_asm.S
+++ b/mlkem/native/aarch64/src/poly_tobytes_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/mlkem/native/aarch64/src/poly_tomont_asm.S
+++ b/mlkem/native/aarch64/src/poly_tomont_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/poly_tomont_asm.S
+++ b/mlkem/native/aarch64/src/poly_tomont_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include "../../../common.h"

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/rej_uniform_asm.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*************************************************

--- a/mlkem/native/aarch64/src/rej_uniform_asm.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/aarch64/src/rej_uniform_table.c
+++ b/mlkem/native/aarch64/src/rej_uniform_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/native/aarch64/src/rej_uniform_table.c
+++ b/mlkem/native/aarch64/src/rej_uniform_table.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/api.h
+++ b/mlkem/native/api.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_NATIVE_API_H

--- a/mlkem/native/api.h
+++ b/mlkem/native/api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/meta.h
+++ b/mlkem/native/meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_NATIVE_META_H

--- a/mlkem/native/meta.h
+++ b/mlkem/native/meta.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_NATIVE_META_H
 #define MLK_NATIVE_META_H

--- a/mlkem/native/x86_64/meta.h
+++ b/mlkem/native/x86_64/meta.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_NATIVE_X86_64_META_H

--- a/mlkem/native/x86_64/meta.h
+++ b/mlkem/native/x86_64/meta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/align.h
+++ b/mlkem/native/x86_64/src/align.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/align.h
+++ b/mlkem/native/x86_64/src/align.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/src/arith_native_x86_64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_NATIVE_X86_64_SRC_ARITH_NATIVE_X86_64_H

--- a/mlkem/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/src/arith_native_x86_64.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_NATIVE_X86_64_SRC_ARITH_NATIVE_X86_64_H
 #define MLK_NATIVE_X86_64_SRC_ARITH_NATIVE_X86_64_H

--- a/mlkem/native/x86_64/src/basemul.S
+++ b/mlkem/native/x86_64/src/basemul.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/basemul.S
+++ b/mlkem/native/x86_64/src/basemul.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/basemul.c
+++ b/mlkem/native/x86_64/src/basemul.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/basemul.c
+++ b/mlkem/native/x86_64/src/basemul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/compress_avx2.c
+++ b/mlkem/native/x86_64/src/compress_avx2.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/compress_avx2.c
+++ b/mlkem/native/x86_64/src/compress_avx2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/consts.c
+++ b/mlkem/native/x86_64/src/consts.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/consts.c
+++ b/mlkem/native/x86_64/src/consts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/consts.h
+++ b/mlkem/native/x86_64/src/consts.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/consts.h
+++ b/mlkem/native/x86_64/src/consts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/fq.inc
+++ b/mlkem/native/x86_64/src/fq.inc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/native/x86_64/src/fq.inc
+++ b/mlkem/native/x86_64/src/fq.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/intt.S
+++ b/mlkem/native/x86_64/src/intt.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/intt.S
+++ b/mlkem/native/x86_64/src/intt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/ntt.S
+++ b/mlkem/native/x86_64/src/ntt.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/ntt.S
+++ b/mlkem/native/x86_64/src/ntt.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/nttfrombytes.S
+++ b/mlkem/native/x86_64/src/nttfrombytes.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/nttfrombytes.S
+++ b/mlkem/native/x86_64/src/nttfrombytes.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/nttpack.S
+++ b/mlkem/native/x86_64/src/nttpack.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/nttpack.S
+++ b/mlkem/native/x86_64/src/nttpack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/ntttobytes.S
+++ b/mlkem/native/x86_64/src/ntttobytes.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/ntttobytes.S
+++ b/mlkem/native/x86_64/src/ntttobytes.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/nttunpack.S
+++ b/mlkem/native/x86_64/src/nttunpack.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/nttunpack.S
+++ b/mlkem/native/x86_64/src/nttunpack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/reduce.S
+++ b/mlkem/native/x86_64/src/reduce.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/reduce.S
+++ b/mlkem/native/x86_64/src/reduce.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/rej_uniform_avx2.c
+++ b/mlkem/native/x86_64/src/rej_uniform_avx2.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/rej_uniform_avx2.c
+++ b/mlkem/native/x86_64/src/rej_uniform_avx2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/rej_uniform_table.c
+++ b/mlkem/native/x86_64/src/rej_uniform_table.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/native/x86_64/src/rej_uniform_table.c
+++ b/mlkem/native/x86_64/src/rej_uniform_table.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/shuffle.inc
+++ b/mlkem/native/x86_64/src/shuffle.inc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/native/x86_64/src/shuffle.inc
+++ b/mlkem/native/x86_64/src/shuffle.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/tomont.S
+++ b/mlkem/native/x86_64/src/tomont.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/native/x86_64/src/tomont.S
+++ b/mlkem/native/x86_64/src/tomont.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/native/x86_64/src/x86_64_zetas.i
+++ b/mlkem/native/x86_64/src/x86_64_zetas.i
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/native/x86_64/src/x86_64_zetas.i
+++ b/mlkem/native/x86_64/src/x86_64_zetas.i
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/params.h
+++ b/mlkem/params.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_PARAMS_H
 #define MLK_PARAMS_H

--- a/mlkem/params.h
+++ b/mlkem/params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_PARAMS_H

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/poly_k.c
+++ b/mlkem/poly_k.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/poly_k.c
+++ b/mlkem/poly_k.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/poly_k.h
+++ b/mlkem/poly_k.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/poly_k.h
+++ b/mlkem/poly_k.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/randombytes.h
+++ b/mlkem/randombytes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_RANDOMBYTES_H

--- a/mlkem/randombytes.h
+++ b/mlkem/randombytes.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_RANDOMBYTES_H
 #define MLK_RANDOMBYTES_H

--- a/mlkem/sampling.c
+++ b/mlkem/sampling.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/sampling.c
+++ b/mlkem/sampling.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/sampling.h
+++ b/mlkem/sampling.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/sampling.h
+++ b/mlkem/sampling.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/symmetric.h
+++ b/mlkem/symmetric.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/symmetric.h
+++ b/mlkem/symmetric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/sys.h
+++ b/mlkem/sys.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_SYS_H
 #define MLK_SYS_H

--- a/mlkem/sys.h
+++ b/mlkem/sys.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #ifndef MLK_SYS_H

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include "verify.h"
 

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include "verify.h"

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/mlkem/zetas.inc
+++ b/mlkem/zetas.inc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /*

--- a/mlkem/zetas.inc
+++ b/mlkem/zetas.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/cbmc/barrett_reduce/Makefile
+++ b/proofs/cbmc/barrett_reduce/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/barrett_reduce/Makefile
+++ b/proofs/cbmc/barrett_reduce/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/barrett_reduce/barrett_reduce_harness.c
+++ b/proofs/cbmc/barrett_reduce/barrett_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/check_pct/Makefile
+++ b/proofs/cbmc/check_pct/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/check_pct/Makefile
+++ b/proofs/cbmc/check_pct/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/check_pct/check_pct_harness.c
+++ b/proofs/cbmc/check_pct/check_pct_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/crypto_kem_dec/Makefile
+++ b/proofs/cbmc/crypto_kem_dec/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/crypto_kem_dec/Makefile
+++ b/proofs/cbmc/crypto_kem_dec/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/crypto_kem_dec/crypto_kem_dec_harness.c
+++ b/proofs/cbmc/crypto_kem_dec/crypto_kem_dec_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/crypto_kem_enc/Makefile
+++ b/proofs/cbmc/crypto_kem_enc/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/crypto_kem_enc/Makefile
+++ b/proofs/cbmc/crypto_kem_enc/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/crypto_kem_enc/crypto_kem_enc_harness.c
+++ b/proofs/cbmc/crypto_kem_enc/crypto_kem_enc_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/crypto_kem_enc_derand/Makefile
+++ b/proofs/cbmc/crypto_kem_enc_derand/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/crypto_kem_enc_derand/Makefile
+++ b/proofs/cbmc/crypto_kem_enc_derand/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/crypto_kem_enc_derand/crypto_kem_enc_derand_harness.c
+++ b/proofs/cbmc/crypto_kem_enc_derand/crypto_kem_enc_derand_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/crypto_kem_keypair/Makefile
+++ b/proofs/cbmc/crypto_kem_keypair/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/crypto_kem_keypair/Makefile
+++ b/proofs/cbmc/crypto_kem_keypair/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/crypto_kem_keypair/crypto_kem_keypair_harness.c
+++ b/proofs/cbmc/crypto_kem_keypair/crypto_kem_keypair_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/crypto_kem_keypair_derand/Makefile
+++ b/proofs/cbmc/crypto_kem_keypair_derand/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/crypto_kem_keypair_derand/Makefile
+++ b/proofs/cbmc/crypto_kem_keypair_derand/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/crypto_kem_keypair_derand/crypto_kem_keypair_derand_harness.c
+++ b/proofs/cbmc/crypto_kem_keypair_derand/crypto_kem_keypair_derand_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/ct_cmask_neg_i16/Makefile
+++ b/proofs/cbmc/ct_cmask_neg_i16/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_cmask_neg_i16/Makefile
+++ b/proofs/cbmc/ct_cmask_neg_i16/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_cmask_neg_i16/ct_cmask_neg_i16_harness.c
+++ b/proofs/cbmc/ct_cmask_neg_i16/ct_cmask_neg_i16_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_cmask_nonzero_u16/Makefile
+++ b/proofs/cbmc/ct_cmask_nonzero_u16/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_cmask_nonzero_u16/Makefile
+++ b/proofs/cbmc/ct_cmask_nonzero_u16/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_cmask_nonzero_u16/ct_cmask_nonzero_u16_harness.c
+++ b/proofs/cbmc/ct_cmask_nonzero_u16/ct_cmask_nonzero_u16_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_cmask_nonzero_u8/Makefile
+++ b/proofs/cbmc/ct_cmask_nonzero_u8/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_cmask_nonzero_u8/Makefile
+++ b/proofs/cbmc/ct_cmask_nonzero_u8/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_cmask_nonzero_u8/ct_cmask_nonzero_u8_harness.c
+++ b/proofs/cbmc/ct_cmask_nonzero_u8/ct_cmask_nonzero_u8_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_cmov_zero/Makefile
+++ b/proofs/cbmc/ct_cmov_zero/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_cmov_zero/Makefile
+++ b/proofs/cbmc/ct_cmov_zero/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_cmov_zero/ct_cmov_zero_harness.c
+++ b/proofs/cbmc/ct_cmov_zero/ct_cmov_zero_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_get_optblocker_i32/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_i32/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_get_optblocker_i32/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_i32/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_get_optblocker_i32/ct_get_optblocker_i32_harness.c
+++ b/proofs/cbmc/ct_get_optblocker_i32/ct_get_optblocker_i32_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_get_optblocker_u32/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_u32/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_get_optblocker_u32/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_u32/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_get_optblocker_u32/ct_get_optblocker_u32_harness.c
+++ b/proofs/cbmc/ct_get_optblocker_u32/ct_get_optblocker_u32_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_get_optblocker_u8/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_u8/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_get_optblocker_u8/Makefile
+++ b/proofs/cbmc/ct_get_optblocker_u8/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_get_optblocker_u8/ct_get_optblocker_u8_harness.c
+++ b/proofs/cbmc/ct_get_optblocker_u8/ct_get_optblocker_u8_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_memcmp/Makefile
+++ b/proofs/cbmc/ct_memcmp/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_memcmp/Makefile
+++ b/proofs/cbmc/ct_memcmp/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_memcmp/ct_memcmp_harness.c
+++ b/proofs/cbmc/ct_memcmp/ct_memcmp_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_sel_int16/Makefile
+++ b/proofs/cbmc/ct_sel_int16/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_sel_int16/Makefile
+++ b/proofs/cbmc/ct_sel_int16/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_sel_int16/ct_sel_int16_harness.c
+++ b/proofs/cbmc/ct_sel_int16/ct_sel_int16_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ct_sel_uint8/Makefile
+++ b/proofs/cbmc/ct_sel_uint8/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ct_sel_uint8/Makefile
+++ b/proofs/cbmc/ct_sel_uint8/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ct_sel_uint8/ct_sel_uint8_harness.c
+++ b/proofs/cbmc/ct_sel_uint8/ct_sel_uint8_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/dummy_backend.h
+++ b/proofs/cbmc/dummy_backend.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifdef MLK_ARITH_PROFILE_H

--- a/proofs/cbmc/dummy_backend.h
+++ b/proofs/cbmc/dummy_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/cbmc/dummy_backend_fips202_x1.h
+++ b/proofs/cbmc/dummy_backend_fips202_x1.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifdef MLK_FIPS202_PROFILE_H

--- a/proofs/cbmc/dummy_backend_fips202_x1.h
+++ b/proofs/cbmc/dummy_backend_fips202_x1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/cbmc/dummy_backend_fips202_x2.h
+++ b/proofs/cbmc/dummy_backend_fips202_x2.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifdef MLK_FIPS202_PROFILE_H

--- a/proofs/cbmc/dummy_backend_fips202_x2.h
+++ b/proofs/cbmc/dummy_backend_fips202_x2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/cbmc/dummy_backend_fips202_x4.h
+++ b/proofs/cbmc/dummy_backend_fips202_x4.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifdef MLK_FIPS202_PROFILE_H

--- a/proofs/cbmc/dummy_backend_fips202_x4.h
+++ b/proofs/cbmc/dummy_backend_fips202_x4.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/cbmc/fqmul/Makefile
+++ b/proofs/cbmc/fqmul/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/fqmul/Makefile
+++ b/proofs/cbmc/fqmul/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/fqmul/fqmul_harness.c
+++ b/proofs/cbmc/fqmul/fqmul_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/gen_matrix/Makefile
+++ b/proofs/cbmc/gen_matrix/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/gen_matrix/Makefile
+++ b/proofs/cbmc/gen_matrix/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/gen_matrix/gen_matrix_harness.c
+++ b/proofs/cbmc/gen_matrix/gen_matrix_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/gen_matrix_native/Makefile
+++ b/proofs/cbmc/gen_matrix_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/gen_matrix_native/Makefile
+++ b/proofs/cbmc/gen_matrix_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/gen_matrix_native/gen_matrix_native_harness.c
+++ b/proofs/cbmc/gen_matrix_native/gen_matrix_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/indcpa_dec/Makefile
+++ b/proofs/cbmc/indcpa_dec/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/indcpa_dec/Makefile
+++ b/proofs/cbmc/indcpa_dec/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/indcpa_dec/indcpa_dec_harness.c
+++ b/proofs/cbmc/indcpa_dec/indcpa_dec_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/indcpa_enc/Makefile
+++ b/proofs/cbmc/indcpa_enc/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/indcpa_enc/Makefile
+++ b/proofs/cbmc/indcpa_enc/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/indcpa_enc/indcpa_enc_harness.c
+++ b/proofs/cbmc/indcpa_enc/indcpa_enc_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/indcpa_keypair_derand/Makefile
+++ b/proofs/cbmc/indcpa_keypair_derand/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/indcpa_keypair_derand/Makefile
+++ b/proofs/cbmc/indcpa_keypair_derand/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/indcpa_keypair_derand/indcpa_keypair_derand_harness.c
+++ b/proofs/cbmc/indcpa_keypair_derand/indcpa_keypair_derand_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/invntt_layer/Makefile
+++ b/proofs/cbmc/invntt_layer/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/invntt_layer/invntt_layer_harness.c
+++ b/proofs/cbmc/invntt_layer/invntt_layer_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccak_absorb_once/Makefile
+++ b/proofs/cbmc/keccak_absorb_once/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccak_absorb_once/Makefile
+++ b/proofs/cbmc/keccak_absorb_once/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccak_absorb_once/keccak_absorb_once_harness.c
+++ b/proofs/cbmc/keccak_absorb_once/keccak_absorb_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccak_absorb_once_x4/Makefile
+++ b/proofs/cbmc/keccak_absorb_once_x4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccak_absorb_once_x4/Makefile
+++ b/proofs/cbmc/keccak_absorb_once_x4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccak_absorb_once_x4/keccak_absorb_once_x4_harness.c
+++ b/proofs/cbmc/keccak_absorb_once_x4/keccak_absorb_once_x4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccak_squeeze_once/Makefile
+++ b/proofs/cbmc/keccak_squeeze_once/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccak_squeeze_once/Makefile
+++ b/proofs/cbmc/keccak_squeeze_once/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccak_squeeze_once/keccak_squeeze_once_harness.c
+++ b/proofs/cbmc/keccak_squeeze_once/keccak_squeeze_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccak_squeezeblocks/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccak_squeezeblocks/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccak_squeezeblocks/keccak_squeezeblocks_harness.c
+++ b/proofs/cbmc/keccak_squeezeblocks/keccak_squeezeblocks_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccak_squeezeblocks_x4/keccak_squeezeblocks_x4_harness.c
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/keccak_squeezeblocks_x4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes/keccakf1600_extract_bytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
+++ b/proofs/cbmc/keccakf1600_extract_bytes_BE/keccakf1600_extract_bytes_be_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600_permute/Makefile
+++ b/proofs/cbmc/keccakf1600_permute/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600_permute/Makefile
+++ b/proofs/cbmc/keccakf1600_permute/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600_permute/keccakf1600_permute_harness.c
+++ b/proofs/cbmc/keccakf1600_permute/keccakf1600_permute_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600_permute_native/Makefile
+++ b/proofs/cbmc/keccakf1600_permute_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600_permute_native/Makefile
+++ b/proofs/cbmc/keccakf1600_permute_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600_permute_native/keccakf1600_permute_native_harness.c
+++ b/proofs/cbmc/keccakf1600_permute_native/keccakf1600_permute_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600_xor_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_xor_bytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600_xor_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600_xor_bytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600_xor_bytes/keccakf1600_xor_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600_xor_bytes/keccakf1600_xor_bytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600_xor_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_xor_bytes_BE/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600_xor_bytes_BE/Makefile
+++ b/proofs/cbmc/keccakf1600_xor_bytes_BE/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600_xor_bytes_BE/keccakf1600_xor_bytes_be_harness.c
+++ b/proofs/cbmc/keccakf1600_xor_bytes_BE/keccakf1600_xor_bytes_be_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600x4_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600x4_extract_bytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600x4_extract_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600x4_extract_bytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600x4_extract_bytes/keccakf1600x4_extract_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600x4_extract_bytes/keccakf1600x4_extract_bytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600x4_permute/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600x4_permute/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600x4_permute/keccakf1600x4_permute_harness.c
+++ b/proofs/cbmc/keccakf1600x4_permute/keccakf1600x4_permute_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600x4_permute_native_x2/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute_native_x2/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600x4_permute_native_x2/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute_native_x2/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600x4_permute_native_x2/keccakf1600x4_permute_native_x2_harness.c
+++ b/proofs/cbmc/keccakf1600x4_permute_native_x2/keccakf1600x4_permute_native_x2_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600x4_permute_native_x4/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute_native_x4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600x4_permute_native_x4/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute_native_x4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600x4_permute_native_x4/keccakf1600x4_permute_native_x4_harness.c
+++ b/proofs/cbmc/keccakf1600x4_permute_native_x4/keccakf1600x4_permute_native_x4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/keccakf1600x4_xor_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600x4_xor_bytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/keccakf1600x4_xor_bytes/Makefile
+++ b/proofs/cbmc/keccakf1600x4_xor_bytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/keccakf1600x4_xor_bytes/keccakf1600x4_xor_bytes_harness.c
+++ b/proofs/cbmc/keccakf1600x4_xor_bytes/keccakf1600x4_xor_bytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/list_proofs.sh
+++ b/proofs/cbmc/list_proofs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # This tiny script just lists the proof directories in proof/cbmc,
 # which are those containing a *harness.c file.

--- a/proofs/cbmc/list_proofs.sh
+++ b/proofs/cbmc/list_proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # This tiny script just lists the proof directories in proof/cbmc,

--- a/proofs/cbmc/matvec_mul/Makefile
+++ b/proofs/cbmc/matvec_mul/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/matvec_mul/Makefile
+++ b/proofs/cbmc/matvec_mul/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/matvec_mul/matvec_mul_harness.c
+++ b/proofs/cbmc/matvec_mul/matvec_mul_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/montgomery_reduce/Makefile
+++ b/proofs/cbmc/montgomery_reduce/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/montgomery_reduce/Makefile
+++ b/proofs/cbmc/montgomery_reduce/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/montgomery_reduce/montgomery_reduce_harness.c
+++ b/proofs/cbmc/montgomery_reduce/montgomery_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/ntt_butterfly_block/Makefile
+++ b/proofs/cbmc/ntt_butterfly_block/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ntt_butterfly_block/Makefile
+++ b/proofs/cbmc/ntt_butterfly_block/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
+++ b/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/ntt_layer/Makefile
+++ b/proofs/cbmc/ntt_layer/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/ntt_layer/Makefile
+++ b/proofs/cbmc/ntt_layer/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/ntt_layer/ntt_layer_harness.c
+++ b/proofs/cbmc/ntt_layer/ntt_layer_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_add/Makefile
+++ b/proofs/cbmc/poly_add/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_add/Makefile
+++ b/proofs/cbmc/poly_add/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_add/poly_add_harness.c
+++ b/proofs/cbmc/poly_add/poly_add_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_cbd_eta1/Makefile
+++ b/proofs/cbmc/poly_cbd_eta1/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_cbd_eta1/Makefile
+++ b/proofs/cbmc/poly_cbd_eta1/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_cbd_eta1/poly_cbd_eta1_harness.c
+++ b/proofs/cbmc/poly_cbd_eta1/poly_cbd_eta1_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_cbd_eta2/Makefile
+++ b/proofs/cbmc/poly_cbd_eta2/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_cbd_eta2/Makefile
+++ b/proofs/cbmc/poly_cbd_eta2/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_cbd_eta2/poly_cbd_eta2_harness.c
+++ b/proofs/cbmc/poly_cbd_eta2/poly_cbd_eta2_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_compress_du/Makefile
+++ b/proofs/cbmc/poly_compress_du/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_compress_du/Makefile
+++ b/proofs/cbmc/poly_compress_du/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_compress_du/poly_compress_du_harness.c
+++ b/proofs/cbmc/poly_compress_du/poly_compress_du_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_compress_dv/Makefile
+++ b/proofs/cbmc/poly_compress_dv/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_compress_dv/Makefile
+++ b/proofs/cbmc/poly_compress_dv/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_compress_dv/poly_compress_dv_harness.c
+++ b/proofs/cbmc/poly_compress_dv/poly_compress_dv_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_decompress_du/Makefile
+++ b/proofs/cbmc/poly_decompress_du/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_decompress_du/Makefile
+++ b/proofs/cbmc/poly_decompress_du/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_decompress_du/poly_decompress_du_harness.c
+++ b/proofs/cbmc/poly_decompress_du/poly_decompress_du_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_decompress_dv/Makefile
+++ b/proofs/cbmc/poly_decompress_dv/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_decompress_dv/Makefile
+++ b/proofs/cbmc/poly_decompress_dv/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_decompress_dv/poly_decompress_dv_harness.c
+++ b/proofs/cbmc/poly_decompress_dv/poly_decompress_dv_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_frombytes/Makefile
+++ b/proofs/cbmc/poly_frombytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_frombytes/Makefile
+++ b/proofs/cbmc/poly_frombytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_frombytes/poly_frombytes_harness.c
+++ b/proofs/cbmc/poly_frombytes/poly_frombytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_frombytes_native/Makefile
+++ b/proofs/cbmc/poly_frombytes_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_frombytes_native/Makefile
+++ b/proofs/cbmc/poly_frombytes_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_frombytes_native/poly_frombytes_native_harness.c
+++ b/proofs/cbmc/poly_frombytes_native/poly_frombytes_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_frommsg/Makefile
+++ b/proofs/cbmc/poly_frommsg/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_frommsg/Makefile
+++ b/proofs/cbmc/poly_frommsg/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_frommsg/poly_frommsg_harness.c
+++ b/proofs/cbmc/poly_frommsg/poly_frommsg_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_getnoise_eta1122_4x/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_getnoise_eta1122_4x/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_getnoise_eta1122_4x/poly_getnoise_eta1122_4x_harness.c
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x/poly_getnoise_eta1122_4x_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_getnoise_eta1122_4x_native/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_getnoise_eta1122_4x_native/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_getnoise_eta1122_4x_native/poly_getnoise_eta1122_4x_native_harness.c
+++ b/proofs/cbmc/poly_getnoise_eta1122_4x_native/poly_getnoise_eta1122_4x_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_getnoise_eta1_4x/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta1_4x/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_getnoise_eta1_4x/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta1_4x/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_getnoise_eta1_4x/poly_getnoise_eta1_4x_harness.c
+++ b/proofs/cbmc/poly_getnoise_eta1_4x/poly_getnoise_eta1_4x_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_getnoise_eta2/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta2/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_getnoise_eta2/Makefile
+++ b/proofs/cbmc/poly_getnoise_eta2/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_getnoise_eta2/poly_getnoise_eta2_harness.c
+++ b/proofs/cbmc/poly_getnoise_eta2/poly_getnoise_eta2_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_invntt_tomont/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_invntt_tomont/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_invntt_tomont/poly_invntt_tomont_harness.c
+++ b/proofs/cbmc/poly_invntt_tomont/poly_invntt_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_invntt_tomont_native/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_invntt_tomont_native/Makefile
+++ b/proofs/cbmc/poly_invntt_tomont_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_invntt_tomont_native/poly_invntt_tomont_native_harness.c
+++ b/proofs/cbmc/poly_invntt_tomont_native/poly_invntt_tomont_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_mulcache_compute/Makefile
+++ b/proofs/cbmc/poly_mulcache_compute/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_mulcache_compute/Makefile
+++ b/proofs/cbmc/poly_mulcache_compute/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_mulcache_compute/poly_mulcache_compute_harness.c
+++ b/proofs/cbmc/poly_mulcache_compute/poly_mulcache_compute_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_mulcache_compute_native/Makefile
+++ b/proofs/cbmc/poly_mulcache_compute_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_mulcache_compute_native/Makefile
+++ b/proofs/cbmc/poly_mulcache_compute_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_mulcache_compute_native/poly_mulcache_compute_native_harness.c
+++ b/proofs/cbmc/poly_mulcache_compute_native/poly_mulcache_compute_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_ntt/Makefile
+++ b/proofs/cbmc/poly_ntt/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_ntt/Makefile
+++ b/proofs/cbmc/poly_ntt/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_ntt/poly_ntt_harness.c
+++ b/proofs/cbmc/poly_ntt/poly_ntt_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_ntt_native/Makefile
+++ b/proofs/cbmc/poly_ntt_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_ntt_native/Makefile
+++ b/proofs/cbmc/poly_ntt_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_ntt_native/poly_ntt_native_harness.c
+++ b/proofs/cbmc/poly_ntt_native/poly_ntt_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_permute_bitrev_to_custom/Makefile
+++ b/proofs/cbmc/poly_permute_bitrev_to_custom/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_permute_bitrev_to_custom/Makefile
+++ b/proofs/cbmc/poly_permute_bitrev_to_custom/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_permute_bitrev_to_custom/poly_permute_bitrev_to_custom_harness.c
+++ b/proofs/cbmc/poly_permute_bitrev_to_custom/poly_permute_bitrev_to_custom_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_reduce/Makefile
+++ b/proofs/cbmc/poly_reduce/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_reduce/Makefile
+++ b/proofs/cbmc/poly_reduce/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_reduce/poly_reduce_harness.c
+++ b/proofs/cbmc/poly_reduce/poly_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_reduce_native/Makefile
+++ b/proofs/cbmc/poly_reduce_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_reduce_native/Makefile
+++ b/proofs/cbmc/poly_reduce_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_reduce_native/poly_reduce_native_harness.c
+++ b/proofs/cbmc/poly_reduce_native/poly_reduce_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_rej_uniform/Makefile
+++ b/proofs/cbmc/poly_rej_uniform/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_rej_uniform/Makefile
+++ b/proofs/cbmc/poly_rej_uniform/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_rej_uniform/poly_rej_uniform_harness.c
+++ b/proofs/cbmc/poly_rej_uniform/poly_rej_uniform_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_rej_uniform_x4/Makefile
+++ b/proofs/cbmc/poly_rej_uniform_x4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_rej_uniform_x4/Makefile
+++ b/proofs/cbmc/poly_rej_uniform_x4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_rej_uniform_x4/poly_rej_uniform_x4_harness.c
+++ b/proofs/cbmc/poly_rej_uniform_x4/poly_rej_uniform_x4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_sub/Makefile
+++ b/proofs/cbmc/poly_sub/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_sub/Makefile
+++ b/proofs/cbmc/poly_sub/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_sub/poly_sub_harness.c
+++ b/proofs/cbmc/poly_sub/poly_sub_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_tobytes/Makefile
+++ b/proofs/cbmc/poly_tobytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_tobytes/Makefile
+++ b/proofs/cbmc/poly_tobytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_tobytes/poly_tobytes_harness.c
+++ b/proofs/cbmc/poly_tobytes/poly_tobytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_tobytes_native/Makefile
+++ b/proofs/cbmc/poly_tobytes_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_tobytes_native/Makefile
+++ b/proofs/cbmc/poly_tobytes_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_tobytes_native/poly_tobytes_native_harness.c
+++ b/proofs/cbmc/poly_tobytes_native/poly_tobytes_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/poly_tomont/Makefile
+++ b/proofs/cbmc/poly_tomont/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_tomont/Makefile
+++ b/proofs/cbmc/poly_tomont/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_tomont/poly_tomont_harness.c
+++ b/proofs/cbmc/poly_tomont/poly_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_tomont_native/Makefile
+++ b/proofs/cbmc/poly_tomont_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_tomont_native/Makefile
+++ b/proofs/cbmc/poly_tomont_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_tomont_native/poly_tomont_native_harness.c
+++ b/proofs/cbmc/poly_tomont_native/poly_tomont_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/poly_tomsg/Makefile
+++ b/proofs/cbmc/poly_tomsg/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/poly_tomsg/Makefile
+++ b/proofs/cbmc/poly_tomsg/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/poly_tomsg/poly_tomsg_harness.c
+++ b/proofs/cbmc/poly_tomsg/poly_tomsg_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/polyvec_add/Makefile
+++ b/proofs/cbmc/polyvec_add/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_add/Makefile
+++ b/proofs/cbmc/polyvec_add/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_add/polyvec_add_harness.c
+++ b/proofs/cbmc/polyvec_add/polyvec_add_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/polyvec_basemul_acc_montgomery_cached_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/polyvec_basemul_acc_montgomery_cached_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/polyvec_basemul_acc_montgomery_cached_native_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_native/polyvec_basemul_acc_montgomery_cached_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_compress_du/Makefile
+++ b/proofs/cbmc/polyvec_compress_du/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_compress_du/Makefile
+++ b/proofs/cbmc/polyvec_compress_du/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_compress_du/polyvec_compress_du_harness.c
+++ b/proofs/cbmc/polyvec_compress_du/polyvec_compress_du_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_decompress_du/Makefile
+++ b/proofs/cbmc/polyvec_decompress_du/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_decompress_du/Makefile
+++ b/proofs/cbmc/polyvec_decompress_du/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_decompress_du/polyvec_decompress_du_harness.c
+++ b/proofs/cbmc/polyvec_decompress_du/polyvec_decompress_du_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_frombytes/Makefile
+++ b/proofs/cbmc/polyvec_frombytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_frombytes/Makefile
+++ b/proofs/cbmc/polyvec_frombytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_frombytes/polyvec_frombytes_harness.c
+++ b/proofs/cbmc/polyvec_frombytes/polyvec_frombytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/polyvec_invntt_tomont/Makefile
+++ b/proofs/cbmc/polyvec_invntt_tomont/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_invntt_tomont/Makefile
+++ b/proofs/cbmc/polyvec_invntt_tomont/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_invntt_tomont/polyvec_invntt_tomont_harness.c
+++ b/proofs/cbmc/polyvec_invntt_tomont/polyvec_invntt_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_mulcache_compute/Makefile
+++ b/proofs/cbmc/polyvec_mulcache_compute/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_mulcache_compute/Makefile
+++ b/proofs/cbmc/polyvec_mulcache_compute/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_mulcache_compute/polyvec_mulcache_compute_harness.c
+++ b/proofs/cbmc/polyvec_mulcache_compute/polyvec_mulcache_compute_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_ntt/Makefile
+++ b/proofs/cbmc/polyvec_ntt/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_ntt/Makefile
+++ b/proofs/cbmc/polyvec_ntt/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_ntt/polyvec_ntt_harness.c
+++ b/proofs/cbmc/polyvec_ntt/polyvec_ntt_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/polyvec_reduce/Makefile
+++ b/proofs/cbmc/polyvec_reduce/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_reduce/Makefile
+++ b/proofs/cbmc/polyvec_reduce/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_reduce/polyvec_reduce_harness.c
+++ b/proofs/cbmc/polyvec_reduce/polyvec_reduce_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/polyvec_tobytes/Makefile
+++ b/proofs/cbmc/polyvec_tobytes/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_tobytes/Makefile
+++ b/proofs/cbmc/polyvec_tobytes/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_tobytes/polyvec_tobytes_harness.c
+++ b/proofs/cbmc/polyvec_tobytes/polyvec_tobytes_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/polyvec_tomont/Makefile
+++ b/proofs/cbmc/polyvec_tomont/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/polyvec_tomont/Makefile
+++ b/proofs/cbmc/polyvec_tomont/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/polyvec_tomont/polyvec_tomont_harness.c
+++ b/proofs/cbmc/polyvec_tomont/polyvec_tomont_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/rej_uniform/Makefile
+++ b/proofs/cbmc/rej_uniform/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/rej_uniform/Makefile
+++ b/proofs/cbmc/rej_uniform/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/rej_uniform/rej_uniform_harness.c
+++ b/proofs/cbmc/rej_uniform/rej_uniform_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/rej_uniform_native/Makefile
+++ b/proofs/cbmc/rej_uniform_native/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/rej_uniform_native/Makefile
+++ b/proofs/cbmc/rej_uniform_native/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/rej_uniform_native/rej_uniform_native_harness.c
+++ b/proofs/cbmc/rej_uniform_native/rej_uniform_native_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/rej_uniform_scalar/Makefile
+++ b/proofs/cbmc/rej_uniform_scalar/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/rej_uniform_scalar/Makefile
+++ b/proofs/cbmc/rej_uniform_scalar/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/rej_uniform_scalar/rej_uniform_scalar_harness.c
+++ b/proofs/cbmc/rej_uniform_scalar/rej_uniform_scalar_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_compress_d1/Makefile
+++ b/proofs/cbmc/scalar_compress_d1/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_compress_d1/Makefile
+++ b/proofs/cbmc/scalar_compress_d1/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_compress_d1/scalar_compress_d1_harness.c
+++ b/proofs/cbmc/scalar_compress_d1/scalar_compress_d1_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_compress_d10/Makefile
+++ b/proofs/cbmc/scalar_compress_d10/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_compress_d10/Makefile
+++ b/proofs/cbmc/scalar_compress_d10/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_compress_d10/scalar_compress_d10_harness.c
+++ b/proofs/cbmc/scalar_compress_d10/scalar_compress_d10_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_compress_d11/Makefile
+++ b/proofs/cbmc/scalar_compress_d11/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_compress_d11/Makefile
+++ b/proofs/cbmc/scalar_compress_d11/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_compress_d11/scalar_compress_d11_harness.c
+++ b/proofs/cbmc/scalar_compress_d11/scalar_compress_d11_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_compress_d4/Makefile
+++ b/proofs/cbmc/scalar_compress_d4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_compress_d4/Makefile
+++ b/proofs/cbmc/scalar_compress_d4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_compress_d4/scalar_compress_d4_harness.c
+++ b/proofs/cbmc/scalar_compress_d4/scalar_compress_d4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_compress_d5/Makefile
+++ b/proofs/cbmc/scalar_compress_d5/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_compress_d5/Makefile
+++ b/proofs/cbmc/scalar_compress_d5/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_compress_d5/scalar_compress_d5_harness.c
+++ b/proofs/cbmc/scalar_compress_d5/scalar_compress_d5_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_decompress_d10/Makefile
+++ b/proofs/cbmc/scalar_decompress_d10/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_decompress_d10/Makefile
+++ b/proofs/cbmc/scalar_decompress_d10/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_decompress_d10/scalar_decompress_d10_harness.c
+++ b/proofs/cbmc/scalar_decompress_d10/scalar_decompress_d10_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_decompress_d11/Makefile
+++ b/proofs/cbmc/scalar_decompress_d11/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_decompress_d11/Makefile
+++ b/proofs/cbmc/scalar_decompress_d11/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_decompress_d11/scalar_decompress_d11_harness.c
+++ b/proofs/cbmc/scalar_decompress_d11/scalar_decompress_d11_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_decompress_d4/Makefile
+++ b/proofs/cbmc/scalar_decompress_d4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_decompress_d4/Makefile
+++ b/proofs/cbmc/scalar_decompress_d4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_decompress_d4/scalar_decompress_d4_harness.c
+++ b/proofs/cbmc/scalar_decompress_d4/scalar_decompress_d4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_decompress_d5/Makefile
+++ b/proofs/cbmc/scalar_decompress_d5/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_decompress_d5/Makefile
+++ b/proofs/cbmc/scalar_decompress_d5/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_decompress_d5/scalar_decompress_d5_harness.c
+++ b/proofs/cbmc/scalar_decompress_d5/scalar_decompress_d5_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/scalar_signed_to_unsigned_q/Makefile
+++ b/proofs/cbmc/scalar_signed_to_unsigned_q/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/scalar_signed_to_unsigned_q/Makefile
+++ b/proofs/cbmc/scalar_signed_to_unsigned_q/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/scalar_signed_to_unsigned_q/scalar_signed_to_unsigned_q_harness.c
+++ b/proofs/cbmc/scalar_signed_to_unsigned_q/scalar_signed_to_unsigned_q_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 

--- a/proofs/cbmc/scalar_signed_to_unsigned_q/scalar_signed_to_unsigned_q_harness.c
+++ b/proofs/cbmc/scalar_signed_to_unsigned_q/scalar_signed_to_unsigned_q_harness.c
@@ -1,6 +1,6 @@
 // Copyright (c) 2024-2025 The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #include <stdint.h>
 #include "common.h"

--- a/proofs/cbmc/sha3_256/Makefile
+++ b/proofs/cbmc/sha3_256/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/sha3_256/Makefile
+++ b/proofs/cbmc/sha3_256/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/sha3_256/sha3_256_harness.c
+++ b/proofs/cbmc/sha3_256/sha3_256_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/sha3_512/Makefile
+++ b/proofs/cbmc/sha3_512/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/sha3_512/Makefile
+++ b/proofs/cbmc/sha3_512/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/sha3_512/sha3_512_harness.c
+++ b/proofs/cbmc/sha3_512/sha3_512_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/shake128_absorb_once/Makefile
+++ b/proofs/cbmc/shake128_absorb_once/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/shake128_absorb_once/Makefile
+++ b/proofs/cbmc/shake128_absorb_once/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/shake128_absorb_once/shake128_absorb_once_harness.c
+++ b/proofs/cbmc/shake128_absorb_once/shake128_absorb_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/shake128_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake128_squeezeblocks/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/shake128_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake128_squeezeblocks/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/shake128_squeezeblocks/shake128_squeezeblocks_harness.c
+++ b/proofs/cbmc/shake128_squeezeblocks/shake128_squeezeblocks_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/shake128x4_absorb_once/Makefile
+++ b/proofs/cbmc/shake128x4_absorb_once/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/shake128x4_absorb_once/Makefile
+++ b/proofs/cbmc/shake128x4_absorb_once/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/shake128x4_absorb_once/shake128x4_absorb_once_harness.c
+++ b/proofs/cbmc/shake128x4_absorb_once/shake128x4_absorb_once_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/shake128x4_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake128x4_squeezeblocks/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/shake128x4_squeezeblocks/Makefile
+++ b/proofs/cbmc/shake128x4_squeezeblocks/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/shake128x4_squeezeblocks/shake128x4_squeezeblocks_harness.c
+++ b/proofs/cbmc/shake128x4_squeezeblocks/shake128x4_squeezeblocks_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/shake256/Makefile
+++ b/proofs/cbmc/shake256/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/shake256/Makefile
+++ b/proofs/cbmc/shake256/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/shake256/shake256_harness.c
+++ b/proofs/cbmc/shake256/shake256_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/shake256x4/Makefile
+++ b/proofs/cbmc/shake256x4/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/shake256x4/Makefile
+++ b/proofs/cbmc/shake256x4/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/shake256x4/shake256x4_harness.c
+++ b/proofs/cbmc/shake256x4/shake256x4_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 

--- a/proofs/cbmc/value_barrier_i32/Makefile
+++ b/proofs/cbmc/value_barrier_i32/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/value_barrier_i32/Makefile
+++ b/proofs/cbmc/value_barrier_i32/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/value_barrier_i32/value_barrier_i32_harness.c
+++ b/proofs/cbmc/value_barrier_i32/value_barrier_i32_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/value_barrier_u32/Makefile
+++ b/proofs/cbmc/value_barrier_u32/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/value_barrier_u32/Makefile
+++ b/proofs/cbmc/value_barrier_u32/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/value_barrier_u32/value_barrier_u32_harness.c
+++ b/proofs/cbmc/value_barrier_u32/value_barrier_u32_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/cbmc/value_barrier_u8/Makefile
+++ b/proofs/cbmc/value_barrier_u8/Makefile
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common
 

--- a/proofs/cbmc/value_barrier_u8/Makefile
+++ b/proofs/cbmc/value_barrier_u8/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 include ../Makefile_params.common

--- a/proofs/cbmc/value_barrier_u8/value_barrier_u8_harness.c
+++ b/proofs/cbmc/value_barrier_u8/value_barrier_u8_harness.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 The mlkem-native project authors
+// Copyright (c) The mlkem-native project authors
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0 AND Apache-2.0
 

--- a/proofs/hol_light/arm/list_proofs.sh
+++ b/proofs/hol_light/arm/list_proofs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # This tiny script just lists the names of source files for which
 # we have a spec and proof in HOL-Light.

--- a/proofs/hol_light/arm/list_proofs.sh
+++ b/proofs/hol_light/arm/list_proofs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # This tiny script just lists the names of source files for which

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x1_scalar.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x1_scalar.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x1_v84a.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x1_v84a.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x2_v84a.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x2_v84a.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x4_v8a_scalar.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x4_v8a_scalar.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x4_v8a_v84a_scalar.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x4_v8a_v84a_scalar.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2021-2022 Arm Limited
  * Copyright (c) 2022 Matthias Kannwischer
  * SPDX-License-Identifier: MIT

--- a/proofs/hol_light/arm/mlkem/mlkem_intt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_intt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/proofs/hol_light/arm/mlkem/mlkem_intt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_intt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/proofs/hol_light/arm/mlkem/mlkem_ntt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_ntt.S
@@ -1,7 +1,7 @@
-/* Copyright (c) 2024-2025 The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
+/* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
+ * Copyright (c) 2024-2025 The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/proofs/hol_light/arm/mlkem/mlkem_ntt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_ntt.S
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Arm Limited
  * Copyright (c) 2022 Hanno Becker
  * Copyright (c) 2023 Amin Abdulrahman, Matthias Kannwischer
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_mulcache_compute.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_mulcache_compute.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_mulcache_compute.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_mulcache_compute.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_reduce.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_reduce.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_reduce.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_reduce.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_tomont.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_tomont.S
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_tomont.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_tomont.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 import subprocess
@@ -39,7 +39,7 @@ def status_update(task, msg):
 
 def gen_header():
     yield "/*"
-    yield " * Copyright (c) 2024-2025 The mlkem-native project authors"
+    yield " * Copyright (c) The mlkem-native project authors"
     yield " * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT"
     yield " */"
     yield ""

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 import subprocess
 import tempfile
@@ -40,7 +40,7 @@ def status_update(task, msg):
 def gen_header():
     yield "/*"
     yield " * Copyright (c) 2024-2025 The mlkem-native project authors"
-    yield " * SPDX-License-Identifier: Apache-2.0"
+    yield " * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT"
     yield " */"
     yield ""
     yield "/*"

--- a/scripts/check-contracts
+++ b/scripts/check-contracts
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #

--- a/scripts/check-contracts
+++ b/scripts/check-contracts
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #
 # Looks for CBMC contracts without proof

--- a/scripts/check-magic
+++ b/scripts/check-magic
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #

--- a/scripts/check-magic
+++ b/scripts/check-magic
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #
 # Looks for magic numbers without explanation

--- a/scripts/check-namespace
+++ b/scripts/check-namespace
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # This scripts runs nm on the object files (excluding test objects) and checks that all exported
 # symbols are properly namespaced.

--- a/scripts/check-namespace
+++ b/scripts/check-namespace
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # This scripts runs nm on the object files (excluding test objects) and checks that all exported

--- a/scripts/format
+++ b/scripts/format
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 set -o errexit
 set -o errtrace

--- a/scripts/format
+++ b/scripts/format
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 set -o errexit

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 set -o errexit
@@ -87,7 +87,7 @@ check-spdx()
   done
   for file in $(git ls-files -- "*.[chsS]" "*.py" ":/!proofs/cbmc/*.py" ":/!examples/bring_your_own_fips202/custom_fips202/tiny_sha3/*" ":/!examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/src/*"); do
     # Ignore symlinks
-    if [[ ! -L $file && $(grep "Copyright (c) 2024-2025 The mlkem-native project authors" $file | wc -l) == 0 ]]; then
+    if [[ ! -L $file && $(grep "Copyright (c) The mlkem-native project authors" $file | wc -l) == 0 ]]; then
       echo "::error file=$file,line=${line:-1},title=Missing copyright header error::$file is missing copyright header"
       success=false
     fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 set -o errexit
 set -o errtrace

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 import subprocess

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 import subprocess
 import argparse

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 """Convenience CLI script wrapping various `make` invocations for
 building and running tests and benchmarks.

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 """Convenience CLI script wrapping various `make` invocations for

--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # ACVP client for ML-KEM
 #

--- a/test/acvp_client.py
+++ b/test/acvp_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # ACVP client for ML-KEM

--- a/test/acvp_mlkem.c
+++ b/test/acvp_mlkem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <stddef.h>

--- a/test/acvp_mlkem.c
+++ b/test/acvp_mlkem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <stddef.h>
 #include <stdio.h>

--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <inttypes.h>

--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <inttypes.h>
 #include <stddef.h>

--- a/test/bench_mlkem.c
+++ b/test/bench_mlkem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <inttypes.h>

--- a/test/bench_mlkem.c
+++ b/test/bench_mlkem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <inttypes.h>
 #include <stddef.h>

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/custom_randombytes_config.h
+++ b/test/custom_randombytes_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/test/custom_randombytes_config.h
+++ b/test/custom_randombytes_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/custom_zeroize_config.h
+++ b/test/custom_zeroize_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/test/custom_zeroize_config.h
+++ b/test/custom_zeroize_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <stddef.h>

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <stddef.h>
 #include <stdio.h>

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #include <stdio.h>

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) The mlkem-native project authors
- * Copyright (c) 2022 Arm Limited
  * Copyright (c) 2020 Dougall Johnson
+ * Copyright (c) 2022 Arm Limited
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2022 Arm Limited
  * Copyright (c) 2020 Dougall Johnson
  * SPDX-License-Identifier: MIT

--- a/test/hal/hal.h
+++ b/test/hal/hal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2022 Arm Limited
  * SPDX-License-Identifier: MIT
  *

--- a/test/nistrng/aes.c
+++ b/test/nistrng/aes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
  *
  * SPDX-License-Identifier: MIT

--- a/test/nistrng/aes.h
+++ b/test/nistrng/aes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: MIT
  */
 

--- a/test/nistrng/nistrng.h
+++ b/test/nistrng/nistrng.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef NISTRNG_H

--- a/test/nistrng/nistrng.h
+++ b/test/nistrng/nistrng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/nistrng/rng.c
+++ b/test/nistrng/rng.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 /* References

--- a/test/nistrng/rng.c
+++ b/test/nistrng/rng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/no_asm_config.h
+++ b/test/no_asm_config.h
@@ -9,7 +9,7 @@
  */
 
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 

--- a/test/no_asm_config.h
+++ b/test/no_asm_config.h
@@ -10,7 +10,7 @@
 
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 
 #ifndef MLK_CONFIG_H

--- a/test/notrandombytes/notrandombytes.c
+++ b/test/notrandombytes/notrandombytes.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MI
+ * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT
  */
 
 /* References

--- a/test/notrandombytes/notrandombytes.c
+++ b/test/notrandombytes/notrandombytes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT
  */
 

--- a/test/notrandombytes/notrandombytes.h
+++ b/test/notrandombytes/notrandombytes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MI
  */
 

--- a/test/test_bounds.py
+++ b/test/test_bounds.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2024-2025 The mlkem-native project authors
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #
 # The purpose of this script is to provide either brute-force proof

--- a/test/test_bounds.py
+++ b/test/test_bounds.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 The mlkem-native project authors
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 #

--- a/test/test_mlkem.c
+++ b/test/test_mlkem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 The mlkem-native project authors
+ * Copyright (c) The mlkem-native project authors
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <stddef.h>

--- a/test/test_mlkem.c
+++ b/test/test_mlkem.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024-2025 The mlkem-native project authors
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  */
 #include <stddef.h>
 #include <stdio.h>


### PR DESCRIPTION
Consent to the relicensing has been obtained from all mlkem-native contributors as individual commits to RELICENSE.md. See https://github.com/pq-code-package/mlkem-native/pull/967
