### PR TITLE
tests: Support stack usage measurement

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -46,6 +46,9 @@ inputs:
   check_namespace:
     description: Determine whether to check namespacing or not
     default: "true"
+  stack:
+    description: Determine whether to run stack analysis or not
+    default: "false"
 runs:
   using: composite
   steps:
@@ -58,6 +61,7 @@ runs:
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
           echo ACVP="${{ inputs.acvp == 'true' && 'acvp' || 'no-acvp' }}" >> $GITHUB_ENV
           echo EXAMPLES="${{ inputs.examples == 'true' && 'examples' || 'no-examples' }}" >> $GITHUB_ENV
+          echo STACK="${{ inputs.stack == 'true' && 'stack' || 'no-stack' }}" >> $GITHUB_ENV
       - name: Setup nix
         uses: ./.github/actions/setup-shell
         with:
@@ -88,11 +92,11 @@ runs:
             - $(python3 --version)
             - $(${{ inputs.cross_prefix }}${CC} --version | grep -m1 "")
           EOF
-      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.EXAMPLES }})
+      - name: ${{ env.MODE }} ${{ inputs.opt }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.EXAMPLES }}, ${{ env.STACK }})
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} -v
+          ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -43,6 +43,9 @@ inputs:
   check_namespace:
     description: Determine whether to check namespacing or not
     default: "true"
+  stack:
+    description: Determine whether to run stack analysis or not
+    default: "false"
 runs:
   using: composite
   steps:
