### PR TITLE
Relicense supplementary files (nix, yml, .git)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # clang-format style file for mlkem-native
 #

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.3; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.3/direnvrc" "sha256-0EVQVNSRQWsln+rgPW3mXVmnF5sfcmKEYOmOSfLYxHg="
 fi

--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Bench mlkem-native
 description: Run benchmarking script

--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: CBMC
 description: Run CBMC proofs for mlkem-native

--- a/.github/actions/ct-test/action.yml
+++ b/.github/actions/ct-test/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: CT Test
 description: Builds the library with given flags and runs Valgrind-based constant-time tests

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Functional tests
 description: Run functional tests

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Lint
 description: Lint

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Multiple Functional tests
 description: Run functional tests

--- a/.github/actions/setup-apt/action.yml
+++ b/.github/actions/setup-apt/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Dependencies (apt)
 description: Install dependencies via apt

--- a/.github/actions/setup-aws-lc/action.yml
+++ b/.github/actions/setup-aws-lc/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Setup AWS-LC
 description: Setup AWS-LC

--- a/.github/actions/setup-brew/action.yml
+++ b/.github/actions/setup-brew/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Dependencies (apt)
 description: Install dependencies via brew

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Setup nix
 description: Setup nix

--- a/.github/actions/setup-oqs/action.yml
+++ b/.github/actions/setup-oqs/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Setup libOQS
 description: Setup libOQS

--- a/.github/actions/setup-os/action.yml
+++ b/.github/actions/setup-os/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Setup OS
 description: Setup OS

--- a/.github/actions/setup-shell/action.yml
+++ b/.github/actions/setup-shell/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Set Shell
 description: Setup nix or custom shell for workflows

--- a/.github/actions/setup-yum/action.yml
+++ b/.github/actions/setup-yum/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Dependencies (yum)
 description: Install dependencies via yum

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: CI
 permissions:

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Base
 permissions:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Bench
 on:

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: bench-ec2-any
 permissions:

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: bench-ec2-reusable
 on:

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: CBMC
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Extended
 permissions:

--- a/.github/workflows/ci_ec2_any.yml
+++ b/.github/workflows/ci_ec2_any.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: ci-ec2-any
 permissions:

--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: ci-ec2-reusable
 permissions:

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: ci-ec2-reusable
 permissions:

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Constant-time tests
 permissions:

--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: HOL-Light
 permissions:

--- a/.github/workflows/integration-awslc.yml
+++ b/.github/workflows/integration-awslc.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: AWS-LC
 permissions:

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Test liboqs integration
 permissions:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Nix
 permissions:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: OSSF Scorecard analysis
 on:

--- a/.github/workflows/slothy.yml
+++ b/.github/workflows/slothy.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: SLOTHY re-optimization tests
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .direnv
 .vscode

--- a/BIBLIOGRAPHY.yml
+++ b/BIBLIOGRAPHY.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 - id: FIPS203
   short: FIPS 203

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 O ISC OR MIT
 # Last matching pattern has precedence
 
 * @pq-code-package/pqcp-mlkem-native-admin

--- a/META.yml
+++ b/META.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: ML-KEM
 type: kem

--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 CFLAGS = /nologo /O2 /Imlkem /Imlkem/fips202 /Imlkem/fips202/native /Imlkem/sys /Imlkem/native
 

--- a/examples/mlkem_native_as_code_package/.gitignore
+++ b/examples/mlkem_native_as_code_package/.gitignore
@@ -1,3 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 build

--- a/examples/multilevel_build/.gitignore
+++ b/examples/multilevel_build/.gitignore
@@ -1,3 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 build

--- a/examples/multilevel_build_native/.gitignore
+++ b/examples/multilevel_build_native/.gitignore
@@ -1,3 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 build

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 {
   description = "mlkem-native";

--- a/nix/aarch64_be-none-linux-gnu-gcc.nix
+++ b/nix/aarch64_be-none-linux-gnu-gcc.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 { stdenvNoCC
 , fetchurl

--- a/nix/cbmc/cbmc-viewer.nix
+++ b/nix/cbmc/cbmc-viewer.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 { python3Packages
 , fetchurl
 }:

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 { buildEnv
 , cbmc
 , fetchFromGitHub

--- a/nix/cbmc/litani.nix
+++ b/nix/cbmc/litani.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 { stdenvNoCC
 , fetchFromGitHub

--- a/nix/hol_light/0005-Fix-hollight-path.patch
+++ b/nix/hol_light/0005-Fix-hollight-path.patch
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 diff --git a/hol_4.14.sh b/hol_4.14.sh
 index 0fa0f64..313133e 100755
 --- a/hol_4.14.sh

--- a/nix/hol_light/default.nix
+++ b/nix/hol_light/default.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 { hol_light, fetchFromGitHub, writeText, ... }:
 hol_light.overrideAttrs (old: {

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";

--- a/nix/slothy/default.nix
+++ b/nix/slothy/default.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 { stdenvNoCC
 , fetchFromGitHub
@@ -84,8 +84,8 @@ let
   };
 
   # TODO: switch to unicorn from nixpkgs
-  # nixpkgs 24.11 currently has 2.1.1 - we are experiencing some issues with 
-  # that version on MacOS. 2.1.2/2.1.3 (and also some older versions) don't 
+  # nixpkgs 24.11 currently has 2.1.1 - we are experiencing some issues with
+  # that version on MacOS. 2.1.2/2.1.3 (and also some older versions) don't
   # have that problem
   unicorn_2_1_3 = python312Packages.buildPythonPackage rec {
     pname = "unicorn";

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 { pkgs, cbmc, bitwuzla, z3 }:
 rec {

--- a/nix/valgrind/default.nix
+++ b/nix/valgrind/default.nix
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
 { valgrind, ... }:
 valgrind.overrideAttrs (_: {
   patches = [

--- a/proofs/hol_light/.gitignore
+++ b/proofs/hol_light/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 **/*.o
 **/*.native
 **/*.correct

--- a/test/mk/auto.mk
+++ b/test/mk/auto.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
 # Automatically detect system architecture and set preprocessor etc accordingly
 ifeq ($(HOST_PLATFORM),Linux-x86_64)

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 FIPS202_SRCS = $(wildcard mlkem/fips202/*.c)
 ifeq ($(OPT),1)

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 ifndef _CONFIG
 _CONFIG :=
 

--- a/test/mk/rules.mk
+++ b/test/mk/rules.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 $(BUILD_DIR)/mlkem512/bin/%: $(CONFIG)
 	$(Q)echo "  LD      $@"


### PR DESCRIPTION
* Continuation of #982

The relicensing fron Apache-2.0 to Apache-2.0 OR ISC OR MIT missed a few auxiliary files related to nix, github workflows, or the git configuration.

For uniformity, this commit extends the relicensing to those files.
