### PR TITLE
Fix `-Wconversion` warnings

### DIFF
--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -59,6 +59,7 @@ CFLAGS := \
 	-Werror \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/examples/basic_deterministic/Makefile
+++ b/examples/basic_deterministic/Makefile
@@ -47,6 +47,7 @@ CFLAGS := \
 	-Werror \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/examples/bring_your_own_fips202/Makefile
+++ b/examples/bring_your_own_fips202/Makefile
@@ -65,6 +65,7 @@ CFLAGS := \
 	-Wshadow \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/examples/bring_your_own_fips202/custom_fips202/tiny_sha3/sha3.c
+++ b/examples/bring_your_own_fips202/custom_fips202/tiny_sha3/sha3.c
@@ -96,14 +96,14 @@ void sha3_keccakf(uint64_t st[25])
   {
     v = (uint8_t *)&st[i];
     t = st[i];
-    v[0] = t & 0xFF;
-    v[1] = (t >> 8) & 0xFF;
-    v[2] = (t >> 16) & 0xFF;
-    v[3] = (t >> 24) & 0xFF;
-    v[4] = (t >> 32) & 0xFF;
-    v[5] = (t >> 40) & 0xFF;
-    v[6] = (t >> 48) & 0xFF;
-    v[7] = (t >> 56) & 0xFF;
+    v[0] = (uint8_t)(t & 0xFF);
+    v[1] = (uint8_t)((t >> 8) & 0xFF);
+    v[2] = (uint8_t)((t >> 16) & 0xFF);
+    v[3] = (uint8_t)((t >> 24) & 0xFF);
+    v[4] = (uint8_t)((t >> 32) & 0xFF);
+    v[5] = (uint8_t)((t >> 40) & 0xFF);
+    v[6] = (uint8_t)((t >> 48) & 0xFF);
+    v[7] = (uint8_t)((t >> 56) & 0xFF);
   }
 #endif /* __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__ */
 }

--- a/examples/custom_backend/Makefile
+++ b/examples/custom_backend/Makefile
@@ -62,6 +62,7 @@ CFLAGS := \
 	-Werror \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/examples/monolithic_build/Makefile
+++ b/examples/monolithic_build/Makefile
@@ -67,6 +67,7 @@ CFLAGS := \
 	-Wshadow \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \
@@ -135,6 +136,6 @@ size: build
 	@$(Q)$(SIZE) $(LIB512_FULL)
 	@$(Q)$(SIZE) $(LIB768_FULL)
 	@$(Q)$(SIZE) $(LIB1024_FULL)
-	
+
 clean:
 	rm -rf $(BUILD_DIR)

--- a/examples/monolithic_build_multilevel_native/Makefile
+++ b/examples/monolithic_build_multilevel_native/Makefile
@@ -94,6 +94,7 @@ CFLAGS := \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-unused-command-line-argument \
 	-fomit-frame-pointer \
 	-std=c99 \
@@ -135,7 +136,7 @@ build: $(BINARY_NAME_FULL)
 run: $(BINARY_NAME_FULL)
 	$(EXEC_WRAPPER) ./$(BINARY_NAME_FULL)
 
-size: build 
+size: build
 	$(Q)echo "=== Size info for binaries $(BINARY_NAME_FULL)==="
 	$(Q)$(SIZE) $(BINARY_NAME_FULL)
 	$(Q)echo " "

--- a/examples/monolithic_build_native/Makefile
+++ b/examples/monolithic_build_native/Makefile
@@ -68,6 +68,7 @@ CFLAGS := \
 	-Wshadow \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/examples/multilevel_build/Makefile
+++ b/examples/multilevel_build/Makefile
@@ -85,6 +85,7 @@ CFLAGS := \
 	-Werror \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/examples/multilevel_build_native/Makefile
+++ b/examples/multilevel_build_native/Makefile
@@ -60,6 +60,7 @@ CFLAGS := \
 	-Werror \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/mlkem/src/compress.c
+++ b/mlkem/src/compress.c
@@ -53,10 +53,11 @@ MLK_STATIC_TESTABLE void mlk_poly_compress_d4_c(
       t[j] = mlk_scalar_compress_d4(a->coeffs[8 * i + j]);
     }
 
-    r[i * 4] = t[0] | (t[1] << 4);
-    r[i * 4 + 1] = t[2] | (t[3] << 4);
-    r[i * 4 + 2] = t[4] | (t[5] << 4);
-    r[i * 4 + 3] = t[6] | (t[7] << 4);
+    /* All t[i] are 4-bit wide, so the truncations don't alter the value. */
+    r[i * 4] = (uint8_t)(t[0] | (t[1] << 4));
+    r[i * 4 + 1] = (uint8_t)(t[2] | (t[3] << 4));
+    r[i * 4 + 2] = (uint8_t)(t[4] | (t[5] << 4));
+    r[i * 4 + 3] = (uint8_t)(t[6] | (t[7] << 4));
   }
 }
 
