### PR TITLE
CBMC: Prove AArch64 Keccak native API atop HOL-Light specs

### DIFF
--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -38,9 +38,9 @@ __contract__(
   assigns(memory_slice(state, sizeof(uint64_t) * 25 * 2))
 );
 
-#define mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid \
-  MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
-void mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(uint64_t *state,
+#define mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm \
+  MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_hybrid_asm)
+void mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm(uint64_t *state,
                                                uint64_t const *rc)
 __contract__(
   requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -23,7 +23,12 @@ __contract__(
 );
 
 #define mlk_keccak_f1600_x1_v84a_asm MLK_NAMESPACE(keccak_f1600_x1_v84a_asm)
-void mlk_keccak_f1600_x1_v84a_asm(uint64_t *state, uint64_t const *rc);
+void mlk_keccak_f1600_x1_v84a_asm(uint64_t *state, uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 1))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 1))
+);
 
 #define mlk_keccak_f1600_x2_v84a_asm MLK_NAMESPACE(keccak_f1600_x2_v84a_asm)
 void mlk_keccak_f1600_x2_v84a_asm(uint64_t *state, uint64_t const *rc);

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -51,7 +51,11 @@ __contract__(
 #define mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm)
 void mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm(uint64_t *state,
-                                                    uint64_t const *rc);
-
+                                                    uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 4))
+);
 
 #endif /* !MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H */

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -6,10 +6,21 @@
 #define MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 
 #include <stdint.h>
+#include "../../../../cbmc.h"
 #include "../../../../common.h"
 
+
+#define mlk_keccakf1600_round_constants \
+  MLK_NAMESPACE(keccakf1600_round_constants)
+extern const uint64_t mlk_keccakf1600_round_constants[];
+
 #define mlk_keccak_f1600_x1_scalar_asm MLK_NAMESPACE(keccak_f1600_x1_scalar_asm)
-void mlk_keccak_f1600_x1_scalar_asm(uint64_t *state, uint64_t const *rc);
+void mlk_keccak_f1600_x1_scalar_asm(uint64_t *state, uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 1))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 1))
+);
 
 #define mlk_keccak_f1600_x1_v84a_asm MLK_NAMESPACE(keccak_f1600_x1_v84a_asm)
 void mlk_keccak_f1600_x1_v84a_asm(uint64_t *state, uint64_t const *rc);
@@ -37,8 +48,5 @@ void mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid(uint64_t *state,
 void mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm(uint64_t *state,
                                                     uint64_t const *rc);
 
-#define mlk_keccakf1600_round_constants \
-  MLK_NAMESPACE(keccakf1600_round_constants)
-extern const uint64_t mlk_keccakf1600_round_constants[];
 
 #endif /* !MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H */

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -48,11 +48,6 @@ __contract__(
   assigns(memory_slice(state, sizeof(uint64_t) * 25 * 4))
 );
 
-#define mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid \
-  MLK_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid)
-void mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid(uint64_t *state,
-                                                uint64_t const *rc);
-
 #define mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm)
 void mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm(uint64_t *state,

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -31,7 +31,12 @@ __contract__(
 );
 
 #define mlk_keccak_f1600_x2_v84a_asm MLK_NAMESPACE(keccak_f1600_x2_v84a_asm)
-void mlk_keccak_f1600_x2_v84a_asm(uint64_t *state, uint64_t const *rc);
+void mlk_keccak_f1600_x2_v84a_asm(uint64_t *state, uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 2))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 2))
+);
 
 #define mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -38,11 +38,6 @@ __contract__(
   assigns(memory_slice(state, sizeof(uint64_t) * 25 * 2))
 );
 
-#define mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid \
-  MLK_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
-void mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid(uint64_t *state,
-                                             uint64_t const *rc);
-
 #define mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
 void mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(uint64_t *state,

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -41,7 +41,12 @@ __contract__(
 #define mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
 void mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(uint64_t *state,
-                                               uint64_t const *rc);
+                                               uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 4))
+);
 
 #define mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid)

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -842,9 +842,9 @@
 .endm
 
     .text
-    .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
+    .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_hybrid_asm)
     .balign 4
-MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_asm_hybrid)
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_hybrid_asm)
     alloc_stack
     save_gprs
     save_vregs

