### PR TITLE
tests: Add `--aarch64-fips202-backend` choosing arm fips202 backend

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -49,6 +49,9 @@ inputs:
   stack:
     description: Determine whether to run stack analysis or not
     default: "false"
+  extra_args:
+    description: Additional arguments to pass to the tests script
+    default: ""
 runs:
   using: composite
   steps:
@@ -96,7 +99,7 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v
+          ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} -v ${{ inputs.extra_args }}
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -46,6 +46,9 @@ inputs:
   stack:
     description: Determine whether to run stack analysis or not
     default: "false"
+  extra_args:
+    description: Additional arguments to pass to the tests script
+    default: ""
 runs:
   using: composite
   steps:
@@ -66,6 +69,7 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
       - name: Cross x86_64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-x86_64') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -85,6 +89,7 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
       - name: Cross aarch64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-aarch64') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -104,6 +109,7 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
       - name: Cross ppc64le Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-ppc64le') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -123,6 +129,7 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
       - name: Cross aarch64_be Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-aarch64_be') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -142,6 +149,7 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv64 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv64') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -161,6 +169,7 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}
       - name: Cross riscv32 Tests
         if: ${{ (inputs.compile_mode == 'all' || inputs.compile_mode == 'cross-riscv32') && (success() || failure()) }}
         uses: ./.github/actions/functest
@@ -180,3 +189,4 @@ runs:
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
+          extra_args: ${{ inputs.extra_args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,9 @@ jobs:
           compile_mode: 'native'
           opt: 'opt'
           examples: 'false'
-          cflags: "-DMLKEM_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -DMLK_FORCE_AARCH64 -DMLK_CONFIG_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/${{ matrix.backend }}.h\\\\\\\""
+          cflags: "-DMLKEM_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
           check_namespace: 'false'
+          extra_args: "--fips202-aarch64-backend ${{ matrix.backend }}"
   compiler_tests:
     name: Compiler tests  (${{ matrix.compiler.name }}, ${{ matrix.target.name }}, ${{ matrix.cflags }})
     strategy:

--- a/scripts/tests
+++ b/scripts/tests
@@ -422,6 +422,18 @@ class Tests:
         if test_type.is_example() and self.args.cross_prefix != "":
             cflags += " -static"
 
+        # Add FIPS202 backend selection if specified and this is an OPT build
+        if self.args.fips202_aarch64_backend != "auto" and opt is True:
+            # Make sure we're forcing AArch64 architecture
+            if not " -DMLK_FORCE_AARCH64" in cflags:
+                cflags += " -DMLK_FORCE_AARCH64"
+
+            # Enable native backend for FIPS202
+            cflags += " -DMLK_CONFIG_USE_NATIVE_BACKEND_FIPS202"
+
+            # Specify the backend file
+            cflags += f' -DMLK_CONFIG_FIPS202_BACKEND_FILE=\\"fips202/native/aarch64/{self.args.fips202_aarch64_backend}.h\\"'
+
         env_update = {}
         if cflags != "":
             env_update["CFLAGS"] = cflags
@@ -931,6 +943,21 @@ def cli():
         choices=["ALL", "OPT", "NO_OPT"],
         type=str.upper,
         default="ALL",
+    )
+
+    common_parser.add_argument(
+        "--fips202-aarch64-backend",
+        help="Select FIPS202 AArch64 backend",
+        choices=[
+            "auto",
+            "x1_scalar",
+            "x1_v84a",
+            "x2_v84a",
+            "x4_v8a_scalar",
+            "x4_v8a_v84a_scalar",
+        ],
+        default="auto",
+        type=str,
     )
 
     # --run / --no-run


### PR DESCRIPTION
This commit extends `tests` to support `tests --aarch64-fips202-backend` for easier testing of the various FIPS202 AArch64 backends. The CI is adjusted to make use of this option.

Fixes #1009