### PR TITLE
Use asm macros instead of local function calls in x86 asm

### DIFF
--- a/dev/x86_64/src/nttfrombytes.S
+++ b/dev/x86_64/src/nttfrombytes.S
@@ -27,26 +27,14 @@
 #include "fq.inc"
 #include "shuffle.inc"
 
-.text
-.global MLK_ASM_NAMESPACE(nttfrombytes_avx2)
-.balign 4
-MLK_ASM_FN_SYMBOL(nttfrombytes_avx2)
-#consts
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMASK*2(%rdx),%ymm0
-call		nttfrombytes_avx2_core
-add		$256,%rdi
-add		$192,%rsi
-call		nttfrombytes_avx2_core
-ret
-
-nttfrombytes_avx2_core:
+.macro nttfrombytes_128_coefficients offset_in offset_out
 #load
-vmovdqu		(%rsi),%ymm4
-vmovdqu		32(%rsi),%ymm5
-vmovdqu		64(%rsi),%ymm6
-vmovdqu		96(%rsi),%ymm7
-vmovdqu		128(%rsi),%ymm8
-vmovdqu		160(%rsi),%ymm9
+vmovdqu	(\offset_in +  0)(%rsi), %ymm4
+vmovdqu	(\offset_in + 32)(%rsi), %ymm5
+vmovdqu	(\offset_in + 64)(%rsi), %ymm6
+vmovdqu	(\offset_in + 96)(%rsi), %ymm7
+vmovdqu	(\offset_in +128)(%rsi), %ymm8
+vmovdqu	(\offset_in +160)(%rsi), %ymm9
 
 shuffle8	4,7,3,7
 shuffle8	5,8,4,8
@@ -94,14 +82,25 @@ vpsrlw		$4,%ymm9,%ymm1
 vpand		%ymm0,%ymm1,%ymm1
 
 #store
-vmovdqa		%ymm10,(%rdi)
-vmovdqa		%ymm11,32(%rdi)
-vmovdqa		%ymm12,64(%rdi)
-vmovdqa		%ymm13,96(%rdi)
-vmovdqa		%ymm8,128(%rdi)
-vmovdqa		%ymm14,160(%rdi)
-vmovdqa		%ymm15,192(%rdi)
-vmovdqa		%ymm1,224(%rdi)
+vmovdqa	%ymm10, (\offset_out +  0)(%rdi)
+vmovdqa	%ymm11, (\offset_out + 32)(%rdi)
+vmovdqa	%ymm12, (\offset_out + 64)(%rdi)
+vmovdqa	%ymm13, (\offset_out + 96)(%rdi)
+vmovdqa	%ymm8,  (\offset_out +128)(%rdi)
+vmovdqa	%ymm14, (\offset_out +160)(%rdi)
+vmovdqa	%ymm15, (\offset_out +192)(%rdi)
+vmovdqa	%ymm1,  (\offset_out +224)(%rdi)
+.endm
+
+.text
+.global MLK_ASM_NAMESPACE(nttfrombytes_avx2)
+.balign 4
+MLK_ASM_FN_SYMBOL(nttfrombytes_avx2)
+#consts
+vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMASK*2(%rdx),%ymm0
+
+nttfrombytes_128_coefficients 0 0
+nttfrombytes_128_coefficients 192 256
 
 ret
 

--- a/dev/x86_64/src/ntttobytes.S
+++ b/dev/x86_64/src/ntttobytes.S
@@ -27,28 +27,16 @@
 #include "fq.inc"
 #include "shuffle.inc"
 
-.text
-.global MLK_ASM_NAMESPACE(ntttobytes_avx2)
-.balign 4
-MLK_ASM_FN_SYMBOL(ntttobytes_avx2)
-#consts
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rdx),%ymm0
-call            ntttobytes_avx2_core
-add		$256,%rsi
-add		$192,%rdi
-call		ntttobytes_avx2_core
-ret
-
-ntttobytes_avx2_core:
+.macro ntttobytes_128_coefficients offset_in offset_out
 #load
-vmovdqa		(%rsi),%ymm5
-vmovdqa		32(%rsi),%ymm6
-vmovdqa		64(%rsi),%ymm7
-vmovdqa		96(%rsi),%ymm8
-vmovdqa		128(%rsi),%ymm9
-vmovdqa		160(%rsi),%ymm10
-vmovdqa		192(%rsi),%ymm11
-vmovdqa		224(%rsi),%ymm12
+vmovdqa (\offset_in +   0)(%rsi), %ymm5
+vmovdqa (\offset_in +  32)(%rsi), %ymm6
+vmovdqa (\offset_in +  64)(%rsi), %ymm7
+vmovdqa (\offset_in +  96)(%rsi), %ymm8
+vmovdqa (\offset_in + 128)(%rsi), %ymm9
+vmovdqa (\offset_in + 160)(%rsi), %ymm10
+vmovdqa (\offset_in + 192)(%rsi), %ymm11
+vmovdqa (\offset_in + 224)(%rsi), %ymm12
 
 #bitpack
 vpsllw		$12,%ymm6,%ymm4
@@ -90,12 +78,24 @@ shuffle8	6,3,7,3
 shuffle8	4,9,6,9
 
 #store
-vmovdqu		%ymm5,(%rdi)
-vmovdqu		%ymm7,32(%rdi)
-vmovdqu		%ymm6,64(%rdi)
-vmovdqu		%ymm8,96(%rdi)
-vmovdqu		%ymm3,128(%rdi)
-vmovdqu		%ymm9,160(%rdi)
+vmovdqu	%ymm5, (\offset_out +  0)(%rdi)
+vmovdqu	%ymm7, (\offset_out + 32)(%rdi)
+vmovdqu	%ymm6, (\offset_out + 64)(%rdi)
+vmovdqu	%ymm8, (\offset_out + 96)(%rdi)
+vmovdqu	%ymm3, (\offset_out +128)(%rdi)
+vmovdqu	%ymm9, (\offset_out +160)(%rdi)
+.endm
+
+
+.text
+.global MLK_ASM_NAMESPACE(ntttobytes_avx2)
+.balign 4
+MLK_ASM_FN_SYMBOL(ntttobytes_avx2)
+#consts
+vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rdx),%ymm0
+
+ntttobytes_128_coefficients 0 0
+ntttobytes_128_coefficients 256 192
 
 ret
 