@@ -105,11 +106,11 @@ MLK_STATIC_TESTABLE void mlk_poly_compress_d10_c(
      * Make all implicit truncation explicit. No data is being
      * truncated for the LHS's since each t[i] is 10-bit in size.
      */
-    r[5 * j + 0] = (t[0] >> 0) & 0xFF;
-    r[5 * j + 1] = (t[0] >> 8) | ((t[1] << 2) & 0xFF);
-    r[5 * j + 2] = (t[1] >> 6) | ((t[2] << 4) & 0xFF);
-    r[5 * j + 3] = (t[2] >> 4) | ((t[3] << 6) & 0xFF);
-    r[5 * j + 4] = (t[3] >> 2);
+    r[5 * j + 0] = (uint8_t)((t[0] >> 0) & 0xFF);
+    r[5 * j + 1] = (uint8_t)((t[0] >> 8) | ((t[1] << 2) & 0xFF));
+    r[5 * j + 2] = (uint8_t)((t[1] >> 6) | ((t[2] << 4) & 0xFF));
+    r[5 * j + 3] = (uint8_t)((t[2] >> 4) | ((t[3] << 6) & 0xFF));
+    r[5 * j + 4] = (uint8_t)(t[3] >> 2);
   }
 }
 
@@ -241,16 +242,11 @@ MLK_STATIC_TESTABLE void mlk_poly_compress_d5_c(
       t[j] = mlk_scalar_compress_d5(a->coeffs[8 * i + j]);
     }
 
-    /*
-     * Explicitly truncate to avoid warning about
-     * implicit truncation in CBMC, and use array indexing into
-     * r rather than pointer-arithmetic to simplify verification
-     */
-    r[i * 5] = 0xFF & ((t[0] >> 0) | (t[1] << 5));
-    r[i * 5 + 1] = 0xFF & ((t[1] >> 3) | (t[2] << 2) | (t[3] << 7));
-    r[i * 5 + 2] = 0xFF & ((t[3] >> 1) | (t[4] << 4));
-    r[i * 5 + 3] = 0xFF & ((t[4] >> 4) | (t[5] << 1) | (t[6] << 6));
-    r[i * 5 + 4] = 0xFF & ((t[6] >> 2) | (t[7] << 3));
+    r[i * 5] = (uint8_t)(0xFF & ((t[0] >> 0) | (t[1] << 5)));
+    r[i * 5 + 1] = (uint8_t)(0xFF & ((t[1] >> 3) | (t[2] << 2) | (t[3] << 7)));
+    r[i * 5 + 2] = (uint8_t)(0xFF & ((t[3] >> 1) | (t[4] << 4)));
+    r[i * 5 + 3] = (uint8_t)(0xFF & ((t[4] >> 4) | (t[5] << 1) | (t[6] << 6)));
+    r[i * 5 + 4] = (uint8_t)(0xFF & ((t[6] >> 2) | (t[7] << 3)));
   }
 }
 
@@ -300,17 +296,17 @@ MLK_STATIC_TESTABLE void mlk_poly_compress_d11_c(
      * Make all implicit truncation explicit. No data is being
      * truncated for the LHS's since each t[i] is 11-bit in size.
      */
-    r[11 * j + 0] = (t[0] >> 0) & 0xFF;
-    r[11 * j + 1] = (t[0] >> 8) | ((t[1] << 3) & 0xFF);
-    r[11 * j + 2] = (t[1] >> 5) | ((t[2] << 6) & 0xFF);
-    r[11 * j + 3] = (t[2] >> 2) & 0xFF;
-    r[11 * j + 4] = (t[2] >> 10) | ((t[3] << 1) & 0xFF);
-    r[11 * j + 5] = (t[3] >> 7) | ((t[4] << 4) & 0xFF);
-    r[11 * j + 6] = (t[4] >> 4) | ((t[5] << 7) & 0xFF);
-    r[11 * j + 7] = (t[5] >> 1) & 0xFF;
-    r[11 * j + 8] = (t[5] >> 9) | ((t[6] << 2) & 0xFF);
-    r[11 * j + 9] = (t[6] >> 6) | ((t[7] << 5) & 0xFF);
-    r[11 * j + 10] = (t[7] >> 3);
+    r[11 * j + 0] = (uint8_t)((t[0] >> 0) & 0xFF);
+    r[11 * j + 1] = (uint8_t)((t[0] >> 8) | ((t[1] << 3) & 0xFF));
+    r[11 * j + 2] = (uint8_t)((t[1] >> 5) | ((t[2] << 6) & 0xFF));
+    r[11 * j + 3] = (uint8_t)((t[2] >> 2) & 0xFF);
+    r[11 * j + 4] = (uint8_t)((t[2] >> 10) | ((t[3] << 1) & 0xFF));
+    r[11 * j + 5] = (uint8_t)((t[3] >> 7) | ((t[4] << 4) & 0xFF));
+    r[11 * j + 6] = (uint8_t)((t[4] >> 4) | ((t[5] << 7) & 0xFF));
+    r[11 * j + 7] = (uint8_t)((t[5] >> 1) & 0xFF);
+    r[11 * j + 8] = (uint8_t)((t[5] >> 9) | ((t[6] << 2) & 0xFF));
+    r[11 * j + 9] = (uint8_t)((t[6] >> 6) | ((t[7] << 5) & 0xFF));
+    r[11 * j + 10] = (uint8_t)(t[7] >> 3);
   }
 }
 
