### PR TITLE
Prevent signedness of "char" causing CBMC instability.

### DIFF
--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -311,7 +311,7 @@ CHECKFLAGS += $(CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK)
 NONDET_STATIC ?=
 
 # Flags to pass to goto-cc for compilation and linking
-COMPILE_FLAGS ?= -Wall -Werror --native-compiler $(CC)
+COMPILE_FLAGS ?= -Wall -Werror -fsigned-char --native-compiler $(CC)
 LINK_FLAGS ?= -Wall -Werror
 EXPORT_FILE_LOCAL_SYMBOLS ?= --export-file-local-symbols
 


### PR DESCRIPTION
Prevent signedness of "char" causing CBMC instability.

1. Add -fsigned-char to goto-cc COMPILE_FLAGS in Makefile.common to force consistent proof behaviour on all platforms where plain "char" is unsigned by default (e.g. Graviton/Linux) AND where CBMC contract libraries contain use of plain "char *" type.