@@ -62,6 +65,7 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}
       - name: Cross x86_64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-x86_64') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -80,6 +84,7 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}
       - name: Cross aarch64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-aarch64') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -98,6 +103,7 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}
       - name: Cross ppc64le Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-ppc64le') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -116,6 +122,7 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}
       - name: Cross aarch64_be Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-aarch64_be') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -134,6 +141,7 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}
       - name: Cross riscv64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -152,6 +160,7 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}
       - name: Cross riscv32 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv32') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -170,3 +179,4 @@ runs:
           acvp: ${{ inputs.acvp }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
+          stack: ${{ inputs.stack }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,39 @@ jobs:
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
           cflags: "-std=c23 ${{ matrix.cflags }}"
+  stack_analysis:
+    name: Stack analysis (${{ matrix.target.name }}, ${{ matrix.cflags }})
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+          - runner: pqcp-x64
+            name: x86_64
+          - runner: pqcp-arm64
+            name: aarch64
+        cflags: ['-O3', '-Os']
+        exclude:
+          - external: true
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Stack analysis
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          nix-shell: ci_valgrind-varlat_gcc14
+          nix-cache: false
+          opt: all
+          cflags: "${{ matrix.cflags }}"
+          func: false
+          kat: false
+          acvp: false
+          examples: false
+          stack: true
+          check_namespace: false
   config_variations:
     name: Non-standard configurations
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-.PHONY: func kat acvp \
-	func_512 kat_512 acvp_512 \
-	func_768 kat_768 acvp_768 \
-	func_1024 kat_1024 acvp_1024 \
-	run_func run_kat run_acvp \
-	run_func_512 run_kat_512 \
-	run_func_768 run_kat_768 \
-	run_func_1024 run_kat_1024 \
+.PHONY: func kat acvp stack \
+	func_512 kat_512 acvp_512 stack_512 \
+	func_768 kat_768 acvp_768 stack_768 \
+	func_1024 kat_1024 acvp_1024 stack_1024 \
+	run_func run_kat run_acvp run_stack \
+	run_func_512 run_kat_512 run_stack_512 \
+	run_func_768 run_kat_768 run_stack_768 \
+	run_func_1024 run_kat_1024 run_stack_1024 \
 	bench_512 bench_768 bench_1024 bench \
 	run_bench_512 run_bench_768 run_bench_1024 run_bench \
 	bench_components_512 bench_components_768 bench_components_1024 bench_components \
@@ -75,6 +75,22 @@ acvp_768:  $(MLKEM768_DIR)/bin/acvp_mlkem768
 acvp_1024: $(MLKEM1024_DIR)/bin/acvp_mlkem1024
 	$(Q)echo "  ACVP       ML-KEM-1024:  $^"
 acvp: acvp_512 acvp_768 acvp_1024
+
+stack_512: $(MLKEM512_DIR)/bin/test_stack512
+	$(Q)echo "  STACK      ML-KEM-512:   $^"
+stack_768: $(MLKEM768_DIR)/bin/test_stack768
+	$(Q)echo "  STACK      ML-KEM-768:   $^"
+stack_1024: $(MLKEM1024_DIR)/bin/test_stack1024
+	$(Q)echo "  STACK      ML-KEM-1024:  $^"
+stack: stack_512 stack_768 stack_1024
+
+run_stack_512: stack_512
+	$(Q)python3 scripts/stack $(MLKEM512_DIR)/bin/test_stack512 --build-dir $(MLKEM512_DIR) $(STACK_ANALYSIS_FLAGS)
+run_stack_768: stack_768
+	$(Q)python3 scripts/stack $(MLKEM768_DIR)/bin/test_stack768 --build-dir $(MLKEM768_DIR) $(STACK_ANALYSIS_FLAGS)
+run_stack_1024: stack_1024
+	$(Q)python3 scripts/stack $(MLKEM1024_DIR)/bin/test_stack1024 --build-dir $(MLKEM1024_DIR) $(STACK_ANALYSIS_FLAGS)
+run_stack: run_stack_512 run_stack_768 run_stack_1024
 
 lib: $(BUILD_DIR)/libmlkem.a $(BUILD_DIR)/libmlkem512.a $(BUILD_DIR)/libmlkem768.a $(BUILD_DIR)/libmlkem1024.a
 

--- a/scripts/stack
+++ b/scripts/stack
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+import argparse
+import glob
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+
+
+def parse_su_files(build_dir):
+    """Parse GCC stack usage (.su) files"""
+    stack_usage = {}
+    su_files = glob.glob(os.path.join(build_dir, "**", "*.su"), recursive=True)
+
+    for su_file in su_files:
+        with open(su_file, "r") as f:
+            content = f.read()
+
+        for line_num, line in enumerate(content.splitlines(), 1):
+            line = line.strip()
+            if not line:
+                continue
+
+            # Parse format: filename:line:column:function_name size qualifier
+            parts = line.split()
+            if len(parts) < 3:
+                raise ValueError(
+                    f"Unexpected .su file format in {su_file}:{line_num}: "
+                    f"Expected at least 3 parts, got {len(parts)} in line: '{line}'"
+                )
+
+            location_func = parts[0]
+            size_str = parts[1]
+            qualifier = parts[2] if len(parts) > 2 else "static"
+
+            # Extract function name from location:function format
+            if ":" in location_func:
+                func_name = location_func.split(":")[-1]
+            else:
+                func_name = location_func
+
+            size = int(size_str)
+            stack_usage[func_name] = {
+                "size": size,
+                "qualifier": qualifier,
+            }
+
+    return stack_usage
+
+
+def run_valgrind_massif_per_api(stack_test_binary, dump_massif=False):
+    """Run valgrind massif with API-level stack analysis using dedicated test binary"""
+    # Determine parameter set from binary path
+    if "test_stack512" in stack_test_binary:
+        param_set = "512"
+    elif "test_stack768" in stack_test_binary:
+        param_set = "768"
+    elif "test_stack1024" in stack_test_binary:
+        param_set = "1024"
+    else:
+        return (
+            False,
+            "Could not determine ML-KEM parameter set from stack test binary path",
+        )
+
+    api_results = {}
+    api_names = ["keygen", "encaps", "decaps"]
+    api_display_names = [
+        f"ML-KEM{param_set}-KeyGen",
+        f"ML-KEM{param_set}-Encaps",
+        f"ML-KEM{param_set}-Decaps",
+    ]
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".massif") as temp_file:
+        massif_output = temp_file.name
+
+        for api_name in api_names:
+            cmd = [
+                "valgrind",
+                "--tool=massif",
+                "--stacks=yes",
+                f"--massif-out-file={massif_output}",
+                "--quiet",
+                stack_test_binary,
+                api_name,
+            ]
+
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+            if result.returncode != 0:
+                return (
+                    False,
+                    f"Valgrind massif failed for {api_name} with return code {result.returncode}: {result.stderr}",
+                )
+
+            try:
+                with open(massif_output, "r") as f:
+                    massif_content = f.read()
+            except (OSError, IOError) as e:
+                return False, f"Failed to read massif output file: {e}"
+
+            # Dump full massif log if dump_massif mode is enabled
+            if dump_massif:
+                print(f"\n--- Full massif log for {api_name} ---")
+                print(massif_content)
+                print(f"--- End massif log for {api_name} ---\n")
+
+            peak_stack = 0
+            for line in massif_content.split("\n"):
+                if line.startswith("mem_stacks_B="):
+                    try:
+                        stack_bytes = int(line.split("=")[1])
+                        peak_stack = max(peak_stack, stack_bytes)
+                    except (ValueError, IndexError):
+                        # Individual line parsing can fail, continue with other lines
+                        continue
+
+            api_results[api_name] = peak_stack
+
+        # Format results
+        result_lines = []
+        for i, api_name in enumerate(api_names):
+            stack_usage = api_results[api_name]
+            display_name = api_display_names[i]
+            if stack_usage > 0:
+                result_lines.append(f"  {display_name:20}: {stack_usage:,} bytes")
+            else:
+                result_lines.append(f"  {display_name:20}: measurement failed")
+
+        total_max = max(api_results.values())
+        result_lines.append(
+            f"  {'Peak':20}: {total_max:,} bytes (maximum across all APIs)"
+        )
+
+        return (
+            True,
+            f"API-specific stack usage (measured with valgrind massif):\n"
+            + "\n".join(result_lines),
+        )
+
+
+def run_runtime_analysis(binary_path, dump_massif=False):
+    """Run runtime stack analysis"""
+    try:
+        # Test the stack test binary with keygen argument
+        test_result = subprocess.run(
+            [binary_path, "keygen"], capture_output=True, text=True, timeout=30
+        )
+        if test_result.returncode != 0:
+            return False, f"Stack test binary execution failed: {test_result.stderr}"
+    except subprocess.TimeoutExpired:
+        return False, "Binary execution timeout"
+    except Exception as e:
+        return False, str(e)
+
+    # On Linux, try to use valgrind massif for runtime stack analysis
+    if platform.system() == "Linux":
+        try:
+            subprocess.run(["valgrind", "--version"], capture_output=True, check=True)
+            return run_valgrind_massif_per_api(binary_path, dump_massif)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return (
+                True,
+                "Binary executed successfully (valgrind not available for runtime analysis)",
+            )
+    else:
+        return (
+            True,
+            "Binary executed successfully (detailed runtime stack analysis requires valgrind on Linux)",
+        )
+
+
+def analyze_stack_usage(
+    binary_path, build_dir, show_per_function=False, dump_massif=False
+):
+    """Analyze stack usage for a binary"""
+
+    if show_per_function:
+        print(f"Analyzing stack usage for: {binary_path}")
+        print("=" * 50)
+
+        # Static Analysis
+        print("Static Analysis (GCC -fstack-usage):")
+        print("-" * 40)
+
+        stack_usage = parse_su_files(build_dir)
+
+        # Sort by stack size
+        sorted_functions = sorted(
+            stack_usage.items(), key=lambda x: x[1]["size"], reverse=True
+        )
+
+        for func_name, info in sorted_functions[:20]:  # Show top 20
+            print(f"{func_name:50} {info['size']:6} bytes {info['qualifier']}")
+
+        if len(sorted_functions) > 20:
+            print(f"... and {len(sorted_functions) - 20} more functions")
+
+        print(f"Total functions analyzed: {len(sorted_functions)}")
+
+        if sorted_functions:
+            # Always show the largest function for summary
+            top_func, top_info = sorted_functions[0]
+            print(
+                f"Largest function: {top_func} ({top_info['size']:,} bytes {top_info['qualifier']})"
+            )
+
+        print()  # Add spacing before runtime analysis
+
+        # Runtime Analysis
+        print("Runtime Analysis:")
+        print("-" * 40)
+
+    # Runtime Analysis
+    success, message = run_runtime_analysis(binary_path, dump_massif)
+
+    if show_per_function:
+        print(f"Runtime analysis: {message}")
+        print()  # Empty line for spacing
+    else:
+        # For non-per-function mode, just show the message directly
+        print(message)
+
+    return success
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze stack usage of ML-KEM binaries"
+    )
+    parser.add_argument("binary", help="Path to the binary to analyze")
+    parser.add_argument(
+        "--build-dir", default="test/build", help="Build directory containing .su files"
+    )
+    parser.add_argument(
+        "--peak-only",
+        action="store_true",
+        help="Show only runtime peak stack usage (skip per-function analysis)",
+    )
+    parser.add_argument(
+        "--dump-massif",
+        action="store_true",
+        help="Dump full massif log for debugging",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.binary):
+        print(f"Error: Binary not found: {args.binary}")
+        return 1
+
+    if not os.path.exists(args.build_dir):
+        print(f"Error: Build directory not found: {args.build_dir}")
+        return 1
+
+    # Show per-function details by default, unless --peak-only is specified
+    show_per_function = not args.peak_only
+
+    success = analyze_stack_usage(
+        args.binary, args.build_dir, show_per_function, args.dump_massif
+    )
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests
+++ b/scripts/tests
@@ -206,6 +206,7 @@ class TEST_TYPES(Enum):
     MULTILEVEL_BUILD_NATIVE = 12
     MONOLITHIC_BUILD_MULTILEVEL_NATIVE = 13
     MONOLITHIC_BUILD_NATIVE = 14
