### PR TITLE
bitwuzla: update the bitwuzla version from 0.7.0 to 0.8.2 in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           util = pkgs.callPackage ./nix/util.nix {
             # Keep those around in case we want to switch to unstable versions
             cbmc = pkgs-unstable.cbmc;
-            bitwuzla = pkgs.bitwuzla;
+            bitwuzla = pkgs-unstable.bitwuzla;
             z3 = pkgs.z3;
           };
           zigWrapCC = zig: pkgs.symlinkJoin {
@@ -170,7 +170,7 @@
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
               cbmc = pkgs-unstable.cbmc;
-              bitwuzla = pkgs.bitwuzla;
+              bitwuzla = pkgs-unstable.bitwuzla;
               z3 = pkgs.z3;
             };
           in

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -62,7 +62,7 @@ buildEnv {
 
       inherit
         cadical#2.1.3
-        bitwuzla# 0.7.0
+        bitwuzla# 0.8.2
         ninja; # 1.12.1
     };
 }


### PR DESCRIPTION
- Resolves #1122 
- This PR update the bitwuzla form 0.7.0 to 0.8.2(unstable)