### PR TITLE
autogen: Add monolithic assembly file

### DIFF
--- a/examples/monolithic_build_multilevel_native/Makefile
+++ b/examples/monolithic_build_multilevel_native/Makefile
@@ -21,12 +21,7 @@ endif
 # mlkem-native source and header files
 #
 # Here, the mlkem-native C source is directly included in main.c.
-MLK_SOURCE_ASM = $(wildcard \
-	mlkem/**/*.S                 \
-	mlkem/**/**/*.S              \
-	mlkem/**/**/**/*.S           \
-	mlkem/**/**/**/**/*.S        \
-	mlkem/**/**/**/**/**/*.S)
+MLK_SOURCE_ASM = mlkem_native_monobuild.S
 
 INC=-Imlkem/ -I./
 

--- a/examples/monolithic_build_multilevel_native/mlkem_native_monobuild.S
+++ b/examples/monolithic_build_multilevel_native/mlkem_native_monobuild.S
@@ -9,28 +9,26 @@
  */
 
 /*
- * Monolithic compilation unit bundling all compilation units within
- * mlkem-native
+ * Monolithic assembly unit bundling all assembly units within mlkem-native
  */
 
 /******************************************************************************
  *
- * Single compilation unit (SCU) for fixed-level build of mlkem-native
+ * Single assembly unit for fixed-level build of mlkem-native
  *
- * This compilation unit bundles together all source files for a build
+ * This assembly unit bundles together all assembly files for a build
  * of mlkem-native for a fixed security level (MLKEM-512/768/1024).
- *
- * # API
- *
- * The API exposed by this file is described in mlkem_native.h.
  *
  * # Multi-level build
  *
  * If you want an SCU build of mlkem-native with support for multiple security
- * levels, you need to include this file multiple times, and set
- * MLK_CONFIG_MULTILEVEL_WITH_SHARED and MLK_CONFIG_MULTILEVEL_NO_SHARED
- * appropriately. This is exemplified in examples/monolithic_build_multilevel
- * and examples/monolithic_build_multilevel_native.
+ * levels, you should include this file once with
+ * MLK_CONFIG_MULTILEVEL_WITH_SHARED set. For convenience, you can also follow
+ * the same pattern as for mlkem_native_monobuild.c and include it for every
+ * level, setting MLK_CONFIG_MULTILEVEL_NO_SHARED for all but one. For builds
+ * with MLK_CONFIG_MULTILEVEL_NO_SHARED, this file will then be ignored. See
+ * examples/monolithic_build_multilevel and
+ * examples/monolithic_build_multilevel_native.
  *
  * # Configuration
  *
@@ -57,47 +55,47 @@
  *
  * Example:
  * ```bash
- * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_monobuild.c
+ * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_monobuild.S
  * ```
  */
 
 #include "mlkem/common.h"
 
-#include "mlkem/compress.c"
-#include "mlkem/debug.c"
-#include "mlkem/indcpa.c"
-#include "mlkem/kem.c"
-#include "mlkem/poly.c"
-#include "mlkem/poly_k.c"
-#include "mlkem/sampling.c"
-#include "mlkem/verify.c"
-
-#if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)
-#include "mlkem/fips202/fips202.c"
-#include "mlkem/fips202/fips202x4.c"
-#include "mlkem/fips202/keccakf1600.c"
-#endif
-
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
 #if defined(MLK_SYS_AARCH64)
-#include "mlkem/native/aarch64/src/aarch64_zetas.c"
-#include "mlkem/native/aarch64/src/rej_uniform_table.c"
-#endif
+#include "mlkem/native/aarch64/src/intt.S"
+#include "mlkem/native/aarch64/src/ntt.S"
+#include "mlkem/native/aarch64/src/poly_mulcache_compute_asm.S"
+#include "mlkem/native/aarch64/src/poly_reduce_asm.S"
+#include "mlkem/native/aarch64/src/poly_tobytes_asm.S"
+#include "mlkem/native/aarch64/src/poly_tomont_asm.S"
+#include "mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S"
+#include "mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S"
+#include "mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S"
+#include "mlkem/native/aarch64/src/rej_uniform_asm.S"
+#endif /* MLK_SYS_AARCH64 */
 #if defined(MLK_SYS_X86_64)
