### PR TITLE
OQS CI: Enable constant-time tests

### DIFF
--- a/.github/actions/config-variations/action.yml
+++ b/.github/actions/config-variations/action.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-name: 'Cuatom config tests'
+name: 'Custom config tests'
 description: 'Build and test mlkem-native with various custom configs'
 inputs:
   gh_token:

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -15,9 +15,9 @@ jobs:
         system: [ubuntu-latest, pqcp-arm64]
         cmake:
           - name: Auto
-            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=auto -DCMAKE_BUILD_TYPE=Release
+            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=auto -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           - name: C
-            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Release
+            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
     name: Build (${{ matrix.cmake.name }}, ${{ matrix.system }})
     runs-on: ${{ matrix.system }}
     steps:

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -35,8 +35,12 @@ jobs:
           sed -i "/name: mlkem-native/,/preserve_folder_structure/s%git_url: .*%git_url: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY%" scripts/copy_from_upstream/copy_from_upstream.yml
           sed -i "/name: mlkem-native/,/preserve_folder_structure/s/git_branch: .*/git_branch: $GITHUB_SHA/" scripts/copy_from_upstream/copy_from_upstream.yml
           sed -i "/name: mlkem-native/,/preserve_folder_structure/s/git_commit: .*/git_commit: $GITHUB_SHA/" scripts/copy_from_upstream/copy_from_upstream.yml
+          # TODO: Remove once patch is removed upstream
           # Remove patch
           sed -i "/name: mlkem-native/,/preserve_folder_structure/{/patches:/d}" scripts/copy_from_upstream/copy_from_upstream.yml
+          # TODO: Remove one it has been removed upstream
+          # Remove CT test suppressions
+          echo "" > tests/constant_time/kem/passes/ml_kem
           # Temporarily remove oldpqclean because of build failures in its SHA3 assembly
           yq e -i 'del(.kems[] | select(.name == "kyber"))' scripts/copy_from_upstream/copy_from_upstream.yml
           yq e -i 'del(.sigs[] | select(.name == "dilithium"))' scripts/copy_from_upstream/copy_from_upstream.yml

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -15,6 +15,15 @@
 #ifndef MLK_INTEGRATION_LIBOQS_CONFIG_AARCH64_H
 #define MLK_INTEGRATION_LIBOQS_CONFIG_AARCH64_H
 
+/* Enable valgrind-based assertions in mlkem-native through macro
+ * from libOQS. */
+#if !defined(__ASSEMBLER__)
+#include <oqs/common.h>
+#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
+#define MLK_CONFIG_CT_TESTING_ENABLED
+#endif
+#endif /* !__ASSEMBLER__ */
+
 /******************************************************************************
  * Name:        MLK_CONFIG_PARAMETER_SET
  *
@@ -249,14 +258,5 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
-
-/* Enable valgrind-based assertions in mlkem-native through macro
- * from libOQS. */
-#if !defined(__ASSEMBLER__)
-#include <oqs/common.h>
-#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
-#define MLK_CONFIG_CT_TESTING_ENABLED
-#endif
-#endif /* !__ASSEMBLER__ */
 
 #endif /* !MLK_INTEGRATION_LIBOQS_CONFIG_AARCH64_H */

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -15,6 +15,16 @@
 #ifndef MLK_INTEGRATION_LIBOQS_CONFIG_C_H
 #define MLK_INTEGRATION_LIBOQS_CONFIG_C_H
 
+/* Enable valgrind-based assertions in mlkem-native through macro
+ * from libOQS. */
+#if !defined(__ASSEMBLER__)
+#include <oqs/common.h>
+#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
+#define MLK_CONFIG_CT_TESTING_ENABLED
+#endif
+#endif /* !__ASSEMBLER__ */
+
+
 /******************************************************************************
  * Name:        MLK_CONFIG_PARAMETER_SET
  *
@@ -211,14 +221,5 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
-
-/* Enable valgrind-based assertions in mlkem-native through macro
- * from libOQS. */
-#if !defined(__ASSEMBLER__)
-#include <oqs/common.h>
-#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
-#define MLK_CONFIG_CT_TESTING_ENABLED
-#endif
-#endif /* !__ASSEMBLER__ */
 
 #endif /* !MLK_INTEGRATION_LIBOQS_CONFIG_C_H */

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -15,6 +15,15 @@
 #ifndef MLK_INTEGRATION_LIBOQS_CONFIG_X86_64_H
 #define MLK_INTEGRATION_LIBOQS_CONFIG_X86_64_H
 
+/* Enable valgrind-based assertions in mlkem-native through macro
+ * from libOQS. */
+#if !defined(__ASSEMBLER__)
+#include <oqs/common.h>
+#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
+#define MLK_CONFIG_CT_TESTING_ENABLED
+#endif
+#endif /* !__ASSEMBLER__ */
+
 /******************************************************************************
  * Name:        MLK_CONFIG_PARAMETER_SET
  *
@@ -250,14 +259,5 @@ static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
    }
    #endif
 */
-
-/* Enable valgrind-based assertions in mlkem-native through macro
- * from libOQS. */
-#if !defined(__ASSEMBLER__)
-#include <oqs/common.h>
-#if defined(OQS_ENABLE_TEST_CONSTANT_TIME)
-#define MLK_CONFIG_CT_TESTING_ENABLED
-#endif
-#endif /* !__ASSEMBLER__ */
 
 #endif /* !MLK_INTEGRATION_LIBOQS_CONFIG_X86_64_H */


### PR DESCRIPTION
Currently our liboqs integration tests are skipping the oqs constant time tests. There is no reason to skip those.

This commit adds
-DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON which enables the constant-time tests.

 - Resolves https://github.com/pq-code-package/mlkem-native/issues/1199