### PR TITLE
Remove unnecessary MLK_CONFIG_MONOBUILD_XXX configuration options

### DIFF
--- a/examples/monolithic_build/mlkem_native_monobuild.c
+++ b/examples/monolithic_build/mlkem_native_monobuild.c
@@ -33,14 +33,16 @@
  *
  * # Configuration
  *
- * - MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202
+ * The following options from the mlkem-native configuration are relevant:
+ *
+ * - MLK_CONFIG_FIPS202_CUSTOM_HEADER
  *   Set this option if you use a custom FIPS202 implementation.
  *
- * - MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH
+ * - MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
  *   Set this option if you want to include the native arithmetic backends
  *   in your build.
  *
- * - MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202
+ * - MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202
  *   Set this option if you want to include the native FIPS202 backends
  *   in your build.
  *
@@ -54,11 +56,11 @@
  *
  * Example:
  * ```bash
- * unifdef -UMLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH mlkem_native_monobuild.c
+ * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_monobuild.c
  * ```
  */
 
-#include "mlkem/sys.h"
+#include "mlkem/common.h"
 
 #include "mlkem/compress.c"
 #include "mlkem/debug.c"
@@ -69,13 +71,13 @@
 #include "mlkem/sampling.c"
 #include "mlkem/verify.c"
 
-#if !defined(MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202)
+#if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)
 #include "mlkem/fips202/fips202.c"
 #include "mlkem/fips202/fips202x4.c"
 #include "mlkem/fips202/keccakf1600.c"
 #endif
 
-#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH)
+#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
 #if defined(MLK_SYS_AARCH64)
 #include "mlkem/native/aarch64/src/aarch64_zetas.c"
 #include "mlkem/native/aarch64/src/rej_uniform_table.c"
@@ -87,16 +89,16 @@
 #include "mlkem/native/x86_64/src/rej_uniform_avx2.c"
 #include "mlkem/native/x86_64/src/rej_uniform_table.c"
 #endif /* MLK_SYS_X86_64 */
-#endif /* MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH */
+#endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
 
-#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202)
+#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 #if defined(MLK_SYS_AARCH64)
 #include "mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c"
 #endif
 #if defined(MLK_SYS_X86_64)
 #include "mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c"
 #endif
-#endif /* MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202 */
+#endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 
 /*
  * Undefine macros from MLK_CONFIG_PARAMETER_SET-specific files
@@ -326,7 +328,7 @@
 #undef __contract__
 #undef __loop__
 
-#if !defined(MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202)
+#if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)
 /*
  * Undefine macros from FIPS-202 files
  */
@@ -364,9 +366,9 @@
 #undef mlk_keccakf1600x4_extract_bytes
 #undef mlk_keccakf1600x4_permute
 #undef mlk_keccakf1600x4_xor_bytes
-#endif /* !MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202 */
+#endif /* !MLK_CONFIG_FIPS202_CUSTOM_HEADER */
 
-#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202)
+#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 /*
  * Undefine macros from native code
  */
@@ -411,8 +413,8 @@
 #undef MLK_FIPS202_NATIVE_X86_64_XKCP_H
 #undef MLK_FIPS202_X86_64_XKCP
 #undef MLK_USE_FIPS202_X4_NATIVE
-#endif /* MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202 */
-#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH)
+#endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
+#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
 /*
  * Undefine macros from native code
  */
@@ -519,5 +521,5 @@
 #undef MLK_AVX2_BACKEND_DATA_OFFSET_ZETAS_EXP
 #undef MLK_NATIVE_X86_64_SRC_CONSTS_H
 #undef mlk_qdata
-#endif /* MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH */
+#endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
 #endif /* !MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */

--- a/examples/monolithic_build_multilevel_native/README.md
+++ b/examples/monolithic_build_multilevel_native/README.md
@@ -19,10 +19,6 @@ appropriately first, and then includes the monobuild:
 
 #define MLK_CONFIG_FILE "multilevel_config.h"
 
-/* Include C files accompanying native code */
-#define MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH
-#define MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202
-
 /* Include level-independent code */
 #define MLK_CONFIG_MULTILEVEL_WITH_SHARED 1
 /* Keep level-independent headers at the end of monobuild file */

--- a/examples/monolithic_build_multilevel_native/mlkem_native_all.c
+++ b/examples/monolithic_build_multilevel_native/mlkem_native_all.c
@@ -7,10 +7,6 @@
 
 #define MLK_CONFIG_FILE "multilevel_config.h"
 
-/* Include C files accompanying native code */
-#define MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH
-#define MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202
-
 /* Include level-independent code */
 #define MLK_CONFIG_MULTILEVEL_WITH_SHARED 1
 /* Keep level-independent headers at the end of monobuild file */