-#include "mlkem/native/x86_64/src/basemul.c"
-#include "mlkem/native/x86_64/src/compress_avx2.c"
-#include "mlkem/native/x86_64/src/consts.c"
-#include "mlkem/native/x86_64/src/rej_uniform_avx2.c"
-#include "mlkem/native/x86_64/src/rej_uniform_table.c"
+#include "mlkem/native/x86_64/src/basemul.S"
+#include "mlkem/native/x86_64/src/intt.S"
+#include "mlkem/native/x86_64/src/mulcache_compute.S"
+#include "mlkem/native/x86_64/src/ntt.S"
+#include "mlkem/native/x86_64/src/nttfrombytes.S"
+#include "mlkem/native/x86_64/src/ntttobytes.S"
+#include "mlkem/native/x86_64/src/nttunpack.S"
+#include "mlkem/native/x86_64/src/reduce.S"
+#include "mlkem/native/x86_64/src/tomont.S"
 #endif /* MLK_SYS_X86_64 */
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
 #if defined(MLK_SYS_AARCH64)
-#include "mlkem/fips202/native/aarch64/src/keccakf1600_round_constants.c"
-#endif
+#include "mlkem/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S"
+#include "mlkem/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S"
+#include "mlkem/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S"
+#include "mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S"
+#include "mlkem/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S"
+#endif /* MLK_SYS_AARCH64 */
 #if defined(MLK_SYS_X86_64)
-#include "mlkem/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c"
 #endif
 #endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
 
@@ -324,10 +322,6 @@
 #undef MLK_USE_ASM_VALUE_BARRIER
 #undef MLK_VERIFY_H
 #undef mlk_ct_opt_blocker_u64
-/* mlkem/cbmc.h */
-#undef MLK_CBMC_H
-#undef __contract__
-#undef __loop__
 
 #if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)
 /*
@@ -369,7 +363,7 @@
 #undef mlk_keccakf1600x4_xor_bytes
 #endif /* !MLK_CONFIG_FIPS202_CUSTOM_HEADER */
 
-#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
+#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202)
 /*
  * Undefine macros from native code
  */
@@ -414,8 +408,8 @@
 #undef MLK_FIPS202_NATIVE_X86_64_XKCP_H
 #undef MLK_FIPS202_X86_64_XKCP
 #undef MLK_USE_FIPS202_X4_NATIVE
-#endif /* MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
-#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
+#endif /* MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202 */
+#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH)
 /*
  * Undefine macros from native code
  */
@@ -522,5 +516,5 @@
 #undef MLK_AVX2_BACKEND_DATA_OFFSET_ZETAS_EXP
 #undef MLK_NATIVE_X86_64_SRC_CONSTS_H
 #undef mlk_qdata
-#endif /* MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
+#endif /* MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH */
 #endif /* !MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1233,7 +1233,8 @@ def gen_monolithic_source_file(dry_run=False):
         yield " * If you want an SCU build of mlkem-native with support for multiple security"
         yield " * levels, you need to include this file multiple times, and set"
         yield " * MLK_CONFIG_MULTILEVEL_WITH_SHARED and MLK_CONFIG_MULTILEVEL_NO_SHARED"
-        yield " * appropriately. This is exemplified in examples/monolithic_build_multilevel."
+        yield " * appropriately. This is exemplified in examples/monolithic_build_multilevel"
+        yield " * and examples/monolithic_build_multilevel_native."
         yield " *"
         yield " * # Configuration"
         yield " *"
