### PR TITLE
Fix API consistency check for backends

### DIFF
--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -100,6 +100,7 @@
 #endif
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
+#include MLK_CONFIG_ARITH_BACKEND_FILE
 /* Include to enforce consistency of API and implementation,
  * and conduct sanity checks on the backend.
  *
@@ -108,10 +109,10 @@
 #if defined(MLK_CHECK_APIS) && !defined(__ASSEMBLER__)
 #include "native/api.h"
 #endif
-#include MLK_CONFIG_ARITH_BACKEND_FILE
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
+#include MLK_CONFIG_FIPS202_BACKEND_FILE
 /* Include to enforce consistency of API and implementation,
  * and conduct sanity checks on the backend.
  *
@@ -120,7 +121,6 @@
 #if defined(MLK_CHECK_APIS) && !defined(__ASSEMBLER__)
 #include "fips202/native/api.h"
 #endif
-#include MLK_CONFIG_FIPS202_BACKEND_FILE
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 
 #if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)


### PR DESCRIPTION
The backend API `native/api.h` only declares backend functions for which the relevant `MLK_USE_XXX` macro has been set. Those macros are set by the backend header, which hence must be included _before_ inclusion of `native/api.h`. The code in `common.h` which includes both `native/api.h` and the backend header says as much, but then plainly does the opposite: It includes `native/api.h` first, then the backend header. This renders the API consistency checks useless.

This commit fixes this by moving the inclusion of the backend headers ahead of the backend API headers.
