### PR TITLE
LIBOQS CT CI: Always compile for Haswell to avoid valgrind AVX512 failures

### DIFF
--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -1,3 +1,4 @@
+# Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 name: Test liboqs integration
@@ -12,13 +13,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64]
-        cmake:
-          - name: Auto
-            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=auto -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
-          - name: C
+        include:
+          # x86
+          - system: ubuntu-latest
+            name: Haswell
+            # ubuntu-latest may have AVX512 instructions that are not supported by valgrind
+            # We explicitly compile for an older uarch to work around valgrind failures
+            # TODO: switch this back to auto once valgrind supports AVX512 well
+            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
+          - system: ubuntu-latest
+            name: C
             flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
-    name: Build (${{ matrix.cmake.name }}, ${{ matrix.system }})
+          # AArch64
+          - system: pqcp-arm64
+            name: Auto
+            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=auto -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
+          - system: pqcp-arm64
+            name: C
+            flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
+    name: Build (${{ matrix.name }}, ${{ matrix.system }})
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -60,7 +73,7 @@ jobs:
           cd $LIBOQS_DIR
           mkdir build
           cd build
-          cmake ${{ matrix.cmake.flags }} ..
+          cmake ${{ matrix.flags }} ..
           make -j$(nproc)
       - name: Run KEM-test
         run: |


### PR DESCRIPTION
…lures

valgrind has poor support for AVX512 right now. Since recently Github's ubuntu-latest runners occasionally have AVX512 support causing the OQS_OPT_TARGET=auto flag to result in AVX512 instructions to be generated. Consequently, valgrind fails during the constant time tests. We have seen such failures in the main branch:
https://github.com/pq-code-package/mlkem-native/actions/runs/18371183652/job/52353870351

Similar failures do not happen in our own constant-time CI as we never compile with AVX512 enabled.