### PR TITLE
WIP: Enable and test AArch64 backend on Arm Windows machines 

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -187,6 +187,18 @@ jobs:
           # print compiler version
           cl
           nmake /f ./Makefile.Microsoft_nmake quickcheck
+      - name: Setup MSVC (arm64)
+        if: ${{ matrix.system == 'windows-11-arm' }}
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm64
+      - name: Check MSVC setup (armasm64)
+        if: ${{ matrix.system == 'windows-11-arm' }}
+        shell: powershell
+        run: |
+          where cl ; where armasm64
+          cl
+          armasm64 -h
   quickcheck-windows-mingw-w64:
     strategy:
       fail-fast: false

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -175,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [windows-2025, windows-2022]
+        system: [windows-2025, windows-2022, windows-11-arm]
     name: Quickcheck ${{ matrix.system }}
     runs-on: ${{ matrix.system }}
     steps:


### PR DESCRIPTION
- Resolved: #1132 
- This PR want to do following two things: 
  - add the `windows-11-arm` label in `base.yml`  to enable the windows-11-arm CI testing
  - Enable the arm(aarch64) and x64 native backend for windows:
    1. First change the nmake so that it build the aarch64 backend only
    2. Then later we can worry about building both the C + aarch64 backend
    3. Then later we can worry about not having this break on x86 