### PR TITLE
CBMC: Prove AArch64 native API for basemul atop HOL-Light spec

### DIFF
--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -54,21 +54,54 @@ void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
 uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -63,7 +63,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 2 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 
@@ -81,7 +81,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 3 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 
@@ -99,7 +99,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 4 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -54,21 +54,54 @@ void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
 uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -63,7 +63,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 2 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 
@@ -81,7 +81,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 3 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 
@@ -99,7 +99,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 4 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -54,21 +54,54 @@ void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a);
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
+    requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
 uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -63,7 +63,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 2 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 
@@ -81,7 +81,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 3 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 
@@ -99,7 +99,7 @@ __contract__(
     requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
     requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
     requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
-    requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+    requires(array_abs_bound(a, 0, 4 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
     assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 

--- a/mlkem/native/api.h
+++ b/mlkem/native/api.h
@@ -242,17 +242,7 @@ __contract__(
   requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
   requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
   requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
-  /* Because of https://github.com/diffblue/cbmc/issues/8570, we can't
-   * just use a single flattened array_bound(...) here.
-   *
-   * Once fixed, change to:
-   * ```
-   * requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
-   * ```
-   */
-  requires(forall(kN, 0, 2,					  \
-              array_bound(&((int16_t(*)[MLKEM_N])(a))[kN][0], 0, MLKEM_N, \
-			  0, MLKEM_UINT12_LIMIT)))
+  requires(array_bound(a, 0, 2 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
   assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 2 */
@@ -285,17 +275,7 @@ __contract__(
   requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
   requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
   requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
-  /* Because of https://github.com/diffblue/cbmc/issues/8570, we can't
-   * just use a single flattened array_bound(...) here.
-   *
-   * Once fixed, change to:
-   * ```
-   * requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
-   * ```
-   */
-  requires(forall(kN, 0, 3,					  \
-              array_bound(&((int16_t(*)[MLKEM_N])(a))[kN][0], 0, MLKEM_N, \
-			  0, MLKEM_UINT12_LIMIT)))
+  requires(array_bound(a, 0, 3 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
   assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 3 */
@@ -328,17 +308,7 @@ __contract__(
   requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
   requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
   requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
-  /* Because of https://github.com/diffblue/cbmc/issues/8570, we can't
-   * just use a single flattened array_bound(...) here.
-   *
-   * Once fixed, change to:
-   * ```
-   * requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
-   * ```
-   */
-  requires(forall(kN, 0, 4,					  \
-              array_bound(&((int16_t(*)[MLKEM_N])(a))[kN][0], 0, MLKEM_N, \
-			  0, MLKEM_UINT12_LIMIT)))
+  requires(array_bound(a, 0, 4 * MLKEM_N, 0, MLKEM_UINT12_LIMIT))
   assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
 );
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 4 */

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_aarch64/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_aarch64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_basemul_acc_montgomery_cached_k2_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_basemul_acc_montgomery_cached_k2_native_aarch64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/native/aarch64/meta.h\"" -DMLK_CHECK_APIS -DMLK_CONFIG_MULTILEVEL_WITH_SHARED
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly_k.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_k2_native
+USE_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_asm_k2
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvec_basemul_acc_montgomery_cached_k2_native_aarch64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_aarch64/polyvec_basemul_acc_montgomery_cached_k2_native_aarch64_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_aarch64/polyvec_basemul_acc_montgomery_cached_k2_native_aarch64_harness.c
@@ -1,0 +1,21 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+#include "cbmc.h"
+#include "common.h"
+
+void mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
+    int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
+    const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)]);
+
+void harness(void)
+{
+  int16_t *r;
+  const int16_t *a;
+  const int16_t *b;
+  const int16_t *b_cache;
+  mlk_polyvec_basemul_acc_montgomery_cached_k2_native(r, a, b, b_cache);
+}

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_aarch64/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_aarch64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_basemul_acc_montgomery_cached_k3_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_basemul_acc_montgomery_cached_k3_native_aarch64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/native/aarch64/meta.h\"" -DMLK_CHECK_APIS -DMLK_CONFIG_MULTILEVEL_WITH_SHARED
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly_k.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_k3_native
+USE_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_asm_k3
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvec_basemul_acc_montgomery_cached_k3_native_aarch64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_aarch64/polyvec_basemul_acc_montgomery_cached_k3_native_aarch64_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_aarch64/polyvec_basemul_acc_montgomery_cached_k3_native_aarch64_harness.c
@@ -1,0 +1,21 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+#include "cbmc.h"
+#include "common.h"
+
+void mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
+    int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
+    const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)]);
+
+void harness(void)
+{
+  int16_t *r;
+  const int16_t *a;
+  const int16_t *b;
+  const int16_t *b_cache;
+  mlk_polyvec_basemul_acc_montgomery_cached_k3_native(r, a, b, b_cache);
+}

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_aarch64/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_aarch64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_basemul_acc_montgomery_cached_k4_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_basemul_acc_montgomery_cached_k4_native_aarch64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/native/aarch64/meta.h\"" -DMLK_CHECK_APIS -DMLK_CONFIG_MULTILEVEL_WITH_SHARED
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly_k.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_k4_native
+USE_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_asm_k4
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvec_basemul_acc_montgomery_cached_k4_native_aarch64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_aarch64/polyvec_basemul_acc_montgomery_cached_k4_native_aarch64_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_aarch64/polyvec_basemul_acc_montgomery_cached_k4_native_aarch64_harness.c
@@ -1,0 +1,21 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+#include "cbmc.h"
+#include "common.h"
+
+void mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
+    int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
+    const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)]);
+
+void harness(void)
+{
+  int16_t *r;
+  const int16_t *a;
+  const int16_t *b;
+  const int16_t *b_cache;
+  mlk_polyvec_basemul_acc_montgomery_cached_k4_native(r, a, b, b_cache);
+}

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
@@ -378,7 +378,8 @@ let poly_basemul_acc_montgomery_cached_k2_SPEC = prove(poly_basemul_acc_montgome
     CONV_TAC INT_RING
 );;
 
