### PR TITLE
Nix: Remove zig 0.10 and zig 0.11 shells and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,20 +236,6 @@ jobs:
          #
          # We omit all examples since there is currently no way to run
          # only those examples not involving native code.
-         - name: zig-0.10
-           shell: ci_zig0_10
-           darwin: False
-           c17: True
-           c23: False
-           examples: False
-           opt: no_opt
-         - name: zig-0.11
-           shell: ci_zig0_11
-           darwin: True
-           c17: True
-           c23: False
-           examples: False
-           opt: no_opt
          - name: zig-0.12
            shell: ci_zig0_12
            darwin: True

--- a/flake.nix
+++ b/flake.nix
@@ -50,8 +50,6 @@
                 gcc48 = pkgs-2405.gcc48;
                 gcc49 = pkgs-2405.gcc49;
                 gcc7 = pkgs-2405.gcc7;
-                zig_0_10 = pkgs-2405.zig_0_10;
-                zig_0_11 = pkgs-2405.zig_0_11;
               })
             ];
           };
@@ -107,8 +105,6 @@
           devShells.ci_clang19 = util.mkShellWithCC' pkgs.clang_19;
           devShells.ci_clang20 = util.mkShellWithCC' pkgs.clang_20;
 
-          devShells.ci_zig0_10 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_10);
-          devShells.ci_zig0_11 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_11);
           devShells.ci_zig0_12 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_12);
           devShells.ci_zig0_13 = util.mkShellWithCC' (zigWrapCC pkgs.zig_0_13);
           devShells.ci_zig0_14 = util.mkShellWithCC' (zigWrapCC pkgs.zig);


### PR DESCRIPTION
zig0.11 seems to have dropped from the nix binary cache for MacOS. This means it has to be built from source in the CI significanlty slowing down CI.
Note that both zig 0.10 and zig 0.11 have been dropped in nixpkgs 25.05, so it is expected that it is eventually dropped from the cache. This commit removes zig 0.11 and the even older zig 0.10.