@@ -470,8 +466,10 @@ __contract__(
   for (i = 0; i < MLKEM_N / 2; i++)
   __loop__(invariant(i <= MLKEM_N / 2))
   {
-    const uint16_t t0 = a->coeffs[2 * i];
-    const uint16_t t1 = a->coeffs[2 * i + 1];
+    /* The conversion to uint16_t is safe since we assume that
+     * the coefficients of `a` are non-negative. */
+    const uint16_t t0 = (uint16_t)a->coeffs[2 * i];
+    const uint16_t t1 = (uint16_t)a->coeffs[2 * i + 1];
     /*
      * t0 and t1 are both < MLKEM_Q, so contain at most 12 bits each of
      * significant data, so these can be packed into 24 bits or exactly
@@ -479,17 +477,20 @@ __contract__(
      */
 
     /* Least significant bits 0 - 7 of t0. */
-    r[3 * i + 0] = t0 & 0xFF;
+    r[3 * i + 0] = (uint8_t)(t0 & 0xFF);
 
     /*
      * Most significant bits 8 - 11 of t0 become the least significant
      * nibble of the second byte. The least significant 4 bits
      * of t1 become the upper nibble of the second byte.
+     *
+     * The conversion to uint8_t does not alter the value.
      */
-    r[3 * i + 1] = (t0 >> 8) | ((t1 << 4) & 0xF0);
+    r[3 * i + 1] = (uint8_t)((t0 >> 8) | ((t1 << 4) & 0xF0));
 
-    /* Bits 4 - 11 of t1 become the third byte. */
-    r[3 * i + 2] = t1 >> 4;
+    /* Bits 4 - 11 of t1 become the third byte. The conversion to uint8_t
+     * does not alter the value because t1 is 12-bit wide. */
+    r[3 * i + 2] = (uint8_t)(t1 >> 4);
   }
 }
 
@@ -528,8 +529,8 @@ __contract__(
     const uint8_t t0 = a[3 * i + 0];
     const uint8_t t1 = a[3 * i + 1];
     const uint8_t t2 = a[3 * i + 2];
-    r->coeffs[2 * i + 0] = t0 | ((t1 << 8) & 0xFFF);
-    r->coeffs[2 * i + 1] = (t1 >> 4) | (t2 << 4);
+    r->coeffs[2 * i + 0] = (int16_t)(t0 | ((t1 << 8) & 0xFFF));
+    r->coeffs[2 * i + 1] = (int16_t)((t1 >> 4) | (t2 << 4));
   }
 
   /* Note that the coefficients are not canonical */
@@ -580,7 +581,7 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
        * as per @[FIPS203, Eq (4.8)]. */
 
       /* Prevent the compiler from recognizing this as a bit selection */
-      uint8_t mask = mlk_value_barrier_u8(1u << j);
+      uint8_t mask = mlk_value_barrier_u8((uint8_t)(1u << j));
       r->coeffs[8 * i + j] = mlk_ct_sel_int16(MLKEM_Q_HALF, 0, msg[i] & mask);
     }
   }
@@ -609,7 +610,7 @@ void mlk_poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const mlk_poly *a)
       invariant(i <= MLKEM_N / 8 && j <= 8))
     {
       uint32_t t = mlk_scalar_compress_d1(a->coeffs[8 * i + j]);
-      msg[i] |= t << j;
+      msg[i] |= (uint8_t)(t << j);
     }
   }
 }

--- a/mlkem/src/compress.h
+++ b/mlkem/src/compress.h
@@ -50,9 +50,9 @@
 #endif
 
 /* Reference: Part of poly_tomsg() in the reference implementation @[REF]. */
