### PR TITLE
CBMC: Prove AArch64 native API for rej_uniform atop HOL-Light spec

### DIFF
--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -6,6 +6,7 @@
 #define MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H
 
 #include <stdint.h>
+#include "../../../cbmc.h"
 #include "../../../common.h"
 
 #define mlk_aarch64_ntt_zetas_layer12345 \
@@ -35,10 +36,6 @@ void mlk_ntt_asm(int16_t *, const int16_t *, const int16_t *);
 #define mlk_intt_asm MLK_NAMESPACE(intt_asm)
 void mlk_intt_asm(int16_t *, const int16_t *, const int16_t *);
 
-#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
-uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
-                             const uint8_t *table);
-
 #define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
 void mlk_poly_reduce_asm(int16_t *);
 
@@ -48,7 +45,6 @@ void mlk_poly_tomont_asm(int16_t *);
 #define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
 void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
                                    const int16_t *);
-
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
 void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
@@ -73,5 +69,20 @@ void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
                                                       const int16_t *b_cache);
+
+#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
+uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
+                             const uint8_t *table)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml. */
+__contract__(
+    requires(buflen % 24 == 0)
+    requires(memory_no_alias(buf, buflen))
+    requires(table == mlk_rej_uniform_table)
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+    ensures(return_value <= MLKEM_N)
+    ensures(array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
+);
 
 #endif /* !MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H */

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -6,6 +6,7 @@
 #define MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H
 
 #include <stdint.h>
+#include "../../../cbmc.h"
 #include "../../../common.h"
 
 #define mlk_aarch64_ntt_zetas_layer12345 \
@@ -71,6 +72,17 @@ void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
 
 #define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
 uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
-                             const uint8_t *table);
+                             const uint8_t *table)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml. */
+__contract__(
+    requires(buflen % 24 == 0)
+    requires(memory_no_alias(buf, buflen))
+    requires(table == mlk_rej_uniform_table)
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+    ensures(return_value <= MLKEM_N)
+    ensures(array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
+);
 
 #endif /* !MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H */

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -100,6 +100,7 @@
 #endif
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
+#include MLK_CONFIG_ARITH_BACKEND_FILE
 /* Include to enforce consistency of API and implementation,
  * and conduct sanity checks on the backend.
  *
@@ -108,10 +109,10 @@
 #if defined(MLK_CHECK_APIS) && !defined(__ASSEMBLER__)
 #include "native/api.h"
 #endif
-#include MLK_CONFIG_ARITH_BACKEND_FILE
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
+#include MLK_CONFIG_FIPS202_BACKEND_FILE
 /* Include to enforce consistency of API and implementation,
  * and conduct sanity checks on the backend.
  *
@@ -120,7 +121,6 @@
 #if defined(MLK_CHECK_APIS) && !defined(__ASSEMBLER__)
 #include "fips202/native/api.h"
 #endif
-#include MLK_CONFIG_FIPS202_BACKEND_FILE
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 
 #if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -6,6 +6,7 @@
 #define MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H
 
 #include <stdint.h>
+#include "../../../cbmc.h"
 #include "../../../common.h"
 
 #define mlk_aarch64_ntt_zetas_layer12345 \
@@ -71,6 +72,17 @@ void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
 
 #define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
 uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
-                             const uint8_t *table);
+                             const uint8_t *table)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml. */
+__contract__(
+    requires(buflen % 24 == 0)
+    requires(memory_no_alias(buf, buflen))
+    requires(table == mlk_rej_uniform_table)
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+    ensures(return_value <= MLKEM_N)
+    ensures(array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
+);
 
 #endif /* !MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H */

--- a/proofs/cbmc/rej_uniform_native_aarch64/Makefile
+++ b/proofs/cbmc/rej_uniform_native_aarch64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = rej_uniform_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = rej_uniform_native_aarch64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/native/aarch64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/sampling.c $(SRCDIR)/mlkem/native/aarch64/src/rej_uniform_table.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_rej_uniform_native
+USE_FUNCTION_CONTRACTS=mlk_rej_uniform_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = rej_uniform_native_aarch64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/rej_uniform_native_aarch64/rej_uniform_native_aarch64_harness.c
+++ b/proofs/cbmc/rej_uniform_native_aarch64/rej_uniform_native_aarch64_harness.c
@@ -1,0 +1,20 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+
+
+int mlk_rej_uniform_native(int16_t *r, unsigned len, const uint8_t *buf,
+                           unsigned buflen);
+
+void harness(void)
+{
+  int16_t *r;
+  unsigned len;
+  const uint8_t *buf;
+  unsigned buflen;
+
+  mlk_rej_uniform_native(r, len, buf, buflen);
+}

--- a/proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml
@@ -455,6 +455,9 @@ let DIMINDEX_384 = DIMINDEX_CONV `dimindex(:384)`;;
 (* Now the actual proof.                                                     *)
 (* ------------------------------------------------------------------------- *)
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
+
 let MLKEM_REJ_UNIFORM_CORRECT = prove
  (`!res buf buflen table (inlist:(12 word)list) pc stackpointer.
         24 divides val buflen /\


### PR DESCRIPTION
* Build on  #1026 
* Part of #1025 

This commit shows that the AArch64 implementation of `rej_uniform_native`
satisfies its CBMC spec atop the HOL-Light spec for the underlying
assembly routine `rej_uniform_asm`.

More precisely, we translate relevant aspects of the HOL-Light spec
for `rej_uniform_asm` to a CBMC spec, and then show that assuming this
spec, the AArch64 implementation for `rej_uniform_native` upholds the
contract defined in `native/api.h`.