--- a/dev/fips202/aarch64/x4_v8a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_scalar.h
@@ -15,7 +15,7 @@
 #include "src/fips202_native_aarch64.h"
 static MLK_INLINE void mlk_keccak_f1600_x4_native(uint64_t *state)
 {
-  mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(state,
+  mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm(state,
                                             mlk_keccakf1600_round_constants);
 }
 #endif /* !__ASSEMBLER__ */

--- a/dev/fips202/aarch64_symbolic/keccak_f1600_x4_v8a_scalar_hybrid_clean.S
+++ b/dev/fips202/aarch64_symbolic/keccak_f1600_x4_v8a_scalar_hybrid_clean.S
@@ -842,9 +842,9 @@
 .endm
 
     .text
-    .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
+    .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_hybrid_asm)
     .balign 4
-MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_asm_hybrid)
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_hybrid_asm)
     alloc_stack
     save_gprs
     save_vregs

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -376,7 +376,6 @@
 #undef mlk_keccak_f1600_x1_scalar_asm
 #undef mlk_keccak_f1600_x1_v84a_asm
 #undef mlk_keccak_f1600_x2_v84a_asm
-#undef mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid
 #undef mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid
 #undef mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm
 #undef mlk_keccakf1600_round_constants

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -376,7 +376,6 @@
 #undef mlk_keccak_f1600_x1_scalar_asm
 #undef mlk_keccak_f1600_x1_v84a_asm
 #undef mlk_keccak_f1600_x2_v84a_asm
-#undef mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid
 #undef mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid
 #undef mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid
 #undef mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm

--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -376,7 +376,7 @@
 #undef mlk_keccak_f1600_x1_scalar_asm
 #undef mlk_keccak_f1600_x1_v84a_asm
 #undef mlk_keccak_f1600_x2_v84a_asm
-#undef mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid
+#undef mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm
 #undef mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm
 #undef mlk_keccakf1600_round_constants
 /* mlkem/fips202/native/aarch64/x1_scalar.h */

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -6,10 +6,21 @@
 #define MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 
 #include <stdint.h>
+#include "../../../../cbmc.h"
 #include "../../../../common.h"
 
+
+#define mlk_keccakf1600_round_constants \
+  MLK_NAMESPACE(keccakf1600_round_constants)
+extern const uint64_t mlk_keccakf1600_round_constants[];
+
 #define mlk_keccak_f1600_x1_scalar_asm MLK_NAMESPACE(keccak_f1600_x1_scalar_asm)
-void mlk_keccak_f1600_x1_scalar_asm(uint64_t *state, uint64_t const *rc);
+void mlk_keccak_f1600_x1_scalar_asm(uint64_t *state, uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 1))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 1))
+);
 
 #define mlk_keccak_f1600_x1_v84a_asm MLK_NAMESPACE(keccak_f1600_x1_v84a_asm)
 void mlk_keccak_f1600_x1_v84a_asm(uint64_t *state, uint64_t const *rc);
@@ -37,8 +48,5 @@ void mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid(uint64_t *state,
 void mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm(uint64_t *state,
                                                     uint64_t const *rc);
 
-#define mlk_keccakf1600_round_constants \
-  MLK_NAMESPACE(keccakf1600_round_constants)
-extern const uint64_t mlk_keccakf1600_round_constants[];
 
 #endif /* !MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H */

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -51,7 +51,11 @@ __contract__(
 #define mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm)
 void mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm(uint64_t *state,
-                                                    uint64_t const *rc);
-
+                                                    uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 4))
+);
 
 #endif /* !MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H */

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -38,9 +38,9 @@ __contract__(
   assigns(memory_slice(state, sizeof(uint64_t) * 25 * 2))
 );
 
-#define mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid \
-  MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
-void mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(uint64_t *state,
+#define mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm \
+  MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_hybrid_asm)
+void mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm(uint64_t *state,
                                                uint64_t const *rc)
 __contract__(
   requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -23,7 +23,12 @@ __contract__(
 );
 
 #define mlk_keccak_f1600_x1_v84a_asm MLK_NAMESPACE(keccak_f1600_x1_v84a_asm)
-void mlk_keccak_f1600_x1_v84a_asm(uint64_t *state, uint64_t const *rc);
+void mlk_keccak_f1600_x1_v84a_asm(uint64_t *state, uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 1))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 1))
+);
 
 #define mlk_keccak_f1600_x2_v84a_asm MLK_NAMESPACE(keccak_f1600_x2_v84a_asm)
 void mlk_keccak_f1600_x2_v84a_asm(uint64_t *state, uint64_t const *rc);

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -48,11 +48,6 @@ __contract__(
   assigns(memory_slice(state, sizeof(uint64_t) * 25 * 4))
 );
 