-static MLK_INLINE uint32_t mlk_scalar_compress_d1(uint16_t u)
+static MLK_INLINE uint8_t mlk_scalar_compress_d1(int16_t u)
 __contract__(
-  requires(u <= MLKEM_Q - 1)
+  requires(0 <= u && u <= MLKEM_Q - 1)
   ensures(return_value < 2)
   ensures(return_value == (((uint32_t)u * 2 + MLKEM_Q / 2) / MLKEM_Q) % 2)  )
 {
@@ -65,7 +65,8 @@ __contract__(
    */
   /* check-magic: 1290168 == 2*round(2^31 / MLKEM_Q) */
   uint32_t d0 = (uint32_t)u * 1290168;
-  return (d0 + (1u << 30)) >> 31;
+  /* Unsigned shifting by 31 positions leaves only the top bit. */
+  return (uint8_t)((d0 + (1u << 30)) >> 31);
 }
 #ifdef CBMC
 #pragma CPROVER check pop
@@ -93,9 +94,9 @@ __contract__(
 
 /* Reference: Embedded into `poly_compress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint32_t mlk_scalar_compress_d4(uint16_t u)
+static MLK_INLINE uint8_t mlk_scalar_compress_d4(int16_t u)
 __contract__(
-  requires(u <= MLKEM_Q - 1)
+  requires(0 <= u && u <= MLKEM_Q - 1)
   ensures(return_value < 16)
   ensures(return_value == (((uint32_t)u * 16 + MLKEM_Q / 2) / MLKEM_Q) % 16))
 {
@@ -108,7 +109,8 @@ __contract__(
    */
   /* check-magic: 1290160 == 16 * round(2^28 / MLKEM_Q) */
   uint32_t d0 = (uint32_t)u * 1290160;
-  return (d0 + (1u << 27)) >> 28; /* round(d0/2^28) */
+  /* The return value is < 16, so not altered by the conversion to uint8_t. */
+  return (uint8_t)((d0 + (1u << 27)) >> 28); /* round(d0/2^28) */
 }
 #ifdef CBMC
 #pragma CPROVER check pop
@@ -128,11 +130,16 @@ __contract__(
 
 /* Reference: Embedded into `poly_decompress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint16_t mlk_scalar_decompress_d4(uint32_t u)
+static MLK_INLINE int16_t mlk_scalar_decompress_d4(uint8_t u)
 __contract__(
   requires(0 <= u && u < 16)
   ensures(return_value <= (MLKEM_Q - 1))
-) { return ((u * MLKEM_Q) + 8) >> 4; }
+)
+{
+  /* The return value is in 0..MLKEM_Q-1, hence not altered by the
+   * conversion to int16_t. */
+  return (int16_t)(((u * MLKEM_Q) + 8) >> 4);
+}
 
 /************************************************************
  * Name: mlk_scalar_compress_d5
@@ -156,9 +163,9 @@ __contract__(
 
 /* Reference: Embedded into `poly_compress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint32_t mlk_scalar_compress_d5(uint16_t u)
+static MLK_INLINE uint8_t mlk_scalar_compress_d5(int16_t u)
 __contract__(
-  requires(u <= MLKEM_Q - 1)
+  requires(0 <= u && u <= MLKEM_Q - 1)
   ensures(return_value < 32)
   ensures(return_value == (((uint32_t)u * 32 + MLKEM_Q / 2) / MLKEM_Q) % 32)  )
 {
@@ -171,7 +178,8 @@ __contract__(
    */
   /* check-magic: 1290176 == 2^5 * round(2^27 / MLKEM_Q) */
   uint32_t d0 = (uint32_t)u * 1290176;
-  return (d0 + (1u << 26)) >> 27; /* round(d0/2^27) */
+  /* The return value is < 32, so not altered by the conversion to uint8_t. */
+  return (uint8_t)((d0 + (1u << 26)) >> 27); /* round(d0/2^27) */
 }
 #ifdef CBMC
 #pragma CPROVER check pop
@@ -191,11 +199,16 @@ __contract__(
 
 /* Reference: Embedded into `poly_decompress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint16_t mlk_scalar_decompress_d5(uint32_t u)
+static MLK_INLINE int16_t mlk_scalar_decompress_d5(uint8_t u)
 __contract__(
   requires(0 <= u && u < 32)
-  ensures(return_value <= MLKEM_Q - 1)
-) { return ((u * MLKEM_Q) + 16) >> 5; }
+  ensures(0 <= return_value && return_value <= MLKEM_Q - 1)
+)
+{
+  /* The return value is in 0..MLKEM_Q-1, hence not altered by the
+   * conversion to int16_t. */
+  return (int16_t)(((u * MLKEM_Q) + 16) >> 5);
+}
 
 /************************************************************
  * Name: mlk_scalar_compress_d10
@@ -219,9 +232,9 @@ __contract__(
 
 /* Reference: Embedded into `polyvec_compress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint32_t mlk_scalar_compress_d10(uint16_t u)
+static MLK_INLINE uint16_t mlk_scalar_compress_d10(int16_t u)
 __contract__(
-  requires(u <= MLKEM_Q - 1)
+  requires(0 <= u && u <= MLKEM_Q - 1)
   ensures(return_value < (1u << 10))
   ensures(return_value == (((uint32_t)u * (1u << 10) + MLKEM_Q / 2) / MLKEM_Q) % (1 << 10)))
 {
@@ -255,11 +268,16 @@ __contract__(
 
 /* Reference: Embedded into `polyvec_decompress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint16_t mlk_scalar_decompress_d10(uint32_t u)
+static MLK_INLINE int16_t mlk_scalar_decompress_d10(uint16_t u)
 __contract__(
   requires(0 <= u && u < 1024)
-  ensures(return_value <= (MLKEM_Q - 1))
-) { return ((u * MLKEM_Q) + 512) >> 10; }
+  ensures(0 <= return_value && return_value <= (MLKEM_Q - 1))
+)
+{
+  /* The return value is in 0..MLKEM_Q-1, hence not altered by the
+   * conversion to int16_t. */
+  return (int16_t)(((u * MLKEM_Q) + 512) >> 10);
+}
 
 /************************************************************
  * Name: mlk_scalar_compress_d11
@@ -283,9 +301,9 @@ __contract__(
 
 /* Reference: Embedded into `polyvec_compress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint32_t mlk_scalar_compress_d11(uint16_t u)
+static MLK_INLINE uint16_t mlk_scalar_compress_d11(int16_t u)
 __contract__(
-  requires(u <= MLKEM_Q - 1)
+  requires(0 <= u && u <= MLKEM_Q - 1)
   ensures(return_value < (1u << 11))
   ensures(return_value == (((uint32_t)u * (1u << 11) + MLKEM_Q / 2) / MLKEM_Q) % (1 << 11)))
 {
@@ -319,11 +337,16 @@ __contract__(
 
 /* Reference: Embedded into `polyvec_decompress()` in the
  *            reference implementation @[REF]. */
