### PR TITLE
Copyright holder's agreement to relicensing AArch64 assembly under Apache-2.0 OR ISC OR MIT

### DIFF
--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -21,3 +21,16 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Mila Anastasova <manastasova2017@fau.edu>
 - Ry Jones <ry@linux.com>
 - Rod Chapman <rodchap@amazon.co.uk>
+
+# Relicensing of AArch64 assembly
+
+This document gathers consent by copyright holders of the MIT-licensed
+AArch64 assembly in mlkem-native to relicense it to `Apache-2.0 OR ISC OR MIT`.
+
+The relicensing itself is intended to be carried out once all copyright
+holders have given their consent.
+
+## Copyright holders agreeing to relicensing
+
+By adding my name to the list below, I agree to relicensing
+the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -34,3 +34,5 @@ holders have given their consent.
 
 By adding my name to the list below, I agree to relicensing
 the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.
+
+- Hanno Becker <beckphan@amazon.co.uk>


### PR DESCRIPTION
This commit adds to RELICENSE.md a section where copyright holders of the AArch64 assembly in mlkem-native can give consent to the relicensing under `Apache-2.0 OR ISC OR MIT`.