### PR TITLE
CBMC: Prove AArch64 native API for poly_reduce, poly_mulcache_compute atop HOL-Light spec

### DIFF
--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -62,7 +62,14 @@ __contract__(
 );
 
 #define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
-void mlk_poly_reduce_asm(int16_t *);
+void mlk_poly_reduce_asm(int16_t *p)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml */
+__contract__(
+  requires(memory_no_alias(p, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(p, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(p, 0, MLKEM_N, 0, MLKEM_Q))
+);
 
 #define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
 void mlk_poly_tomont_asm(int16_t *p)

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -93,7 +93,6 @@ __contract__(
   requires(zetas == mlk_aarch64_zetas_mulcache_native)
   requires(zetas_twisted == mlk_aarch64_zetas_mulcache_twisted_native)
   assigns(object_whole(cache))
-  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
 );
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -82,8 +82,19 @@ __contract__(
 );
 
 #define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
-void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
-                                   const int16_t *);
+void mlk_poly_mulcache_compute_asm(int16_t *cache, const int16_t *mlk_poly,
+                                   const int16_t *zetas,
+                                   const int16_t *zetas_twisted)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml */
+__contract__(
+  requires(memory_no_alias(cache, sizeof(int16_t) * (MLKEM_N / 2)))
+  requires(memory_no_alias(mlk_poly, sizeof(int16_t) * MLKEM_N))
+  requires(zetas == mlk_aarch64_zetas_mulcache_native)
+  requires(zetas_twisted == mlk_aarch64_zetas_mulcache_twisted_native)
+  assigns(object_whole(cache))
+  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
+);
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
 void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a)

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -62,7 +62,14 @@ __contract__(
 );
 
 #define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
-void mlk_poly_reduce_asm(int16_t *);
+void mlk_poly_reduce_asm(int16_t *p)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml */
+__contract__(
+  requires(memory_no_alias(p, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(p, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(p, 0, MLKEM_N, 0, MLKEM_Q))
+);
 
 #define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
 void mlk_poly_tomont_asm(int16_t *p)

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -93,7 +93,6 @@ __contract__(
   requires(zetas == mlk_aarch64_zetas_mulcache_native)
   requires(zetas_twisted == mlk_aarch64_zetas_mulcache_twisted_native)
   assigns(object_whole(cache))
-  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
 );
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -82,8 +82,19 @@ __contract__(
 );
 
 #define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
-void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
-                                   const int16_t *);
+void mlk_poly_mulcache_compute_asm(int16_t *cache, const int16_t *mlk_poly,
+                                   const int16_t *zetas,
+                                   const int16_t *zetas_twisted)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml */
+__contract__(
+  requires(memory_no_alias(cache, sizeof(int16_t) * (MLKEM_N / 2)))
+  requires(memory_no_alias(mlk_poly, sizeof(int16_t) * MLKEM_N))
+  requires(zetas == mlk_aarch64_zetas_mulcache_native)
+  requires(zetas_twisted == mlk_aarch64_zetas_mulcache_twisted_native)
+  assigns(object_whole(cache))
+  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
+);
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
 void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a)

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -62,7 +62,14 @@ __contract__(
 );
 
 #define mlk_poly_reduce_asm MLK_NAMESPACE(poly_reduce_asm)
