### PR TITLE
CBMC: Add proof for `crypto_kem_check_sk`, `crypto_kem_check_pk`

### DIFF
--- a/mlkem/src/kem.h
+++ b/mlkem/src/kem.h
@@ -79,7 +79,11 @@
 /* Reference: Not implemented in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 MLK_MUST_CHECK_RETURN_VALUE
-int crypto_kem_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES]);
+int crypto_kem_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
+__contract__(
+  requires(memory_no_alias(pk, MLKEM_INDCCA_PUBLICKEYBYTES))
+  ensures(return_value == 0 || return_value == -1)
+);
 
 
 /*************************************************
@@ -103,8 +107,11 @@ int crypto_kem_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES]);
 /* Reference: Not implemented in the reference implementation @[REF]. */
 MLK_INTERNAL_API
 MLK_MUST_CHECK_RETURN_VALUE
-int crypto_kem_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES]);
-
+int crypto_kem_check_sk(const uint8_t sk[MLKEM_INDCCA_SECRETKEYBYTES])
+__contract__(
+  requires(memory_no_alias(sk, MLKEM_INDCCA_SECRETKEYBYTES))
+  ensures(return_value == 0 || return_value == -1)
+);
 /*************************************************
  * Name:        crypto_kem_keypair_derand
  *

--- a/proofs/cbmc/crypto_kem_check_pk/Makefile
+++ b/proofs/cbmc/crypto_kem_check_pk/Makefile
@@ -4,11 +4,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = crypto_kem_enc_derand_harness
+HARNESS_FILE = crypto_kem_check_pk_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = crypto_kem_enc_derand
+PROOF_UID = crypto_kem_check_pk
 
 DEFINES +=
 INCLUDES +=
@@ -19,8 +19,8 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/kem.c
 
-CHECK_FUNCTION_CONTRACTS=mlk_enc_derand
-USE_FUNCTION_CONTRACTS=mlk_check_pk mlk_sha3_256 mlk_sha3_512 mlk_indcpa_enc mlk_polyvec_frombytes mlk_polyvec_reduce mlk_polyvec_tobytes mlk_zeroize
+CHECK_FUNCTION_CONTRACTS=mlk_check_pk
+USE_FUNCTION_CONTRACTS=mlk_polyvec_frombytes mlk_polyvec_reduce mlk_polyvec_tobytes mlk_ct_memcmp mlk_zeroize
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -28,7 +28,7 @@ USE_DYNAMIC_FRAMES=1
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
 
-FUNCTION_NAME = mlk_enc_derand
+FUNCTION_NAME = mlk_check_pk
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/proofs/cbmc/crypto_kem_check_pk/crypto_kem_check_pk_harness.c
+++ b/proofs/cbmc/crypto_kem_check_pk/crypto_kem_check_pk_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <kem.h>
+
+void harness(void)
+{
+  uint8_t *a;
+  crypto_kem_check_pk(a);
+}

--- a/proofs/cbmc/crypto_kem_check_sk/Makefile
+++ b/proofs/cbmc/crypto_kem_check_sk/Makefile
@@ -4,11 +4,11 @@
 include ../Makefile_params.common
 
 HARNESS_ENTRY = harness
-HARNESS_FILE = crypto_kem_enc_derand_harness
+HARNESS_FILE = crypto_kem_check_sk_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = crypto_kem_enc_derand
+PROOF_UID = crypto_kem_check_sk
 
 DEFINES +=
 INCLUDES +=
@@ -19,8 +19,8 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/kem.c
 
-CHECK_FUNCTION_CONTRACTS=mlk_enc_derand
-USE_FUNCTION_CONTRACTS=mlk_check_pk mlk_sha3_256 mlk_sha3_512 mlk_indcpa_enc mlk_polyvec_frombytes mlk_polyvec_reduce mlk_polyvec_tobytes mlk_zeroize
+CHECK_FUNCTION_CONTRACTS=mlk_check_sk
+USE_FUNCTION_CONTRACTS=mlk_sha3_256 mlk_zeroize memcmp
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 
@@ -28,7 +28,7 @@ USE_DYNAMIC_FRAMES=1
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
 
-FUNCTION_NAME = mlk_enc_derand
+FUNCTION_NAME = mlk_check_sk
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/proofs/cbmc/crypto_kem_check_sk/crypto_kem_check_sk_harness.c
+++ b/proofs/cbmc/crypto_kem_check_sk/crypto_kem_check_sk_harness.c
@@ -1,0 +1,11 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <kem.h>
+
+void harness(void)
+{
+  uint8_t *a;
+  crypto_kem_check_sk(a);
+}

--- a/proofs/cbmc/crypto_kem_dec/Makefile
+++ b/proofs/cbmc/crypto_kem_dec/Makefile
@@ -20,7 +20,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/kem.c
 
 CHECK_FUNCTION_CONTRACTS=mlk_dec
-USE_FUNCTION_CONTRACTS=mlk_sha3_512 mlk_sha3_256 mlk_indcpa_enc mlk_indcpa_dec mlk_shake256 mlk_ct_memcmp mlk_ct_cmov_zero memcmp mlk_zeroize
+USE_FUNCTION_CONTRACTS=mlk_check_sk mlk_sha3_512 mlk_sha3_256 mlk_indcpa_enc mlk_indcpa_dec mlk_shake256 mlk_ct_memcmp mlk_ct_cmov_zero mlk_zeroize
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 


### PR DESCRIPTION
- Resolved: #1172 
- This PR add the CMBC proof for the `crypto_kem_check_sk`, `crypto_kem_check_pk`