### PR TITLE
Fixes #1033: CI step nix-post-check fails

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -90,7 +90,7 @@ runs:
 
         echo "cache_prefix=$cache_prefix" >> $GITHUB_OUTPUT
 
-        if [[ ${{ steps.nix-pre-check.outputs.installed }} == 'false' ]]; then
+        if [[ "${{ steps.nix-pre-check.outputs.installed }}" == 'false' ]]; then
           sudo chown -R $USER:nixbld /nix
         fi
 


### PR DESCRIPTION
<!-- 
Security reports

DO NOT submit pull requests related to security issues directly - instead use Github's [private vulnerability reporting](https://github.com/pq-code-package/mlkem-native/security). 
-->

**Summary**:
This PR is currently a work in progress. It aims to fix the CI error occurring in the `nix-post-check` step.

**Fixes**: #1033
the CI showing error about action step: nix-post-check