--- a/dev/x86_64/src/nttunpack.S
+++ b/dev/x86_64/src/nttunpack.S
@@ -27,25 +27,16 @@
 #include "fq.inc"
 #include "shuffle.inc"
 
-.text
-.global MLK_ASM_NAMESPACE(nttunpack_avx2)
-.balign 4
-MLK_ASM_FN_SYMBOL(nttunpack_avx2)
-call		nttunpack_avx2_core
-add		$256,%rdi
-call		nttunpack_avx2_core
-ret
-
-nttunpack_avx2_core:
+.macro nttunpack_128_coefficients offset
 #load
-vmovdqa		(%rdi),%ymm4
-vmovdqa		32(%rdi),%ymm5
-vmovdqa		64(%rdi),%ymm6
-vmovdqa		96(%rdi),%ymm7
-vmovdqa		128(%rdi),%ymm8
-vmovdqa		160(%rdi),%ymm9
-vmovdqa		192(%rdi),%ymm10
-vmovdqa		224(%rdi),%ymm11
+vmovdqa	(\offset +   0)(%rdi), %ymm4
+vmovdqa	(\offset +  32)(%rdi), %ymm5
+vmovdqa	(\offset +  64)(%rdi), %ymm6
+vmovdqa	(\offset +  96)(%rdi), %ymm7
+vmovdqa	(\offset + 128)(%rdi), %ymm8
+vmovdqa	(\offset + 160)(%rdi), %ymm9
+vmovdqa	(\offset + 192)(%rdi), %ymm10
+vmovdqa	(\offset + 224)(%rdi), %ymm11
 
 shuffle8	4,8,3,8
 shuffle8	5,9,4,9
@@ -68,14 +59,23 @@ shuffle1	7,3,8,3
 shuffle1	6,11,7,11
 
 #store
-vmovdqa		%ymm10,(%rdi)
-vmovdqa		%ymm5,32(%rdi)
-vmovdqa		%ymm9,64(%rdi)
-vmovdqa		%ymm4,96(%rdi)
-vmovdqa		%ymm8,128(%rdi)
-vmovdqa		%ymm3,160(%rdi)
-vmovdqa		%ymm7,192(%rdi)
-vmovdqa		%ymm11,224(%rdi)
+vmovdqa	%ymm10, (\offset +  0)(%rdi)
+vmovdqa	%ymm5,  (\offset + 32)(%rdi)
+vmovdqa	%ymm9,  (\offset + 64)(%rdi)
+vmovdqa	%ymm4,  (\offset + 96)(%rdi)
+vmovdqa	%ymm8,  (\offset +128)(%rdi)
+vmovdqa	%ymm3,  (\offset +160)(%rdi)
+vmovdqa	%ymm7,  (\offset +192)(%rdi)
+vmovdqa	%ymm11, (\offset +224)(%rdi)
+.endm
+
+.text
+.global MLK_ASM_NAMESPACE(nttunpack_avx2)
+.balign 4
+MLK_ASM_FN_SYMBOL(nttunpack_avx2)
+
+nttunpack_128_coefficients 0
+nttunpack_128_coefficients 2*128
 
 ret
 

--- a/dev/x86_64/src/reduce.S
+++ b/dev/x86_64/src/reduce.S
@@ -19,7 +19,8 @@
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs
  *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce().
+ *   semantics of mlk_poly_reduce(),
+ * - Use a macro instead of a local function call.
  */
 
 #include "../../../common.h"
@@ -31,56 +32,54 @@
 #include "consts.h"
 #include "fq.inc"
 
+.macro reduce_128_coefficients offset
+vmovdqa (\offset +   0)(%rdi), %ymm2
+vmovdqa (\offset +  32)(%rdi), %ymm3
+vmovdqa (\offset +  64)(%rdi), %ymm4
+vmovdqa (\offset +  96)(%rdi), %ymm5
+vmovdqa (\offset + 128)(%rdi), %ymm6
+vmovdqa (\offset + 160)(%rdi), %ymm7
+vmovdqa (\offset + 192)(%rdi), %ymm8
+vmovdqa (\offset + 224)(%rdi), %ymm9
+
+red16 2
+red16 3
+red16 4
+red16 5
+red16 6
+red16 7
+red16 8
+red16 9
+
+csubq 2
+csubq 3
+csubq 4
+csubq 5
+csubq 6
+csubq 7
+csubq 8
+csubq 9
+
+vmovdqa	%ymm2, (\offset +   0)(%rdi)
+vmovdqa	%ymm3, (\offset +  32)(%rdi)
+vmovdqa	%ymm4, (\offset +  64)(%rdi)
+vmovdqa	%ymm5, (\offset +  96)(%rdi)
+vmovdqa	%ymm6, (\offset + 128)(%rdi)
+vmovdqa	%ymm7, (\offset + 160)(%rdi)
+vmovdqa	%ymm8, (\offset + 192)(%rdi)
+vmovdqa	%ymm9, (\offset + 224)(%rdi)
+.endm
+
 .text
 .global MLK_ASM_NAMESPACE(reduce_avx2)
 .balign 4
 MLK_ASM_FN_SYMBOL(reduce_avx2)
 #consts
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XV*2(%rsi),%ymm1
-call		reduce_avx2_core
-add		$256,%rdi
-call		reduce_avx2_core
-ret
+vmovdqa	MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
+vmovdqa	MLK_AVX2_BACKEND_DATA_OFFSET_16XV*2(%rsi),%ymm1
 