-(* NOTE: This needs to be kept in sync with the CBMC spec in native/api.h *)
+(* NOTE: This needs to be kept in sync with the CBMC spec in
+ * mlkem/native/aarch64/src/arith_native_aarch64.h *)
 let poly_basemul_acc_montgomery_cached_k2_SPEC' = prove(
    `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t pc returnaddress stackpointer.
       aligned 16 stackpointer /\

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
@@ -378,6 +378,7 @@ let poly_basemul_acc_montgomery_cached_k2_SPEC = prove(poly_basemul_acc_montgome
     CONV_TAC INT_RING
 );;
 
+(* NOTE: This needs to be kept in sync with the CBMC spec in native/api.h *)
 let poly_basemul_acc_montgomery_cached_k2_SPEC' = prove(
    `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t pc returnaddress stackpointer.
       aligned 16 stackpointer /\

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
@@ -442,7 +442,8 @@ let basemul3_odd = define
     CONV_TAC INT_RING
   );;
 
- (* NOTE: This needs to be kept in sync with the CBMC spec in native/api.h *)
+ (* NOTE: This needs to be kept in sync with the CBMC spec in
+  * mlkem/native/aarch64/src/arith_native_aarch64.h *)
  let poly_basemul_acc_montgomery_cached_k3_SPEC' = prove(
     `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t pc returnaddress stackpointer.
        aligned 16 stackpointer /\

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
@@ -442,6 +442,7 @@ let basemul3_odd = define
     CONV_TAC INT_RING
   );;
 
+ (* NOTE: This needs to be kept in sync with the CBMC spec in native/api.h *)
  let poly_basemul_acc_montgomery_cached_k3_SPEC' = prove(
     `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t pc returnaddress stackpointer.
        aligned 16 stackpointer /\

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
@@ -508,6 +508,7 @@ let basemul4_odd = define
     CONV_TAC INT_RING
    );;
 
+  (* NOTE: This needs to be kept in sync with the CBMC spec in native/api.h *)
   let poly_basemul_acc_montgomery_cached_k4_SPEC' = prove(
      `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t pc returnaddress stackpointer.
         aligned 16 stackpointer /\

--- a/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
@@ -508,7 +508,8 @@ let basemul4_odd = define
     CONV_TAC INT_RING
    );;
 
-  (* NOTE: This needs to be kept in sync with the CBMC spec in native/api.h *)
+  (* NOTE: This needs to be kept in sync with the CBMC spec in
+   * mlkem/native/aarch64/src/arith_native_aarch64.h *)
   let poly_basemul_acc_montgomery_cached_k4_SPEC' = prove(
      `forall srcA srcB srcBt dst x0 y0 y0t x1 y1 y1t x2 y2 y2t x3 y3 y3t pc returnaddress stackpointer.
         aligned 16 stackpointer /\


### PR DESCRIPTION
* Part of #1025

This commit shows that the AArch64 implementations of `polyvec_basemul_acc_montgomery_cached_k{2,3,4}_native` satisfiy their CBMC spec atop the HOL-Light spec for the underlying assembly routines.

More precisely, we translate relevant aspects of the HOL-Light specs to CBMC specs, and then show that assuming those specs, the AArch64 implementations uphold their CBMC contracts defined in `native/api.h`.
