### PR TITLE
Add make targets for building SMT files.

### DIFF
--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -262,6 +262,21 @@ CBMC_FLAG_UNWINDING_ASSERTIONS ?= # set to --no-unwinding-assertions to disable
 CBMC_DEFAULT_UNWIND ?= --unwind 1
 CBMC_FLAG_FLUSH ?= --flush
 
+# Determine SMT back-end and prover combination chosen by the user
+ifeq ($(findstring --smt2,$(CBMCFLAGS)),--smt2) # User has chosen SMT2 (which defaults to Z3)
+CBMCFLAGS := $(subst --smt2,,$(CBMCFLAGS)) # Remove --smt2 from CBMCFLAGS
+BACKEND := --smt2
+SMT_FORMAT := --z3
+else ifeq ($(findstring --bitwuzla,$(CBMCFLAGS)),--bitwuzla) # User has chosen Bitwuzla
+CBMCFLAGS := $(subst --bitwuzla,,$(CBMCFLAGS)) # Remove --bitwuzla from CBMCFLAGS
+BACKEND := --bitwuzla
+SMT_FORMAT := --bitwuzla
+else ifeq ($(findstring --cvc5,$(CBMCFLAGS)),--cvc5) # User has chosen cvc5
+CBMCFLAGS := $(subst --cvc5,,$(CBMCFLAGS)) # Remove --cvc5 from CBMCFLAGS
+BACKEND := --cvc5
+SMT_FORMAT := --cvc5
+endif
+
 # CBMC flags used for property checking and coverage checking
 
 CBMCFLAGS += $(CBMC_FLAG_FLUSH)
@@ -859,7 +874,7 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  $(POOL) \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace --xml-ui $<' \
+	  '$(CBMC) $(CBMC_VERBOSITY) $(BACKEND) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \
@@ -876,7 +891,7 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  $(POOL) \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(BACKEND) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \
@@ -889,10 +904,82 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 	  --stderr-file $(LOGDIR)/result-err-log.txt \
 	  --description "$(PROOF_UID): checking safety properties"
 
+# Force SMT generation to file using whatever backend (one of Z3, Bitwuzla, or cvc5) that the user specified
+$(HARNESS_GOTO).smt2: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(BACKEND) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --outfile $@ $(SMT_FORMAT) $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $(LOGDIR)/smt2-log.txt \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/smt2-err-log.txt \
+	  --description "$(PROOF_UID): checking safety properties (SMT to file only)"
+
+# Force SMT generation to file, but for Z3, ignoring whatever back-end the user specified
+$(HARNESS_GOTO).smtz: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --smt2 $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --outfile $@ --z3 $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $(LOGDIR)/smtz-log.txt \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/smtz-err-log.txt \
+	  --description "$(PROOF_UID): checking safety properties (SMT for Z3 only)"
+
+# Force SMT generation to file, but for Bitwuzla, ignoring whatever back-end the user specified
+$(HARNESS_GOTO).smtb: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --bitwuzla $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --outfile $@ --bitwuzla $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $(LOGDIR)/smtb-log.txt \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/smtb-err-log.txt \
+	  --description "$(PROOF_UID): checking safety properties (SMT for Bitwuzla only)"
+
+# Force SMT generation to file, but for cvc5, ignoring whatever back-end the user specified
+$(HARNESS_GOTO).smtc: $(HARNESS_GOTO).goto
+	$(LITANI) add-job \
+	  $(POOL) \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --cvc5 $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --outfile $@ --cvc5 $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --ci-stage test \
+	  --stdout-file $(LOGDIR)/smtc-log.txt \
+	  $(MEMORY_PROFILING) \
+	  --ignore-returns 10 \
+	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/smtc-err-log.txt \
+	  --description "$(PROOF_UID): checking safety properties (SMT for cvc5 only)"
+
 $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(BACKEND) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \
@@ -906,7 +993,7 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  $(POOL) \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(BACKEND) $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \
@@ -971,6 +1058,50 @@ result:
 	tail -4 $(LOGDIR)/result.txt
 	-grep FAILURE $(LOGDIR)/result.txt
 
