### PR TITLE
AWS-LC integration: Keep flat file structure

### DIFF
--- a/integration/awslc/awslc.patch
+++ b/integration/awslc/awslc.patch
@@ -1,24 +1,18 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 diff --git a/crypto/fipsmodule/ml_kem/importer.sh b/crypto/fipsmodule/ml_kem/importer.sh
-index b1114479c..0d9d2810e 100755
+index b1114479c..8cbf7015e 100755
 --- a/crypto/fipsmodule/ml_kem/importer.sh
 +++ b/crypto/fipsmodule/ml_kem/importer.sh
-@@ -73,11 +73,11 @@ popd
- echo "Pull source code from remote repository..."
-
+@@ -74,7 +74,7 @@ echo "Pull source code from remote repository..."
+ 
  # Copy mlkem-native source tree -- C-only, no FIPS-202
--mkdir $SRC
+ mkdir $SRC
 -cp $TMP/mlkem/* $SRC
-+mkdir -p $SRC/src
-+cp $TMP/mlkem/src/* $SRC/src
-
++cp $TMP/mlkem/src/* $SRC
+ 
  # We use the custom `mlkem_native_config.h`, so can remove the default one
--rm $SRC/config.h
-+rm $SRC/src/config.h
-
- # Copy formatting file
- cp $TMP/.clang-format $SRC
+ rm $SRC/config.h
 @@ -86,10 +86,10 @@ cp $TMP/.clang-format $SRC
  # The static simplification is not necessary, but improves readability
  # by removing directives related to native backends that are irrelevant
@@ -32,72 +26,43 @@ index b1114479c..0d9d2810e 100755
 +        -UMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202                        \
 +        $TMP/mlkem/mlkem_native.c                                      \
          > $SRC/mlkem_native_bcm.c
-
+ 
  # Modify include paths to match position of mlkem_native_bcm.c
-@@ -101,8 +101,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
- else
+@@ -102,7 +102,7 @@ else
    SED_I=(-i)
  fi
--echo "Fixup include paths"
+ echo "Fixup include paths"
 -sed "${SED_I[@]}" 's/#include "mlkem\/\([^"]*\)"/#include "\1"/' $SRC/mlkem_native_bcm.c
-
++sed "${SED_I[@]}" 's/#include "src\/\([^"]*\)"/#include "\1"/' $SRC/mlkem_native_bcm.c
+ 
  echo "Remove temporary artifacts ..."
  rm -rf $TMP
 diff --git a/crypto/fipsmodule/ml_kem/ml_kem.c b/crypto/fipsmodule/ml_kem/ml_kem.c
-index 2d6f5ad91..325dee563 100644
+index 2d6f5ad91..21a4a591b 100644
 --- a/crypto/fipsmodule/ml_kem/ml_kem.c
 +++ b/crypto/fipsmodule/ml_kem/ml_kem.c
-@@ -4,9 +4,7 @@
- // mlkem-native source code
-
+@@ -5,8 +5,6 @@
+ 
  // Include level-independent code
--#define MLK_CONFIG_FILE "../mlkem_native_config.h"
+ #define MLK_CONFIG_FILE "../mlkem_native_config.h"
 -#define MLK_CONFIG_FIPS202_CUSTOM_HEADER "../fips202_glue.h"
 -#define MLK_CONFIG_FIPS202X4_CUSTOM_HEADER "../fips202x4_glue.h"
-+#define MLK_CONFIG_FILE "../../mlkem_native_config.h"
  #define MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
-
+ 
  // MLKEM-512
 diff --git a/crypto/fipsmodule/ml_kem/mlkem_native_config.h b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
-index 643b8a833..0ee77ff6a 100644
+index 643b8a833..aa4f24f72 100644
 --- a/crypto/fipsmodule/ml_kem/mlkem_native_config.h
 +++ b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
 @@ -11,6 +11,11 @@
  // mlkem512*, mlkem768*, mlkem1024*.
  #define MLK_CONFIG_NAMESPACE_PREFIX mlkem
-
+ 
 +// Replace mlkem-native's FIPS 202 headers with glue code to
 +// AWS-LC's own FIPS 202 implementation.
-+#define MLK_CONFIG_FIPS202_CUSTOM_HEADER "../../fips202_glue.h"
-+#define MLK_CONFIG_FIPS202X4_CUSTOM_HEADER "../../fips202x4_glue.h"
++#define MLK_CONFIG_FIPS202_CUSTOM_HEADER "../fips202_glue.h"
++#define MLK_CONFIG_FIPS202X4_CUSTOM_HEADER "../fips202x4_glue.h"
 +
  // Everything is built in a single CU, so both internal and external
  // mlkem-native API can have internal linkage.
  #define MLK_CONFIG_INTERNAL_API_QUALIFIER static
-@@ -24,7 +29,7 @@
- #if defined(BORINGSSL_FIPS_BREAK_TESTS)
- #define MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
- #if !defined(__ASSEMBLER__) && !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
--#include "mlkem/sys.h"
-+#include "mlkem/src/sys.h"
- static MLK_INLINE int mlk_break_pct(void) {
-   return boringssl_fips_break_test("MLKEM_PWCT");
- }
-@@ -41,7 +46,7 @@ static MLK_INLINE int mlk_break_pct(void) {
- #define MLK_CONFIG_CUSTOM_ZEROIZE
- #if !defined(__ASSEMBLER__) && !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
- #include <stdint.h>
--#include "mlkem/sys.h"
-+#include "mlkem/src/sys.h"
- #include <openssl/base.h>
- static MLK_INLINE void mlk_zeroize(void *ptr, size_t len) {
-     OPENSSL_cleanse(ptr, len);
-@@ -52,7 +57,7 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len) {
- #define MLK_CONFIG_CUSTOM_RANDOMBYTES
- #if !defined(__ASSEMBLER__) && !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
- #include <stdint.h>
--#include "mlkem/sys.h"
-+#include "mlkem/src/sys.h"
- #include <openssl/rand.h>
- static MLK_INLINE void mlk_randombytes(void *ptr, size_t len) {
-     RAND_bytes(ptr, len);


### PR DESCRIPTION
This commit modifies the AWS-LC importer patch to that the mlkem/src/* files are imported into `crypto/fipsmodule/ml_kem/mlkem/*` rather than `crypto/fipsmodule/ml_kem/mlkem/src/*`. The SCU file mlkem_native.c was already part of `crypto/fipsmodule/ml_kem/mlkem/*`,] and `mlkem_native.S` and `mlkem_native.h` are not used in the AWS-LC import for the time being.