+    STACK = 15
 
     def is_benchmark(self):
         return self in [TEST_TYPES.BENCH, TEST_TYPES.BENCH_COMPONENTS]
@@ -250,6 +251,8 @@ class TEST_TYPES(Enum):
             return "Kat Test"
         if self == TEST_TYPES.ACVP:
             return "ACVP Test"
+        if self == TEST_TYPES.STACK:
+            return "Stack Usage Test"
         if self == TEST_TYPES.BRING_YOUR_OWN_FIPS202:
             return "Example (Bring-Your-Own-FIPS202)"
         if self == TEST_TYPES.CUSTOM_BACKEND:
@@ -301,6 +304,8 @@ class TEST_TYPES(Enum):
             return "kat"
         if self == TEST_TYPES.ACVP:
             return "acvp"
+        if self == TEST_TYPES.STACK:
+            return "stack"
         if self == TEST_TYPES.BRING_YOUR_OWN_FIPS202:
             return ""
         if self == TEST_TYPES.CUSTOM_BACKEND:
@@ -478,6 +483,16 @@ class Tests:
         env_update = {}
         if len(self.cmd_prefix()) > 0:
             env_update["EXEC_WRAPPER"] = " ".join(self.cmd_prefix())
+
+        # Add stack analysis flags for stack tests
+        if test_type == TEST_TYPES.STACK:
+            stack_flags = []
+            if hasattr(self.args, "peak_only") and self.args.peak_only:
+                stack_flags.append("--peak-only")
+            if hasattr(self.args, "dump_massif") and self.args.dump_massif:
+                stack_flags.append("--dump-massif")
+            if stack_flags:
+                env_update["STACK_ANALYSIS_FLAGS"] = " ".join(stack_flags)
 
         env = os.environ.copy()
         env.update(env_update)