-reduce_avx2_core:
-#load
-vmovdqa		(%rdi),%ymm2
-vmovdqa		32(%rdi),%ymm3
-vmovdqa		64(%rdi),%ymm4
-vmovdqa		96(%rdi),%ymm5
-vmovdqa		128(%rdi),%ymm6
-vmovdqa		160(%rdi),%ymm7
-vmovdqa		192(%rdi),%ymm8
-vmovdqa		224(%rdi),%ymm9
-
-red16		2
-red16		3
-red16		4
-red16		5
-red16		6
-red16		7
-red16		8
-red16		9
-
-csubq		2
-csubq		3
-csubq		4
-csubq		5
-csubq		6
-csubq		7
-csubq		8
-csubq		9
-
-#store
-vmovdqa		%ymm2,(%rdi)
-vmovdqa		%ymm3,32(%rdi)
-vmovdqa		%ymm4,64(%rdi)
-vmovdqa		%ymm5,96(%rdi)
-vmovdqa		%ymm6,128(%rdi)
-vmovdqa		%ymm7,160(%rdi)
-vmovdqa		%ymm8,192(%rdi)
-vmovdqa		%ymm9,224(%rdi)
+reduce_128_coefficients 0
+reduce_128_coefficients 128*2
 
 ret
 

--- a/dev/x86_64/src/tomont.S
+++ b/dev/x86_64/src/tomont.S
@@ -18,7 +18,8 @@
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs
  *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce().
+ *   semantics of mlk_poly_reduce(),
+ * - Use a macro instead of a local function call.
  */
 
 #include "../../../common.h"
@@ -29,29 +30,16 @@
 #include "consts.h"
 #include "fq.inc"
 
-.text
-.global MLK_ASM_NAMESPACE(tomont_avx2)
-.balign 4
-MLK_ASM_FN_SYMBOL(tomont_avx2)
-#consts
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMONTSQLO*2(%rsi),%ymm1
-vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMONTSQHI*2(%rsi),%ymm2
-call		tomont_avx2_core
-add		$256,%rdi
-call		tomont_avx2_core
-ret
-
-tomont_avx2_core:
+.macro tomont_128_coefficients offset
 #load
-vmovdqa		(%rdi),%ymm3
-vmovdqa		32(%rdi),%ymm4
-vmovdqa		64(%rdi),%ymm5
-vmovdqa		96(%rdi),%ymm6
-vmovdqa		128(%rdi),%ymm7
-vmovdqa		160(%rdi),%ymm8
-vmovdqa		192(%rdi),%ymm9
-vmovdqa		224(%rdi),%ymm10
+vmovdqa	(\offset +  0)(%rdi), %ymm3
+vmovdqa	(\offset + 32)(%rdi), %ymm4
+vmovdqa	(\offset + 64)(%rdi), %ymm5
+vmovdqa	(\offset + 96)(%rdi), %ymm6
+vmovdqa	(\offset +128)(%rdi), %ymm7
+vmovdqa	(\offset +160)(%rdi), %ymm8
+vmovdqa	(\offset +192)(%rdi), %ymm9
+vmovdqa	(\offset +224)(%rdi), %ymm10
 
 fqmulprecomp	1,2,3,11
 fqmulprecomp	1,2,4,12
@@ -63,14 +51,27 @@ fqmulprecomp	1,2,9,12
 fqmulprecomp	1,2,10,13
 
 #store
-vmovdqa		%ymm3,(%rdi)
-vmovdqa		%ymm4,32(%rdi)
-vmovdqa		%ymm5,64(%rdi)
-vmovdqa		%ymm6,96(%rdi)
-vmovdqa		%ymm7,128(%rdi)
-vmovdqa		%ymm8,160(%rdi)
-vmovdqa		%ymm9,192(%rdi)
-vmovdqa		%ymm10,224(%rdi)
+vmovdqa	%ymm3,  (\offset +  0)(%rdi)
+vmovdqa	%ymm4,  (\offset + 32)(%rdi)
+vmovdqa	%ymm5,  (\offset + 64)(%rdi)
+vmovdqa	%ymm6,  (\offset + 96)(%rdi)
+vmovdqa	%ymm7,  (\offset +128)(%rdi)
+vmovdqa	%ymm8,  (\offset +160)(%rdi)
+vmovdqa	%ymm9,  (\offset +192)(%rdi)
+vmovdqa	%ymm10, (\offset +224)(%rdi)
+.endm
+
+.text
+.global MLK_ASM_NAMESPACE(tomont_avx2)
+.balign 4
+MLK_ASM_FN_SYMBOL(tomont_avx2)
+#consts
+vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XQ*2(%rsi),%ymm0
+vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMONTSQLO*2(%rsi),%ymm1
+vmovdqa		MLK_AVX2_BACKEND_DATA_OFFSET_16XMONTSQHI*2(%rsi),%ymm2
+
+tomont_128_coefficients 0
+tomont_128_coefficients 2*128
 
 ret
 

--- a/mlkem/src/native/x86_64/src/nttfrombytes.S
+++ b/mlkem/src/native/x86_64/src/nttfrombytes.S
@@ -35,15 +35,6 @@ MLK_ASM_FN_SYMBOL(nttfrombytes_avx2)
 
         .cfi_startproc
         vmovdqa	0xe0(%rdx), %ymm0
-        callq	Lnttfrombytes_avx2_core
-        addq	$0x100, %rdi            # imm = 0x100
-        addq	$0xc0, %rsi
-        callq	Lnttfrombytes_avx2_core
-        retq
-        .cfi_endproc
-
-Lnttfrombytes_avx2_core:
-        .cfi_startproc
         vmovdqu	(%rsi), %ymm4
         vmovdqu	0x20(%rsi), %ymm5
         vmovdqu	0x40(%rsi), %ymm6
@@ -116,6 +107,78 @@ Lnttfrombytes_avx2_core:
         vmovdqa	%ymm14, 0xa0(%rdi)
         vmovdqa	%ymm15, 0xc0(%rdi)
         vmovdqa	%ymm1, 0xe0(%rdi)