@@ -1338,6 +1339,186 @@ def gen_monolithic_source_file(dry_run=False):
         "examples/monolithic_build/mlkem_native_monobuild.c",
         "\n".join(gen()),
         dry_run=dry_run,
+    )
+
+
+def gen_monolithic_asm_file(dry_run=False):
+
+    def native(c):
+        return "native/" in c
+
+    def fips202(c):
+        return "fips202" in c
+
+    def aarch64(c):
+        return "aarch64" in c
+
+    def x86_64(c):
+        return "x86_64" in c
+
+    def native_fips202(c):
+        return native(c) and fips202(c)
+
+    def native_arith(c):
+        return native(c) and not fips202(c)
+
+    def native_fips202_aarch64(c):
+        return native_fips202(c) and aarch64(c)
+
+    def native_fips202_x86_64(c):
+        return native_fips202(c) and x86_64(c)
+
+    def native_arith_aarch64(c):
+        return native_arith(c) and aarch64(c)
+
+    def native_arith_x86_64(c):
+        return native_arith(c) and x86_64(c)
+
+    # List of level-specific source files
+    # All other files only need including and building once
+    # in multi-level build.
+    def k_specific(c):
+        k_specific_sources = [
+            # sys.h is not k-specific, but has some macro-overlap with
+            # mlkem_native.h. Since the macros from mlkem_native.h are
+            # undef'ed after each level-include in a multi-level build
+            # we thus have to re-include sys.h as well.
+            "sys.h",
+            "mlkem_native.h",
+            "params.h",
+            # Deliberately omit config.h, which is not #undef'ed
+            "common.h",
+            "indcpa.c",
+            "indcpa.h",
+            "kem.c",
+            "kem.h",
+            "poly_k.c",
+            "poly_k.h",
+        ]
+        for f in k_specific_sources:
+            if c.endswith(f):
+                return True
+        return False
+
+    def k_generic(c):
+        return not k_specific(c) and c != "mlkem/config.h"
+
+    def gen():
+        asm_sources = get_asm_source_files(main_only=True)
+        yield from gen_header()
+        yield "/*"
+        yield " * Monolithic assembly unit bundling all assembly units within mlkem-native"
+        yield " */"
+        yield ""
+        yield "/******************************************************************************"
+        yield " *"
+        yield " * Single assembly unit for fixed-level build of mlkem-native"
+        yield " *"
+        yield " * This assembly unit bundles together all assembly files for a build"
+        yield " * of mlkem-native for a fixed security level (MLKEM-512/768/1024)."
+        yield " *"
+        yield " * # Multi-level build"
+        yield " *"
+        yield " * If you want an SCU build of mlkem-native with support for multiple security"
+        yield " * levels, you should include this file once with MLK_CONFIG_MULTILEVEL_WITH_SHARED set."
+        yield " * For convenience, you can also follow the same pattern as for mlkem_native_monobuild.c"
+        yield " * and include it for every level, setting MLK_CONFIG_MULTILEVEL_NO_SHARED for all but one."
+        yield " * For builds with MLK_CONFIG_MULTILEVEL_NO_SHARED, this file will then be ignored."
+        yield " * See examples/monolithic_build_multilevel and examples/monolithic_build_multilevel_native."
+        yield " *"
+        yield " * # Configuration"
+        yield " *"
+        yield " * The following options from the mlkem-native configuration are relevant:"
+        yield " *"
+        yield " * - MLK_CONFIG_FIPS202_CUSTOM_HEADER"
+        yield " *   Set this option if you use a custom FIPS202 implementation."
+        yield " *"
+        yield " * - MLK_CONFIG_USE_NATIVE_BACKEND_ARITH"
+        yield " *   Set this option if you want to include the native arithmetic backends"
+        yield " *   in your build."
+        yield " *"
+        yield " * - MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202"
+        yield " *   Set this option if you want to include the native FIPS202 backends"
+        yield " *   in your build."
+        yield " *"
+        yield " * - MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS"
+        yield " *   Set this option if you want to keep the directives defined in"
+        yield " *   level-independent headers. This is needed for a multi-level build."
+        yield " */"
+        yield ""
+        yield "/* If parts of the mlkem-native source tree are not used,"
+        yield " * consider reducing this header via `unifdef`."
+        yield " *"
+        yield " * Example:"
+        yield " * ```bash"
+        yield " * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_monobuild.S"
+        yield " * ```"
+        yield " */"
+        yield ""
+        yield '#include "mlkem/common.h"'
+        yield ""
+        yield "#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)"
+        yield "#if defined(MLK_SYS_AARCH64)"
+        for c in filter(native_arith_aarch64, asm_sources):
+            yield f'#include "{c}"'
+        yield "#endif"
+        yield "#if defined(MLK_SYS_X86_64)"
+        for c in filter(native_arith_x86_64, asm_sources):
+            yield f'#include "{c}"'
+        yield "#endif"
+        yield "#endif"
+        yield ""
+        yield "#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)"
+        yield "#if defined(MLK_SYS_AARCH64)"
+        for c in filter(native_fips202_aarch64, asm_sources):
+            yield f'#include "{c}"'
+        yield "#endif"
+        yield "#if defined(MLK_SYS_X86_64)"
+        for c in filter(native_fips202_x86_64, asm_sources):
+            yield f'#include "{c}"'
+        yield "#endif"
+        yield "#endif"
+        yield ""
+        # We generate #undef's for all headers, even though most are not
+        # included by the assembly files. This does not harm, and avoids
+        # having to trace which headers are being pulled in from common.h
+        # included from the assembly files.
+        yield from gen_monolithic_undef_all_core(
+            filt=k_specific, desc="MLK_CONFIG_PARAMETER_SET-specific files"
+        )
+        yield ""
+        yield "#if !defined(MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS)"
+        yield from gen_monolithic_undef_all_core(
+            filt=lambda c: not native(c)
+            and k_generic(c)
+            and not fips202(c)
+            and "cbmc.h" not in c,
+            desc="MLK_CONFIG_PARAMETER_SET-generic files",
+        )
+        yield ""
+        yield "#if !defined(MLK_CONFIG_FIPS202_CUSTOM_HEADER)"
+        yield from gen_monolithic_undef_all_core(
+            filt=lambda c: not native(c) and k_generic(c) and fips202(c),
+            desc="FIPS-202 files",
+        )
+        yield "#endif"
+        yield ""
+        yield "#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_FIPS202)"
+        yield from gen_monolithic_undef_all_core(
+            filt=native_fips202, desc="native code"
+        )
+        yield "#endif"
+        yield "#if defined(MLK_CONFIG_MONOBUILD_WITH_NATIVE_ARITH)"
+        yield from gen_monolithic_undef_all_core(filt=native_arith, desc="native code")
+        yield "#endif"
+        yield "#endif"
+        yield ""
+
+    update_file(
+        "examples/monolithic_build_multilevel_native/mlkem_native_monobuild.S",
+        "\n".join(gen()),
+        dry_run=dry_run,
+        force_format=True,
     )
 
 
@@ -2305,6 +2486,7 @@ def _main():
     gen_header_guards(args.dry_run)
     gen_preprocessor_comments(args.dry_run)
     gen_monolithic_source_file(args.dry_run)
+    gen_monolithic_asm_file(args.dry_run)
     gen_undefs(args.dry_run)
 
     synchronize_backends(


### PR DESCRIPTION
* Builds on #1067 
* Builds on #1063

Analogous to the SCU file examples/monolithic_build/mlkem_native_monobuild.c,
this commit extends autogen to emit a monolithic mlkem_native_monobuild.S
in the monolithic_build_multilevel_native example. This demonstrates that
all ASM files are concatenable into a single assembly unit. This relies on
the prework undefining register aliases, assembly directives, and making
ASM labels unique.