### PR TITLE
CI: Run extended tests only after optional nix cache rebuild

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,10 +11,6 @@ on:
     branches: ["main"]
     types: [ "opened", "synchronize" ]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   base:
     name: Base
@@ -23,12 +19,20 @@ jobs:
       id-token: 'write'
     uses: ./.github/workflows/base.yml
     secrets: inherit
+  nix:
+    name: Nix
+    permissions:
+      actions: 'write'
+      contents: 'read'
+      id-token: 'write'
+    uses: ./.github/workflows/nix.yml
+    secrets: inherit
   ci:
     name: Extended
     permissions:
       contents: 'read'
       id-token: 'write'
-    needs: [ base ]
+    needs: [ base, nix ]
     uses: ./.github/workflows/ci.yml
     secrets: inherit
   cbmc:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,20 +4,7 @@ name: Nix
 permissions:
   contents: read
 on:
-  push:
-    branches: ["main"]
-    # Only run upon changes to nix files
-    paths:
-      - 'flake.lock'
-      - 'flake.nix'
-      - 'nix/**'
-  pull_request:
-    branches: ["main"]
-    # Only run upon changes to nix files
-    paths:
-      - 'flake.lock'
-      - 'flake.nix'
-      - 'nix/**'
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
@@ -25,7 +12,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_modified_files:
+    runs-on: ubuntu-latest
+    outputs:
+      run_needed: ${{ steps.check_run.outputs.run_needed }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        if: github.event_name != 'workflow_dispatch'
+        id: changed-files
+        uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 # v46.0.3
+      - name: Check if dependencies changed
+        id: check_run
+        shell: bash
+        run: |
+          if [[ ${{ (github.event_name == 'workflow_dispatch' && '1') || '0' }} == "1" ]]; then
+            run_needed=1
+          else
+            run_needed=0
+            changed_files="${{ steps.changed-files.outputs.all_changed_files }}"
+            dependencies="flake.lock flake.nix nix/"
+            for changed in $changed_files; do
+              for needs in $dependencies; do
+                 if [[ "$changed" == "$needs"* ]]; then
+                   run_needed=1
+                 fi
+              done
+            done
+          fi
+          echo "run_needed=${run_needed}" >> $GITHUB_OUTPUT
+
   build_nix_cache:
+    needs: [ check_modified_files ]
+    if: ${{ needs.check_modified_files.outputs.run_needed == '1' }}
     permissions:
       actions: 'write'
       contents: 'read'
@@ -58,7 +80,8 @@ jobs:
             nix develop --profile tmp
             nix-collect-garbage
   develop_environment:
-    needs: [ build_nix_cache ]
+    needs: [ check_modified_files ]
+    if: ${{ needs.check_modified_files.outputs.run_needed == '1' }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +106,6 @@ jobs:
             install: 'installer'
     name: nix setup test (${{ matrix.target.container != '' && matrix.target.container || matrix.target.runner }}, nix via ${{ matrix.target.install }})
     runs-on: ${{ matrix.target.runner }}
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     container:
       ${{ matrix.target.container }}
     steps:


### PR DESCRIPTION
This commit moves the nix workflow nix.yml into all.yml
and triggers the extended tests ci.yml only once the nix
workflow completes. This prevents concurrent rebuilding
of the expensive ci-cross shell. With the current patch,
the ci-cross shell is built and cached once in nix.yml,
and can then be reused by ci.yml.

Also, the dependency of the nix development tests on the
nix cache build for ci-cross is unnecessary and removed.