### PR TITLE
Update CBMC proof guide and README to include installation instructions

### DIFF
--- a/proofs/cbmc/README.md
+++ b/proofs/cbmc/README.md
@@ -42,6 +42,18 @@ void mlk_poly_add(mlk_poly *r, const mlk_poly *b)
 
 See the [Proof Guide](proof_guide.md) for a walkthrough of how to use CBMC and develop new proofs.
 
+## Installation
+
+To reproduce the CBMC proofs, you will require several tools ([CBMC](https://github.com/diffblue/cbmc), [z3](https://github.com/Z3Prover/z3), [bitwuzla](https://github.com/bitwuzla/bitwuzla), [litani](https://github.com/awslabs/aws-build-accumulator), [cbmc-viewer](https://github.com/model-checking/cbmc-viewer)) installed.
+It is not uncommon for proofs to fail or have significantly worse performance when switching to different tool versions.
+Therefore, **we highly recommend using our Nix development environment** to install all the necessary tools. See [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+Note that nix installation is straightforward and only requires running a single command: See https://nixos.org/download/.
+Once Nix is installed, it takes a single command to install all the required tools at the version that have been tested to work well with the mlkem-native proofs:
+```sh
+nix develop --experimental-features 'nix-command flakes'
+```
+
 ## Reproducing the proofs
 
 To run all proofs, print a summary at the end and reflect overall

--- a/proofs/cbmc/proof_guide.md
+++ b/proofs/cbmc/proof_guide.md
@@ -6,6 +6,12 @@ This document acts as a guide to how we develop proofs of mlkem-native's C code 
 [CBMC](https://model-checking.github.io/cbmc-training/). It concentrates on the use of _contracts_ to achieve
 _unbounded_ and _modular_ proofs of type-safety and correctness properties.
 
+## Installation
+
+Before you start, follow the installation instructions [here](README.md) to ensure you have all the
+required tools installed at the right version.
+It is not uncommon for proofs to fail or have significantly worse performance when switching to different tool versions.
+
 ## Scope
 
 Our CBMC proofs confirm the absence of certain classes of undefined behaviour, such as integer overflow or out of bounds


### PR DESCRIPTION
We have seen numerous people trying to reproduce CBMC proofs with tool versions not installed via nix. The results are mixed, but mostly a disaster.

This commit clarifies this in the README adding explicit installation instructions and stressing that you _cannot_ expect to use any version and proofs to work just fine.