@@ -657,11 +672,27 @@ class Tests:
 
         self.check_fail()
 
+    def stack(self):
+        """Stack usage analysis"""
+
+        def _stack(opt):
+            self._compile_schemes(TEST_TYPES.STACK, opt)
+            if self.args.run:
+                self._run_schemes(TEST_TYPES.STACK, opt, suppress_output=False)
+
+        if self.do_no_opt():
+            _stack(False)
+        if self.do_opt():
+            _stack(True)
+
+        self.check_fail()
+
     def all(self):
         func = self.args.func
         kat = self.args.kat
         acvp = self.args.acvp
         examples = self.args.examples
+        stack = self.args.stack
 
         def _all(opt):
             if func is True:
@@ -670,6 +701,8 @@ class Tests:
                 self._compile_schemes(TEST_TYPES.KAT, opt)
             if acvp is True:
                 self._compile_schemes(TEST_TYPES.ACVP, opt)
+            if stack is True:
+                self._compile_schemes(TEST_TYPES.STACK, opt)
 
             if self.args.run is False:
                 return
@@ -680,6 +713,8 @@ class Tests:
                 self._run_schemes(TEST_TYPES.KAT, opt)
             if acvp is True:
                 self._run_scheme(TEST_TYPES.ACVP, opt, None)
