### PR TITLE
Fix bibliography, add all authors for mupq

### DIFF
--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -287,7 +287,11 @@ source code and documentation.
 
 * Common files for pqm4, pqm3, pqriscv
 * Author(s):
-  - Kannwischer et. al
+  - Matthias J. Kannwischer
+  - Richard Petri
+  - Joost Rijneveld
+  - Peter Schwabe
+  - Ko Stoffelen
 * URL: https://github.com/mupq/mupq
 * Referenced from:
   - [mlkem/src/fips202/fips202.c](mlkem/src/fips202/fips202.c)

--- a/BIBLIOGRAPHY.yml
+++ b/BIBLIOGRAPHY.yml
@@ -111,7 +111,12 @@
   url: https://eprint.iacr.org/2018/039
 
 - id: mupq
-  author: Kannwischer et. al
+  author: 
+  - Kannwischer, Matthias J. 
+  - Petri, Richard
+  - Rijneveld, Joost
+  - Schwabe, Peter 
+  - Stoffelen, Ko
   name: Common files for pqm4, pqm3, pqriscv
   url: https://github.com/mupq/mupq
 

--- a/mlkem/src/fips202/fips202.c
+++ b/mlkem/src/fips202/fips202.c
@@ -13,7 +13,7 @@
  *
  * - [mupq]
  *   Common files for pqm4, pqm3, pqriscv
- *   Kannwischer et. al
+ *   Kannwischer, Petri, Rijneveld, Schwabe, Stoffelen
  *   https://github.com/mupq/mupq
  *
  * - [supercop]

--- a/mlkem/src/fips202/keccakf1600.c
+++ b/mlkem/src/fips202/keccakf1600.c
@@ -8,7 +8,7 @@
  *
  * - [mupq]
  *   Common files for pqm4, pqm3, pqriscv
- *   Kannwischer et. al
+ *   Kannwischer, Petri, Rijneveld, Schwabe, Stoffelen
  *   https://github.com/mupq/mupq
  *
  * - [supercop]


### PR DESCRIPTION
- This is a samll fix about bibliography, this PR add all authors for `mupq` instead of just use the  `et.al`
- see https://github.com/pq-code-package/mldsa-native/pull/482#discussion_r2381480490