### PR TITLE
Nix: Simplify SLOTHY flake (use ortools from nixpkgs)

### DIFF
--- a/nix/slothy/default.nix
+++ b/nix/slothy/default.nix
@@ -2,68 +2,17 @@
 
 { stdenvNoCC
 , fetchFromGitHub
-, python312
+, python3
 , pkgs
-, python312Packages
-, fetchPypi
-, stdenv
-, cmake
-, pkg-config
 , llvm
-, gcc
 }:
 
-
 let
-
-  # I have experimented with the ortools (9.12) that is packaged in nixpkgs.
-  # However, it results in _much_ poorer SLOTHY performance and, we hence,
-  # instead stick to the pre-built ones from pypi.
-  ortools912 = python312Packages.buildPythonPackage rec {
-    pname = "ortools";
-    version = "9.12.4544";
-
-    format = "wheel";
-
-    src = fetchPypi {
-      inherit pname version;
-      format = "wheel";
-      dist = "cp312";
-      python = "cp312";
-      abi = "cp312";
-      platform =
-        if stdenv.isDarwin then
-          if stdenv.isAarch64 then "macosx_11_0_arm64"
-          else "macosx_10_15_x86_64"
-        else if stdenv.isLinux then
-          if stdenv.isAarch64 then "manylinux_2_27_aarch64.manylinux_2_28_aarch64"
-          else "manylinux_2_27_x86_64.manylinux_2_28_x86_64"
-        else throw "Unsupported platform";
-
-      hash =
-        if stdenv.isDarwin then
-          if stdenv.isAarch64 then "sha256-Z/4bhlMndFZ4okBm2CbbJaEBmqIH6pAXygGvLPIUVlI="
-          else "sha256-FnaLGfyzBT9EvYTEYMuXjyop1046XZugYSNYn+sQrxI="
-        else if stdenv.isLinux then
-          if stdenv.isAarch64 then "sha256-VVD+nuVSt7jtAcrZHVimjsDkjNQN0necELGZFCmncFg="
-          else "sha256-kiEh1vSPjuseuIqMZF/wC2H2CFYxkxTOK48iD6uJYIM="
-        else throw "Unsupported platform";
-    };
-
-    propagatedBuildInputs = with python312Packages; [
-      numpy
-      pandas
-      protobuf
-    ];
-
-  };
-
-  pythonEnv = python312.withPackages (ps: with ps; [
-    ortools912
+  pythonEnv = python3.withPackages (ps: with ps; [
+    ortools
     sympy
     unicorn
   ]);
-
 in
 stdenvNoCC.mkDerivation rec {
   pname = "slothy-cli";
@@ -89,10 +38,9 @@ stdenvNoCC.mkDerivation rec {
             --run exec
   '';
 
-
   dontStrip = true;
   noAuditTmpdir = true;
-  propagatedBuildInputs = [ pythonEnv llvm gcc ];
+  propagatedBuildInputs = [ pythonEnv llvm ];
 
   meta = {
     description = "Slothy: assembly-level superoptimizer";


### PR DESCRIPTION
I experimented more with using the ortools packaged in nixpkgs rather than taking it from pypi. I do not see any performance difference after running more experiments.
I think we can safely switch, greatly simplifying the flake.