+            if stack is True:
+                self._run_schemes(TEST_TYPES.STACK, opt, suppress_output=False)
 
         if self.do_no_opt():
             _all(False)
@@ -973,6 +1008,21 @@ def cli():
         help="Do not run examples",
     )
 
+    stack_group = all_parser.add_mutually_exclusive_group()
+    stack_group.add_argument(
+        "--stack",
+        action="store_true",
+        dest="stack",
+        help="Run stack analysis",
+        default=False,
+    )
+    stack_group.add_argument(
+        "--no-stack",
+        action="store_false",
+        dest="stack",
+        help="Do not run stack analysis",
+    )
+
     # acvp arguments
     acvp_parser = cmd_subparsers.add_parser(
         "acvp", help="Run ACVP client", parents=[common_parser]
@@ -1133,6 +1183,25 @@ def cli():
         "kat", help="Run the kat tests for all parameter sets", parents=[common_parser]
     )
 
+    # stack arguments
+    stack_parser = cmd_subparsers.add_parser(
+        "stack",
+        help="Analyze stack usage for all parameter sets",
+        parents=[common_parser],
+    )
+    stack_parser.add_argument(
+        "--peak-only",
+        action="store_true",
+        help="Show only runtime peak stack usage (skip per-function analysis)",
+        default=False,
+    )
+    stack_parser.add_argument(
+        "--dump-massif",
+        action="store_true",
+        help="Dump full massif log for debugging",
+        default=False,
+    )
+
     args = main_parser.parse_args()
 
     if not hasattr(args, "mac_taskpolicy"):
@@ -1158,6 +1227,8 @@ def cli():
         Tests(args).func()
     elif args.cmd == "kat":
         Tests(args).kat()
+    elif args.cmd == "stack":
+        Tests(args).stack()
 
 
 if __name__ == "__main__":

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -11,7 +11,7 @@ ifeq ($(OPT),1)
 	CFLAGS += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202
 endif
 
-ALL_TESTS = test_mlkem acvp_mlkem bench_mlkem bench_components_mlkem gen_KAT
+ALL_TESTS = test_mlkem acvp_mlkem bench_mlkem bench_components_mlkem gen_KAT test_stack
 
 MLKEM512_DIR = $(BUILD_DIR)/mlkem512
 MLKEM768_DIR = $(BUILD_DIR)/mlkem768
@@ -23,6 +23,9 @@ MLKEM768_OBJS = $(call MAKE_OBJS,$(MLKEM768_DIR),$(SOURCES) $(FIPS202_SRCS))
 $(MLKEM768_OBJS): CFLAGS += -DMLK_CONFIG_PARAMETER_SET=768
 MLKEM1024_OBJS = $(call MAKE_OBJS,$(MLKEM1024_DIR),$(SOURCES) $(FIPS202_SRCS))
 $(MLKEM1024_OBJS): CFLAGS += -DMLK_CONFIG_PARAMETER_SET=1024
