### PR TITLE
CI: Add windows-2025 tests, remove windows-2019 tests

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [windows-latest, windows-2022, windows-2019]
+        system: [windows-2025, windows-2022]
     name: Quickcheck ${{ matrix.system }}
     runs-on: ${{ matrix.system }}
     steps:


### PR DESCRIPTION
Github is phasing out windows-2019:
https://github.com/actions/runner-images/issues/12045

This commit removes windows-2019 from the tests and instead adds windows-2025 tests.
It also removes the duplicate windows-latest (which is equivalent to windows-2022)