+        vmovdqu	0xc0(%rsi), %ymm4
+        vmovdqu	0xe0(%rsi), %ymm5
+        vmovdqu	0x100(%rsi), %ymm6
+        vmovdqu	0x120(%rsi), %ymm7
+        vmovdqu	0x140(%rsi), %ymm8
+        vmovdqu	0x160(%rsi), %ymm9
+        vperm2i128	$0x20, %ymm7, %ymm4, %ymm3 # ymm3 = ymm4[0,1],ymm7[0,1]
+        vperm2i128	$0x31, %ymm7, %ymm4, %ymm7 # ymm7 = ymm4[2,3],ymm7[2,3]
+        vperm2i128	$0x20, %ymm8, %ymm5, %ymm4 # ymm4 = ymm5[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm5, %ymm8 # ymm8 = ymm5[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm6, %ymm5 # ymm5 = ymm6[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm6, %ymm9 # ymm9 = ymm6[2,3],ymm9[2,3]
+        vpunpcklqdq	%ymm8, %ymm3, %ymm6 # ymm6 = ymm3[0],ymm8[0],ymm3[2],ymm8[2]
+        vpunpckhqdq	%ymm8, %ymm3, %ymm8 # ymm8 = ymm3[1],ymm8[1],ymm3[3],ymm8[3]
+        vpunpcklqdq	%ymm5, %ymm7, %ymm3 # ymm3 = ymm7[0],ymm5[0],ymm7[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm7, %ymm5 # ymm5 = ymm7[1],ymm5[1],ymm7[3],ymm5[3]
+        vpunpcklqdq	%ymm9, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm9[0],ymm4[2],ymm9[2]
+        vpunpckhqdq	%ymm9, %ymm4, %ymm9 # ymm9 = ymm4[1],ymm9[1],ymm4[3],ymm9[3]
+        vmovsldup	%ymm5, %ymm4    # ymm4 = ymm5[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm4, %ymm6, %ymm4 # ymm4 = ymm6[0],ymm4[1],ymm6[2],ymm4[3],ymm6[4],ymm4[5],ymm6[6],ymm4[7]
+        vpsrlq	$0x20, %ymm6, %ymm6
+        vpblendd	$0xaa, %ymm5, %ymm6, %ymm5 # ymm5 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+        vmovsldup	%ymm7, %ymm6    # ymm6 = ymm7[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm6, %ymm8, %ymm6 # ymm6 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
+        vpsrlq	$0x20, %ymm8, %ymm8
+        vpblendd	$0xaa, %ymm7, %ymm8, %ymm7 # ymm7 = ymm8[0],ymm7[1],ymm8[2],ymm7[3],ymm8[4],ymm7[5],ymm8[6],ymm7[7]
+        vmovsldup	%ymm9, %ymm8    # ymm8 = ymm9[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm8, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm9, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm9[1],ymm3[2],ymm9[3],ymm3[4],ymm9[5],ymm3[6],ymm9[7]
+        vpslld	$0x10, %ymm7, %ymm10
+        vpblendw	$0xaa, %ymm10, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm10[1],ymm4[2],ymm10[3],ymm4[4],ymm10[5],ymm4[6],ymm10[7],ymm4[8],ymm10[9],ymm4[10],ymm10[11],ymm4[12],ymm10[13],ymm4[14],ymm10[15]
+        vpsrld	$0x10, %ymm4, %ymm4
+        vpblendw	$0xaa, %ymm7, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm7[1],ymm4[2],ymm7[3],ymm4[4],ymm7[5],ymm4[6],ymm7[7],ymm4[8],ymm7[9],ymm4[10],ymm7[11],ymm4[12],ymm7[13],ymm4[14],ymm7[15]
+        vpslld	$0x10, %ymm8, %ymm4
+        vpblendw	$0xaa, %ymm4, %ymm5, %ymm4 # ymm4 = ymm5[0],ymm4[1],ymm5[2],ymm4[3],ymm5[4],ymm4[5],ymm5[6],ymm4[7],ymm5[8],ymm4[9],ymm5[10],ymm4[11],ymm5[12],ymm4[13],ymm5[14],ymm4[15]
+        vpsrld	$0x10, %ymm5, %ymm5
+        vpblendw	$0xaa, %ymm8, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm8[1],ymm5[2],ymm8[3],ymm5[4],ymm8[5],ymm5[6],ymm8[7],ymm5[8],ymm8[9],ymm5[10],ymm8[11],ymm5[12],ymm8[13],ymm5[14],ymm8[15]
+        vpslld	$0x10, %ymm9, %ymm5
+        vpblendw	$0xaa, %ymm5, %ymm6, %ymm5 # ymm5 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7],ymm6[8],ymm5[9],ymm6[10],ymm5[11],ymm6[12],ymm5[13],ymm6[14],ymm5[15]
+        vpsrld	$0x10, %ymm6, %ymm6
+        vpblendw	$0xaa, %ymm9, %ymm6, %ymm9 # ymm9 = ymm6[0],ymm9[1],ymm6[2],ymm9[3],ymm6[4],ymm9[5],ymm6[6],ymm9[7],ymm6[8],ymm9[9],ymm6[10],ymm9[11],ymm6[12],ymm9[13],ymm6[14],ymm9[15]
+        vpsrlw	$0xc, %ymm10, %ymm11
+        vpsllw	$0x4, %ymm7, %ymm12
+        vpor	%ymm11, %ymm12, %ymm11
+        vpand	%ymm0, %ymm10, %ymm10
+        vpand	%ymm0, %ymm11, %ymm11
+        vpsrlw	$0x8, %ymm7, %ymm12
+        vpsllw	$0x8, %ymm4, %ymm13
+        vpor	%ymm12, %ymm13, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpsrlw	$0x4, %ymm4, %ymm13
+        vpand	%ymm0, %ymm13, %ymm13
+        vpsrlw	$0xc, %ymm8, %ymm14
+        vpsllw	$0x4, %ymm5, %ymm15
+        vpor	%ymm14, %ymm15, %ymm14
+        vpand	%ymm0, %ymm8, %ymm8
+        vpand	%ymm0, %ymm14, %ymm14
+        vpsrlw	$0x8, %ymm5, %ymm15
+        vpsllw	$0x8, %ymm9, %ymm1
+        vpor	%ymm15, %ymm1, %ymm15
+        vpand	%ymm0, %ymm15, %ymm15
+        vpsrlw	$0x4, %ymm9, %ymm1
+        vpand	%ymm0, %ymm1, %ymm1
+        vmovdqa	%ymm10, 0x100(%rdi)
+        vmovdqa	%ymm11, 0x120(%rdi)
+        vmovdqa	%ymm12, 0x140(%rdi)
+        vmovdqa	%ymm13, 0x160(%rdi)
+        vmovdqa	%ymm8, 0x180(%rdi)
+        vmovdqa	%ymm14, 0x1a0(%rdi)
+        vmovdqa	%ymm15, 0x1c0(%rdi)
+        vmovdqa	%ymm1, 0x1e0(%rdi)
         retq
         .cfi_endproc
 

