### PR TITLE
Change citation style in source files

### DIFF
--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -226,6 +226,7 @@ source code and documentation.
   - Damien Stehlé
 * URL: https://github.com/pq-crystals/kyber/tree/main/avx2
 * Referenced from:
+  - [dev/x86_64/README.md](dev/x86_64/README.md)
   - [dev/x86_64/src/align.h](dev/x86_64/src/align.h)
   - [dev/x86_64/src/basemul.S](dev/x86_64/src/basemul.S)
   - [dev/x86_64/src/basemul.c](dev/x86_64/src/basemul.c)

--- a/dev/aarch64_clean/src/intt.S
+++ b/dev/aarch64_clean/src/intt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM inverse NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM inverse NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
@@ -49,7 +49,7 @@
 //
 // See mlken/reduce.c and test/test_bounds.py for more details.
 .macro mulmodq dst, src, const, idx0, idx1
-        // Signed barrett multiplication [@NeonNTT, Section 3.1.2] using
+        // Signed barrett multiplication @[NeonNTT, Section 3.1.2] using
         // round-to-nearest-even-integer approximation. Following loc.cit.,
         // this is functionally the same as a signed Montgomery multiplication
         // with a suitable constant of absolute value < q.

--- a/dev/aarch64_clean/src/ntt.S
+++ b/dev/aarch64_clean/src/ntt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM forward NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM forward NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
@@ -49,7 +49,7 @@
 //
 // See mlken/reduce.c and test/test_bounds.py for more details.
 .macro mulmodq dst, src, const, idx0, idx1
-        // Signed barrett multiplication [@NeonNTT, Section 3.1.2] using
+        // Signed barrett multiplication @[NeonNTT, Section 3.1.2] using
         // round-to-nearest-even-integer approximation. Following loc.cit.,
         // this is functionally the same as a signed Montgomery multiplication
         // with a suitable constant of absolute value < q.

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/dev/aarch64_opt/src/intt.S
+++ b/dev/aarch64_opt/src/intt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM inverse NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM inverse NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) &&  !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
@@ -48,7 +48,7 @@
 
 // See mlken/reduce.c and test/test_bounds.py for more details.
 .macro mulmodq dst, src, const, idx0, idx1
-        // Signed barrett multiplication [@NeonNTT, Section 3.1.2] using
+        // Signed barrett multiplication @[NeonNTT, Section 3.1.2] using
         // round-to-nearest-even-integer approximation. Following loc.cit.,
         // this is functionally the same as a signed Montgomery multiplication
         // with a suitable constant of absolute value < q.

--- a/dev/aarch64_opt/src/ntt.S
+++ b/dev/aarch64_opt/src/ntt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM forward NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM forward NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
@@ -49,7 +49,7 @@
 
 // See mlken/reduce.c and test/test_bounds.py for more details.
 .macro mulmodq dst, src, const, idx0, idx1
-        // Signed barrett multiplication [@NeonNTT, Section 3.1.2] using
+        // Signed barrett multiplication @[NeonNTT, Section 3.1.2] using
         // round-to-nearest-even-integer approximation. Following loc.cit.,
         // this is functionally the same as a signed Montgomery multiplication
         // with a suitable constant of absolute value < q.

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/dev/fips202/aarch64/auto.h
+++ b/dev/fips202/aarch64/auto.h
@@ -26,7 +26,7 @@
  *
  * - On Arm-based Apple CPUs, we pick a pure Neon implementation.
  * - Otherwise, unless MLK_SYS_AARCH64_SLOW_BARREL_SHIFTER is set,
- *   we use lazy-rotation scalar assembly from [@HYBRID].
+ *   we use lazy-rotation scalar assembly from @[HYBRID].
  * - Otherwise, if MLK_SYS_AARCH64_SLOW_BARREL_SHIFTER is set, we
  *   fall back to the standard C implementation.
  */
@@ -39,7 +39,7 @@
 /*
  * Keccak-f1600x2/x4
  *
- * The optimal implementation is highly CPU-specific; see [@HYBRID].
+ * The optimal implementation is highly CPU-specific; see @[HYBRID].
  *
  * For now, if v8.4-A is not implemented, we fall back to Keccak-f1600.
  * If v8.4-A is implemented and we are on an Apple CPU, we use a plain

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_asm.S
@@ -37,7 +37,7 @@
 // Author: Hanno Becker <hanno.becker@arm.com>
 // Author: Matthias Kannwischer <matthias@kannwischer.eu>
 //
-// This implementation is essentially from the paper [@HYBRID].
+// This implementation is essentially from the paper @[HYBRID].
 // The only difference is interleaving/deinterleaving of Keccak state
 // during load and store, so that the caller need not do this.
 //

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_asm.S
@@ -37,7 +37,7 @@
 // Author: Hanno Becker <hanno.becker@arm.com>
 // Author: Matthias Kannwischer <matthias@kannwischer.eu>
 //
-// This implementation is essentially from the paper [@HYBRID].
+// This implementation is essentially from the paper @[HYBRID].
 // The only difference is interleaving/deinterleaving of Keccak state
 // during load and store, so that the caller need not do this.
 //

--- a/dev/x86_64/README.md
+++ b/dev/x86_64/README.md
@@ -1,4 +1,7 @@
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)
 
 This directory contains the native x86_64 arithmetic backend for ML-KEM provided by
-the official Kyber AVX2 implementation @[REF_AVX2].
+the official Kyber AVX2 implementation [^REF_AVX2].
+
+<!--- bibliography --->
+[^REF_AVX2]: Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé: CRYSTALS-Kyber optimized AVX2 implementation, [https://github.com/pq-crystals/kyber/tree/main/avx2](https://github.com/pq-crystals/kyber/tree/main/avx2)

--- a/dev/x86_64/README.md
+++ b/dev/x86_64/README.md
@@ -1,4 +1,4 @@
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)
 
 This directory contains the native x86_64 arithmetic backend for ML-KEM provided by
-the official Kyber AVX2 implementation [@REF_AVX2].
+the official Kyber AVX2 implementation @[REF_AVX2].

--- a/dev/x86_64/src/align.h
+++ b/dev/x86_64/src/align.h
@@ -17,7 +17,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include <immintrin.h>

--- a/dev/x86_64/src/basemul.S
+++ b/dev/x86_64/src/basemul.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
  * The main difference is the use of a mulcache.
  */

--- a/dev/x86_64/src/basemul.c
+++ b/dev/x86_64/src/basemul.c
@@ -19,7 +19,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"
@@ -76,7 +76,7 @@ void mlk_polyvec_basemul_acc_montgomery_cached_avx2(unsigned k,
   }
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(t, sizeof(t));
 }
 

--- a/dev/x86_64/src/compress_avx2.c
+++ b/dev/x86_64/src/compress_avx2.c
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/consts.c
+++ b/dev/x86_64/src/consts.c
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/consts.h
+++ b/dev/x86_64/src/consts.h
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #ifndef MLK_DEV_X86_64_SRC_CONSTS_H

--- a/dev/x86_64/src/fq.inc
+++ b/dev/x86_64/src/fq.inc
@@ -5,7 +5,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 .macro red16 r,rs=0,x=12

--- a/dev/x86_64/src/intt.S
+++ b/dev/x86_64/src/intt.S
@@ -19,9 +19,9 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
- * The core ideas behind the implementation are described in [@AVX2_NTT].
+ * The core ideas behind the implementation are described in @[AVX2_NTT].
  *
  * Changes:
  * - Different placement of modular reductions to simplify
@@ -168,7 +168,7 @@ butterfly	10,3,6,5,4,8,7,11,2,2,9,9
  * 5,6 abs bound < 2q
  * 4,8,7,11 abs bound < q */
 
-/* Reference: The official AVX2 implementation from [@REF_AVX2]
+/* Reference: The official AVX2 implementation from @[REF_AVX2]
  * does not have this reduction. We add it here to simplify reasoning of
  * non-overflow. Without it, one has to work with more precise bounds for
  * the output of a Montgomery multiplication; with this reduction,

--- a/dev/x86_64/src/ntt.S
+++ b/dev/x86_64/src/ntt.S
@@ -19,9 +19,9 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
- * The core ideas behind the implementation are described in [@AVX2_NTT].
+ * The core ideas behind the implementation are described in @[AVX2_NTT].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/nttfrombytes.S
+++ b/dev/x86_64/src/nttfrombytes.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/nttpack.S
+++ b/dev/x86_64/src/nttpack.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/ntttobytes.S
+++ b/dev/x86_64/src/ntttobytes.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/nttunpack.S
+++ b/dev/x86_64/src/nttunpack.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/reduce.S
+++ b/dev/x86_64/src/reduce.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs

--- a/dev/x86_64/src/rej_uniform_avx2.c
+++ b/dev/x86_64/src/rej_uniform_avx2.c
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/dev/x86_64/src/shuffle.inc
+++ b/dev/x86_64/src/shuffle.inc
@@ -5,7 +5,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 .macro shuffle8 r0,r1,r2,r3

--- a/dev/x86_64/src/tomont.S
+++ b/dev/x86_64/src/tomont.S
@@ -13,7 +13,7 @@
  */
 
 /*
- * Implementation from Kyber reference repository [@REF_AVX2]
+ * Implementation from Kyber reference repository @[REF_AVX2]
  *
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -215,7 +215,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -177,7 +177,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -216,7 +216,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/mlkem/compress.c
+++ b/mlkem/compress.c
@@ -29,7 +29,7 @@
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || (MLKEM_K == 2 || MLKEM_K == 3)
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D4)
-/* Reference: `poly_compress()` in the reference implementation [@REF],
+/* Reference: `poly_compress()` in the reference implementation @[REF],
  *            for ML-KEM-{512,768}.
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
@@ -119,7 +119,7 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D10 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D4)
-/* Reference: `poly_decompress()` in the reference implementation [@REF],
+/* Reference: `poly_decompress()` in the reference implementation @[REF],
  *            for ML-KEM-{512,768}. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d4(mlk_poly *r,
@@ -193,7 +193,7 @@ void mlk_poly_decompress_d10(mlk_poly *r,
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 4
 #if !defined(MLK_USE_NATIVE_POLY_COMPRESS_D5)
-/* Reference: `poly_compress()` in the reference implementation [@REF],
+/* Reference: `poly_compress()` in the reference implementation @[REF],
  *            for ML-KEM-1024.
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
@@ -296,7 +296,7 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
 #endif /* MLK_USE_NATIVE_POLY_COMPRESS_D11 */
 
 #if !defined(MLK_USE_NATIVE_POLY_DECOMPRESS_D5)
