### PR TITLE
Fix relicensing gap

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0 O ISC OR MIT
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 # Last matching pattern has precedence
 
 * @pq-code-package/pqcp-mlkem-native-admin

--- a/META.sh
+++ b/META.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: CC-BY-4.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # Helper script to query META.yml
 #

--- a/nix/cbmc/0001-Do-not-download-sources-in-cmake.patch
+++ b/nix/cbmc/0001-Do-not-download-sources-in-cmake.patch
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 diff --git a/src/solvers/CMakeLists.txt b/src/solvers/CMakeLists.txt
 index 003a0d957b..79751ef8b2 100644
 --- a/src/solvers/CMakeLists.txt

--- a/proofs/cbmc/.gitignore
+++ b/proofs/cbmc/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # Emitted when running CBMC proofs
 **/logs


### PR DESCRIPTION
Two files were erroneously and unintentionally left out of the relicensing from Apache-2.0 to Apache-2.0 OR ISC OR MIT. This commit fixes that.

See RELICENSE.md for the relicensing consent.
