### PR TITLE
simpasm: Add marker at start/end of core assembly

### DIFF
--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_scalar_asm.S
@@ -22,6 +22,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x1_scalar_asm)
 MLK_ASM_FN_SYMBOL(keccak_f1600_x1_scalar_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: keccak_f1600_x1_scalar_asm */
 
         sub	sp, sp, #0x80
         stp	x19, x20, [sp, #0x20]
@@ -315,6 +320,8 @@ keccak_f1600_x1_scalar_loop:
         ldp	x29, x30, [sp, #0x70]
         add	sp, sp, #0x80
         ret
+
+/* Assembly end: keccak_f1600_x1_scalar_asm */
 
 #endif /* MLK_FIPS202_AARCH64_NEED_X1_SCALAR && \
           !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_asm.S
@@ -39,6 +39,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x1_v84a_asm)
 MLK_ASM_FN_SYMBOL(keccak_f1600_x1_v84a_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: keccak_f1600_x1_v84a_asm */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -149,6 +154,8 @@ keccak_f1600_x1_v84a_loop:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: keccak_f1600_x1_v84a_asm */
 
 #endif /* __ARM_FEATURE_SHA3 */
 

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_asm.S
@@ -39,6 +39,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x2_v84a_asm)
 MLK_ASM_FN_SYMBOL(keccak_f1600_x2_v84a_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: keccak_f1600_x2_v84a_asm */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -203,6 +208,8 @@ keccak_f1600_x2_v84a_loop:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: keccak_f1600_x2_v84a_asm */
 
 #endif /* __ARM_FEATURE_SHA3 */
 

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_asm.S
@@ -22,6 +22,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_hybrid_asm)
 MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_hybrid_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: keccak_f1600_x4_scalar_v8a_hybrid_asm */
 
         sub	sp, sp, #0xe0
         stp	x19, x20, [sp, #0x30]
@@ -999,6 +1004,8 @@ keccak_f1600_x4_scalar_v8a_hybrid_done:
         ldp	x29, x30, [sp, #0x80]
         add	sp, sp, #0xe0
         ret
+
+/* Assembly end: keccak_f1600_x4_scalar_v8a_hybrid_asm */
 
 #endif /* MLK_FIPS202_AARCH64_NEED_X4_V8A_SCALAR_HYBRID && \
           !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm.S
@@ -24,6 +24,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm)
 MLK_ASM_FN_SYMBOL(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm */
 
         sub	sp, sp, #0xe0
         stp	x19, x20, [sp, #0x30]
@@ -907,6 +912,8 @@ keccak_f1600_x4_scalar_v8a_v84a_hybrid_done:
         ldp	x29, x30, [sp, #0x80]
         add	sp, sp, #0xe0
         ret
+
+/* Assembly end: keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm */
 
 #endif /* __ARM_FEATURE_SHA3 */
 

--- a/mlkem/src/native/aarch64/src/intt.S
+++ b/mlkem/src/native/aarch64/src/intt.S
@@ -34,6 +34,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(intt_asm)
 MLK_ASM_FN_SYMBOL(intt_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: intt_asm */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -563,5 +568,7 @@ intt_layer123_start:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: intt_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/aarch64/src/ntt.S
+++ b/mlkem/src/native/aarch64/src/ntt.S
@@ -34,6 +34,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(ntt_asm)
 MLK_ASM_FN_SYMBOL(ntt_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: ntt_asm */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -360,5 +365,7 @@ ntt_layer4567_start:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: ntt_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/aarch64/src/poly_mulcache_compute_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -17,6 +17,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_mulcache_compute_asm)
 MLK_ASM_FN_SYMBOL(poly_mulcache_compute_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: poly_mulcache_compute_asm */
 
         mov	w5, #0xd01              // =3329
         dup	v6.8h, w5
@@ -47,5 +52,7 @@ poly_mulcache_compute_loop:
         mls	v2.8h, v27.8h, v6.h[0]
         str	q2, [x0], #0x10
         ret
+
+/* Assembly end: poly_mulcache_compute_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/aarch64/src/poly_reduce_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_reduce_asm.S
@@ -17,6 +17,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_reduce_asm)
 MLK_ASM_FN_SYMBOL(poly_reduce_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: poly_reduce_asm */
 
         mov	w2, #0xd01              // =3329
         dup	v3.8h, w2
@@ -93,5 +98,7 @@ poly_reduce_loop:
         add	v24.8h, v24.8h, v31.8h
         stur	q24, [x0, #-0x40]
         ret
+
+/* Assembly end: poly_reduce_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/aarch64/src/poly_tobytes_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_tobytes_asm.S
@@ -16,6 +16,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_tobytes_asm)
 MLK_ASM_FN_SYMBOL(poly_tobytes_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: poly_tobytes_asm */
 
         mov	x2, #0x10               // =16
         ldr	q6, [x1], #0x20
@@ -105,5 +110,7 @@ poly_tobytes_loop_start:
         sli	v23.8b, v5.8b, #0x4
         st3	{ v22.8b, v23.8b, v24.8b }, [x0], #24
         ret
+
+/* Assembly end: poly_tobytes_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/aarch64/src/poly_tomont_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_tomont_asm.S
@@ -17,6 +17,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_tomont_asm)
 MLK_ASM_FN_SYMBOL(poly_tomont_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: poly_tomont_asm */
 
         mov	w2, #0xd01              // =3329
         dup	v4.8h, w2
@@ -73,5 +78,7 @@ poly_tomont_loop:
         stur	q27, [x0, #-0x20]
         stur	q23, [x0, #-0x40]
         ret
+
+/* Assembly end: poly_tomont_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
+++ b/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S
@@ -29,6 +29,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
 MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: polyvec_basemul_acc_montgomery_cached_asm_k2 */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -198,6 +203,8 @@ polyvec_basemul_acc_montgomery_cached_k2_loop:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: polyvec_basemul_acc_montgomery_cached_asm_k2 */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 2) */

--- a/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
+++ b/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
@@ -29,6 +29,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
 MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k3)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: polyvec_basemul_acc_montgomery_cached_asm_k3 */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -252,6 +257,8 @@ polyvec_basemul_acc_montgomery_cached_k3_loop:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: polyvec_basemul_acc_montgomery_cached_asm_k3 */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 3) */

--- a/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
+++ b/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
@@ -29,6 +29,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
 MLK_ASM_FN_SYMBOL(polyvec_basemul_acc_montgomery_cached_asm_k4)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: polyvec_basemul_acc_montgomery_cached_asm_k4 */
 
         sub	sp, sp, #0x40
         stp	d8, d9, [sp]
@@ -306,6 +311,8 @@ polyvec_basemul_acc_montgomery_cached_k4_loop:
         ldp	d14, d15, [sp, #0x30]
         add	sp, sp, #0x40
         ret
+
+/* Assembly end: polyvec_basemul_acc_montgomery_cached_asm_k4 */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED && \
           (MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 4) */

--- a/mlkem/src/native/aarch64/src/rej_uniform_asm.S
+++ b/mlkem/src/native/aarch64/src/rej_uniform_asm.S
@@ -32,6 +32,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(rej_uniform_asm)
 MLK_ASM_FN_SYMBOL(rej_uniform_asm)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: rej_uniform_asm */
 
         sub	sp, sp, #0x240
         mov	x7, #0x1                // =1
@@ -195,5 +200,7 @@ rej_uniform_final_copy:
 rej_uniform_return:
         add	sp, sp, #0x240
         ret
+
+/* Assembly end: rej_uniform_asm */
 
 #endif /* MLK_ARITH_BACKEND_AARCH64 && !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/native/x86_64/src/basemul.S
+++ b/mlkem/src/native/x86_64/src/basemul.S
@@ -33,6 +33,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(basemul_avx2)
 MLK_ASM_FN_SYMBOL(basemul_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: basemul_avx2 */
 
         movq	%rsp, %r11
         andq	$-0x20, %rsp
@@ -267,6 +272,8 @@ MLK_ASM_FN_SYMBOL(basemul_avx2)
         vmovdqa	%ymm11, 0x1e0(%rdi)
         movq	%r11, %rsp
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/intt.S
+++ b/mlkem/src/native/x86_64/src/intt.S
@@ -42,6 +42,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(invntt_avx2)
 MLK_ASM_FN_SYMBOL(invntt_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: invntt_avx2 */
 
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0x60(%rsi), %ymm2
@@ -693,6 +698,8 @@ MLK_ASM_FN_SYMBOL(invntt_avx2)
         vmovdqa	%ymm10, 0x1c0(%rdi)
         vmovdqa	%ymm11, 0x1e0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/mulcache_compute.S
+++ b/mlkem/src/native/x86_64/src/mulcache_compute.S
@@ -17,6 +17,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(poly_mulcache_compute_avx2)
 MLK_ASM_FN_SYMBOL(poly_mulcache_compute_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: poly_mulcache_compute_avx2 */
 
         vmovdqa	(%rdx), %ymm0
         vmovdqa	0x20(%rsi), %ymm2
@@ -76,6 +81,8 @@ MLK_ASM_FN_SYMBOL(poly_mulcache_compute_avx2)
         vmovdqa	%ymm7, 0xc0(%rdi)
         vmovdqa	%ymm8, 0xe0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/ntt.S
+++ b/mlkem/src/native/x86_64/src/ntt.S
@@ -38,6 +38,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(ntt_avx2)
 MLK_ASM_FN_SYMBOL(ntt_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: ntt_avx2 */
 
         vmovdqa	(%rsi), %ymm0
         vpbroadcastq	0x140(%rsi), %ymm15
@@ -625,6 +630,8 @@ MLK_ASM_FN_SYMBOL(ntt_avx2)
         vmovdqa	%ymm9, 0x1c0(%rdi)
         vmovdqa	%ymm11, 0x1e0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/nttfrombytes.S
+++ b/mlkem/src/native/x86_64/src/nttfrombytes.S
@@ -32,6 +32,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(nttfrombytes_avx2)
 MLK_ASM_FN_SYMBOL(nttfrombytes_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: nttfrombytes_avx2 */
 
         vmovdqa	0xe0(%rdx), %ymm0
         callq	nttfrombytes_avx2_core
@@ -114,6 +119,8 @@ nttfrombytes_avx2_core:
         vmovdqa	%ymm15, 0xc0(%rdi)
         vmovdqa	%ymm1, 0xe0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/ntttobytes.S
+++ b/mlkem/src/native/x86_64/src/ntttobytes.S
@@ -32,6 +32,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(ntttobytes_avx2)
 MLK_ASM_FN_SYMBOL(ntttobytes_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: ntttobytes_avx2 */
 
         vmovdqa	(%rdx), %ymm0
         callq	ntttobytes_avx2_core
@@ -108,6 +113,8 @@ ntttobytes_avx2_core:
         vmovdqu	%ymm3, 0x80(%rdi)
         vmovdqu	%ymm9, 0xa0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/nttunpack.S
+++ b/mlkem/src/native/x86_64/src/nttunpack.S
@@ -32,6 +32,12 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(nttunpack_avx2)
 MLK_ASM_FN_SYMBOL(nttunpack_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: nttunpack_avx2 */
+
 
         callq	nttunpack_avx2_core
         addq	$0x100, %rdi            # imm = 0x100
@@ -104,6 +110,8 @@ nttunpack_avx2_core:
         vmovdqa	%ymm7, 0xc0(%rdi)
         vmovdqa	%ymm11, 0xe0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/reduce.S
+++ b/mlkem/src/native/x86_64/src/reduce.S
@@ -37,6 +37,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(reduce_avx2)
 MLK_ASM_FN_SYMBOL(reduce_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: reduce_avx2 */
 
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0x40(%rsi), %ymm1
@@ -127,6 +132,8 @@ reduce_avx2_core:
         vmovdqa	%ymm8, 0xc0(%rdi)
         vmovdqa	%ymm9, 0xe0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/mlkem/src/native/x86_64/src/tomont.S
+++ b/mlkem/src/native/x86_64/src/tomont.S
@@ -35,6 +35,11 @@
 .balign 4
 .global MLK_ASM_NAMESPACE(tomont_avx2)
 MLK_ASM_FN_SYMBOL(tomont_avx2)
+/* The following marker may be useful for implementing basic assembly
+   transformations (e.g. changing the header and footer) making it suitable
+   for other toolchains. */
+
+/* Assembly start: tomont_avx2 */
 
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0xa0(%rsi), %ymm1
@@ -94,6 +99,8 @@ tomont_avx2_core:
         vmovdqa	%ymm9, 0xc0(%rdi)
         vmovdqa	%ymm10, 0xe0(%rdi)
         retq
+
+/* Assembly end */
 
 #endif /* MLK_ARITH_BACKEND_X86_64_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \
         */

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -175,6 +175,7 @@ def simplify(logger, args, asm_input, asm_output=None):
         )
         raise Exception("simpasm failed")
     sym = syms[0]
+    func_name = re.sub(r'MLK_ASM_NAMESPACE\((.*?)\)', r'\1', sym)
 
     if args.cflags is not None:
         cflags = args.cflags.split(" ")
@@ -278,11 +279,22 @@ def simplify(logger, args, asm_input, asm_output=None):
         else:
             autogen_header += [
                 f".global {sym}",
-                f"{sym.replace('MLK_ASM_NAMESPACE', 'MLK_ASM_FN_SYMBOL')}",
+                f"MLK_ASM_FN_SYMBOL({func_name})"
                 "",
             ]
+
+            start_marker = [
+                "/* The following marker may be useful for implementing basic assembly",
+                "   transformations (e.g. changing the header and footer) making it suitable",
+                "   for other toolchains. */", "",
+                f"/* Assembly start: {func_name} */", ""]
+            end_marker = [f"/* Assembly end: {func_name} */", ""]
+
+            autogen_header += start_marker
+
             simplified_header = header
-            simplified_footer = footer
+            simplified_footer = end_marker + footer
+
 
         # Write simplified assembly file
         full_simplified = (


### PR DESCRIPTION
This commit modifies `scripts/simpasm` to emit textual markers at the beginning and end of the actual assembly. The purpose of those markers -- as indicated by comments also added -- is to facilitate basic assembly transformations, such as the removal or modification of headers, to suit other build infrastructures.