--- a/mlkem/src/native/x86_64/src/ntttobytes.S
+++ b/mlkem/src/native/x86_64/src/ntttobytes.S
@@ -35,15 +35,6 @@ MLK_ASM_FN_SYMBOL(ntttobytes_avx2)
 
         .cfi_startproc
         vmovdqa	(%rdx), %ymm0
-        callq	Lntttobytes_avx2_core
-        addq	$0x100, %rsi            # imm = 0x100
-        addq	$0xc0, %rdi
-        callq	Lntttobytes_avx2_core
-        retq
-        .cfi_endproc
-
-Lntttobytes_avx2_core:
-        .cfi_startproc
         vmovdqa	(%rsi), %ymm5
         vmovdqa	0x20(%rsi), %ymm6
         vmovdqa	0x40(%rsi), %ymm7
@@ -110,6 +101,72 @@ Lntttobytes_avx2_core:
         vmovdqu	%ymm8, 0x60(%rdi)
         vmovdqu	%ymm3, 0x80(%rdi)
         vmovdqu	%ymm9, 0xa0(%rdi)
+        vmovdqa	0x100(%rsi), %ymm5
+        vmovdqa	0x120(%rsi), %ymm6
+        vmovdqa	0x140(%rsi), %ymm7
+        vmovdqa	0x160(%rsi), %ymm8
+        vmovdqa	0x180(%rsi), %ymm9
+        vmovdqa	0x1a0(%rsi), %ymm10
+        vmovdqa	0x1c0(%rsi), %ymm11
+        vmovdqa	0x1e0(%rsi), %ymm12
+        vpsllw	$0xc, %ymm6, %ymm4
+        vpor	%ymm4, %ymm5, %ymm4
+        vpsrlw	$0x4, %ymm6, %ymm5
+        vpsllw	$0x8, %ymm7, %ymm6
+        vpor	%ymm5, %ymm6, %ymm5
+        vpsrlw	$0x8, %ymm7, %ymm6
+        vpsllw	$0x4, %ymm8, %ymm7
+        vpor	%ymm6, %ymm7, %ymm6
+        vpsllw	$0xc, %ymm10, %ymm7
+        vpor	%ymm7, %ymm9, %ymm7
+        vpsrlw	$0x4, %ymm10, %ymm8
+        vpsllw	$0x8, %ymm11, %ymm9
+        vpor	%ymm8, %ymm9, %ymm8
+        vpsrlw	$0x8, %ymm11, %ymm9
+        vpsllw	$0x4, %ymm12, %ymm10
+        vpor	%ymm9, %ymm10, %ymm9
+        vpslld	$0x10, %ymm5, %ymm3
+        vpblendw	$0xaa, %ymm3, %ymm4, %ymm3 # ymm3 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7],ymm4[8],ymm3[9],ymm4[10],ymm3[11],ymm4[12],ymm3[13],ymm4[14],ymm3[15]
+        vpsrld	$0x10, %ymm4, %ymm4
+        vpblendw	$0xaa, %ymm5, %ymm4, %ymm5 # ymm5 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7],ymm4[8],ymm5[9],ymm4[10],ymm5[11],ymm4[12],ymm5[13],ymm4[14],ymm5[15]
+        vpslld	$0x10, %ymm7, %ymm4
+        vpblendw	$0xaa, %ymm4, %ymm6, %ymm4 # ymm4 = ymm6[0],ymm4[1],ymm6[2],ymm4[3],ymm6[4],ymm4[5],ymm6[6],ymm4[7],ymm6[8],ymm4[9],ymm6[10],ymm4[11],ymm6[12],ymm4[13],ymm6[14],ymm4[15]
+        vpsrld	$0x10, %ymm6, %ymm6
+        vpblendw	$0xaa, %ymm7, %ymm6, %ymm7 # ymm7 = ymm6[0],ymm7[1],ymm6[2],ymm7[3],ymm6[4],ymm7[5],ymm6[6],ymm7[7],ymm6[8],ymm7[9],ymm6[10],ymm7[11],ymm6[12],ymm7[13],ymm6[14],ymm7[15]
+        vpslld	$0x10, %ymm9, %ymm6
+        vpblendw	$0xaa, %ymm6, %ymm8, %ymm6 # ymm6 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7],ymm8[8],ymm6[9],ymm8[10],ymm6[11],ymm8[12],ymm6[13],ymm8[14],ymm6[15]
+        vpsrld	$0x10, %ymm8, %ymm8
+        vpblendw	$0xaa, %ymm9, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm9[1],ymm8[2],ymm9[3],ymm8[4],ymm9[5],ymm8[6],ymm9[7],ymm8[8],ymm9[9],ymm8[10],ymm9[11],ymm8[12],ymm9[13],ymm8[14],ymm9[15]
+        vmovsldup	%ymm4, %ymm8    # ymm8 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm8, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm5, %ymm3    # ymm3 = ymm5[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm6, %ymm3 # ymm3 = ymm6[0],ymm3[1],ymm6[2],ymm3[3],ymm6[4],ymm3[5],ymm6[6],ymm3[7]
+        vpsrlq	$0x20, %ymm6, %ymm6
+        vpblendd	$0xaa, %ymm5, %ymm6, %ymm5 # ymm5 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+        vmovsldup	%ymm9, %ymm6    # ymm6 = ymm9[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm6, %ymm7, %ymm6 # ymm6 = ymm7[0],ymm6[1],ymm7[2],ymm6[3],ymm7[4],ymm6[5],ymm7[6],ymm6[7]
+        vpsrlq	$0x20, %ymm7, %ymm7
+        vpblendd	$0xaa, %ymm9, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+        vpunpcklqdq	%ymm3, %ymm8, %ymm7 # ymm7 = ymm8[0],ymm3[0],ymm8[2],ymm3[2]
+        vpunpckhqdq	%ymm3, %ymm8, %ymm3 # ymm3 = ymm8[1],ymm3[1],ymm8[3],ymm3[3]
+        vpunpcklqdq	%ymm4, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm4[0],ymm6[2],ymm4[2]
+        vpunpckhqdq	%ymm4, %ymm6, %ymm4 # ymm4 = ymm6[1],ymm4[1],ymm6[3],ymm4[3]
+        vpunpcklqdq	%ymm9, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm9[0],ymm5[2],ymm9[2]
+        vpunpckhqdq	%ymm9, %ymm5, %ymm9 # ymm9 = ymm5[1],ymm9[1],ymm5[3],ymm9[3]
+        vperm2i128	$0x20, %ymm8, %ymm7, %ymm5 # ymm5 = ymm7[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm3, %ymm6, %ymm7 # ymm7 = ymm6[0,1],ymm3[0,1]
+        vperm2i128	$0x31, %ymm3, %ymm6, %ymm3 # ymm3 = ymm6[2,3],ymm3[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm4, %ymm6 # ymm6 = ymm4[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm4, %ymm9 # ymm9 = ymm4[2,3],ymm9[2,3]
+        vmovdqu	%ymm5, 0xc0(%rdi)
+        vmovdqu	%ymm7, 0xe0(%rdi)
+        vmovdqu	%ymm6, 0x100(%rdi)
+        vmovdqu	%ymm8, 0x120(%rdi)
+        vmovdqu	%ymm3, 0x140(%rdi)
+        vmovdqu	%ymm9, 0x160(%rdi)
         retq
         .cfi_endproc
 

