### PR TITLE
[TEST]: Update bitwuzla to 0.8.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748460289,
-        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
+        "lastModified": 1753250450,
+        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
+        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           util = pkgs.callPackage ./nix/util.nix {
             # Keep those around in case we want to switch to unstable versions
             cbmc = pkgs-unstable.cbmc;
-            bitwuzla = pkgs.bitwuzla;
+            bitwuzla = pkgs-unstable.bitwuzla;
             z3 = pkgs.z3;
           };
           zigWrapCC = zig: pkgs.symlinkJoin {
@@ -165,7 +165,7 @@
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
               cbmc = pkgs-unstable.cbmc;
-              bitwuzla = pkgs.bitwuzla;
+              bitwuzla = pkgs-unstable.bitwuzla;
               z3 = pkgs.z3;
             };
           in

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -61,8 +61,8 @@ buildEnv {
       });
 
       inherit
-        cadical#2.1.3
-        bitwuzla# 0.7.0
+        cadical# 2.1.3
+        bitwuzla# 0.8.1
         ninja; # 1.12.1
     };
 }


### PR DESCRIPTION
This commit updates bitwuzla to 0.8.1.
As we have received some reports of potential problems with this bitwuzla version, this is mostly to make sure the proofs in mlkem-native still work. Resolves https://github.com/pq-code-package/mlkem-native/issues/1122