-static MLK_INLINE uint16_t mlk_scalar_decompress_d11(uint32_t u)
+static MLK_INLINE int16_t mlk_scalar_decompress_d11(uint16_t u)
 __contract__(
   requires(0 <= u && u < 2048)
-  ensures(return_value <= (MLKEM_Q - 1))
-) { return ((u * MLKEM_Q) + 1024) >> 11; }
+  ensures(0 <= return_value && return_value <= (MLKEM_Q - 1))
+)
+{
+  /* The return value is in 0..MLKEM_Q-1, hence not altered by the
+   * conversion to int16_t. */
+  return (int16_t)(((u * MLKEM_Q) + 1024) >> 11);
+}
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || (MLKEM_K == 2 || MLKEM_K == 3)
 #define mlk_poly_compress_d4 MLK_NAMESPACE(poly_compress_d4)

--- a/mlkem/src/fips202/fips202.c
+++ b/mlkem/src/fips202/fips202.c
@@ -85,19 +85,21 @@ __contract__(
     m += r;
   }
 
+  /* At this point, mlen < r, so the truncations to unsigned are safe below. */
+
   if (mlen > 0)
   {
-    mlk_keccakf1600_xor_bytes(s, m, 0, mlen);
+    mlk_keccakf1600_xor_bytes(s, m, 0, (unsigned int)mlen);
   }
 
   if (mlen == r - 1)
   {
     p |= 128;
-    mlk_keccakf1600_xor_bytes(s, &p, mlen, 1);
+    mlk_keccakf1600_xor_bytes(s, &p, (unsigned int)mlen, 1);
   }
   else
   {
-    mlk_keccakf1600_xor_bytes(s, &p, mlen, 1);
+    mlk_keccakf1600_xor_bytes(s, &p, (unsigned int)mlen, 1);
     p = 128;
     mlk_keccakf1600_xor_bytes(s, &p, r - 1, 1);
   }
@@ -179,7 +181,7 @@ __contract__(
     {
       len = r;
     }
-    mlk_keccakf1600_extract_bytes(s, h, 0, len);
+    mlk_keccakf1600_extract_bytes(s, h, 0, (unsigned int)len);
     h += len;
     outlen -= len;
   }

--- a/mlkem/src/fips202/fips202x4.c
+++ b/mlkem/src/fips202/fips202x4.c
@@ -55,19 +55,21 @@ __contract__(
     inlen -= r;
   }
 
+  /* At this point, inlen < r, so the truncations to unsigned are safe below. */
+
   if (inlen > 0)
   {
-    mlk_keccakf1600x4_xor_bytes(s, in0, in1, in2, in3, 0, inlen);
+    mlk_keccakf1600x4_xor_bytes(s, in0, in1, in2, in3, 0, (unsigned int)inlen);
   }
 
   if (inlen == r - 1)
   {
     p |= 128;
-    mlk_keccakf1600x4_xor_bytes(s, &p, &p, &p, &p, inlen, 1);
+    mlk_keccakf1600x4_xor_bytes(s, &p, &p, &p, &p, (unsigned int)inlen, 1);
   }
   else
   {
-    mlk_keccakf1600x4_xor_bytes(s, &p, &p, &p, &p, inlen, 1);
+    mlk_keccakf1600x4_xor_bytes(s, &p, &p, &p, &p, (unsigned int)inlen, 1);
     p = 128;
     mlk_keccakf1600x4_xor_bytes(s, &p, &p, &p, &p, r - 1, 1);
   }