+_smt: $(HARNESS_GOTO).smt2
+smt:
+	@ echo Running 'litani init'
+	$(LITANI) init $(INIT_POOLS) --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _smt
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_smtz: $(HARNESS_GOTO).smtz
+smtz:
+	@ echo Running 'litani init'
+	$(LITANI) init $(INIT_POOLS) --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _smtz
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_smtb: $(HARNESS_GOTO).smtb
+smtb:
+	@ echo Running 'litani init'
+	$(LITANI) init $(INIT_POOLS) --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _smtb
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_smtc: $(HARNESS_GOTO).smtc
+smtc:
+	@ echo Running 'litani init'
+	$(LITANI) init $(INIT_POOLS) --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _smtc
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
+_smtall: $(HARNESS_GOTO).smtz $(HARNESS_GOTO).smtb $(HARNESS_GOTO).smtc
+smtall:
+	@ echo Running 'litani init'
+	$(LITANI) init $(INIT_POOLS) --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _smtall
+	@ echo Running 'litani build'
+	$(LITANI) run-build
 
 _property: $(LOGDIR)/property.xml
 property:

--- a/proofs/cbmc/proof_guide.md
+++ b/proofs/cbmc/proof_guide.md
@@ -330,9 +330,8 @@ Edit the Makefile and update the definition of the following variables:
   function for proof, rather than 'inlining' the called function for proof. Include the `mlk_` prefix if
   required
 * EXTERNAL_SAT_SOLVER - should _always_ be "nothing" to prevent CBMC selecting a SAT backend over the selected SMT backend.
-* CBMCFLAGS - additional flags to pass to the final run of CBMC. This is normally set to `--smt2` which tells cbmc to
-  run Z3 as its underlying solver. Can also be set to `--bitwuzla` which is sometimes better at generating
-  counter-examples when Z3 fails.
+* CBMCFLAGS - additional flags to pass to the final run of CBMC. This is normally set to `--smt2` which tells CBMC to
+  run Z3 as its underlying solver. Can also be set to `--bitwuzla` which is sometimes faster than Z3 for some functions.
 * FUNCTION_NAME - set to `XXX` with the `mlk_` prefix if required
 * CBMC_OBJECT_BITS. Normally set to 8, but might need to be increased if CBMC runs out of memory for this proof.
 
@@ -439,6 +438,35 @@ make result VERBOSE=1 >log.txt
 ```
 
 and then inspect `log.txt` to see the exact sequence of commands that has been run. With that, you should be able to reproduce a failure on the command-line directly.
+
+### Debugging a proof - additional proof targets to get GOTO and SMT files
+
+The `Makefile.common` also contains make targets that can be used to generate the intermediate files
+for inspection, but without actually running the (time consuming) provers at all.
+
+`make goto` generates all the GOTO files (in `gotos/*.goto`) and then stops. For a function
+x(), the final GOTO file ends up in `gotos/x_harness.goto`.
+
+There are also targets that generate the SMT proof files, but without actually running the selected prover.
+
+For a function x(), (so you're in sub-directory `proofs/cbmc/x`), you can do:
+
+`make smt` generates `gotos/x_harness.smt2` for the prover selected in the `Makefile` (which must be one
+of Z3, Bitwuzla, or CVC5)
+
+`make smtz` generates `gotos/x_harness.smtz` but forces generation for the Z3 prover, ignoring the prover
+selected in the `Makefile`. Similarly
+
+`make smtb` generates `gotos/x_harness.smtb` but forces generation for Bitwuzla.
+
+`make smtc` generates `gotos/x_harness.smtb` but forces generation for cvc5.
+
+Finally,
+
+`make smtall` generates SMT files for all three provers as above.
+
+The final target is useful to generate SMT files for all three provers to see which one is
+most successful and/or fastest on a particular problem.
 
 ## Worked Example - proving mlk_poly_tobytes()
 


### PR DESCRIPTION
When investigating and/or debugging CBMC proof failures, it can be very useful to generate the SMT file(s), but without actually running the provers. It's also useful to generate the SMT files for one or all of Z3, Bitwuzla, or CVC5 for comparison.

Update Makefile.common for CBMC so that for a function x, new Makefile targets are:

smt: generates gotos/x.smt2 for prover (z3, bitwuzla, or cvc5) chosen by the user
     in the specific Makefile for that function.

smtz: generates gotos/x.smtz, but always for Z3, ignoring the choice in the Makefile
smtb: generates gotos/x.smtb, but always for Bitwuzla, ignoring the choice in the Makefile
smtc: generates gotos/x.smtc, but always for cvc5, ignoring the choice in the Makefile

smtall: generates all three targets smtz, smtb, smtc as above.