### PR TITLE
Nix: Fix cbmc-viewer hash

### DIFF
--- a/nix/cbmc/cbmc-viewer.nix
+++ b/nix/cbmc/cbmc-viewer.nix
@@ -8,7 +8,7 @@ python3Packages.buildPythonApplication rec {
   version = "3.11";
   src = fetchurl {
     url = "https://github.com/model-checking/${pname}/releases/download/viewer-${version}/cbmc_viewer-${version}-py3-none-any.whl";
-    hash = "sha256-nt3AUmuL3kT1+Bl1XXDHHkMzPR1GbxvceFYluAnzkJ8=";
+    hash = "sha256-Oy51I64KMbtE8lG8xuFXdK4RvXFvWt4zYKBlcXqwILg=";
   };
   format = "wheel";
   dontUseSetuptoolsCheck = true;


### PR DESCRIPTION
The cbmc-viewer 3.11 release got retroactively updated and now contains a new whl that no longer matches the expected hash in our flake. This commit updates the hash to the one matching the current release.