### PR TITLE
CI: Try `brew install` only if package not yet installed

### DIFF
--- a/.github/actions/setup-brew/action.yml
+++ b/.github/actions/setup-brew/action.yml
@@ -19,12 +19,9 @@ runs:
       shell: bash
       run: |
         brew update
-    - name: Install base packages
+    - name: Install packages
       shell: bash
       run: |
-        brew install make
-    - name: Install additional packages
-      if: ${{ inputs.packages != ''}}
-      shell: bash
-      run: |
-        brew install ${{ inputs.packages }}
+        for pkg in make ${{ inputs.packages }}; do
+          brew list "$pkg" &>/dev/null || brew install "$pkg"
+        done


### PR DESCRIPTION
CI sometimes fails on MacOS when trying to run `brew install cmake` because `cmake` has already been installed from a separate brew tap.

This commit attempts to resolve this by modifying the setup-brew CI action to only run `brew install` if `brew list` indicates that the target package is not yet installed.