### PR TITLE
AArch64: Zeroize rejection sampling stack buffer

### DIFF
--- a/dev/aarch64_clean/src/rej_uniform_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_asm.S
@@ -56,6 +56,7 @@
 
     /* Temporary registers */
     tmp                         .req w11
+    initial_zero_count          .req w11
     final_copy_count            .req w11
 
     rec_idx_0                   .req w12
@@ -136,6 +137,22 @@ MLK_ASM_FN_SYMBOL(rej_uniform_asm)
     dup  mlkem_q.8h, tmp
 
     add output_tmp_base, sp, #STACK_OFFSET_TMP_OUTPUT
+    mov output_tmp, output_tmp_base
+
+    // The entire temporary stack buffer is copied to the output buffer
+    // at the end of this routine. To avoid leaking original stack contents
+    // in case not enough bytes have been sampled, zero the temporary buffer.
+    mov initial_zero_count, #0
+    eor val0.16b, val0.16b, val0.16b
+initial_zero:
+        str val0q, [output_tmp], #64
+        str val0q, [output_tmp, #-48]
+        str val0q, [output_tmp, #-32]
+        str val0q, [output_tmp, #-16]
+        add initial_zero_count, initial_zero_count, #32
+        cmp initial_zero_count, #MLKEM_N
+        b.lt initial_zero
+
     mov output_tmp, output_tmp_base
 
     mov count, #0
@@ -359,6 +376,7 @@ return:
     .unreq tmp
     .unreq xtmp
     .unreq final_copy_count
+    .unreq initial_zero_count
     .unreq rec_idx_0
     .unreq rec_idx_1
     .unreq rec_idx_2

--- a/dev/aarch64_opt/src/rej_uniform_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_asm.S
@@ -19,8 +19,8 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64)  \
-    && !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
+    !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 /* simpasm: header-end */
 
 // We save the output on the stack first, and copy to the actual
@@ -56,6 +56,7 @@
 
     /* Temporary registers */
     tmp                         .req w11
+    initial_zero_count          .req w11
     final_copy_count            .req w11
 
     rec_idx_0                   .req w12
@@ -136,6 +137,22 @@ MLK_ASM_FN_SYMBOL(rej_uniform_asm)
     dup  mlkem_q.8h, tmp
 
     add output_tmp_base, sp, #STACK_OFFSET_TMP_OUTPUT
+    mov output_tmp, output_tmp_base
+
+    // The entire temporary stack buffer is copied to the output buffer
+    // at the end of this routine. To avoid leaking original stack contents
+    // in case not enough bytes have been sampled, zero the temporary buffer.
+    mov initial_zero_count, #0
+    eor val0.16b, val0.16b, val0.16b
+initial_zero:
+        str val0q, [output_tmp], #64
+        str val0q, [output_tmp, #-48]
+        str val0q, [output_tmp, #-32]
+        str val0q, [output_tmp, #-16]
+        add initial_zero_count, initial_zero_count, #32
+        cmp initial_zero_count, #MLKEM_N
+        b.lt initial_zero
+
     mov output_tmp, output_tmp_base
 
     mov count, #0
@@ -359,6 +376,7 @@ return:
     .unreq tmp
     .unreq xtmp
     .unreq final_copy_count
+    .unreq initial_zero_count
     .unreq rec_idx_0
     .unreq rec_idx_1
     .unreq rec_idx_2

--- a/mlkem/native/aarch64/src/rej_uniform_asm.S
+++ b/mlkem/native/aarch64/src/rej_uniform_asm.S
@@ -19,8 +19,8 @@
  * Returns number of sampled 16-bit integers (at most MLKEM_N).
  **************************************************/
 #include "../../../common.h"
-#if defined(MLK_ARITH_BACKEND_AARCH64)  \
-    && !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
+#if defined(MLK_ARITH_BACKEND_AARCH64) && \
+    !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
 /*
  * WARNING: This file is auto-derived from the mlkem-native source file
@@ -47,6 +47,18 @@ MLK_ASM_FN_SYMBOL(rej_uniform_asm)
         mov	w11, #0xd01             // =3329
         dup	v30.8h, w11
         mov	x8, sp
+        mov	x7, x8
+        mov	w11, #0x0               // =0
+        eor	v16.16b, v16.16b, v16.16b
+
+initial_zero:
+        str	q16, [x7], #0x40
+        stur	q16, [x7, #-0x30]
+        stur	q16, [x7, #-0x20]
+        stur	q16, [x7, #-0x10]
+        add	w11, w11, #0x20
+        cmp	w11, #0x100
+        b.lt	initial_zero
         mov	x7, x8
         mov	w9, #0x0                // =0
         mov	w4, #0x100              // =256


### PR DESCRIPTION
The AArch64 rejection sampling routine samples data into a temporary stack buffer. This stack buffer is copied in full to the output buffer at the end of the routine, regardless of how many bytes were actually sampled. This leaks parts of the original stack values to the output buffer. While the call-site eventually fills the output buffer fully, thereby overwriting the temporary values copied from the stack, this temporary leakage is still undesirable and should be avoided.

This commit avoids unnecessarily leaking uninitialized stack values by explicitly zeroing the temporary stack buffer prior to starting the sampling.
