### PR TITLE
Update liboqs and AWS-LC dependencies

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -52,14 +52,14 @@ jobs:
     uses: ./.github/workflows/integration-liboqs.yml
     secrets: inherit
   awslc_integration_fixed:
-    name: AWS-LC (14e3dc8)
+    name: AWS-LC (8568a08)
     permissions:
       contents: 'read'
       id-token: 'write'
     needs: [ base ]
     uses: ./.github/workflows/integration-awslc.yml
     with:
-      commit: 14e3dc8b07b2ba783463021fd6833cd75946c495
+      commit: 8568a08d366bcbd5c1279132ccb299c0826799de # v1.54.0
     secrets: inherit
   awslc_integration_head:
     name: AWS-LC (HEAD)

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -36,7 +36,7 @@ jobs:
           packages: 'cmake python3-jinja2 python3-tabulate python3-git python3-pytest valgrind'
       - uses: ./.github/actions/setup-oqs
         with:
-          commit: '429c98ee7e4aae548cca2a97265ca4337600cb59'
+          commit: 'b5d3dac4ebdfbbc5de1f6ab9fc6a94c3fd47d13d' # latest from main as of 2025-07-02
       - name: Apply patch
         run: |
           cd $LIBOQS_DIR


### PR DESCRIPTION
- Updates liboqs to latest commit from main branch (b5d3dac)
- Updates AWS-LC to latest release v1.54.0 (8568a08)
- Adds version comments for better tracking