-void mlk_poly_reduce_asm(int16_t *);
+void mlk_poly_reduce_asm(int16_t *p)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml */
+__contract__(
+  requires(memory_no_alias(p, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(p, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(p, 0, MLKEM_N, 0, MLKEM_Q))
+);
 
 #define mlk_poly_tomont_asm MLK_NAMESPACE(poly_tomont_asm)
 void mlk_poly_tomont_asm(int16_t *p)

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -93,7 +93,6 @@ __contract__(
   requires(zetas == mlk_aarch64_zetas_mulcache_native)
   requires(zetas_twisted == mlk_aarch64_zetas_mulcache_twisted_native)
   assigns(object_whole(cache))
-  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
 );
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)

--- a/mlkem/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/src/arith_native_aarch64.h
@@ -82,8 +82,19 @@ __contract__(
 );
 
 #define mlk_poly_mulcache_compute_asm MLK_NAMESPACE(poly_mulcache_compute_asm)
-void mlk_poly_mulcache_compute_asm(int16_t *, const int16_t *, const int16_t *,
-                                   const int16_t *);
+void mlk_poly_mulcache_compute_asm(int16_t *cache, const int16_t *mlk_poly,
+                                   const int16_t *zetas,
+                                   const int16_t *zetas_twisted)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml */
+__contract__(
+  requires(memory_no_alias(cache, sizeof(int16_t) * (MLKEM_N / 2)))
+  requires(memory_no_alias(mlk_poly, sizeof(int16_t) * MLKEM_N))
+  requires(zetas == mlk_aarch64_zetas_mulcache_native)
+  requires(zetas_twisted == mlk_aarch64_zetas_mulcache_twisted_native)
+  assigns(object_whole(cache))
+  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
+);
 
 #define mlk_poly_tobytes_asm MLK_NAMESPACE(poly_tobytes_asm)
 void mlk_poly_tobytes_asm(uint8_t *r, const int16_t *a)

--- a/mlkem/native/api.h
+++ b/mlkem/native/api.h
@@ -209,7 +209,6 @@ __contract__(
   requires(memory_no_alias(cache, sizeof(int16_t) * (MLKEM_N / 2)))
   requires(memory_no_alias(mlk_poly, sizeof(int16_t) * MLKEM_N))
   assigns(object_whole(cache))
-  ensures(array_abs_bound(cache, 0, MLKEM_N / 2, MLKEM_Q))
 );
 #endif /* MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE */
 

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -283,12 +283,6 @@ MLK_INTERNAL_API
 void mlk_poly_mulcache_compute(mlk_poly_mulcache *x, const mlk_poly *a)
 {
   mlk_poly_mulcache_compute_native(x->coeffs, a->coeffs);
-  /*
-   * This bound is true for the AArch64 and AVX2 implementations,
-   * but not needed in the higher level bounds reasoning.
-   * It is thus omitted from the spec but checked here nonetheless.
-   */
-  mlk_assert_abs_bound(x, MLKEM_N / 2, MLKEM_Q);
 }
 #endif /* MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE */
 

--- a/proofs/cbmc/poly_mulcache_compute_native_aarch64/Makefile
+++ b/proofs/cbmc/poly_mulcache_compute_native_aarch64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_mulcache_compute_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_mulcache_compute_native_aarch64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/native/aarch64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c  $(SRCDIR)/mlkem/native/aarch64/src/aarch64_zetas.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_mulcache_compute_native
+USE_FUNCTION_CONTRACTS=mlk_poly_mulcache_compute_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_mulcache_compute_native_aarch64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_mulcache_compute_native_aarch64/poly_mulcache_compute_native_aarch64_harness.c
+++ b/proofs/cbmc/poly_mulcache_compute_native_aarch64/poly_mulcache_compute_native_aarch64_harness.c
@@ -1,0 +1,16 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+void mlk_poly_mulcache_compute_native(int16_t cache[MLKEM_N / 2],
+                                      const int16_t mlk_poly[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r, *c;
+  mlk_poly_mulcache_compute_native(c, r);
+}

--- a/proofs/cbmc/poly_reduce_native_aarch64/Makefile
+++ b/proofs/cbmc/poly_reduce_native_aarch64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_reduce_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_reduce_native_aarch64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/native/aarch64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_reduce_native
+USE_FUNCTION_CONTRACTS=mlk_poly_reduce_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_reduce_native_aarch64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_reduce_native_aarch64/poly_reduce_native_aarch64_harness.c
+++ b/proofs/cbmc/poly_reduce_native_aarch64/poly_reduce_native_aarch64_harness.c
@@ -1,0 +1,15 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+void mlk_poly_reduce_native(int16_t p[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r;
+  mlk_poly_reduce_native(r);
+}

--- a/proofs/hol_light/arm/proofs/mlkem_intt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_intt.ml
@@ -482,8 +482,6 @@ let intt_constants = define
 (* Correctness proof.                                                        *)
 (* ------------------------------------------------------------------------- *)
 
-(* NOTE: This must be kept in sync with the CBMC specification
- * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
 
 let MLKEM_INTT_CORRECT = prove
  (`!a z_12345 z_67 x pc.
@@ -577,6 +575,9 @@ let MLKEM_INTT_CORRECT = prove
       CONV_TAC INT_REDUCE_CONV]));;
 
 (*** Subroutine form, somewhat messy elaboration of the usual wrapper ***)
+
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
 
 let MLKEM_INTT_SUBROUTINE_CORRECT = prove
  (`!a z_12345 z_67 x pc stackpointer returnaddress.

--- a/proofs/hol_light/arm/proofs/mlkem_ntt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_ntt.ml
@@ -357,9 +357,6 @@ let ntt_constants = define
 (* Correctness proof.                                                        *)
 (* ------------------------------------------------------------------------- *)
 
-(* NOTE: This must be kept in sync with the CBMC specification
- * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
-
 let MLKEM_NTT_CORRECT = prove
  (`!a z_12345 z_67 x pc.
       ALL (nonoverlapping (a,512))
@@ -458,6 +455,9 @@ let MLKEM_NTT_CORRECT = prove
       CONV_TAC INT_REDUCE_CONV]));;
 
 (*** Subroutine form, somewhat messy elaboration of the usual wrapper ***)
+
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
 
 let MLKEM_NTT_SUBROUTINE_CORRECT = prove
  (`!a z_12345 z_67 x pc stackpointer returnaddress.

--- a/proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_mulcache_compute.ml
@@ -95,6 +95,9 @@ let have_mulcache_zetas = define
                          iword (EL i mulcache_zetas_twisted))
  `;;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
+
 let poly_mulcache_compute_GOAL = `forall pc src dst zetas zetas_twisted x y returnaddress.
     ALL (nonoverlapping (dst, 256))
         [(word pc, LENGTH poly_mulcache_compute_mc); (src, 512); (zetas, 256); (zetas_twisted, 256)]

--- a/proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml
@@ -118,6 +118,9 @@ let overall_lemma = prove
   REWRITE_TAC[MATCH_MP lemma_rem (CONGBOUND_RULE `barred x`)] THEN
   BITBLAST_TAC);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
+
 let MLKEM_POLY_REDUCE_CORRECT = prove
  (`!a x pc.
         nonoverlapping (word pc,0x124) (a,512)

--- a/proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_reduce.ml
@@ -118,9 +118,6 @@ let overall_lemma = prove
   REWRITE_TAC[MATCH_MP lemma_rem (CONGBOUND_RULE `barred x`)] THEN
   BITBLAST_TAC);;
 
-(* NOTE: This must be kept in sync with the CBMC specification
- * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
-
 let MLKEM_POLY_REDUCE_CORRECT = prove
  (`!a x pc.
         nonoverlapping (word pc,0x124) (a,512)
@@ -182,6 +179,9 @@ let MLKEM_POLY_REDUCE_CORRECT = prove
   CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV) THEN
   ASM_REWRITE_TAC[WORD_ADD_0] THEN DISCARD_STATE_TAC "s276" THEN
   REWRITE_TAC[GSYM barred; overall_lemma]);;
+
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
 
 let MLKEM_POLY_REDUCE_SUBROUTINE_CORRECT = prove
  (`!a x pc returnaddress.

--- a/proofs/hol_light/arm/proofs/mlkem_poly_tobytes.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_poly_tobytes.ml
@@ -168,9 +168,6 @@ let lemma =
   CONV_RULE(EXPAND_CASES_CONV THENC
             DEPTH_CONV (NUM_RED_CONV ORELSEC EL_CONV)) th';;
 
-(* NOTE: This must be kept in sync with the CBMC specification
- * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
-
 let MLKEM_POLY_TOBYTES_CORRECT = prove
  (`!r a (l:int16 list) pc.
         ALL (nonoverlapping (r,384)) [(word pc,0x158); (a,512)]
@@ -246,6 +243,9 @@ let MLKEM_POLY_TOBYTES_CORRECT = prove
     GEN_REWRITE_CONV I [BITVAL_CLAUSES; OR_CLAUSES; AND_CLAUSES])) THEN
   REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
   ABBREV_TAC `twae = &2:real` THEN REAL_ARITH_TAC);;
+
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
 
 let MLKEM_POLY_TOBYTES_SUBROUTINE_CORRECT = prove
  (`!r a (l:int16 list) pc returnaddress.

--- a/proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_rej_uniform.ml
@@ -455,9 +455,6 @@ let DIMINDEX_384 = DIMINDEX_CONV `dimindex(:384)`;;
 (* Now the actual proof.                                                     *)
 (* ------------------------------------------------------------------------- *)
 
-(* NOTE: This must be kept in sync with the CBMC specification
- * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
-
 let MLKEM_REJ_UNIFORM_CORRECT = prove
  (`!res buf buflen table (inlist:(12 word)list) pc stackpointer.
         24 divides val buflen /\
@@ -1603,6 +1600,9 @@ let MLKEM_REJ_UNIFORM_CORRECT = prove
   SUBST1_TAC(SYM(ASSUME `curlen1 + len1:num = curlen2`)) THEN
   SUBST1_TAC(SYM(ASSUME `curlen + len0:num = curlen1`)) THEN
   CONV_TAC WORD_RULE);;
+
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/native/aarch64/src/arith_native_aarch64.h *)
 
 let MLKEM_REJ_UNIFORM_SUBROUTINE_CORRECT = prove
  (`!res buf buflen table (inlist:(12 word)list) pc stackpointer returnaddress.


### PR DESCRIPTION
This commit shows that the AArch64 implementations of `poly_reduce_native` and `poly_mulcache_compute_native` satisfiy their CBMC spec atop the HOL-Light spec for the underlying assembly routines.

More precisely, we translate relevant aspects of the HOL-Light specs to CBMC specs, and then show that assuming those specs, the AArch64 implementations uphold their CBMC contracts defined in native/api.h.