--- a/mlkem/src/indcpa.c
+++ b/mlkem/src/indcpa.c
@@ -222,8 +222,9 @@ void mlk_gen_matrix(mlk_polymat a, const uint8_t seed[MLKEM_SYMBYTES],
     for (j = 0; j < 4; j++)
     {
       uint8_t x, y;
-      x = (i + j) / MLKEM_K;
-      y = (i + j) % MLKEM_K;
+      /* MLKEM_K <= 4, so the values fit in uint8_t. */
+      x = (uint8_t)((i + j) / MLKEM_K);
+      y = (uint8_t)((i + j) % MLKEM_K);
       if (transposed)
       {
         seed_ext[j][MLKEM_SYMBYTES + 0] = x;
@@ -243,8 +244,9 @@ void mlk_gen_matrix(mlk_polymat a, const uint8_t seed[MLKEM_SYMBYTES],
   if (i < MLKEM_K * MLKEM_K)
   {
     uint8_t x, y;
-    x = i / MLKEM_K;
-    y = i % MLKEM_K;
+    /* MLKEM_K <= 4, so the values fit in uint8_t. */
+    x = (uint8_t)(i / MLKEM_K);
+    y = (uint8_t)(i % MLKEM_K);
 
     if (transposed)
     {

--- a/mlkem/src/poly.h
+++ b/mlkem/src/poly.h
@@ -103,7 +103,7 @@ __contract__(
   const uint32_t QINV = 62209;
 
   /*  Compute a*q^{-1} mod 2^16 in unsigned representatives */
-  const uint16_t a_reduced = a & UINT16_MAX;
+  const uint16_t a_reduced = (uint16_t)(a & UINT16_MAX);
   const uint16_t a_inverted = (a_reduced * QINV) & UINT16_MAX;
 
   /* Lift to signed canonical representative mod 2^16. */

--- a/mlkem/src/sampling.c
+++ b/mlkem/src/sampling.c
@@ -43,7 +43,7 @@ __contract__(
   ensures(array_bound(r, 0, return_value, 0, MLKEM_Q)))
 {
   unsigned ctr, pos;
-  uint16_t val0, val1;
+  int16_t val0, val1;
 
   mlk_assert_bound(r, offset, 0, MLKEM_Q);
 
@@ -55,8 +55,8 @@ __contract__(
     invariant(offset <= ctr && ctr <= target && pos <= buflen)
     invariant(array_bound(r, 0, ctr, 0, MLKEM_Q)))
   {
-    val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
-    val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;
+    val0 = ((buf[pos + 0] >> 0) | (buf[pos + 1] << 8)) & 0xFFF;
+    val1 = ((buf[pos + 1] >> 4) | (buf[pos + 2] << 4)) & 0xFFF;
     pos += 3;
 
     if (val0 < MLKEM_Q)
@@ -293,7 +293,7 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
     {
       const int16_t a = (d >> (4 * j + 0)) & 0x3;
       const int16_t b = (d >> (4 * j + 2)) & 0x3;
-      r->coeffs[8 * i + j] = a - b;
+      r->coeffs[8 * i + j] = (int16_t)(a - b);
     }
   }
 }
@@ -345,7 +345,7 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4])
     {
       const int16_t a = (d >> (6 * j + 0)) & 0x7;
       const int16_t b = (d >> (6 * j + 3)) & 0x7;
-      r->coeffs[4 * i + j] = a - b;
+      r->coeffs[4 * i + j] = (int16_t)(a - b);
     }
   }
 }

--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -161,7 +161,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFFFF)))
 {
   uint32_t tmp = mlk_value_barrier_u32(-((uint32_t)x));
   tmp >>= 16;
-  return tmp;
+  return (uint16_t)tmp;
 }
 
 /*************************************************
@@ -183,7 +183,7 @@ __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFF)))
 {
   uint32_t tmp = mlk_value_barrier_u32(-((uint32_t)x));
   tmp >>= 24;
-  return tmp;
+  return (uint8_t)tmp;
 }
 
 /* Put unsigned overflow warnings in CBMC back into scope */
@@ -224,7 +224,10 @@ __contract__(ensures(return_value == ((x < 0) ? 0xFFFF : 0)))
 {
   int32_t tmp = mlk_value_barrier_i32((int32_t)x);
   tmp >>= 16;
-  return (int16_t)tmp;
+  /* This truncation does alter the value of tmp. We deliberately
+   * rely on the defined behavior of signed-to-unsigned conversion
+   * for negative inputs. */
+  return (uint16_t)tmp;
 }
 
 /* Put unsigned-to-signed warnings in CBMC back into scope */
@@ -279,7 +282,10 @@ __contract__(ensures(return_value == ((x < 0) ? 0xFFFF : 0)))
 static MLK_INLINE int16_t mlk_ct_sel_int16(int16_t a, int16_t b, uint16_t cond)
 __contract__(ensures(return_value == (cond ? a : b)))
 {
-  uint16_t au = a, bu = b;
+  /* We work with the bit-presentation of a and b in two's complement here,
+   * relying on the defined conversion from signed to unsigned integers, and
+   * assuming that unsigned to signed conversion is its inverse (see above). */
+  uint16_t au = (uint16_t)a, bu = (uint16_t)b;
   uint16_t res = bu ^ (mlk_ct_cmask_nonzero_u16(cond) & (au ^ bu));
   return (int16_t)res;
 }

--- a/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
+++ b/proofs/cbmc/ntt_butterfly_block/ntt_butterfly_block_harness.c
@@ -7,12 +7,11 @@
 
 
 void mlk_ntt_butterfly_block(int16_t *r, int16_t root, unsigned start,
-                             unsigned len, int bound);
+                             unsigned len, unsigned bound);
 
 void harness(void)
 {
   int16_t *r, root;
-  unsigned start, stride;
-  int bound;
+  unsigned start, stride, bound;
   mlk_ntt_butterfly_block(r, root, start, stride, bound);
 }

--- a/proofs/cbmc/scalar_compress_d1/scalar_compress_d1_harness.c
+++ b/proofs/cbmc/scalar_compress_d1/scalar_compress_d1_harness.c
@@ -6,8 +6,8 @@
 
 void harness(void)
 {
-  uint16_t u;
+  int16_t u;
 
   /* Contracts for this function are in compress.h */
-  uint32_t d = mlk_scalar_compress_d1(u);
+  uint8_t d = mlk_scalar_compress_d1(u);
 }

