### PR TITLE
Use cpp __COUNTER__ macro instead of __LINE__

### DIFF
--- a/mlkem/src/cbmc.h
+++ b/mlkem/src/cbmc.h
@@ -135,7 +135,7 @@
   }
 
 #define array_bound(array_var, qvar_lb, qvar_ub, value_lb, value_ub) \
-  array_bound_core(CBMC_CONCAT(_cbmc_idx, __LINE__), (qvar_lb),      \
+  array_bound_core(CBMC_CONCAT(_cbmc_idx, __COUNTER__), (qvar_lb),      \
       (qvar_ub), (array_var), (value_lb), (value_ub))
 
 #define array_unchanged_core(qvar, qvar_lb, qvar_ub, array_var)        \
@@ -147,7 +147,7 @@
   }
 
 #define array_unchanged(array_var, N) \
-    array_unchanged_core(CBMC_CONCAT(_cbmc_idx, __LINE__), 0, (N), (array_var))
+    array_unchanged_core(CBMC_CONCAT(_cbmc_idx, __COUNTER__), 0, (N), (array_var))
 
 #define array_unchanged_u64_core(qvar, qvar_lb, qvar_ub, array_var)        \
   __CPROVER_forall                                                     \
@@ -158,7 +158,7 @@
   }
 
 #define array_unchanged_u64(array_var, N) \
-    array_unchanged_u64_core(CBMC_CONCAT(_cbmc_idx, __LINE__), 0, (N), (array_var))
+    array_unchanged_u64_core(CBMC_CONCAT(_cbmc_idx, __COUNTER__), 0, (N), (array_var))
 /* clang-format on */
 
 /* Wrapper around array_bound operating on absolute values.

--- a/proofs/cbmc/proof_guide.md
+++ b/proofs/cbmc/proof_guide.md
@@ -529,7 +529,7 @@ __contract__(
   assigns(object_whole(r)));
 ```
 
-`array_bound` is a macro that expands to a quantified expression that expresses that the elemtns of `a->coeffs` between
+`array_bound` is a macro that expands to a quantified expression that expresses that the elements of `a->coeffs` between
 index values `0` (inclusive) and `MLKEM_N` (exclusive) are in the range `0` (inclusive) through `MLKEM_Q` (exclusive). See the macro definition in [mlkem/src/cbmc.h](../../mlkem/src/cbmc.h) for details.
 
 ### Interior contracts and loop invariants


### PR DESCRIPTION
Use cpp __COUNTER__ macro instead of __LINE__ when creating names of quantified variables. This improves proof stability, since minor changes (such as adding a single blank line) do not affect naming of such variables.

No change required to proof_guide.md, but also fix a typo en-passant.

Proofs are all OK locally on both M1/macOS and Grv3/Ubuntu, with timings for MLKEM_K=2,3,4 as follows:

macos (8 cores): 8m27s, 8m57s, 8m12s
Grv3/Ubuntu (64 cores): 3m50s, 3m33s, 3m36s