-#define mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid \
-  MLK_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid)
-void mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid(uint64_t *state,
-                                                uint64_t const *rc);
-
 #define mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm)
 void mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm(uint64_t *state,

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -31,7 +31,12 @@ __contract__(
 );
 
 #define mlk_keccak_f1600_x2_v84a_asm MLK_NAMESPACE(keccak_f1600_x2_v84a_asm)
-void mlk_keccak_f1600_x2_v84a_asm(uint64_t *state, uint64_t const *rc);
+void mlk_keccak_f1600_x2_v84a_asm(uint64_t *state, uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 2))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 2))
+);
 
 #define mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -38,11 +38,6 @@ __contract__(
   assigns(memory_slice(state, sizeof(uint64_t) * 25 * 2))
 );
 
-#define mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid \
-  MLK_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
-void mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid(uint64_t *state,
-                                             uint64_t const *rc);
-
 #define mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
 void mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(uint64_t *state,

--- a/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -41,7 +41,12 @@ __contract__(
 #define mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
 void mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(uint64_t *state,
-                                               uint64_t const *rc);
+                                               uint64_t const *rc)
+__contract__(
+  requires(memory_no_alias(state, sizeof(uint64_t) * 25 * 4))
+  requires(rc == mlk_keccakf1600_round_constants)
+  assigns(memory_slice(state, sizeof(uint64_t) * 25 * 4))
+);
 
 #define mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid \
   MLK_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid)

--- a/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -39,8 +39,8 @@
 
 .text
 .balign 4