--- a/proofs/cbmc/scalar_compress_d10/scalar_compress_d10_harness.c
+++ b/proofs/cbmc/scalar_compress_d10/scalar_compress_d10_harness.c
@@ -6,8 +6,8 @@
 
 void harness(void)
 {
-  uint16_t u;
+  int16_t u;
 
   /* Contracts for this function are in compress.h */
-  uint32_t d = mlk_scalar_compress_d10(u);
+  uint16_t d = mlk_scalar_compress_d10(u);
 }

--- a/proofs/cbmc/scalar_compress_d11/scalar_compress_d11_harness.c
+++ b/proofs/cbmc/scalar_compress_d11/scalar_compress_d11_harness.c
@@ -6,8 +6,8 @@
 
 void harness(void)
 {
-  uint16_t u;
+  int16_t u;
 
   /* Contracts for this function are in compress.h */
-  uint32_t d = mlk_scalar_compress_d11(u);
+  uint16_t d = mlk_scalar_compress_d11(u);
 }

--- a/proofs/cbmc/scalar_compress_d4/scalar_compress_d4_harness.c
+++ b/proofs/cbmc/scalar_compress_d4/scalar_compress_d4_harness.c
@@ -6,8 +6,8 @@
 
 void harness(void)
 {
-  uint16_t u;
+  int16_t u;
 
   /* Contracts for this function are in compress.h */
-  uint32_t d = mlk_scalar_compress_d4(u);
+  uint8_t d = mlk_scalar_compress_d4(u);
 }

--- a/proofs/cbmc/scalar_compress_d5/scalar_compress_d5_harness.c
+++ b/proofs/cbmc/scalar_compress_d5/scalar_compress_d5_harness.c
@@ -6,8 +6,8 @@
 
 void harness(void)
 {
-  uint16_t u;
+  int16_t u;
 
   /* Contracts for this function are in compress.h */
-  uint32_t d = mlk_scalar_compress_d5(u);
+  uint8_t d = mlk_scalar_compress_d5(u);
 }

--- a/proofs/cbmc/scalar_decompress_d10/scalar_decompress_d10_harness.c
+++ b/proofs/cbmc/scalar_decompress_d10/scalar_decompress_d10_harness.c
@@ -6,7 +6,7 @@
 
 void harness(void)
 {
-  uint32_t u;
-  uint16_t d;
+  uint16_t u;
+  int16_t d;
   d = mlk_scalar_decompress_d10(u);
 }

--- a/proofs/cbmc/scalar_decompress_d11/scalar_decompress_d11_harness.c
+++ b/proofs/cbmc/scalar_decompress_d11/scalar_decompress_d11_harness.c
@@ -6,7 +6,7 @@
 
 void harness(void)
 {
-  uint32_t u;
-  uint16_t d;
+  uint16_t u;
+  int16_t d;
   d = mlk_scalar_decompress_d11(u);
 }

--- a/proofs/cbmc/scalar_decompress_d4/scalar_decompress_d4_harness.c
+++ b/proofs/cbmc/scalar_decompress_d4/scalar_decompress_d4_harness.c
@@ -6,7 +6,7 @@
 
 void harness(void)
 {
-  uint32_t u;
-  uint16_t d;
+  uint8_t u;
+  int16_t d;
   d = mlk_scalar_decompress_d4(u);
 }

--- a/proofs/cbmc/scalar_decompress_d5/scalar_decompress_d5_harness.c
+++ b/proofs/cbmc/scalar_decompress_d5/scalar_decompress_d5_harness.c
@@ -6,7 +6,7 @@
 
 void harness(void)
 {
-  uint32_t u;
-  uint16_t d;
+  uint8_t u;
+  int16_t d;
   d = mlk_scalar_decompress_d5(u);
 }

--- a/proofs/cbmc/scalar_signed_to_unsigned_q/scalar_signed_to_unsigned_q_harness.c
+++ b/proofs/cbmc/scalar_signed_to_unsigned_q/scalar_signed_to_unsigned_q_harness.c
@@ -5,12 +5,12 @@
 #include <stdint.h>
 #include "common.h"
 
-uint16_t mlk_scalar_signed_to_unsigned_q(int16_t c);
+int16_t mlk_scalar_signed_to_unsigned_q(int16_t c);
 
 void harness(void)
 {
   int16_t u;
 
   /* Contracts for this function are in poly.h */
-  uint16_t d = mlk_scalar_signed_to_unsigned_q(u);
+  int16_t d = mlk_scalar_signed_to_unsigned_q(u);
 }

--- a/test/acvp_mlkem.c
+++ b/test/acvp_mlkem.c
@@ -61,11 +61,11 @@ static unsigned char decode_hex_char(char hex)
   }
   else if (hex >= 'A' && hex <= 'F')
   {
-    return 10 + (unsigned char)(hex - 'A');
+    return (unsigned char)(10 + (unsigned char)(hex - 'A'));
   }
   else if (hex >= 'a' && hex <= 'f')
   {
-    return 10 + (unsigned char)(hex - 'a');
+    return (unsigned char)(10 + (unsigned char)(hex - 'a'));
   }
   else
   {
@@ -106,7 +106,7 @@ static int decode_hex(const char *prefix, unsigned char *out, size_t out_len,
       goto hex_usage;
     }
 
-    *out = (hex0 << 4) | hex1;
+    *out = (unsigned char)((hex0 << 4) | hex1);
   }
 
   return 0;

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -121,7 +121,7 @@ void enable_cyclecounter(void)
   pe.exclude_kernel = 1;
   pe.exclude_hv = 1;
 