--- a/mlkem/config.h
+++ b/mlkem/config.h
@@ -116,6 +116,22 @@
 /* #define MLK_CONFIG_MULTILEVEL_NO_SHARED */
 
 /******************************************************************************
+ * Name:        MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mlkem-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
+/******************************************************************************
  * Name:        MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
  * Description: Determines whether an native arithmetic backend should be used.

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1212,6 +1212,7 @@ def gen_monolithic_source_file(dry_run=False):
     def gen():
         c_sources = get_c_source_files(main_only=True)
         yield from gen_header()
+
         yield "/*"
         yield " * Monolithic compilation unit bundling all compilation units within mlkem-native"
         yield " */"
@@ -1236,14 +1237,16 @@ def gen_monolithic_source_file(dry_run=False):
         yield " *"
         yield " * # Configuration"
         yield " *"
-        yield " * - MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202"
+        yield " * The following options from the mlkem-native configuration are relevant:"
+        yield " *"
+        yield " * - MLK_CONFIG_FIPS202_CUSTOM_HEADER"
         yield " *   Set this option if you use a custom FIPS202 implementation."
         yield " *"
-        yield " * - MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH"
+        yield " * - MLK_CONFIG_USE_NATIVE_BACKEND_ARITH"
         yield " *   Set this option if you want to include the native arithmetic backends"
         yield " *   in your build."
         yield " *"
-        yield " * - MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202"
+        yield " * - MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202"
         yield " *   Set this option if you want to include the native FIPS202 backends"
         yield " *   in your build."
         yield " *"
@@ -1251,27 +1254,27 @@ def gen_monolithic_source_file(dry_run=False):
         yield " *   Set this option if you want to keep the directives defined in"
         yield " *   level-independent headers. This is needed for a multi-level build."
         yield " */"
-        yield ""
-        yield "/* If parts of the mlkem-native source tree are not used,"
+        yield " "
+        yield " /* If parts of the mlkem-native source tree are not used,"
         yield " * consider reducing this header via `unifdef`."
         yield " *"
         yield " * Example:"
         yield " * ```bash"
-        yield " * unifdef -UMLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH mlkem_native_monobuild.c"
+        yield " * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_monobuild.c"
         yield " * ```"
         yield " */"
         yield ""
-        yield '#include "mlkem/sys.h"'
+        yield '#include "mlkem/common.h"'
         yield ""
         for c in filter(lambda c: not native(c) and not fips202(c), c_sources):
             yield f'#include "{c}"'
         yield ""
-        yield "#if !defined(MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202)"
+        yield "#if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)"
         for c in filter(lambda c: not native(c) and fips202(c), c_sources):
             yield f'#include "{c}"'
         yield "#endif"
         yield ""
-        yield "#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH)"
+        yield "#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)"
         yield "#if defined(MLK_SYS_AARCH64)"
         for c in filter(native_arith_aarch64, c_sources):
             yield f'#include "{c}"'
@@ -1282,7 +1285,7 @@ def gen_monolithic_source_file(dry_run=False):
         yield "#endif"
         yield "#endif"
         yield ""
-        yield "#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202)"
+        yield "#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)"
         yield "#if defined(MLK_SYS_AARCH64)"
         for c in filter(native_fips202_aarch64, c_sources):
             yield f'#include "{c}"'
@@ -1313,19 +1316,19 @@ def gen_monolithic_source_file(dry_run=False):
         yield "#undef __contract__"
         yield "#undef __loop__"
         yield ""
-        yield "#if !defined(MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202)"
+        yield "#if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)"
         yield from gen_monolithic_undef_all_core(
             filt=lambda c: not native(c) and k_generic(c) and fips202(c),
             desc="FIPS-202 files",
         )
         yield "#endif"
         yield ""
-        yield "#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202)"
+        yield "#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)"
         yield from gen_monolithic_undef_all_core(
             filt=native_fips202, desc="native code"
         )
         yield "#endif"
-        yield "#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH)"
+        yield "#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)"
         yield from gen_monolithic_undef_all_core(filt=native_arith, desc="native code")
         yield "#endif"
         yield "#endif"


### PR DESCRIPTION
Previously, we had a various configurations options

MLK_CONFIG_MONOBUILD_XXX

which would control what the SCU file mlkem_native_monobuild.c does.

However, most of those options are actually already covered by the mlkem-native configuration, which the SCU file must have access to anyway. This is different from the configuration options for mlkem_native.h, which may be used in a context where the original sources, including the full configuration, are not present -- in this case, separate configuration options are required.

For the SCU file, however, the following monobuild configuration options are subsumed by configuration options, and can just be suitably renamed:

- MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH -> MLK_CONFIG_USE_NATIVE_BACKEND_ARITH

- MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202 -> MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202

- MLK_CONFIG_MONOBUILD_CUSTOM_FIPS202 -> defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)