-/* Reference: `poly_decompress()` in the reference implementation [@REF],
+/* Reference: `poly_decompress()` in the reference implementation @[REF],
  *            for ML-KEM-1024. */
 MLK_INTERNAL_API
 void mlk_poly_decompress_d5(mlk_poly *r,
@@ -403,7 +403,7 @@ void mlk_poly_decompress_d11(mlk_poly *r,
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 4 */
 
 #if !defined(MLK_USE_NATIVE_POLY_TOBYTES)
-/* Reference: `poly_tobytes()` in the reference implementation [@REF].
+/* Reference: `poly_tobytes()` in the reference implementation @[REF].
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
  *              The reference implementation works with coefficients
@@ -449,7 +449,7 @@ void mlk_poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const mlk_poly *a)
 #endif /* MLK_USE_NATIVE_POLY_TOBYTES */
 
 #if !defined(MLK_USE_NATIVE_POLY_FROMBYTES)
-/* Reference: `poly_frombytes()` in the reference implementation [@REF]. */
+/* Reference: `poly_frombytes()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 {
@@ -477,7 +477,7 @@ void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
 }
 #endif /* MLK_USE_NATIVE_POLY_FROMBYTES */
 
-/* Reference: `poly_frommsg()` in the reference implementation [@REF].
+/* Reference: `poly_frommsg()` in the reference implementation @[REF].
  *            - We use a value barrier around the bit-selection mask to
  *              reduce the risk of compiler-introduced branches.
  *              The reference implementation contains the expression
@@ -503,7 +503,7 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
       invariant(array_bound(r->coeffs, 0, 8 * i + j, 0, MLKEM_Q)))
     {
       /* mlk_ct_sel_int16(MLKEM_Q_HALF, 0, b) is `Decompress_1(b != 0)`
-       * as per [@FIPS203, Eq (4.8)]. */
+       * as per @[FIPS203, Eq (4.8)]. */
 
       /* Prevent the compiler from recognizing this as a bit selection */
       uint8_t mask = mlk_value_barrier_u8(1u << j);
@@ -513,7 +513,7 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
   mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
 }
 
-/* Reference: `poly_tomsg()` in the reference implementation [@REF].
+/* Reference: `poly_tomsg()` in the reference implementation @[REF].
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
  *              The reference implementation works with coefficients

--- a/mlkem/compress.h
+++ b/mlkem/compress.h
@@ -36,7 +36,7 @@
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_1 from [@FIPS203, Eq (4.7)].
+ * Specification: Compress_1 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 
@@ -49,7 +49,7 @@
 #pragma CPROVER check disable "unsigned-overflow"
 #endif
 
-/* Reference: Part of poly_tomsg() in the reference implementation [@REF]. */
+/* Reference: Part of poly_tomsg() in the reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d1(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -79,7 +79,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_4 from [@FIPS203, Eq (4.7)].
+ * Specification: Compress_4 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -92,7 +92,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `poly_compress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d4(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -122,12 +122,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 16
  *                 to be decompressed.
  *
- * Specification: Decompress_4 from [@FIPS203, Eq (4.8)].
+ * Specification: Decompress_4 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `poly_decompress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d4(uint32_t u)
 __contract__(
   requires(0 <= u && u < 16)
@@ -142,7 +142,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_5 from [@FIPS203, Eq (4.7)].
+ * Specification: Compress_5 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -155,7 +155,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `poly_compress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d5(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -185,12 +185,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 32
  *                 to be decompressed.
  *
- * Specification: Decompress_5 from [@FIPS203, Eq (4.8)].
+ * Specification: Decompress_5 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `poly_decompress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d5(uint32_t u)
 __contract__(
   requires(0 <= u && u < 32)
@@ -205,7 +205,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_10 from [@FIPS203, Eq (4.7)].
+ * Specification: Compress_10 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -218,7 +218,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `polyvec_compress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d10(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -249,12 +249,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 1024
  *                 to be decompressed.
  *
- * Specification: Decompress_10 from [@FIPS203, Eq (4.8)].
+ * Specification: Decompress_10 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `polyvec_decompress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d10(uint32_t u)
 __contract__(
   requires(0 <= u && u < 1024)
@@ -269,7 +269,7 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  *
- * Specification: Compress_11 from [@FIPS203, Eq (4.7)].
+ * Specification: Compress_11 from @[FIPS203, Eq (4.7)].
  *
  ************************************************************/
 /*
@@ -282,7 +282,7 @@ __contract__(
 #endif
 
 /* Reference: Embedded into `polyvec_compress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint32_t mlk_scalar_compress_d11(uint16_t u)
 __contract__(
   requires(u <= MLKEM_Q - 1)
@@ -313,12 +313,12 @@ __contract__(
  * Arguments: - u: Unsigned canonical modulus modulo 2048
  *                 to be decompressed.
  *
- * Specification: Decompress_11 from [@FIPS203, Eq (4.8)].
+ * Specification: Decompress_11 from @[FIPS203, Eq (4.8)].
  *
  ************************************************************/
 
 /* Reference: Embedded into `polyvec_decompress()` in the
- *            reference implementation [@REF]. */
+ *            reference implementation @[REF]. */
 static MLK_INLINE uint16_t mlk_scalar_decompress_d11(uint32_t u)
 __contract__(
   requires(0 <= u && u < 2048)
@@ -340,13 +340,13 @@ __contract__(
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_4 (Compress_4 (a))`:
- *                - ByteEncode_d: [@FIPS203, Algorithm 5],
- *                - Compress_d: [@FIPS203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_v} (Compress_{d_v} (v))` appears in
- *                  [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L23],
- *                  where `d_v=4` for ML-KEM-{512,768} [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L23],
+ *                  where `d_v=4` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -367,13 +367,13 @@ void mlk_poly_compress_d4(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_10 (Compress_10 (a))`:
- *                - ByteEncode_d: [@FIPS203, Algorithm 5],
- *                - Compress_d: [@FIPS203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_u} (Compress_{d_u} (u))` appears in
- *                  [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
- *                  where `d_u=10` for ML-KEM-{512,768} [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
+ *                  where `d_u=10` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -395,13 +395,13 @@ void mlk_poly_compress_d10(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_4 (ByteDecode_4 (a))`:
- *                - ByteDecode_d: [@FIPS203, Algorithm 6],
- *                - Decompress_d: [@FIPS203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_v} (ByteDecode_{d_v} (v))` appears in
- *                  [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L4],
- *                  where `d_v=4` for ML-KEM-{512,768} [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L4],
+ *                  where `d_v=4` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -423,13 +423,13 @@ void mlk_poly_decompress_d4(mlk_poly *r,
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_10 (ByteDecode_10 (a))`:
- *                - ByteDecode_d: [@FIPS203, Algorithm 6],
- *                - Decompress_d: [@FIPS203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_u} (ByteDecode_{d_u} (u))` appears in
- *                  [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L3],
- *                  where `d_u=10` for ML-KEM-{512,768} [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3],
+ *                  where `d_u=10` for ML-KEM-{512,768} @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -452,13 +452,13 @@ void mlk_poly_decompress_d10(mlk_poly *r,
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_5 (Compress_5 (a))`:
- *                - ByteEncode_d: [@FIPS203, Algorithm 5],
- *                - Compress_d: [@FIPS203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_v} (Compress_{d_v} (v))` appears in
- *                  [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L23],
- *                  where `d_v=5` for ML-KEM-1024 [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L23],
+ *                  where `d_v=5` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -479,13 +479,13 @@ void mlk_poly_compress_d5(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: `ByteEncode_11 (Compress_11 (a))`:
- *                - ByteEncode_d: [@FIPS203, Algorithm 5],
- *                - Compress_d: [@FIPS203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_{d_u} (Compress_{d_u} (u))` appears in
- *                  [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
- *                  where `d_u=11` for ML-KEM-1024 [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
+ *                  where `d_u=11` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -507,13 +507,13 @@ void mlk_poly_compress_d11(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D11],
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_5 (ByteDecode_5 (a))`:
- *                - ByteDecode_d: [@FIPS203, Algorithm 6],
- *                - Decompress_d: [@FIPS203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_v} (ByteDecode_{d_v} (v))` appears in
- *                  [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L4],
- *                  where `d_v=5` for ML-KEM-1024 [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L4],
+ *                  where `d_v=5` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -535,13 +535,13 @@ void mlk_poly_decompress_d5(mlk_poly *r,
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_11 (ByteDecode_11 (a))`:
- *                - ByteDecode_d: [@FIPS203, Algorithm 6],
- *                - Decompress_d: [@FIPS203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_{d_u} (ByteDecode_{d_u} (u))` appears in
- *                  [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L3],
- *                  where `d_u=11` for ML-KEM-1024 [@FIPS203, Table 2].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3],
+ *                  where `d_u=11` for ML-KEM-1024 @[FIPS203, Table 2].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -564,9 +564,9 @@ void mlk_poly_decompress_d11(mlk_poly *r,
  *              - r: pointer to output byte array
  *                   (of MLKEM_POLYBYTES bytes)
  *
- * Specification: Implements ByteEncode_12 [@FIPS203, Algorithm 5].
+ * Specification: Implements ByteEncode_12 @[FIPS203, Algorithm 5].
  *                Extended to vectors as per
- *                [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -593,9 +593,9 @@ __contract__(
  *                   each coefficient unsigned and in the range
  *                   0 .. 4095
  *
- * Specification: Implements ByteDecode_12 [@FIPS203, Algorithm 6].
+ * Specification: Implements ByteDecode_12 @[FIPS203, Algorithm 6].
  *                Extended to vectors as per
- *                [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -618,12 +618,12 @@ __contract__(
  *              - const uint8_t *msg: pointer to input message
  *
  * Specification: Implements `Decompress_1 (ByteDecode_1 (a))`:
- *                - ByteDecode_d: [@FIPS203, Algorithm 6],
- *                - Decompress_d: [@FIPS203, Eq (4.8)]
+ *                - ByteDecode_d: @[FIPS203, Algorithm 6],
+ *                - Decompress_d: @[FIPS203, Eq (4.8)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `Decompress_1 (ByteDecode_1 (w))` appears in
- *                  [@FIPS203, Algorithm 15 (K-PKE.Encrypt), L20].
+ *                  @[FIPS203, Algorithm 15 (K-PKE.Encrypt), L20].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -646,12 +646,12 @@ __contract__(
  *                Coefficients must be unsigned canonical
  *
  * Specification: Implements `ByteEncode_1 (Compress_1 (a))`:
- *                - ByteEncode_d: [@FIPS203, Algorithm 5],
- *                - Compress_d: [@FIPS203, Eq (4.7)]
+ *                - ByteEncode_d: @[FIPS203, Algorithm 5],
+ *                - Compress_d: @[FIPS203, Eq (4.7)]
  *                  Extended to vectors as per
- *                  [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                  @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
  *                - `ByteEncode_1 (Compress_1 (w))` appears in
- *                  [@FIPS203, Algorithm 14 (K-PKE.Decrypt), L7].
+ *                  @[FIPS203, Algorithm 14 (K-PKE.Decrypt), L7].
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -360,7 +360,7 @@
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/mlkem/fips202/fips202.c
+++ b/mlkem/fips202/fips202.c
@@ -27,9 +27,9 @@
  *   https://keccak.team/2015/tweetfips202.html
  */
 
-/* Based on the CC0 implementation from [@mupq] and the public domain
- * implementation [@supercop, crypto_hash/keccakc512/simple/]
- * by Ronny Van Keer, and the public domain [@tweetfips] implementation. */
+/* Based on the CC0 implementation from @[mupq] and the public domain
+ * implementation @[supercop, crypto_hash/keccakc512/simple/]
+ * by Ronny Van Keer, and the public domain @[tweetfips] implementation. */
 
 #include "../common.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
@@ -200,7 +200,7 @@ void mlk_shake128_init(mlk_shake128ctx *state) { (void)state; }
 void mlk_shake128_release(mlk_shake128ctx *state)
 {
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(state, sizeof(mlk_shake128ctx));
 }
 
@@ -214,7 +214,7 @@ void mlk_shake256(uint8_t *output, size_t outlen, const uint8_t *input,
   /* Squeeze output */
   mlk_keccak_squeeze_once(output, outlen, state.ctx, SHAKE256_RATE);
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(&state, sizeof(state));
 }
 
@@ -226,7 +226,7 @@ void mlk_sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
   /* Squeeze output */
   mlk_keccak_squeeze_once(output, 32, ctx, SHA3_256_RATE);
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(ctx, sizeof(ctx));
 }
 
@@ -238,7 +238,7 @@ void mlk_sha3_512(uint8_t *output, const uint8_t *input, size_t inlen)
   /* Squeeze output */
   mlk_keccak_squeeze_once(output, 64, ctx, SHA3_512_RATE);
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(ctx, sizeof(ctx));
 }
 

--- a/mlkem/fips202/fips202x4.c
+++ b/mlkem/fips202/fips202x4.c
@@ -136,7 +136,7 @@ void mlk_shake128x4_init(mlk_shake128x4ctx *state) { (void)state; }
 void mlk_shake128x4_release(mlk_shake128x4ctx *state)
 {
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(state, sizeof(mlk_shake128x4ctx));
 }
 
@@ -190,7 +190,7 @@ void mlk_shake256x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
   }
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(&statex, sizeof(statex));
   mlk_zeroize(tmp0, sizeof(tmp0));
   mlk_zeroize(tmp1, sizeof(tmp1));

--- a/mlkem/fips202/keccakf1600.c
+++ b/mlkem/fips202/keccakf1600.c
@@ -22,9 +22,9 @@
  *   https://keccak.team/2015/tweetfips202.html
  */
 
-/* Based on the CC0 implementation from [@mupq] and the public domain
- * implementation [@supercop, crypto_hash/keccakc512/simple/]
- * by Ronny Van Keer, and the public domain [@tweetfips] implementation. */
+/* Based on the CC0 implementation from @[mupq] and the public domain
+ * implementation @[supercop, crypto_hash/keccakc512/simple/]
+ * by Ronny Van Keer, and the public domain @[tweetfips] implementation. */
 
 #include <assert.h>
 #include <stdint.h>

--- a/mlkem/fips202/native/aarch64/auto.h
+++ b/mlkem/fips202/native/aarch64/auto.h
@@ -26,7 +26,7 @@
  *
  * - On Arm-based Apple CPUs, we pick a pure Neon implementation.
  * - Otherwise, unless MLK_SYS_AARCH64_SLOW_BARREL_SHIFTER is set,
- *   we use lazy-rotation scalar assembly from [@HYBRID].
+ *   we use lazy-rotation scalar assembly from @[HYBRID].
  * - Otherwise, if MLK_SYS_AARCH64_SLOW_BARREL_SHIFTER is set, we
  *   fall back to the standard C implementation.
  */
@@ -39,7 +39,7 @@
 /*
  * Keccak-f1600x2/x4
  *
- * The optimal implementation is highly CPU-specific; see [@HYBRID].
+ * The optimal implementation is highly CPU-specific; see @[HYBRID].
  *
  * For now, if v8.4-A is not implemented, we fall back to Keccak-f1600.
  * If v8.4-A is implemented and we are on an Apple CPU, we use a plain

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
@@ -37,7 +37,7 @@
 // Author: Hanno Becker <hanno.becker@arm.com>
 // Author: Matthias Kannwischer <matthias@kannwischer.eu>
 //
-// This implementation is essentially from the paper [@HYBRID].
+// This implementation is essentially from the paper @[HYBRID].
 // The only difference is interleaving/deinterleaving of Keccak state
 // during load and store, so that the caller need not do this.
 //

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
@@ -37,7 +37,7 @@
 // Author: Hanno Becker <hanno.becker@arm.com>
 // Author: Matthias Kannwischer <matthias@kannwischer.eu>
 //
-// This implementation is essentially from the paper [@HYBRID].
+// This implementation is essentially from the paper @[HYBRID].
 // The only difference is interleaving/deinterleaving of Keccak state
 // during load and store, so that the caller need not do this.
 //

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -56,7 +56,7 @@
  *              const uint8_t *seed: pointer to the input public seed
  *
  * Specification:
- * Implements [@FIPS203, Algorithm 13 (K-PKE.KeyGen), L19]
+ * Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen), L19]
  *
  **************************************************/
 static void mlk_pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], mlk_polyvec pk,
@@ -80,7 +80,7 @@ static void mlk_pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES], mlk_polyvec pk,
  *                  key.
  *
  * Specification:
- * Implements [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L2-3]
+ * Implements @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L2-3]
  *
  **************************************************/
 static void mlk_unpack_pk(mlk_polyvec pk, uint8_t seed[MLKEM_SYMBYTES],
@@ -105,7 +105,7 @@ static void mlk_unpack_pk(mlk_polyvec pk, uint8_t seed[MLKEM_SYMBYTES],
  *                (secret key)
  *
  * Specification:
- * Implements [@FIPS203, Algorithm 13 (K-PKE.KeyGen), L20]
+ * Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen), L20]
  *
  **************************************************/
 static void mlk_pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], mlk_polyvec sk)
@@ -125,7 +125,7 @@ static void mlk_pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], mlk_polyvec sk)
  *                key
  *
  * Specification:
- * Implements [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L5]
+ * Implements @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L5]
  *
  **************************************************/
 static void mlk_unpack_sk(mlk_polyvec sk,
@@ -146,7 +146,7 @@ static void mlk_unpack_sk(mlk_polyvec sk,
  *              mlk_poly *v: pointer to the input polynomial v
  *
  * Specification:
- * Implements [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L22-23]
+ * Implements @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22-23]
  *
  **************************************************/
 static void mlk_pack_ciphertext(uint8_t r[MLKEM_INDCPA_BYTES], mlk_polyvec b,
@@ -167,7 +167,7 @@ static void mlk_pack_ciphertext(uint8_t r[MLKEM_INDCPA_BYTES], mlk_polyvec b,
  *              - const uint8_t *c: pointer to the input serialized ciphertext
  *
  * Specification:
- * Implements [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L1-4]
+ * Implements @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L1-4]
  *
  **************************************************/
 static void mlk_unpack_ciphertext(mlk_polyvec b, mlk_poly *v,
@@ -193,7 +193,7 @@ __contract__(
   ensures(array_bound(data, 0, MLKEM_N, 0, MLKEM_Q))) { ((void)data); }
 #endif /* !MLK_USE_NATIVE_NTT_CUSTOM_ORDER */
 
-/* Reference: `gen_matrix()` in the reference implementation [@REF].
+/* Reference: `gen_matrix()` in the reference implementation @[REF].
  *            - We use a special subroutine to generate 4 polynomials
  *              at a time, to be able to leverage batched Keccak-f1600
  *              implementations. The reference implementation generates
@@ -280,7 +280,7 @@ void mlk_gen_matrix(mlk_polymat a, const uint8_t seed[MLKEM_SYMBYTES],
   }
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(seed_ext, sizeof(seed_ext));
 }
 
@@ -298,7 +298,7 @@ void mlk_gen_matrix(mlk_polymat a, const uint8_t seed[MLKEM_SYMBYTES],
  *              - mlk_polyvec vc: Mulcache for v, computed via
  *                  mlk_polyvec_mulcache_compute().
  *
- * Specification: Implements [@FIPS203, Section 2.4.7, Eq (2.12), (2.13)]
+ * Specification: Implements @[FIPS203, Section 2.4.7, Eq (2.12), (2.13)]
  *
  **************************************************/
 static void mlk_matvec_mul(mlk_polyvec out, const mlk_polymat a,
@@ -322,7 +322,7 @@ __contract__(
   }
 }
 
-/* Reference: `indcpa_keypair_derand()` in the reference implementation [@REF].
+/* Reference: `indcpa_keypair_derand()` in the reference implementation @[REF].
  *            - We use x4-batched versions of `poly_getnoise` to leverage
  *              batched x4-batched Keccak-f1600.
  *            - We use a different implementation of `gen_matrix()` which
@@ -394,7 +394,7 @@ void mlk_indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
   mlk_pack_pk(pk, pkpv, publicseed);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(coins_with_domain_separator, sizeof(coins_with_domain_separator));
   mlk_zeroize(a, sizeof(a));
@@ -403,7 +403,7 @@ void mlk_indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
   mlk_zeroize(&skpv_cache, sizeof(skpv_cache));
 }
 
-/* Reference: `indcpa_enc()` in the reference implementation [@REF].
+/* Reference: `indcpa_enc()` in the reference implementation @[REF].
  *            - We use x4-batched versions of `poly_getnoise` to leverage
  *              batched x4-batched Keccak-f1600.
  *            - We use a different implementation of `gen_matrix()` which
@@ -474,7 +474,7 @@ void mlk_indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
   mlk_pack_ciphertext(c, b, &v);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(seed, sizeof(seed));
   mlk_zeroize(&sp, sizeof(sp));
   mlk_zeroize(&sp_cache, sizeof(sp_cache));
@@ -486,7 +486,7 @@ void mlk_indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
   mlk_zeroize(&epp, sizeof(epp));
 }
 
-/* Reference: `indcpa_dec()` in the reference implementation [@REF].
+/* Reference: `indcpa_dec()` in the reference implementation @[REF].
  *            - We use a mulcache for the scalar product.
  *            - We include buffer zeroization. */
 MLK_INTERNAL_API
@@ -512,7 +512,7 @@ void mlk_indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
   mlk_poly_tomsg(m, &v);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(&skpv, sizeof(skpv));
   mlk_zeroize(&b, sizeof(b));
   mlk_zeroize(&b_cache, sizeof(b_cache));

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -33,8 +33,8 @@
  *              - const uint8_t *seed: pointer to input seed
  *              - int transposed: boolean deciding whether A or A^T is generated
  *
- * Specification: Implements [@FIPS203, Algorithm 13 (K-PKE.KeyGen), L3-7]
- *                and [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L4-8].
+ * Specification: Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen), L3-7]
+ *                and @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L4-8].
  *                The `transposed` parameter only affects internal presentation.
  *
  **************************************************/
@@ -64,7 +64,7 @@ __contract__(
  *              - const uint8_t *coins: pointer to input randomness
  *                             (of length MLKEM_SYMBYTES bytes)
  *
- * Specification: Implements [@FIPS203, Algorithm 13 (K-PKE.KeyGen)].
+ * Specification: Implements @[FIPS203, Algorithm 13 (K-PKE.KeyGen)].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -96,7 +96,7 @@ __contract__(
  *                 seed (of length MLKEM_SYMBYTES) to deterministically generate
  *                 all randomness
  *
- * Specification: Implements [@FIPS203, Algorithm 14 (K-PKE.Encrypt)].
+ * Specification: Implements @[FIPS203, Algorithm 14 (K-PKE.Encrypt)].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -126,7 +126,7 @@ __contract__(
  *              - const uint8_t *sk: pointer to input secret key
  *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
  *
- * Specification: Implements [@FIPS203, Algorithm 15 (K-PKE.Decrypt)].
+ * Specification: Implements @[FIPS203, Algorithm 15 (K-PKE.Decrypt)].
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -63,11 +63,11 @@ __contract__(
  * Returns: - 0 on success
  *          - -1 on failure
  *
- * Specification: Implements [@FIPS203, Section 7.2, 'modulus check']
+ * Specification: Implements @[FIPS203, Section 7.2, 'modulus check']
  *
  **************************************************/
 
-/* Reference: Not implemented in the reference implementation [@REF]. */
+/* Reference: Not implemented in the reference implementation @[REF]. */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
 {
@@ -84,7 +84,7 @@ static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
   res = mlk_ct_memcmp(pk, p_reencoded, MLKEM_POLYVECBYTES) ? -1 : 0;
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(p_reencoded, sizeof(p_reencoded));
   mlk_zeroize(&p, sizeof(p));
   return res;
@@ -104,11 +104,11 @@ static int mlk_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
  * Returns: - 0 on success
  *          - -1 on failure
  *
- * Specification: Implements [@FIPS203, Section 7.3, 'hash check']
+ * Specification: Implements @[FIPS203, Section 7.3, 'hash check']
  *
  **************************************************/
 
-/* Reference: Not implemented in the reference implementation [@REF]. */
+/* Reference: Not implemented in the reference implementation @[REF]. */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
@@ -134,7 +134,7 @@ static int mlk_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
             : 0;
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(test, sizeof(test));
   return res;
 }
@@ -148,10 +148,10 @@ __contract__(
 
 #if defined(MLK_CONFIG_KEYGEN_PCT)
 /* Specification:
- * Partially implements 'Pairwise Consistency Test' [@FIPS140_3_IG, p.87] and
- * [@FIPS203, Section 7.1, Pairwise Consistency]. */
+ * Partially implements 'Pairwise Consistency Test' @[FIPS140_3_IG, p.87] and
+ * @[FIPS203, Section 7.1, Pairwise Consistency]. */
 
-/* Reference: Not implemented in the reference implementation [@REF]. */
+/* Reference: Not implemented in the reference implementation @[REF]. */
 static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                          uint8_t const sk[MLKEM_INDCCA_SECRETKEYBYTES])
 {
@@ -186,7 +186,7 @@ cleanup:
   MLK_CT_TESTING_DECLASSIFY(&res, sizeof(res));
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(ct, sizeof(ct));
   mlk_zeroize(ss_enc, sizeof(ss_enc));
   mlk_zeroize(ss_dec, sizeof(ss_dec));
@@ -204,7 +204,7 @@ static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
 #endif /* !MLK_CONFIG_KEYGEN_PCT */
 
 /* Reference: `crypto_kem_keypair_derand()` in the reference implementation
- *            [@REF].
+ *            @[REF].
  *            - We optionally include PCT which is not present in
  *              the reference code. */
 MLK_EXTERNAL_API
@@ -223,7 +223,7 @@ int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   /* Declassify public key */
   MLK_CT_TESTING_DECLASSIFY(pk, MLKEM_INDCCA_PUBLICKEYBYTES);
 
-  /* Pairwise Consistency Test (PCT) [@FIPS140_3_IG, p.87] */
+  /* Pairwise Consistency Test (PCT) @[FIPS140_3_IG, p.87] */
   if (mlk_check_pct(pk, sk))
   {
     return -1;
@@ -232,7 +232,7 @@ int crypto_kem_keypair_derand(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   return 0;
 }
 
-/* Reference: `crypto_kem_keypair()` in the reference implementation [@REF]
+/* Reference: `crypto_kem_keypair()` in the reference implementation @[REF]
  *            - We zeroize the stack buffer */
 MLK_EXTERNAL_API
 int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
@@ -248,12 +248,12 @@ int crypto_kem_keypair(uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   res = crypto_kem_keypair_derand(pk, sk, coins);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(coins, sizeof(coins));
   return res;
 }
 
-/* Reference: `crypto_kem_enc_derand()` in the reference implementation [@REF]
+/* Reference: `crypto_kem_enc_derand()` in the reference implementation @[REF]
  *            - We include public key check
  *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
@@ -266,7 +266,7 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   /* Will contain key, coins */
   MLK_ALIGN uint8_t kr[2 * MLKEM_SYMBYTES];
 
-  /* Specification: Implements [@FIPS203, Section 7.2, Modulus check] */
+  /* Specification: Implements @[FIPS203, Section 7.2, Modulus check] */
   if (mlk_check_pk(pk))
   {
     return -1;
@@ -284,14 +284,14 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   memcpy(ss, kr, MLKEM_SYMBYTES);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(kr, sizeof(kr));
 
   return 0;
 }
 
-/* Reference: `crypto_kem_enc()` in the reference implementation [@REF]
+/* Reference: `crypto_kem_enc()` in the reference implementation @[REF]
  *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
 int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
@@ -307,12 +307,12 @@ int crypto_kem_enc(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
   res = crypto_kem_enc_derand(ct, ss, pk, coins);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(coins, sizeof(coins));
   return res;
 }
 
-/* Reference: `crypto_kem_dec()` in the reference implementation [@REF]
+/* Reference: `crypto_kem_dec()` in the reference implementation @[REF]
  *            - We include secret key check
  *            - We include stack buffer zeroization */
 MLK_EXTERNAL_API
@@ -328,7 +328,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
 
   const uint8_t *pk = sk + MLKEM_INDCPA_SECRETKEYBYTES;
 
-  /* Specification: Implements [@FIPS203, Section 7.3, Hash check] */
+  /* Specification: Implements @[FIPS203, Section 7.3, Hash check] */
   if (mlk_check_sk(sk))
   {
     return -1;
@@ -356,7 +356,7 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
   mlk_ct_cmov_zero(ss, kr, MLKEM_SYMBYTES, fail);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(kr, sizeof(kr));
   mlk_zeroize(tmp, sizeof(tmp));

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -69,7 +69,7 @@
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [@FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -101,7 +101,7 @@ __contract__(
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [@FIPS203, Algorithm 19, ML-KEM.KeyGen]
+ * Specification: Implements @[FIPS203, Algorithm 19, ML-KEM.KeyGen]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -134,10 +134,10 @@ __contract__(
  *                 bytes)
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [@FIPS203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [@FIPS203, Algorithm 17, ML-KEM.Encaps_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 17, ML-KEM.Encaps_Internal]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -171,10 +171,10 @@ __contract__(
  *                 bytes)
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [@FIPS203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [@FIPS203, Algorithm 20, ML-KEM.Encaps]
+ * Specification: Implements @[FIPS203, Algorithm 20, ML-KEM.Encaps]
  *
  **************************************************/
 MLK_EXTERNAL_API
@@ -206,10 +206,10 @@ __contract__(
  *                 bytes)
  *
  * Returns: - 0 on success
- *          - -1 if the 'hash check' [@FIPS203, Section 7.3]
+ *          - -1 if the 'hash check' @[FIPS203, Section 7.3]
  *            for the secret key fails.
  *
- * Specification: Implements [@FIPS203, Algorithm 21, ML-KEM.Decaps]
+ * Specification: Implements @[FIPS203, Algorithm 21, ML-KEM.Decaps]
  *
  **************************************************/
 MLK_EXTERNAL_API

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -146,7 +146,7 @@
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [@FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -169,7 +169,7 @@ int MLK_API_NAMESPACE(keypair_derand)(
  * Returns:     - 0: On success
  *              - -1: On PCT failure (if MLK_CONFIG_KEYGEN_PCT) is enabled.
  *
- * Specification: Implements [@FIPS203, Algorithm 19, ML-KEM.KeyGen]
+ * Specification: Implements @[FIPS203, Algorithm 19, ML-KEM.KeyGen]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -193,10 +193,10 @@ int MLK_API_NAMESPACE(keypair)(
  *                 MLKEM_SYMBYTES bytes.
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [@FIPS203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [@FIPS203, Algorithm 17, ML-KEM.Encaps_Internal]
+ * Specification: Implements @[FIPS203, Algorithm 17, ML-KEM.Encaps_Internal]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -220,10 +220,10 @@ int MLK_API_NAMESPACE(enc_derand)(
  *                 MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
  *
  * Returns: - 0 on success
- *          - -1 if the 'modulus check' [@FIPS203, Section 7.2]
+ *          - -1 if the 'modulus check' @[FIPS203, Section 7.2]
  *            for the public key fails.
  *
- * Specification: Implements [@FIPS203, Algorithm 20, ML-KEM.Encaps]
+ * Specification: Implements @[FIPS203, Algorithm 20, ML-KEM.Encaps]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE
@@ -246,10 +246,10 @@ int MLK_API_NAMESPACE(enc)(
  *                 MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
  *
  * Returns: - 0 on success
- *          - -1 if the 'hash check' [@FIPS203, Section 7.3]
+ *          - -1 if the 'hash check' @[FIPS203, Section 7.3]
  *            for the secret key fails.
  *
- * Specification: Implements [@FIPS203, Algorithm 21, ML-KEM.Decaps]
+ * Specification: Implements @[FIPS203, Algorithm 21, ML-KEM.Decaps]
  *
  **************************************************/
 MLK_API_MUST_CHECK_RETURN_VALUE

--- a/mlkem/native/aarch64/src/intt.S
+++ b/mlkem/native/aarch64/src/intt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM inverse NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM inverse NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) &&  !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)

--- a/mlkem/native/aarch64/src/ntt.S
+++ b/mlkem/native/aarch64/src/ntt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM forward NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM forward NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \

--- a/mlkem/native/x86_64/src/align.h
+++ b/mlkem/native/x86_64/src/align.h
@@ -17,7 +17,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include <immintrin.h>

--- a/mlkem/native/x86_64/src/basemul.S
+++ b/mlkem/native/x86_64/src/basemul.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
  * The main difference is the use of a mulcache.
  */

--- a/mlkem/native/x86_64/src/basemul.c
+++ b/mlkem/native/x86_64/src/basemul.c
@@ -19,7 +19,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"
@@ -76,7 +76,7 @@ void mlk_polyvec_basemul_acc_montgomery_cached_avx2(unsigned k,
   }
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(t, sizeof(t));
 }
 

--- a/mlkem/native/x86_64/src/compress_avx2.c
+++ b/mlkem/native/x86_64/src/compress_avx2.c
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/consts.c
+++ b/mlkem/native/x86_64/src/consts.c
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/consts.h
+++ b/mlkem/native/x86_64/src/consts.h
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #ifndef MLK_NATIVE_X86_64_SRC_CONSTS_H

--- a/mlkem/native/x86_64/src/fq.inc
+++ b/mlkem/native/x86_64/src/fq.inc
@@ -5,7 +5,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 .macro red16 r,rs=0,x=12

--- a/mlkem/native/x86_64/src/intt.S
+++ b/mlkem/native/x86_64/src/intt.S
@@ -19,9 +19,9 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
- * The core ideas behind the implementation are described in [@AVX2_NTT].
+ * The core ideas behind the implementation are described in @[AVX2_NTT].
  *
  * Changes:
  * - Different placement of modular reductions to simplify

--- a/mlkem/native/x86_64/src/ntt.S
+++ b/mlkem/native/x86_64/src/ntt.S
@@ -19,9 +19,9 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
- * The core ideas behind the implementation are described in [@AVX2_NTT].
+ * The core ideas behind the implementation are described in @[AVX2_NTT].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/nttfrombytes.S
+++ b/mlkem/native/x86_64/src/nttfrombytes.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/nttpack.S
+++ b/mlkem/native/x86_64/src/nttpack.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/ntttobytes.S
+++ b/mlkem/native/x86_64/src/ntttobytes.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/nttunpack.S
+++ b/mlkem/native/x86_64/src/nttunpack.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/reduce.S
+++ b/mlkem/native/x86_64/src/reduce.S
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  *
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs

--- a/mlkem/native/x86_64/src/rej_uniform_avx2.c
+++ b/mlkem/native/x86_64/src/rej_uniform_avx2.c
@@ -14,7 +14,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 #include "../../../common.h"

--- a/mlkem/native/x86_64/src/shuffle.inc
+++ b/mlkem/native/x86_64/src/shuffle.inc
@@ -5,7 +5,7 @@
 
 /*
  * This file is derived from the public domain
- * AVX2 Kyber implementation [@REF_AVX2].
+ * AVX2 Kyber implementation @[REF_AVX2].
  */
 
 .macro shuffle8 r0,r1,r2,r3

--- a/mlkem/native/x86_64/src/tomont.S
+++ b/mlkem/native/x86_64/src/tomont.S
@@ -13,7 +13,7 @@
  */
 
 /*
- * Implementation from Kyber reference repository [@REF_AVX2]
+ * Implementation from Kyber reference repository @[REF_AVX2]
  *
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -47,7 +47,7 @@
  *
  **************************************************/
 
-/* Reference: `fqmul()` in the reference implementation [@REF]. */
+/* Reference: `fqmul()` in the reference implementation @[REF]. */
 static MLK_INLINE int16_t mlk_fqmul(int16_t a, int16_t b)
 __contract__(
   requires(b > -MLKEM_Q_HALF && b < MLKEM_Q_HALF)
@@ -85,7 +85,7 @@ __contract__(
  *
  **************************************************/
 
-/* Reference: `barrett_reduce()` in the reference implementation [@REF]. */
+/* Reference: `barrett_reduce()` in the reference implementation @[REF]. */
 static MLK_INLINE int16_t mlk_barrett_reduce(int16_t a)
 __contract__(
   ensures(return_value > -MLKEM_Q_HALF && return_value < MLKEM_Q_HALF)
@@ -121,7 +121,7 @@ __contract__(
 #endif /* !MLK_USE_NATIVE_POLY_REDUCE || !MLK_USE_NATIVE_INTT */
 
 #if !defined(MLK_USE_NATIVE_POLY_TOMONT)
-/* Reference: `poly_tomont()` in the reference implementation [@REF]. */
+/* Reference: `poly_tomont()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_poly_tomont(mlk_poly *r)
 {
@@ -158,9 +158,9 @@ void mlk_poly_tomont(mlk_poly *r)
  *
  ************************************************************/
 
-/* Reference: Not present in the reference implementation [@REF].
+/* Reference: Not present in the reference implementation @[REF].
  *            - Used here to implement different semantics of `poly_reduce()`;
- *              see below. in the reference implementation [@REF], this logic is
+ *              see below. in the reference implementation @[REF], this logic is
  *              part of all compression functions (see `compress.c`). */
 static MLK_INLINE uint16_t mlk_scalar_signed_to_unsigned_q(int16_t c)
 __contract__(
@@ -178,7 +178,7 @@ __contract__(
   return (uint16_t)c;
 }
 
-/* Reference: `poly_reduce()` in the reference implementation [@REF]
+/* Reference: `poly_reduce()` in the reference implementation @[REF]
  *            - We use _unsigned_ canonical outputs, while the reference
  *              implementation uses _signed_ canonical outputs.
  *              Accordingly, we need a conditional addition of MLKEM_Q
@@ -211,7 +211,7 @@ void mlk_poly_reduce(mlk_poly *r)
 }
 #endif /* MLK_USE_NATIVE_POLY_REDUCE */
 
-/* Reference: `poly_add()` in the reference implementation [@REF].
+/* Reference: `poly_add()` in the reference implementation @[REF].
  *            - We use destructive version (output=first input) to avoid
  *              reasoning about aliasing in the CBMC specification */
 MLK_INTERNAL_API
@@ -228,7 +228,7 @@ void mlk_poly_add(mlk_poly *r, const mlk_poly *b)
   }
 }
 
-/* Reference: `poly_sub()` in the reference implementation [@REF].
+/* Reference: `poly_sub()` in the reference implementation @[REF].
  *            - We use destructive version (output=first input) to avoid
  *              reasoning about aliasing in the CBMC specification */
 MLK_INTERNAL_API
@@ -253,10 +253,10 @@ void mlk_poly_sub(mlk_poly *r, const mlk_poly *b)
 #endif
 
 #if !defined(MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE)
-/* Reference: Does not exist in the reference implementation [@REF].
+/* Reference: Does not exist in the reference implementation @[REF].
  *            - The reference implementation does not use a
  *              multiplication cache ('mulcache'). This idea originates
- *              from [@NeonNTT] and is used at the C level here. */
+ *              from @[NeonNTT] and is used at the C level here. */
 MLK_INTERNAL_API
 void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
 {
@@ -320,7 +320,7 @@ void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
  *             5 -- 7
  */
 
-/* Reference: Embedded in `ntt()` in the reference implementation [@REF]. */
+/* Reference: Embedded in `ntt()` in the reference implementation @[REF]. */
 static void mlk_ntt_butterfly_block(int16_t r[MLKEM_N], int16_t zeta,
                                     unsigned start, unsigned len, int bound)
 __contract__(
@@ -364,7 +364,7 @@ __contract__(
  * - layer: Variable indicating which layer is being applied.
  */
 
-/* Reference: Embedded in `ntt()` in the reference implementation [@REF]. */
+/* Reference: Embedded in `ntt()` in the reference implementation @[REF]. */
 static void mlk_ntt_layer(int16_t r[MLKEM_N], unsigned layer)
 __contract__(
   requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
@@ -398,7 +398,7 @@ __contract__(
  * the proof may need strengthening.
  */
 
-/* Reference: `ntt()` in the reference implementation [@REF].
+/* Reference: `ntt()` in the reference implementation @[REF].
  * - Iterate over `layer` instead of `len` in the outer loop
  *   to simplify computation of zeta index. */
 MLK_INTERNAL_API
@@ -435,7 +435,7 @@ void mlk_poly_ntt(mlk_poly *p)
 
 /* Compute one layer of inverse NTT */
 
-/* Reference: Embedded into `invntt()` in the reference implementation [@REF] */
+/* Reference: Embedded into `invntt()` in the reference implementation @[REF] */
 static void mlk_invntt_layer(int16_t *r, unsigned layer)
 __contract__(
   requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
@@ -470,7 +470,7 @@ __contract__(
   }
 }
 
-/* Reference: `invntt()` in the reference implementation [@REF]
+/* Reference: `invntt()` in the reference implementation @[REF]
  *            - We normalize at the beginning of the inverse NTT,
  *              while the reference implementation normalizes at
  *              the end. This allows us to drop a call to `poly_reduce()`

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -144,7 +144,7 @@ __contract__(
  *
  * Specification: Internal normalization required in `mlk_indcpa_keypair_derand`
  *                as part of matrix-vector multiplication
- *                [@FIPS203, Algorithm 13, K-PKE.KeyGen, L18].
+ *                @[FIPS203, Algorithm 13, K-PKE.KeyGen, L18].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -174,7 +174,7 @@ __contract__(
  *            - a: Pointer to input polynomial
  *
  * Specification:
- * - Caches `b_1 * \gamma` in [@FIPS203, Algorithm 12, BaseCaseMultiply, L1]
+ * - Caches `b_1 * \gamma` in @[FIPS203, Algorithm 12, BaseCaseMultiply, L1]
  *
  ************************************************************/
 /*
@@ -202,7 +202,7 @@ __contract__(
  * Arguments:   - mlk_poly *r: pointer to input/output polynomial
  *
  * Specification: Normalizes on unsigned canoncial representatives
- *                ahead of calling [@FIPS203, Compress_d, Eq (4.7)].
+ *                ahead of calling @[FIPS203, Compress_d, Eq (4.7)].
  *                This is not made explicit in FIPS 203.
  *
  **************************************************/
@@ -235,8 +235,8 @@ __contract__(
  * not overflow. Otherwise, the behaviour of this function is undefined.
  *
  * Specification:
- * - [@FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
- * - Used in [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L21]
+ * - @[FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
+ * - Used in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L21]
  *
  ************************************************************/
 /*
@@ -264,8 +264,8 @@ __contract__(
  *            - const mlk_poly *b: Pointer to second input polynomial
  *
  * Specification:
- * - [@FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
- * - Used in [@FIPS203, Algorithm 15, K-PKE.Decrypt, L6]
+ * - @[FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
+ * - Used in @[FIPS203, Algorithm 15, K-PKE.Decrypt, L6]
  *
  **************************************************/
 /*
@@ -301,7 +301,7 @@ __contract__(
  *
  * Arguments:   - mlk_poly *p: pointer to in/output polynomial
  *
- * Specification: Implements [@FIPS203, Algorithm 9, NTT]
+ * Specification: Implements @[FIPS203, Algorithm 9, NTT]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -330,7 +330,7 @@ __contract__(
  *
  * Arguments:   - uint16_t *a: pointer to in/output polynomial
  *
- * Specification: Implements composition of [@FIPS203, Algorithm 10, NTT^{-1}]
+ * Specification: Implements composition of @[FIPS203, Algorithm 10, NTT^{-1}]
  *                and elementwise modular multiplication with a suitable
  *                Montgomery factor introduced during the base multiplication.
  *

--- a/mlkem/poly_k.c
+++ b/mlkem/poly_k.c
@@ -39,7 +39,7 @@
 #define mlk_poly_cbd_eta2 MLK_ADD_PARAM_SET(mlk_poly_cbd_eta2)
 /* End of parameter set namespacing */
 
-/* Reference: `polyvec_compress()` in the reference implementation [@REF]
+/* Reference: `polyvec_compress()` in the reference implementation @[REF]
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
  *              The reference implementation works with coefficients
@@ -57,7 +57,7 @@ void mlk_polyvec_compress_du(uint8_t r[MLKEM_POLYVECCOMPRESSEDBYTES_DU],
   }
 }
 
-/* Reference: `polyvec_decompress()` in the reference implementation [@REF]. */
+/* Reference: `polyvec_decompress()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_polyvec_decompress_du(mlk_polyvec r,
                                const uint8_t a[MLKEM_POLYVECCOMPRESSEDBYTES_DU])
@@ -71,7 +71,7 @@ void mlk_polyvec_decompress_du(mlk_polyvec r,
   mlk_assert_bound_2d(r, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
 }
 
-/* Reference: `polyvec_tobytes()` in the reference implementation [@REF].
+/* Reference: `polyvec_tobytes()` in the reference implementation @[REF].
  *            - In contrast to the reference implementation, we assume
  *              unsigned canonical coefficients here.
  *              The reference implementation works with coefficients
@@ -88,7 +88,7 @@ void mlk_polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const mlk_polyvec a)
   }
 }
 
-/* Reference: `polyvec_frombytes()` in the reference implementation [@REF]. */
+/* Reference: `polyvec_frombytes()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_polyvec_frombytes(mlk_polyvec r, const uint8_t a[MLKEM_POLYVECBYTES])
 {
@@ -101,7 +101,7 @@ void mlk_polyvec_frombytes(mlk_polyvec r, const uint8_t a[MLKEM_POLYVECBYTES])
   mlk_assert_bound_2d(r, MLKEM_K, MLKEM_N, 0, MLKEM_UINT12_LIMIT);
 }
 
-/* Reference: `polyvec_ntt()` in the reference implementation [@REF]. */
+/* Reference: `polyvec_ntt()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_polyvec_ntt(mlk_polyvec r)
 {
@@ -114,7 +114,7 @@ void mlk_polyvec_ntt(mlk_polyvec r)
   mlk_assert_abs_bound_2d(r, MLKEM_K, MLKEM_N, MLK_NTT_BOUND);
 }
 
-/* Reference: `polyvec_invntt_tomont()` in the reference implementation [@REF].
+/* Reference: `polyvec_invntt_tomont()` in the reference implementation @[REF].
  *            - We normalize at the beginning of the inverse NTT,
  *              while the reference implementation normalizes at
  *              the end. This allows us to drop a call to `poly_reduce()`
@@ -133,10 +133,10 @@ void mlk_polyvec_invntt_tomont(mlk_polyvec r)
 
 #if !defined(MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED)
 /* Reference: `polyvec_basemul_acc_montgomery()` in the
- *            reference implementation [@REF].
+ *            reference implementation @[REF].
  *            - We use a multiplication cache ('mulcache') here
- *              which is not present in the reference implementation [@REF].
- *              This idea originates from [@NeonNTT] and is used
+ *              which is not present in the reference implementation @[REF].
+ *              This idea originates from @[NeonNTT] and is used
  *              at the C level here.
  *            - We compute the coefficients of the scalar product in 32-bit
  *              coefficients and perform only a single modular reduction
@@ -199,10 +199,10 @@ void mlk_polyvec_basemul_acc_montgomery_cached(
 }
 #endif /* MLK_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED */
 
-/* Reference: Does not exist in the reference implementation [@REF].
+/* Reference: Does not exist in the reference implementation @[REF].
  *            - The reference implementation does not use a
  *              multiplication cache ('mulcache'). This idea originates
- *              from [@NeonNTT] and is used at the C level here. */
+ *              from @[NeonNTT] and is used at the C level here. */
 MLK_INTERNAL_API
 void mlk_polyvec_mulcache_compute(mlk_polyvec_mulcache x, const mlk_polyvec a)
 {
@@ -213,7 +213,7 @@ void mlk_polyvec_mulcache_compute(mlk_polyvec_mulcache x, const mlk_polyvec a)
   }
 }
 
-/* Reference: `polyvec_reduce()` in the reference implementation [@REF].
+/* Reference: `polyvec_reduce()` in the reference implementation @[REF].
  *            - We use _unsigned_ canonical outputs, while the reference
  *              implementation uses _signed_ canonical outputs.
  *              Accordingly, we need a conditional addition of MLKEM_Q
@@ -232,7 +232,7 @@ void mlk_polyvec_reduce(mlk_polyvec r)
   mlk_assert_bound_2d(r, MLKEM_K, MLKEM_N, 0, MLKEM_Q);
 }
 
-/* Reference: `polyvec_add()` in the reference implementation [@REF].
+/* Reference: `polyvec_add()` in the reference implementation @[REF].
  *            - We use destructive version (output=first input) to avoid
  *              reasoning about aliasing in the CBMC specification */
 MLK_INTERNAL_API
@@ -245,7 +245,7 @@ void mlk_polyvec_add(mlk_polyvec r, const mlk_polyvec b)
   }
 }
 
-/* Reference: `polyvec_tomont()` in the reference implementation [@REF]. */
+/* Reference: `polyvec_tomont()` in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 void mlk_polyvec_tomont(mlk_polyvec r)
 {
@@ -269,13 +269,13 @@ void mlk_polyvec_tomont(mlk_polyvec r)
  * Arguments:   - mlk_poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  *
- * Specification: Implements [@FIPS203, Algorithm 8, SamplePolyCBD_eta1], where
- *                eta1 is specified per parameter set in [@FIPS203, Table 2]
+ * Specification: Implements @[FIPS203, Algorithm 8, SamplePolyCBD_eta1], where
+ *                eta1 is specified per parameter set in @[FIPS203, Table 2]
  *                and represented as MLKEM_ETA1 here.
  *
  **************************************************/
 
-/* Reference: `poly_cbd_eta1` in the reference implementation [@REF]. */
+/* Reference: `poly_cbd_eta1` in the reference implementation @[REF]. */
 static MLK_INLINE void mlk_poly_cbd_eta1(
     mlk_poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4])
 __contract__(
@@ -294,7 +294,7 @@ __contract__(
 #endif
 }
 
-/* Reference: Does not exist in the reference implementation [@REF].
+/* Reference: Does not exist in the reference implementation @[REF].
  *            - This implements a x4-batched version of `poly_getnoise_eta1()`
  *              from the reference implementation, to leverage
  *              batched Keccak-f1600.*/
@@ -326,7 +326,7 @@ void mlk_poly_getnoise_eta1_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
   mlk_assert_abs_bound(r3, MLKEM_N, MLKEM_ETA1 + 1);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(extkey, sizeof(extkey));
 }
@@ -342,13 +342,13 @@ void mlk_poly_getnoise_eta1_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
  * Arguments:   - mlk_poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  *
- * Specification: Implements [@FIPS203, Algorithm 8, SamplePolyCBD_eta2], where
- *                eta2 is specified per parameter set in [@FIPS203, Table 2]
+ * Specification: Implements @[FIPS203, Algorithm 8, SamplePolyCBD_eta2], where
+ *                eta2 is specified per parameter set in @[FIPS203, Table 2]
  *                and represented as MLKEM_ETA2 here.
  *
  **************************************************/
 
-/* Reference: `poly_cbd_eta2` in the reference implementation [@REF]. */
+/* Reference: `poly_cbd_eta2` in the reference implementation @[REF]. */
 static MLK_INLINE void mlk_poly_cbd_eta2(
     mlk_poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4])
 __contract__(
@@ -364,7 +364,7 @@ __contract__(
 #endif
 }
 
-/* Reference: `poly_getnoise_eta1()` in the reference implementation [@REF].
+/* Reference: `poly_getnoise_eta1()` in the reference implementation @[REF].
  *            - We include buffer zeroization. */
 MLK_INTERNAL_API
 void mlk_poly_getnoise_eta2(mlk_poly *r, const uint8_t seed[MLKEM_SYMBYTES],
@@ -382,14 +382,14 @@ void mlk_poly_getnoise_eta2(mlk_poly *r, const uint8_t seed[MLKEM_SYMBYTES],
   mlk_assert_abs_bound(r, MLKEM_N, MLKEM_ETA1 + 1);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(extkey, sizeof(extkey));
 }
 #endif /* MLKEM_K == 2 || MLKEM_K == 4 */
 
 #if MLKEM_K == 2
-/* Reference: Does not exist in the reference implementation [@REF].
+/* Reference: Does not exist in the reference implementation @[REF].
  *            - This implements a x4-batched version of `poly_getnoise_eta1()`
  *              and `poly_getnoise_eta1()` from the reference implementation,
  *              leveraging batched Keccak-f1600.
@@ -441,7 +441,7 @@ void mlk_poly_getnoise_eta1122_4x(mlk_poly *r0, mlk_poly *r1, mlk_poly *r2,
   mlk_assert_abs_bound(r3, MLKEM_N, MLKEM_ETA2 + 1);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
   mlk_zeroize(extkey, sizeof(extkey));
 }

--- a/mlkem/poly_k.h
+++ b/mlkem/poly_k.h
@@ -47,8 +47,8 @@ typedef mlk_poly_mulcache mlk_polyvec_mulcache[MLKEM_K];
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_{d_u} (Compress_{d_u} (u))`
- *                in [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
- *                with level-specific d_u defined in [@FIPS203, Table 2],
+ *                in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22],
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -84,8 +84,8 @@ __contract__(
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_{d_u} (ByteDecode_{d_u} (u))`
- *                in [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L3].
- *                with level-specific d_u defined in [@FIPS203, Table 2],
+ *                in @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3].
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -120,8 +120,8 @@ __contract__(
  *                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_{d_v} (Compress_{d_v} (v))`
- *                in [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L23].
- *                with level-specific d_v defined in [@FIPS203, Table 2],
+ *                in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L23].
+ *                with level-specific d_v defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DV here.
  *
  **************************************************/
@@ -158,8 +158,8 @@ __contract__(
  * (non-negative and smaller than MLKEM_Q).
  *
  * Specification: Implements `Decompress_{d_v} (ByteDecode_{d_v} (v))`
- *                in [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L4].
- *                with level-specific d_v defined in [@FIPS203, Table 2],
+ *                in @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L4].
+ *                with level-specific d_v defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DV here.
  *
  **************************************************/
@@ -193,8 +193,8 @@ __contract__(
  *                                  i.e. in [0,1,..,MLKEM_Q-1].
  *
  * Specification: Implements `ByteEncode_{d_u} (Compress_{d_u} (u))`
- *                in [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L22].
- *                with level-specific d_u defined in [@FIPS203, Table 2],
+ *                in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L22].
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -222,8 +222,8 @@ __contract__(
  *                                  (of length MLKEM_POLYVECCOMPRESSEDBYTES_DU)
  *
  * Specification: Implements `Decompress_{d_u} (ByteDecode_{d_u} (u))`
- *                in [@FIPS203, Algorithm 15 (K-PKE.Decrypt), L3].
- *                with level-specific d_u defined in [@FIPS203, Table 2],
+ *                in @[FIPS203, Algorithm 15 (K-PKE.Decrypt), L3].
+ *                with level-specific d_u defined in @[FIPS203, Table 2],
  *                and given by MLKEM_DU here.
  *
  **************************************************/
@@ -249,10 +249,10 @@ __contract__(
  *              - const mlk_polyvec a: pointer to input vector of polynomials
  *                  Each polynomial must have coefficients in [0,..,q-1].
  *
- * Specification: Implements ByteEncode_12 [@FIPS203, Algorithm 5].
+ * Specification: Implements ByteEncode_12 @[FIPS203, Algorithm 5].
  *                Extended to vectors as per
- *                [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
- *                and [@FIPS203, 2.4.6, Matrices and Vectors]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                and @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -277,10 +277,10 @@ __contract__(
  *                 normalized in [0..4095].
  *              - uint8_t *r: pointer to input byte array
  *
- * Specification: Implements ByteDecode_12 [@FIPS203, Algorithm 6].
+ * Specification: Implements ByteDecode_12 @[FIPS203, Algorithm 6].
  *                Extended to vectors as per
- *                [@FIPS203, 2.4.8 Applying Algorithms to Arrays]
- *                and [@FIPS203, 2.4.6, Matrices and Vectors]
+ *                @[FIPS203, 2.4.8 Applying Algorithms to Arrays]
+ *                and @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -308,8 +308,8 @@ __contract__(
  * Arguments:   - mlk_polyvec r: pointer to in/output vector of polynomials
  *
  * Specification:
- * - Implements [@FIPS203, Algorithm 9, NTT]
- * - Extended to vectors as per [@FIPS203, 2.4.6, Matrices and Vectors]
+ * - Implements @[FIPS203, Algorithm 9, NTT]
+ * - Extended to vectors as per @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -339,8 +339,8 @@ __contract__(
  * Arguments:   - mlk_polyvec r: pointer to in/output vector of polynomials
  *
  * Specification:
- * - Implements [@FIPS203, Algorithm 10, NTT^{-1}]
- * - Extended to vectors as per [@FIPS203, 2.4.6, Matrices and Vectors]
+ * - Implements @[FIPS203, Algorithm 10, NTT^{-1}]
+ * - Extended to vectors as per @[FIPS203, 2.4.6, Matrices and Vectors]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -373,9 +373,9 @@ __contract__(
  *                  via mlk_polyvec_mulcache_compute().
  *
  * Specification: Implements
- *                - [@FIPS203, Section 2.4.7, Eq (2.14)]
- *                - [@FIPS203, Algorithm 11, MultiplyNTTs]
- *                - [@FIPS203, Algorithm 12, BaseCaseMultiply]
+ *                - @[FIPS203, Section 2.4.7, Eq (2.14)]
+ *                - @[FIPS203, Algorithm 11, MultiplyNTTs]
+ *                - @[FIPS203, Algorithm 12, BaseCaseMultiply]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -414,7 +414,7 @@ __contract__(
  *            - a: Pointer to input polynomial vector
  *
  * Specification:
- * - Caches `b_1 * \gamma` in [@FIPS203, Algorithm 12, BaseCaseMultiply, L1]
+ * - Caches `b_1 * \gamma` in @[FIPS203, Algorithm 12, BaseCaseMultiply, L1]
  *
  ************************************************************/
 /*
@@ -441,7 +441,7 @@ __contract__(
  * Arguments:   - mlk_polyvec r: pointer to input/output polynomial
  *
  * Specification: Normalizes on unsigned canoncial representatives
- *                ahead of calling [@FIPS203, Compress_d, Eq (4.7)].
+ *                ahead of calling @[FIPS203, Compress_d, Eq (4.7)].
  *                This is not made explicit in FIPS 203.
  *
  **************************************************/
@@ -480,8 +480,8 @@ __contract__(
  * ensures clause is required on this function.
  *
  * Specification:
- * - [@FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
- * - Used in [@FIPS203, Algorithm 14 (K-PKE.Encrypt), L19]
+ * - @[FIPS203, 2.4.5, Arithmetic With Polynomials and NTT Representations]
+ * - Used in @[FIPS203, Algorithm 14 (K-PKE.Encrypt), L19]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -510,7 +510,7 @@ __contract__(
  *
  * Specification: Internal normalization required in `mlk_indcpa_keypair_derand`
  *                as part of matrix-vector multiplication
- *                [@FIPS203, Algorithm 13, K-PKE.KeyGen, L18].
+ *                @[FIPS203, Algorithm 13, K-PKE.KeyGen, L18].
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -538,11 +538,11 @@ __contract__(
  *
  * Specification:
  * Implements 4x `SamplePolyCBD_{eta1} (PRF_{eta1} (sigma, N))`:
- * - [@FIPS203, Algorithm 8, SamplePolyCBD_eta]
- * - [@FIPS203, Eq (4.3), PRF_eta]
+ * - @[FIPS203, Algorithm 8, SamplePolyCBD_eta]
+ * - @[FIPS203, Eq (4.3), PRF_eta]
  * - `SamplePolyCBD_{eta1} (PRF_{eta1} (sigma, N))` appears in
- *   [@FIPS203, Algorithm 13, K-PKE.KeyGen, L{9, 13}]
- *   [@FIPS203, Algorithm 14, K-PKE.Encrypt, L10]
+ *   @[FIPS203, Algorithm 13, K-PKE.KeyGen, L{9, 13}]
+ *   @[FIPS203, Algorithm 14, K-PKE.Encrypt, L10]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -592,10 +592,10 @@ __contract__(
  *
  * Specification:
  * Implements `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))`:
- * - [@FIPS203, Algorithm 8, SamplePolyCBD_eta]
- * - [@FIPS203, Eq (4.3), PRF_eta]
+ * - @[FIPS203, Algorithm 8, SamplePolyCBD_eta]
+ * - @[FIPS203, Eq (4.3), PRF_eta]
  * - `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))` appears in
- *   [@FIPS203, Algorithm 14, K-PKE.Encrypt, L14]
+ *   @[FIPS203, Algorithm 14, K-PKE.Encrypt, L14]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -627,10 +627,10 @@ __contract__(
  * Implements two instances each of
  * `SamplePolyCBD_{eta1} (PRF_{eta1} (sigma, N))` and
  * `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))`:
- * - [@FIPS203, Algorithm 8, SamplePolyCBD_eta]
- * - [@FIPS203, Eq (4.3), PRF_eta]
+ * - @[FIPS203, Algorithm 8, SamplePolyCBD_eta]
+ * - @[FIPS203, Eq (4.3), PRF_eta]
  * - `SamplePolyCBD_{eta2} (PRF_{eta2} (sigma, N))` appears in
- *   [@FIPS203, Algorithm 14, K-PKE.Encrypt, L14]
+ *   @[FIPS203, Algorithm 14, K-PKE.Encrypt, L14]
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/mlkem/sampling.c
+++ b/mlkem/sampling.c
@@ -24,7 +24,7 @@
 #include "sampling.h"
 #include "symmetric.h"
 
-/* Reference: `rej_uniform()` in the reference implementation [@REF].
+/* Reference: `rej_uniform()` in the reference implementation @[REF].
  *            - Our signature differs from the reference implementation
  *              in that it adds the offset and always expects the base of the
  *              target buffer. This avoids shifting the buffer base in the
@@ -103,7 +103,7 @@ __contract__(
  * is provided on how many bytes of the input buffer have been consumed.
  **************************************************/
 
-/* Reference: `rej_uniform()` in the reference implementation [@REF].
+/* Reference: `rej_uniform()` in the reference implementation @[REF].
  *            - Our signature differs from the reference implementation
  *              in that it adds the offset and always expects the base of the
  *              target buffer. This avoids shifting the buffer base in the
@@ -142,7 +142,7 @@ __contract__(
   ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + MLK_XOF_RATE) / MLK_XOF_RATE)
 #endif
 
-/* Reference: Does not exist in the reference implementation [@REF].
+/* Reference: Does not exist in the reference implementation @[REF].
  *            - x4-batched version of `rej_uniform()` from the
  *              reference implementation, leveraging x4-batched Keccak-f1600. */
 MLK_INTERNAL_API
@@ -199,7 +199,7 @@ void mlk_poly_rej_uniform_x4(mlk_poly *vec,
   mlk_xof_x4_release(&statex);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
 }
 
@@ -235,7 +235,7 @@ void mlk_poly_rej_uniform(mlk_poly *entry, uint8_t seed[MLKEM_SYMBYTES + 2])
   mlk_xof_release(&state);
 
   /* Specification: Partially implements
-   * [@FIPS203, Section 3.3, Destruction of intermediate values] */
+   * @[FIPS203, Section 3.3, Destruction of intermediate values] */
   mlk_zeroize(buf, sizeof(buf));
 }
 
@@ -251,7 +251,7 @@ void mlk_poly_rej_uniform(mlk_poly *entry, uint8_t seed[MLKEM_SYMBYTES + 2])
  *
  **************************************************/
 
-/* Reference: `load32_littleendian()` in the reference implementation [@REF]. */
+/* Reference: `load32_littleendian()` in the reference implementation @[REF]. */
 static uint32_t mlk_load32_littleendian(const uint8_t x[4])
 {
   uint32_t r;
@@ -262,7 +262,7 @@ static uint32_t mlk_load32_littleendian(const uint8_t x[4])
   return r;
 }
 
-/* Reference: `cbd2()` in the reference implementation [@REF]o. */
+/* Reference: `cbd2()` in the reference implementation @[REF]o. */
 MLK_INTERNAL_API
 void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
 {
@@ -303,7 +303,7 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
  *
  **************************************************/
 
-/* Reference: `load24_littleendian()` in the reference implementation [@REF]. */
+/* Reference: `load24_littleendian()` in the reference implementation @[REF]. */
 static uint32_t mlk_load24_littleendian(const uint8_t x[3])
 {
   uint32_t r;
@@ -313,7 +313,7 @@ static uint32_t mlk_load24_littleendian(const uint8_t x[3])
   return r;
 }
 
-/* Reference: `cbd3()` in the reference implementation [@REF]o. */
+/* Reference: `cbd3()` in the reference implementation @[REF]o. */
 MLK_INTERNAL_API
 void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4])
 {

--- a/mlkem/sampling.h
+++ b/mlkem/sampling.h
@@ -32,7 +32,7 @@
  * Arguments:   - mlk_poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  *
- * Specification: Implements [@FIPS203, Algorithm 8, SamplePolyCBD_2]
+ * Specification: Implements @[FIPS203, Algorithm 8, SamplePolyCBD_2]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -51,7 +51,7 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4]);
  * Arguments:   - mlk_poly *r: pointer to output polynomial
  *              - const uint8_t *buf: pointer to input byte array
  *
- * Specification: Implements [@FIPS203, Algorithm 8, SamplePolyCBD_3]
+ * Specification: Implements @[FIPS203, Algorithm 8, SamplePolyCBD_3]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -71,7 +71,7 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4]);
  *                Pointer consecutive array of seed buffers of size
  *                MLKEM_SYMBYTES + 2 each, plus padding for alignment.
  *
- * Specification: Implements [@FIPS203, Algorithm 7, SampleNTT]
+ * Specification: Implements @[FIPS203, Algorithm 7, SampleNTT]
  *
  **************************************************/
 MLK_INTERNAL_API
@@ -97,7 +97,7 @@ __contract__(
  *              - uint8_t *seed:       Pointer to seed buffer of size
  *                                     MLKEM_SYMBYTES + 2 each.
  *
- * Specification: Implements [@FIPS203, Algorithm 7, SampleNTT]
+ * Specification: Implements @[FIPS203, Algorithm 7, SampleNTT]
  *
  **************************************************/
 MLK_INTERNAL_API

--- a/mlkem/symmetric.h
+++ b/mlkem/symmetric.h
@@ -24,17 +24,17 @@
 
 /* Macros denoting FIPS 203 specific Hash functions */
 
-/* Hash function H, [@FIPS203, Section 4.1, Eq (4.4)] */
+/* Hash function H, @[FIPS203, Section 4.1, Eq (4.4)] */
 #define mlk_hash_h(OUT, IN, INBYTES) mlk_sha3_256(OUT, IN, INBYTES)
 
-/* Hash function G, [@FIPS203, Section 4.1, Eq (4.5)] */
+/* Hash function G, @[FIPS203, Section 4.1, Eq (4.5)] */
 #define mlk_hash_g(OUT, IN, INBYTES) mlk_sha3_512(OUT, IN, INBYTES)
 
-/* Hash function J, [@FIPS203, Section 4.1, Eq (4.4)] */
+/* Hash function J, @[FIPS203, Section 4.1, Eq (4.4)] */
 #define mlk_hash_j(OUT, IN, INBYTES) \
   mlk_shake256(OUT, MLKEM_SYMBYTES, IN, INBYTES)
 
-/* PRF function, [@FIPS203, Section 4.1, Eq (4.3)]
+/* PRF function, @[FIPS203, Section 4.1, Eq (4.3)]
  * Referring to (eq 4.3), `OUT` is assumed to contain `s || b`. */
 #define mlk_prf_eta(ETA, OUT, IN) \
   mlk_shake256(OUT, (ETA) * MLKEM_N / 4, IN, MLKEM_SYMBYTES + 1)

--- a/mlkem/verify.h
+++ b/mlkem/verify.h
@@ -48,8 +48,8 @@
    We consider two approaches to implement a value barrier:
    - An empty inline asm block which marks the target value as clobbered.
    - XOR'ing with the value of a volatile global that's set to 0;
-     see [@optblocker] for a discussion of this idea, and
-     [@libmceliece, inttypes/crypto_intN.h] for an implementation.
+     see @[optblocker] for a discussion of this idea, and
+     @[libmceliece, inttypes/crypto_intN.h] for an implementation.
 
    The first approach is cheap because it only prevents the compiler
    from reasoning about the value of the variable past the barrier,
@@ -154,7 +154,7 @@ __contract__(ensures(return_value == b))
  *
  **************************************************/
 
-/* Reference: Embedded in `cmov_int16()` in the reference implementation [@REF].
+/* Reference: Embedded in `cmov_int16()` in the reference implementation @[REF].
  *            - Use value barrier and shift instead of `b = -b` to
  *              convert condition into mask. */
 static MLK_INLINE uint16_t mlk_ct_cmask_nonzero_u16(uint16_t x)
@@ -175,7 +175,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFFFF)))
  **************************************************/
 
 /* Reference: Embedded in `verify()` and `cmov()` in the
- *            reference implementation [@REF].
+ *            reference implementation @[REF].
  *            - We include a value barrier not present in the
  *              reference implementation, to prevent the compiler
  *              from realizing that this function returns a mask. */
@@ -212,7 +212,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFF)))
  **************************************************/
 
 /* Reference: Embedded in polynomial compression function in the
- *            reference implementation [@REF].
+ *            reference implementation @[REF].
  *            - Used as part of signed->unsigned conversion for modular
  *              representatives to detect whether the input is negative.
  *              This happen in `mlk_poly_reduce()` here, and as part of
@@ -257,21 +257,21 @@ __contract__(ensures(return_value == ((x < 0) ? 0xFFFF : 0)))
  *
  * Specification:
  * - With `a = MLKEM_Q_HALF` and `b=0`, this essentially
- *   implements `Decompress_1` [@FIPS203, Eq (4.8)] in `mlk_poly_frommsg()`.
+ *   implements `Decompress_1` @[FIPS203, Eq (4.8)] in `mlk_poly_frommsg()`.
  * - With `a = x + MLKEM_Q`, `b = x`, and `cond` indicating whether `x`
  *   is negative, implements signed->unsigned conversion of modular
  *   representatives. Questions of representation are not considered
- *   in the specification [@FIPS203, Section 2.4.1, "The pseudocode is
+ *   in the specification @[FIPS203, Section 2.4.1, "The pseudocode is
  *   agnostic regarding how an integer modulo 𝑚 is represented in
  *   actual implementations"].
  *
  **************************************************/
 
 /* Reference: Embedded in polynomial compression function in the
- *            reference implementation [@REF].
+ *            reference implementation @[REF].
  *            - Used as part of signed->unsigned conversion for modular
  *              representatives. This happen in `mlk_poly_reduce()` here,
- *              and as part of polynomial compression functions in [@REF].
+ *              and as part of polynomial compression functions in @[REF].
  *              See `mlk_poly_reduce()`.
  *            - Barrier to reduce the risk of compiler-introduced branches.
  *            For `a = MLKEM_Q_HALF` and `b=0`, also embedded in
@@ -303,7 +303,7 @@ __contract__(ensures(return_value == (cond ? a : b)))
  *
  **************************************************/
 
-/* Reference: Embedded into `cmov()` in the reference implementation [@REF].
+/* Reference: Embedded into `cmov()` in the reference implementation @[REF].
  *            - Use value barrier to get mask from condition value. */
 static MLK_INLINE uint8_t mlk_ct_sel_uint8(uint8_t a, uint8_t b, uint8_t cond)
 __contract__(ensures(return_value == (cond ? a : b)))
@@ -324,11 +324,11 @@ __contract__(ensures(return_value == (cond ? a : b)))
  *
  * Specification:
  * - Used to securely compute conditional move in
- *   [@FIPS203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
+ *   @[FIPS203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
  *
  **************************************************/
 
-/* Reference: `cmov()` in the reference implementation [@REF]
+/* Reference: `cmov()` in the reference implementation @[REF]
  *            - We return `uint8_t`, not `int`.
  *            - We use an additional XOR-accumulator in the comparison loop
  *              which prevents early abort if the OR-accumulator is 0xFF.
@@ -381,11 +381,11 @@ __contract__(
  *
  * Specification:
  * - Used to securely compute conditional move in
- *   [@FIPS203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
+ *   @[FIPS203, Algorithm 18 (ML-KEM.Decaps_Internal, L9-11]
  *
  **************************************************/
 
-/* Reference: `cmov()` in the reference implementation [@REF].
+/* Reference: `cmov()` in the reference implementation @[REF].
  *            - We move if condition value is `0`, not `1`.
  *            - We use `mlk_ct_sel_uint8` for constant-time selection. */
 static MLK_INLINE void mlk_ct_cmov_zero(uint8_t *r, const uint8_t *x,
@@ -412,11 +412,11 @@ __contract__(
  *              size_t len:       Amount of bytes to be zeroed
  *
  * Specification: Used to implement
- * [@FIPS203, Section 3.3, Destruction of intermediate values]
+ * @[FIPS203, Section 3.3, Destruction of intermediate values]
  *
  **************************************************/
 
-/* Reference: Not present in the reference implementation [@REF]. */
+/* Reference: Not present in the reference implementation @[REF]. */
 #if !defined(MLK_CONFIG_CUSTOM_ZEROIZE)
 #if defined(MLK_SYS_WINDOWS)
 #include <windows.h>

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x1_v84a.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x1_v84a.S
@@ -37,7 +37,7 @@
 // Author: Hanno Becker <hanno.becker@arm.com>
 // Author: Matthias Kannwischer <matthias@kannwischer.eu>
 //
-// This implementation is essentially from the paper [@HYBRID].
+// This implementation is essentially from the paper @[HYBRID].
 // The only difference is interleaving/deinterleaving of Keccak state
 // during load and store, so that the caller need not do this.
 //

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x2_v84a.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x2_v84a.S
@@ -37,7 +37,7 @@
 // Author: Hanno Becker <hanno.becker@arm.com>
 // Author: Matthias Kannwischer <matthias@kannwischer.eu>
 //
-// This implementation is essentially from the paper [@HYBRID].
+// This implementation is essentially from the paper @[HYBRID].
 // The only difference is interleaving/deinterleaving of Keccak state
 // during load and store, so that the caller need not do this.
 //

--- a/proofs/hol_light/arm/mlkem/mlkem_intt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_intt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM inverse NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM inverse NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 
 /*

--- a/proofs/hol_light/arm/mlkem/mlkem_ntt.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_ntt.S
@@ -37,7 +37,7 @@
  *   https://eprint.iacr.org/2022/1303
  */
 
-/* AArch64 ML-KEM forward NTT following [@NeonNTT] and [@SLOTHY_Paper]. */
+/* AArch64 ML-KEM forward NTT following @[NeonNTT] and @[SLOTHY_Paper]. */
 
 
 /*

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 
 /*

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 
 /*

--- a/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
+++ b/proofs/hol_light/arm/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S
@@ -12,7 +12,7 @@
  *   https://tches.iacr.org/index.php/TCHES/article/view/9295
  */
 
-/* Re-implementation of asymmetric base multiplication following [@NeonNTT] */
+/* Re-implementation of asymmetric base multiplication following @[NeonNTT] */
 
 
 /*

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1953,7 +1953,6 @@ def gen_markdown_citations_for(filename, bibliography, dry_run=False):
         i = content.index(footnote_footer_start)
         content = content[:i]
     except ValueError:
-        assert len(citations) == 0
         pass
 
     # Add footnotes for all citations found

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1998,10 +1998,10 @@ def gen_c_citations_for(filename, bibliography, dry_run=False):
 
     content = content.split("\n")
 
-    # Lookup all citations in style `[^ID]`
+    # Lookup all citations in style `@[ID]`
     citations = {}
     for i, l in enumerate(content):
-        for m in re.finditer(r"\[@(?P<id>\w+)", l):
+        for m in re.finditer(r"@\[(?P<id>\w+)", l):
             cite_id = m.group("id")
             uses = citations.get(cite_id, [])
             # Remember usage. +1 because line counting starts at 1

--- a/test/break_pct_config.h
+++ b/test/break_pct_config.h
@@ -273,7 +273,7 @@
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/test/custom_randombytes_config.h
+++ b/test/custom_randombytes_config.h
@@ -325,7 +325,7 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/test/custom_zeroize_config.h
+++ b/test/custom_zeroize_config.h
@@ -296,7 +296,7 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -153,7 +153,7 @@ uint64_t get_cyclecounter(void)
   return cpu_cycles;
 }
 #elif defined(MAC_CYCLES)
-/* Based on [@m1cycles] */
+/* Based on @[m1cycles] */
 
 #include <dlfcn.h>
 #include <pthread.h>

--- a/test/nistrng/aes.c
+++ b/test/nistrng/aes.c
@@ -39,7 +39,7 @@
  */
 
 /*
- * AES implementation based on [@BearSSL].
+ * AES implementation based on @[BearSSL].
  */
 
 #include <stdint.h>
@@ -89,7 +89,7 @@ static void br_aes_ct64_bitslice_Sbox(uint64_t *q)
 {
   /*
    * This S-box implementation is a straightforward translation of
-   * the circuit described in [@BoyarPeralta].
+   * the circuit described in @[BoyarPeralta].
    *
    * Note that variables x* (input) and s* (output) are numbered
    * in "reverse" order (x0 is the high bit, x7 is the low bit).

--- a/test/nistrng/rng.c
+++ b/test/nistrng/rng.c
@@ -12,7 +12,7 @@
  *   https://csrc.nist.gov/Projects/post-quantum-cryptography/pqc-archive
  */
 
-/* Derived from [@pqcarchive, Source Code Files for KATs] provided by NIST
+/* Derived from @[pqcarchive, Source Code Files for KATs] provided by NIST
  * under the following terms of use:
  *
  *

--- a/test/no_asm_config.h
+++ b/test/no_asm_config.h
@@ -296,7 +296,7 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
 /******************************************************************************
  * Name:        MLK_CONFIG_KEYGEN_PCT
  *
- * Description: Compliance with [@FIPS140_3_IG, p.87] requires a
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
  *              Pairwise Consistency Test (PCT) to be carried out on a freshly
  *              generated keypair before it can be exported.
  *

--- a/test/notrandombytes/notrandombytes.c
+++ b/test/notrandombytes/notrandombytes.c
@@ -12,7 +12,7 @@
  *   https://cr.yp.to/papers.html#surf
  */
 
-/* Based on [@surf]. */
+/* Based on @[surf]. */
 
 /**
  * WARNING

--- a/test/notrandombytes/notrandombytes.h
+++ b/test/notrandombytes/notrandombytes.h
@@ -12,7 +12,7 @@
  *   https://cr.yp.to/papers.html#surf
  */
 
-/* Based on [@surf]. */
+/* Based on @[surf]. */
 
 #ifndef NOTRANDOMBYTES_H
 #define NOTRANDOMBYTES_H


### PR DESCRIPTION
Switch from `[@ID]` to `@[ID]` in source files.

Along the way, fix a bug in the autoeneration of bibliographies for `.md` files where `autogen` would fail upon first use after adding a citation to an `.md` file which previously didn't have one.