### PR TITLE
Switch macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -40,7 +40,7 @@ jobs:
            name: 'x86_64'
          - runner: macos-latest
            name: 'macos (aarch64)'
-         - runner: macos-13
+         - runner: macos-15-intel
            name: 'macos (x86_64)'
         exclude:
           - {external: true,
@@ -101,7 +101,7 @@ jobs:
            name: 'x86_64'
          - runner: macos-latest
            name: 'macos (aarch64)'
-         - runner: macos-13
+         - runner: macos-15-intel
            name: 'macos (x86_64)'
         exclude:
           - {external: true,
@@ -209,7 +209,7 @@ jobs:
     name: Quickcheck lib
     strategy:
       matrix:
-        system: [macos-latest, macos-13, ubuntu-latest, pqcp-arm64]
+        system: [macos-latest, macos-15-intel, ubuntu-latest, pqcp-arm64]
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -220,7 +220,7 @@ jobs:
     name: Examples
     strategy:
       matrix:
-        system: [macos-latest, macos-13, ubuntu-latest, pqcp-arm64]
+        system: [macos-latest, macos-15-intel, ubuntu-latest, pqcp-arm64]
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
            arch: mac
            mode: native
            nix_shell: ci
-         - runner: macos-13
+         - runner: macos-15-intel
            name: 'MacOS (x86_64)'
            arch: mac
            mode: native

--- a/.github/workflows/integration-awslc.yml
+++ b/.github/workflows/integration-awslc.yml
@@ -126,7 +126,7 @@ jobs:
       max-parallel: 8
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64, macos-latest, macos-13]
+        system: [ubuntu-latest, pqcp-arm64, macos-latest, macos-15-intel]
         test:
           - name: Prefix+Debug
             flags:


### PR DESCRIPTION
- Resolves: #1213 
- This PR switch the macos (x86_64) runners from `macos-13` to `macos-15-intel`, due to the `macos-13` runners will not be supported anymore from December 3, 2025, check the following link:
- https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

