### PR TITLE
nix: Update HOL-Light and s2n-bignum repositories

### DIFF
--- a/nix/hol_light/default.nix
+++ b/nix/hol_light/default.nix
@@ -6,12 +6,12 @@ hol_light.overrideAttrs (old: {
     export HOLDIR="$1/lib/hol_light"
     export HOLLIGHT_DIR="$1/lib/hol_light"
   '';
-  version = "unstable-2024-12-22";
+  version = "unstable-2025-09-22";
   src = fetchFromGitHub {
     owner = "jrh13";
     repo = "hol-light";
-    rev = "157c99b7bb3a485116dc2bfc4ef3ad00912d883b";
-    hash = "sha256-UFK+STxcgvvTuNx1hcm1S77iB9k3KMF59A2iaKNIz7A=";
+    rev = "bed58fa74649fa74015176f8f90e77f7af5cf8e3";
+    hash = "sha256-QDubbUUChvv04239BdcKPSU+E2gdSzqAWfAETK2Xtg0=";
   };
   patches = [ ./0005-Fix-hollight-path.patch ];
   propagatedBuildInputs = old.propagatedBuildInputs ++ old.nativeBuildInputs;

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -2,12 +2,12 @@
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";
-  version = "b93469e03f0a31c7b97fcb0c2ef2f1e1ca478237";
+  version = "2ab2252b8505e58a7c3392f8ad823782032b61e7";
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "s2n-bignum";
     rev = "${version}";
-    hash = "sha256-O5eEKz238b+weTeVpmqnK8kvu53AXpZTm2E8Tk+FBn4=";
+    hash = "sha256-7lil3jAFo5NiyNOSBYZcRjduXkotV3x4PlxXSKt63M8=";
   };
   setupHook = writeText "setup-hook.sh" ''
     export S2N_BIGNUM_DIR="$1"


### PR DESCRIPTION
Moving to latest `main` on both.