+
+
+
 
 $(BUILD_DIR)/libmlkem512.a: $(MLKEM512_OBJS)
 $(BUILD_DIR)/libmlkem768.a: $(MLKEM768_OBJS)
@@ -36,6 +39,10 @@ $(MLKEM1024_DIR)/bin/bench_mlkem1024: CFLAGS += -Itest/hal
 $(MLKEM512_DIR)/bin/bench_components_mlkem512: CFLAGS += -Itest/hal
 $(MLKEM768_DIR)/bin/bench_components_mlkem768: CFLAGS += -Itest/hal
 $(MLKEM1024_DIR)/bin/bench_components_mlkem1024: CFLAGS += -Itest/hal
+
+$(MLKEM512_DIR)/bin/test_stack512: CFLAGS += -Imlkem/src -fstack-usage
+$(MLKEM768_DIR)/bin/test_stack768: CFLAGS += -Imlkem/src -fstack-usage
+$(MLKEM1024_DIR)/bin/test_stack1024: CFLAGS += -Imlkem/src -fstack-usage
 
 $(MLKEM512_DIR)/bin/bench_mlkem512: $(MLKEM512_DIR)/test/hal/hal.c.o
 $(MLKEM768_DIR)/bin/bench_mlkem768: $(MLKEM768_DIR)/test/hal/hal.c.o

--- a/test/test_stack.c
+++ b/test/test_stack.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "kem.h"
+
+static void test_keygen_only(void)
+{
+  unsigned char pk[MLKEM_INDCCA_PUBLICKEYBYTES];
+  unsigned char sk[MLKEM_INDCCA_SECRETKEYBYTES];
+
+  /* Only call keypair - this is what we're measuring */
+  /* Uses the notrandombytes implementation for deterministic randomness */
+  int ret = crypto_kem_keypair(pk, sk);
+  (void)ret; /* Ignore return value - we only care about stack measurement */
+}
+
+static void test_encaps_only(void)
+{
+  unsigned char pk[MLKEM_INDCCA_PUBLICKEYBYTES] = {0};
+  unsigned char ct[MLKEM_INDCCA_CIPHERTEXTBYTES];
+  unsigned char ss[MLKEM_SSBYTES];
+
+  /* Only call encaps - this is what we're measuring */
+  /* pk is zero-initialized (invalid key, but OK for stack measurement) */
+  int ret = crypto_kem_enc(ct, ss, pk);
+  (void)ret; /* Ignore return value - we only care about stack measurement */
+}
+
+static void test_decaps_only(void)
+{
+  unsigned char sk[MLKEM_INDCCA_SECRETKEYBYTES] = {0};
+  unsigned char ct[MLKEM_INDCCA_CIPHERTEXTBYTES] = {0};
+  unsigned char ss[MLKEM_SSBYTES];
+
+  /* Only call decaps - this is what we're measuring */
+  /* sk and ct are zero-initialized (invalid, but OK for stack measurement) */
+  int ret = crypto_kem_dec(ss, ct, sk);
+  (void)ret; /* Ignore return value - we only care about stack measurement */
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc != 2)
+  {
+    fprintf(stderr, "Usage: %s <keygen|encaps|decaps>\n", argv[0]);
+    return 1;
+  }
+
+  if (strcmp(argv[1], "keygen") == 0)
+  {
+    test_keygen_only();
+  }
+  else if (strcmp(argv[1], "encaps") == 0)
+  {
+    test_encaps_only();
+  }
+  else if (strcmp(argv[1], "decaps") == 0)
+  {
+    test_decaps_only();
+  }
+  else
+  {
+    fprintf(stderr, "Unknown test: %s\n", argv[1]);
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Implements static and dynamic stack analysis using GCC -fstack-usage and valgrind massif.

Usage:
  make stack_512
  make run_stack_512
or
  ./scripts/tests stack [--peak-only --dump-massif]