### PR TITLE
Copyright holder's agreement to relicensing AArch64 assembly under Apache-2.0 OR ISC OR MIT 

### DIFF
--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -38,3 +38,17 @@ the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.
 - Hanno Becker <beckphan@amazon.co.uk>
 - Amin Abdulrahman <amin@abdulrahman.de>
 - Matthias J. Kannwischer <matthias@kannwischer.eu>
+
+In https://github.com/pq-code-package/mlkem-native/pull/984, Arm Limited
+has given consent to relicense the following files to `Apache-2.0 OR ISC OR MIT`:
+
+- dev/aarch64_clean/src/intt.S
+- dev/aarch64_clean/src/ntt.S
+- dev/fips202/aarch64_symbolic/keccak_f1600_x1_scalar_symbolic.S
+- dev/fips202/aarch64_symbolic/keccak_f1600_x4_v8a_scalar_hybrid_clean.S
+- dev/fips202/aarch64_symbolic/keccak_f1600_x4_v8a_v84a_scalar_hybrid_clean.S
+- dev/fips202/aarch64/src/keccak_f1600_x1_scalar_asm.S
+- dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm.S
+- dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm.S
+- dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+- dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -21,3 +21,16 @@ in the mlkem-native project under `Apache-2.0 OR ISC OR MIT`.
 - Mila Anastasova <manastasova2017@fau.edu>
 - Ry Jones <ry@linux.com>
 - Rod Chapman <rodchap@amazon.co.uk>
+
+# Relicensing of AArch64 assembly
+
+This document gathers consent by copyright holders of the MIT-licensed
+AArch64 assembly in mlkem-native to relicense it to `Apache-2.0 OR ISC OR MIT`.
+
+The relicensing itself is intended to be carried out once all copyright
+holders have given their consent.
+
+## Copyright holders agreeing to relicensing
+
+By adding my name to the list below, I agree to relicensing
+the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -34,3 +34,5 @@ holders have given their consent.
 
 By adding my name to the list below, I agree to relicensing
 the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.
+
+- Hanno Becker <beckphan@amazon.co.uk>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -37,3 +37,4 @@ the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.
 
 - Hanno Becker <beckphan@amazon.co.uk>
 - Amin Abdulrahman <amin@abdulrahman.de>
+- Matthias J. Kannwischer <matthias@kannwischer.eu>

--- a/RELICENSE.md
+++ b/RELICENSE.md
@@ -36,3 +36,4 @@ By adding my name to the list below, I agree to relicensing
 the AArch64 assembly in mlkem-native to `Apache-2.0 OR ISC OR MIT`.
 
 - Hanno Becker <beckphan@amazon.co.uk>
+- Amin Abdulrahman <amin@abdulrahman.de>


### PR DESCRIPTION
This PR adds to RELICENSE.md a section where copyright holders of the AArch64 assembly in mlkem-native can give consent to the relicensing under Apache-2.0 OR ISC OR MIT.