-.global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid)
-MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_asm_hybrid)
+.global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_hybrid_asm)
+MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_hybrid_asm)
 
         sub	sp, sp, #0xe0
         stp	x19, x20, [sp, #0x30]

--- a/mlkem/fips202/native/aarch64/x4_v8a_scalar.h
+++ b/mlkem/fips202/native/aarch64/x4_v8a_scalar.h
@@ -15,7 +15,7 @@
 #include "src/fips202_native_aarch64.h"
 static MLK_INLINE void mlk_keccak_f1600_x4_native(uint64_t *state)
 {
-  mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid(state,
+  mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm(state,
                                             mlk_keccakf1600_round_constants);
 }
 #endif /* !__ASSEMBLER__ */

--- a/proofs/cbmc/keccak_f1600_x1_native_aarch64/Makefile
+++ b/proofs/cbmc/keccak_f1600_x1_native_aarch64/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccak_f1600_x1_native_aarch64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccak_f1600_x1_native_aarch64
+
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x1_scalar.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c 
+
+CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x1_native
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x1_scalar_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = keccak_f1600_x1_native
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccak_f1600_x1_native_aarch64/keccak_f1600_x1_native_aarch64_harness.c
+++ b/proofs/cbmc/keccak_f1600_x1_native_aarch64/keccak_f1600_x1_native_aarch64_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+void mlk_keccak_f1600_x1_native(uint64_t *state);
+
+void harness(void)
+{
+  uint64_t *s;
+  mlk_keccak_f1600_x1_native(s);
+}

--- a/proofs/cbmc/keccak_f1600_x1_native_aarch64_v84a/Makefile
+++ b/proofs/cbmc/keccak_f1600_x1_native_aarch64_v84a/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccak_f1600_x1_native_aarch64_v84a_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccak_f1600_x1_native_aarch64_v84a
+
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x1_v84a.h\"" -DMLK_CHECK_APIS -D__ARM_FEATURE_SHA3
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c 
+
+CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x1_native
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x1_v84a_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = keccak_f1600_x1_native
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccak_f1600_x1_native_aarch64_v84a/keccak_f1600_x1_native_aarch64_v84a_harness.c
+++ b/proofs/cbmc/keccak_f1600_x1_native_aarch64_v84a/keccak_f1600_x1_native_aarch64_v84a_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+void mlk_keccak_f1600_x1_native(uint64_t *state);
+
+void harness(void)
+{
+  uint64_t *s;
+  mlk_keccak_f1600_x1_native(s);
+}

--- a/proofs/cbmc/keccak_f1600_x2_native_aarch64_v84a/Makefile
+++ b/proofs/cbmc/keccak_f1600_x2_native_aarch64_v84a/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccak_f1600_x2_native_aarch64_v84a_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccak_f1600_x2_native_aarch64_v84a
+
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x2_v84a.h\"" -DMLK_CHECK_APIS -D__ARM_FEATURE_SHA3
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c 
+
+CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x2_native
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x2_v84a_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = keccak_f1600_x2_native_aarch64_v84a
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccak_f1600_x2_native_aarch64_v84a/keccak_f1600_x2_native_aarch64_v84a_harness.c
+++ b/proofs/cbmc/keccak_f1600_x2_native_aarch64_v84a/keccak_f1600_x2_native_aarch64_v84a_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+void mlk_keccak_f1600_x2_native(uint64_t *state);
+
+void harness(void)
+{
+  uint64_t *s;
+  mlk_keccak_f1600_x2_native(s);
+}

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid/Makefile
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid/Makefile
@@ -20,7 +20,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c 
 
 CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_native
-USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_scalar_v8a_hybrid_asm
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid/Makefile
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid
+
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x4_v8a_scalar.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c 
+
+CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_native
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_scalar_v8a_asm_hybrid
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid_harness.c
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid/keccak_f1600_x4_native_aarch64_scalar_v8a_hybrid_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+void mlk_keccak_f1600_x4_native(uint64_t *state);
+
+void harness(void)
+{
+  uint64_t *s;
+  mlk_keccak_f1600_x4_native(s);
+}

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid/Makefile
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid/Makefile
@@ -10,7 +10,7 @@ HARNESS_FILE = keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid_harness
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
 PROOF_UID = keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid
 
-DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h\"" -DMLK_CHECK_APIS
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h\"" -DMLK_CHECK_APIS -D__ARM_FEATURE_SHA3
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid/Makefile
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid
+
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 -DMLK_CONFIG_FIPS202_BACKEND_FILE="\"$(SRCDIR)/mlkem/fips202/native/aarch64/x4_v8a_v84a_scalar.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c 
+
+CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_native
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid_harness.c
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid/keccak_f1600_x4_native_aarch64_scalar_v8a_v84a_hybrid_harness.c
@@ -1,0 +1,13 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+void mlk_keccak_f1600_x4_native(uint64_t *state);
+
+void harness(void)
+{
+  uint64_t *s;
+  mlk_keccak_f1600_x4_native(s);
+}

--- a/proofs/hol_light/arm/mlkem/keccak_f1600_x4_v8a_scalar.S
+++ b/proofs/hol_light/arm/mlkem/keccak_f1600_x4_v8a_scalar.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_asm_hybrid
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_asm_hybrid:
+.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_hybrid_asm
+_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_hybrid_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_asm_hybrid
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_asm_hybrid:
+.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_hybrid_asm
+PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_scalar_v8a_hybrid_asm:
 #endif
 
         sub	sp, sp, #0xe0

--- a/scripts/check-contracts
+++ b/scripts/check-contracts
@@ -42,7 +42,7 @@ def gen_contracts():
 def is_exception(funcname):
     # The functions passing this filter are known not to have a proof
 
-    if funcname.endswith("_native"):
+    if funcname.endswith("_native") or funcname.endswith("_asm"):
         # CBMC proofs are axiomatized against contracts of the backends
         return True
 


### PR DESCRIPTION
- Resolves https://github.com/pq-code-package/mlkem-native/issues/1025

This PR proves the contracts of the native Keccak API based on the AArch64 backend which closely resemble the HOL-Light specifications. This completes #1025. 

It also removes the signatures of the un-used functions ` mlk_keccak_f1600_x2_v8a_v84a_asm_hybrid` and `mlk_keccak_f1600_x4_scalar_v84a_asm_hybrid`. 

Furthermore it renames `keccak_f1600_x4_scalar_v8a_asm_hybrid` to `keccak_f1600_x4_scalar_v8a_hybrid_asm` to be consistent with the other function names.