-  perf_fd = syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
+  perf_fd = (int)syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
 
   ioctl(perf_fd, PERF_EVENT_IOC_RESET, 0);
   ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
@@ -150,7 +150,7 @@ uint64_t get_cyclecounter(void)
     exit(EXIT_FAILURE);
   }
   ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
-  return cpu_cycles;
+  return (uint64_t)cpu_cycles;
 }
 #elif defined(MAC_CYCLES)
 /* Based on @[m1cycles] */

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -39,6 +39,8 @@ CFLAGS := \
 	-Wshadow \
 	-Wpointer-arith \
 	-Wredundant-decls \
+	-Wconversion \
+	-Wsign-conversion \
 	-Wno-long-long \
 	-Wno-unknown-pragmas \
 	-Wno-unused-command-line-argument \

--- a/test/test_unit.c
+++ b/test/test_unit.c
@@ -113,7 +113,8 @@ static void generate_i16_array_ranged(int16_t *data, size_t len, int min_incl,
   randombytes((uint8_t *)data, len * sizeof(int16_t));
   for (i = 0; i < len; i++)
   {
-    data[i] = min_incl + ((unsigned)data[i] % (max_excl - min_incl));
+    data[i] = (int16_t)((unsigned)min_incl +
+                        ((unsigned)data[i] % (unsigned)(max_excl - min_incl)));
   }
 }
 
@@ -215,7 +216,7 @@ static int test_native_poly_reduce(void)
 
   for (pos = 0; pos < MLKEM_N; pos += MLKEM_N / 8)
   {
-    generate_i16_array_single(test_data, MLKEM_N, pos, 1);
+    generate_i16_array_single(test_data, MLKEM_N, (size_t)pos, 1);
     CHECK(test_poly_reduce_core(test_data, "poly_reduce_single") == 0);
   }
 
@@ -259,7 +260,7 @@ static int test_native_poly_tomont(void)
 
   for (pos = 0; pos < MLKEM_N; pos += MLKEM_N / 8)
   {
-    generate_i16_array_single(test_data, MLKEM_N, pos, 1);
+    generate_i16_array_single(test_data, MLKEM_N, (size_t)pos, 1);
     CHECK(test_poly_tomont_core(test_data, "poly_tomont_single") == 0);
   }
 
@@ -314,7 +315,7 @@ static int test_native_ntt(void)
 
   for (pos = 0; pos < MLKEM_N; pos += MLKEM_N / 8)
   {
-    generate_i16_array_single(test_data, MLKEM_N, pos, 1);
+    generate_i16_array_single(test_data, MLKEM_N, (size_t)pos, 1);
     CHECK(test_ntt_core(test_data, "ntt_single") == 0);
   }
 
@@ -362,7 +363,7 @@ static int test_native_intt(void)
 
   for (pos = 0; pos < MLKEM_N; pos += MLKEM_N / 8)
   {
-    generate_i16_array_single(test_data, MLKEM_N, pos, 1);
+    generate_i16_array_single(test_data, MLKEM_N, (size_t)pos, 1);
     CHECK(test_intt_core(test_data, "intt_single") == 0);
   }
 
@@ -381,10 +382,10 @@ static int test_native_intt(void)
    */
   for (coeff = 0; coeff <= INT16_MAX; coeff++)
   {
-    generate_i16_array_constant(test_data, MLKEM_N, coeff);
+    generate_i16_array_constant(test_data, MLKEM_N, (int16_t)coeff);
     CHECK(test_intt_core(test_data, "intt_constant") == 0);
 
-    generate_i16_array_constant(test_data, MLKEM_N, -coeff);
+    generate_i16_array_constant(test_data, MLKEM_N, (int16_t)-coeff);
     CHECK(test_intt_core(test_data, "intt_constant") == 0);
   }
 
@@ -433,7 +434,7 @@ static int test_native_poly_tobytes(void)
 
   for (pos = 0; pos < MLKEM_N; pos += MLKEM_N / 8)
   {
-    generate_i16_array_single(test_data, MLKEM_N, pos, 1);
+    generate_i16_array_single(test_data, MLKEM_N, (size_t)pos, 1);
     CHECK(test_poly_tobytes_core(test_data, "poly_tobytes_single") == 1);
   }
 


### PR DESCRIPTION
This commit enables further compiler warnings and adjusts the code
triggering the warnings. In some cases, we can work around the warnings
by tightening input/output types in function signatures. In other cases,
we explain in a comment why the truncation does not alter the value.
Finally, in some cases, the truncation can actually alter the value,
and we rely on signed->unsigned and unsigned->signed integer conversions.

Note that CBMC already checks that integer conversion does not alter
values, so the comments are a helpful indicator that we thought about
this, but not critical.
Resolves https://github.com/pq-code-package/mlkem-native/issues/1229