--- a/mlkem/src/native/x86_64/src/nttunpack.S
+++ b/mlkem/src/native/x86_64/src/nttunpack.S
@@ -34,14 +34,6 @@
 MLK_ASM_FN_SYMBOL(nttunpack_avx2)
 
         .cfi_startproc
-        callq	Lnttunpack_avx2_core
-        addq	$0x100, %rdi            # imm = 0x100
-        callq	Lnttunpack_avx2_core
-        retq
-        .cfi_endproc
-
-Lnttunpack_avx2_core:
-        .cfi_startproc
         vmovdqa	(%rdi), %ymm4
         vmovdqa	0x20(%rdi), %ymm5
         vmovdqa	0x40(%rdi), %ymm6
@@ -106,6 +98,70 @@ Lnttunpack_avx2_core:
         vmovdqa	%ymm3, 0xa0(%rdi)
         vmovdqa	%ymm7, 0xc0(%rdi)
         vmovdqa	%ymm11, 0xe0(%rdi)
+        vmovdqa	0x100(%rdi), %ymm4
+        vmovdqa	0x120(%rdi), %ymm5
+        vmovdqa	0x140(%rdi), %ymm6
+        vmovdqa	0x160(%rdi), %ymm7
+        vmovdqa	0x180(%rdi), %ymm8
+        vmovdqa	0x1a0(%rdi), %ymm9
+        vmovdqa	0x1c0(%rdi), %ymm10
+        vmovdqa	0x1e0(%rdi), %ymm11
+        vperm2i128	$0x20, %ymm8, %ymm4, %ymm3 # ymm3 = ymm4[0,1],ymm8[0,1]
+        vperm2i128	$0x31, %ymm8, %ymm4, %ymm8 # ymm8 = ymm4[2,3],ymm8[2,3]
+        vperm2i128	$0x20, %ymm9, %ymm5, %ymm4 # ymm4 = ymm5[0,1],ymm9[0,1]
+        vperm2i128	$0x31, %ymm9, %ymm5, %ymm9 # ymm9 = ymm5[2,3],ymm9[2,3]
+        vperm2i128	$0x20, %ymm10, %ymm6, %ymm5 # ymm5 = ymm6[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm6, %ymm10 # ymm10 = ymm6[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm7, %ymm6 # ymm6 = ymm7[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm7, %ymm11 # ymm11 = ymm7[2,3],ymm11[2,3]
+        vpunpcklqdq	%ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[0],ymm3[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm3, %ymm5 # ymm5 = ymm3[1],ymm5[1],ymm3[3],ymm5[3]
+        vpunpcklqdq	%ymm10, %ymm8, %ymm3 # ymm3 = ymm8[0],ymm10[0],ymm8[2],ymm10[2]
+        vpunpckhqdq	%ymm10, %ymm8, %ymm10 # ymm10 = ymm8[1],ymm10[1],ymm8[3],ymm10[3]
+        vpunpcklqdq	%ymm6, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm6[0],ymm4[2],ymm6[2]
+        vpunpckhqdq	%ymm6, %ymm4, %ymm6 # ymm6 = ymm4[1],ymm6[1],ymm4[3],ymm6[3]
+        vpunpcklqdq	%ymm11, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm11[0],ymm9[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm9, %ymm11 # ymm11 = ymm9[1],ymm11[1],ymm9[3],ymm11[3]
+        vmovsldup	%ymm8, %ymm9    # ymm9 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm9, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+        vpsrlq	$0x20, %ymm7, %ymm7
+        vpblendd	$0xaa, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm8[1],ymm7[2],ymm8[3],ymm7[4],ymm8[5],ymm7[6],ymm8[7]
+        vmovsldup	%ymm6, %ymm7    # ymm7 = ymm6[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vmovsldup	%ymm4, %ymm5    # ymm5 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm11, %ymm3   # ymm3 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm10, %ymm3 # ymm3 = ymm10[0],ymm3[1],ymm10[2],ymm3[3],ymm10[4],ymm3[5],ymm10[6],ymm3[7]
+        vpsrlq	$0x20, %ymm10, %ymm10
+        vpblendd	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
+        vpslld	$0x10, %ymm5, %ymm10
+        vpblendw	$0xaa, %ymm10, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7],ymm9[8],ymm10[9],ymm9[10],ymm10[11],ymm9[12],ymm10[13],ymm9[14],ymm10[15]
+        vpsrld	$0x10, %ymm9, %ymm9
+        vpblendw	$0xaa, %ymm5, %ymm9, %ymm5 # ymm5 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7],ymm9[8],ymm5[9],ymm9[10],ymm5[11],ymm9[12],ymm5[13],ymm9[14],ymm5[15]
+        vpslld	$0x10, %ymm4, %ymm9
+        vpblendw	$0xaa, %ymm9, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm9[1],ymm8[2],ymm9[3],ymm8[4],ymm9[5],ymm8[6],ymm9[7],ymm8[8],ymm9[9],ymm8[10],ymm9[11],ymm8[12],ymm9[13],ymm8[14],ymm9[15]
+        vpsrld	$0x10, %ymm8, %ymm8
+        vpblendw	$0xaa, %ymm4, %ymm8, %ymm4 # ymm4 = ymm8[0],ymm4[1],ymm8[2],ymm4[3],ymm8[4],ymm4[5],ymm8[6],ymm4[7],ymm8[8],ymm4[9],ymm8[10],ymm4[11],ymm8[12],ymm4[13],ymm8[14],ymm4[15]
+        vpslld	$0x10, %ymm3, %ymm8
+        vpblendw	$0xaa, %ymm8, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm8[1],ymm7[2],ymm8[3],ymm7[4],ymm8[5],ymm7[6],ymm8[7],ymm7[8],ymm8[9],ymm7[10],ymm8[11],ymm7[12],ymm8[13],ymm7[14],ymm8[15]
+        vpsrld	$0x10, %ymm7, %ymm7
+        vpblendw	$0xaa, %ymm3, %ymm7, %ymm3 # ymm3 = ymm7[0],ymm3[1],ymm7[2],ymm3[3],ymm7[4],ymm3[5],ymm7[6],ymm3[7],ymm7[8],ymm3[9],ymm7[10],ymm3[11],ymm7[12],ymm3[13],ymm7[14],ymm3[15]
+        vpslld	$0x10, %ymm11, %ymm7
+        vpblendw	$0xaa, %ymm7, %ymm6, %ymm7 # ymm7 = ymm6[0],ymm7[1],ymm6[2],ymm7[3],ymm6[4],ymm7[5],ymm6[6],ymm7[7],ymm6[8],ymm7[9],ymm6[10],ymm7[11],ymm6[12],ymm7[13],ymm6[14],ymm7[15]
+        vpsrld	$0x10, %ymm6, %ymm6
+        vpblendw	$0xaa, %ymm11, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm11[1],ymm6[2],ymm11[3],ymm6[4],ymm11[5],ymm6[6],ymm11[7],ymm6[8],ymm11[9],ymm6[10],ymm11[11],ymm6[12],ymm11[13],ymm6[14],ymm11[15]
+        vmovdqa	%ymm10, 0x100(%rdi)
+        vmovdqa	%ymm5, 0x120(%rdi)
+        vmovdqa	%ymm9, 0x140(%rdi)
+        vmovdqa	%ymm4, 0x160(%rdi)
+        vmovdqa	%ymm8, 0x180(%rdi)
+        vmovdqa	%ymm3, 0x1a0(%rdi)
+        vmovdqa	%ymm7, 0x1c0(%rdi)
+        vmovdqa	%ymm11, 0x1e0(%rdi)
         retq
         .cfi_endproc
 

--- a/mlkem/src/native/x86_64/src/reduce.S
+++ b/mlkem/src/native/x86_64/src/reduce.S
@@ -19,7 +19,8 @@
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs
  *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce().
+ *   semantics of mlk_poly_reduce(),
+ * - Use a macro instead of a local function call.
  */
 
 #include "../../../common.h"
@@ -41,14 +42,6 @@ MLK_ASM_FN_SYMBOL(reduce_avx2)
         .cfi_startproc
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0x40(%rsi), %ymm1
-        callq	Lreduce_avx2_core
-        addq	$0x100, %rdi            # imm = 0x100
-        callq	Lreduce_avx2_core
-        retq
-        .cfi_endproc
-
-Lreduce_avx2_core:
-        .cfi_startproc
         vmovdqa	(%rdi), %ymm2
         vmovdqa	0x20(%rdi), %ymm3
         vmovdqa	0x40(%rdi), %ymm4
@@ -129,6 +122,86 @@ Lreduce_avx2_core:
         vmovdqa	%ymm7, 0xa0(%rdi)
         vmovdqa	%ymm8, 0xc0(%rdi)
         vmovdqa	%ymm9, 0xe0(%rdi)
+        vmovdqa	0x100(%rdi), %ymm2
+        vmovdqa	0x120(%rdi), %ymm3
+        vmovdqa	0x140(%rdi), %ymm4
+        vmovdqa	0x160(%rdi), %ymm5
+        vmovdqa	0x180(%rdi), %ymm6
+        vmovdqa	0x1a0(%rdi), %ymm7
+        vmovdqa	0x1c0(%rdi), %ymm8
+        vmovdqa	0x1e0(%rdi), %ymm9
+        vpmulhw	%ymm1, %ymm2, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm2, %ymm2
+        vpmulhw	%ymm1, %ymm3, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm3, %ymm3
+        vpmulhw	%ymm1, %ymm4, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm4, %ymm4
+        vpmulhw	%ymm1, %ymm5, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm5, %ymm5
+        vpmulhw	%ymm1, %ymm6, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm6, %ymm6
+        vpmulhw	%ymm1, %ymm7, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm7, %ymm7
+        vpmulhw	%ymm1, %ymm8, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm8, %ymm8
+        vpmulhw	%ymm1, %ymm9, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm9, %ymm9
+        vpsubw	%ymm0, %ymm2, %ymm2
+        vpsraw	$0xf, %ymm2, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm2, %ymm2
+        vpsubw	%ymm0, %ymm3, %ymm3
+        vpsraw	$0xf, %ymm3, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm3, %ymm3
+        vpsubw	%ymm0, %ymm4, %ymm4
+        vpsraw	$0xf, %ymm4, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm4, %ymm4
+        vpsubw	%ymm0, %ymm5, %ymm5
+        vpsraw	$0xf, %ymm5, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm5, %ymm5
+        vpsubw	%ymm0, %ymm6, %ymm6
+        vpsraw	$0xf, %ymm6, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm6, %ymm6
+        vpsubw	%ymm0, %ymm7, %ymm7
+        vpsraw	$0xf, %ymm7, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm7, %ymm7
+        vpsubw	%ymm0, %ymm8, %ymm8
+        vpsraw	$0xf, %ymm8, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm8, %ymm8
+        vpsubw	%ymm0, %ymm9, %ymm9
+        vpsraw	$0xf, %ymm9, %ymm12
+        vpand	%ymm0, %ymm12, %ymm12
+        vpaddw	%ymm12, %ymm9, %ymm9
+        vmovdqa	%ymm2, 0x100(%rdi)
+        vmovdqa	%ymm3, 0x120(%rdi)
+        vmovdqa	%ymm4, 0x140(%rdi)
+        vmovdqa	%ymm5, 0x160(%rdi)
+        vmovdqa	%ymm6, 0x180(%rdi)
+        vmovdqa	%ymm7, 0x1a0(%rdi)
+        vmovdqa	%ymm8, 0x1c0(%rdi)
+        vmovdqa	%ymm9, 0x1e0(%rdi)
         retq
         .cfi_endproc
 

--- a/mlkem/src/native/x86_64/src/tomont.S
+++ b/mlkem/src/native/x86_64/src/tomont.S
@@ -18,7 +18,8 @@
  * Changes:
  * - Add call to csub in reduce128_avx to produce outputs
  *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce().
+ *   semantics of mlk_poly_reduce(),
+ * - Use a macro instead of a local function call.
  */
 
 #include "../../../common.h"
@@ -40,14 +41,6 @@ MLK_ASM_FN_SYMBOL(tomont_avx2)
         vmovdqa	(%rsi), %ymm0
         vmovdqa	0xa0(%rsi), %ymm1
         vmovdqa	0xc0(%rsi), %ymm2
-        callq	Ltomont_avx2_core
-        addq	$0x100, %rdi            # imm = 0x100
-        callq	Ltomont_avx2_core
-        retq
-        .cfi_endproc
-
-Ltomont_avx2_core:
-        .cfi_startproc
         vmovdqa	(%rdi), %ymm3
         vmovdqa	0x20(%rdi), %ymm4
         vmovdqa	0x40(%rdi), %ymm5
@@ -96,6 +89,54 @@ Ltomont_avx2_core:
         vmovdqa	%ymm8, 0xa0(%rdi)
         vmovdqa	%ymm9, 0xc0(%rdi)
         vmovdqa	%ymm10, 0xe0(%rdi)
+        vmovdqa	0x100(%rdi), %ymm3
+        vmovdqa	0x120(%rdi), %ymm4
+        vmovdqa	0x140(%rdi), %ymm5
+        vmovdqa	0x160(%rdi), %ymm6
+        vmovdqa	0x180(%rdi), %ymm7
+        vmovdqa	0x1a0(%rdi), %ymm8
+        vmovdqa	0x1c0(%rdi), %ymm9
+        vmovdqa	0x1e0(%rdi), %ymm10
+        vpmullw	%ymm1, %ymm3, %ymm11
+        vpmulhw	%ymm2, %ymm3, %ymm3
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm11, %ymm3, %ymm3
+        vpmullw	%ymm1, %ymm4, %ymm12
+        vpmulhw	%ymm2, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm4, %ymm4
+        vpmullw	%ymm1, %ymm5, %ymm13
+        vpmulhw	%ymm2, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm13, %ymm13
+        vpsubw	%ymm13, %ymm5, %ymm5
+        vpmullw	%ymm1, %ymm6, %ymm14
+        vpmulhw	%ymm2, %ymm6, %ymm6
+        vpmulhw	%ymm0, %ymm14, %ymm14
+        vpsubw	%ymm14, %ymm6, %ymm6
+        vpmullw	%ymm1, %ymm7, %ymm15
+        vpmulhw	%ymm2, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm15, %ymm15
+        vpsubw	%ymm15, %ymm7, %ymm7
+        vpmullw	%ymm1, %ymm8, %ymm11
+        vpmulhw	%ymm2, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm11, %ymm8, %ymm8
+        vpmullw	%ymm1, %ymm9, %ymm12
+        vpmulhw	%ymm2, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm9, %ymm9
+        vpmullw	%ymm1, %ymm10, %ymm13
+        vpmulhw	%ymm2, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm13, %ymm13
+        vpsubw	%ymm13, %ymm10, %ymm10
+        vmovdqa	%ymm3, 0x100(%rdi)
+        vmovdqa	%ymm4, 0x120(%rdi)
+        vmovdqa	%ymm5, 0x140(%rdi)
+        vmovdqa	%ymm6, 0x160(%rdi)
+        vmovdqa	%ymm7, 0x180(%rdi)
+        vmovdqa	%ymm8, 0x1a0(%rdi)
+        vmovdqa	%ymm9, 0x1c0(%rdi)
+        vmovdqa	%ymm10, 0x1e0(%rdi)
         retq
         .cfi_endproc
 


### PR DESCRIPTION
Rewrite the x86 assembly functions to use macros instead of local function calls.
This significantly simplifies the formal verification effort.