### PR TITLE
FIPS202: Add FIPS202 state machine to custom-FIPS202 example

### DIFF
--- a/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
+++ b/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
@@ -19,66 +19,58 @@
 #include "cbmc.h"
 #include "fips202.h"
 
-typedef mlk_shake128ctx mlk_shake128x4ctx[4];
+typedef struct
+{
+  /* We introduce the explicit state as a mechanism to check that
+   * mlkem-native adheres to the FIPS202 state machine. You can safely
+   * remove this from your custom wrapper. */
+  fips202_state_t state;
+  mlk_shake128ctx ctx[4];
+} mlk_shake128x4ctx;
 
 #define mlk_shake128x4_absorb_once MLK_NAMESPACE(shake128x4_absorb_once)
 static MLK_INLINE void mlk_shake128x4_absorb_once(
     mlk_shake128x4ctx *state, const uint8_t *in0, const uint8_t *in1,
     const uint8_t *in2, const uint8_t *in3, size_t inlen)
-__contract__(
-  requires(memory_no_alias(state, sizeof(mlk_shake128x4ctx)))
-  requires(memory_no_alias(in0, inlen))
-  requires(memory_no_alias(in1, inlen))
-  requires(memory_no_alias(in2, inlen))
-  requires(memory_no_alias(in3, inlen))
-  assigns(object_whole(state))
-)
 {
-  mlk_shake128_absorb_once(&(*state)[0], in0, inlen);
-  mlk_shake128_absorb_once(&(*state)[1], in1, inlen);
-  mlk_shake128_absorb_once(&(*state)[2], in2, inlen);
-  mlk_shake128_absorb_once(&(*state)[3], in3, inlen);
+  assert(state->state == FIPS202_STATE_ABSORBING);
+  mlk_shake128_absorb_once(&state->ctx[0], in0, inlen);
+  mlk_shake128_absorb_once(&state->ctx[1], in1, inlen);
+  mlk_shake128_absorb_once(&state->ctx[2], in2, inlen);
+  mlk_shake128_absorb_once(&state->ctx[3], in3, inlen);
+  state->state = FIPS202_STATE_SQUEEZING;
 }
 
 #define mlk_shake128x4_squeezeblocks MLK_NAMESPACE(shake128x4_squeezeblocks)
 static MLK_INLINE void mlk_shake128x4_squeezeblocks(
     uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t nblocks,
     mlk_shake128x4ctx *state)
-__contract__(
-  requires(memory_no_alias(state, sizeof(mlk_shake128x4ctx)))
-  requires(memory_no_alias(out0, nblocks * SHAKE128_RATE))
-  requires(memory_no_alias(out1, nblocks * SHAKE128_RATE))
-  requires(memory_no_alias(out2, nblocks * SHAKE128_RATE))
-  requires(memory_no_alias(out3, nblocks * SHAKE128_RATE))
-  assigns(memory_slice(out0, nblocks * SHAKE128_RATE),
-    memory_slice(out1, nblocks * SHAKE128_RATE),
-    memory_slice(out2, nblocks * SHAKE128_RATE),
-    memory_slice(out3, nblocks * SHAKE128_RATE),
-    object_whole(state))
-)
 {
-  mlk_shake128_squeezeblocks(out0, nblocks, &(*state)[0]);
-  mlk_shake128_squeezeblocks(out1, nblocks, &(*state)[1]);
-  mlk_shake128_squeezeblocks(out2, nblocks, &(*state)[2]);
-  mlk_shake128_squeezeblocks(out3, nblocks, &(*state)[3]);
+  assert(state->state == FIPS202_STATE_SQUEEZING);
+  mlk_shake128_squeezeblocks(out0, nblocks, &state->ctx[0]);
+  mlk_shake128_squeezeblocks(out1, nblocks, &state->ctx[1]);
+  mlk_shake128_squeezeblocks(out2, nblocks, &state->ctx[2]);
+  mlk_shake128_squeezeblocks(out3, nblocks, &state->ctx[3]);
 }
 
 #define mlk_shake128x4_init MLK_NAMESPACE(shake128x4_init)
 static MLK_INLINE void mlk_shake128x4_init(mlk_shake128x4ctx *state)
 {
-  mlk_shake128_init(&(*state)[0]);
-  mlk_shake128_init(&(*state)[1]);
-  mlk_shake128_init(&(*state)[2]);
-  mlk_shake128_init(&(*state)[3]);
+  mlk_shake128_init(&state->ctx[0]);
+  mlk_shake128_init(&state->ctx[1]);
+  mlk_shake128_init(&state->ctx[2]);
+  mlk_shake128_init(&state->ctx[3]);
+  state->state = FIPS202_STATE_ABSORBING;
 }
 
 #define mlk_shake128x4_release MLK_NAMESPACE(shake128x4_release)
 static MLK_INLINE void mlk_shake128x4_release(mlk_shake128x4ctx *state)
 {
-  mlk_shake128_release(&(*state)[0]);
-  mlk_shake128_release(&(*state)[1]);
-  mlk_shake128_release(&(*state)[2]);
-  mlk_shake128_release(&(*state)[3]);
+  mlk_shake128_release(&state->ctx[0]);
+  mlk_shake128_release(&state->ctx[1]);
+  mlk_shake128_release(&state->ctx[2]);
+  mlk_shake128_release(&state->ctx[3]);
+  state->state = FIPS202_STATE_RESET;
 }
 
 #define mlk_shake256x4 MLK_NAMESPACE(shake256x4)
@@ -86,21 +78,6 @@ static MLK_INLINE void mlk_shake256x4(uint8_t *out0, uint8_t *out1,
                                       uint8_t *out2, uint8_t *out3,
                                       size_t outlen, uint8_t *in0, uint8_t *in1,
                                       uint8_t *in2, uint8_t *in3, size_t inlen)
-__contract__(
-/* Refine +prove this spec, e.g. add disjointness constraints? */
-  requires(readable(in0, inlen))
-  requires(readable(in1, inlen))
-  requires(readable(in2, inlen))
-  requires(readable(in3, inlen))
-  requires(writeable(out0, outlen))
-  requires(writeable(out1, outlen))
-  requires(writeable(out2, outlen))
-  requires(writeable(out3, outlen))
-  assigns(memory_slice(out0, outlen))
-  assigns(memory_slice(out1, outlen))
-  assigns(memory_slice(out2, outlen))
-  assigns(memory_slice(out3, outlen))
-)
 {
   mlk_shake256(out0, outlen, in0, inlen);
   mlk_shake256(out1, outlen, in1, inlen);


### PR DESCRIPTION
We want mlkem-native to adhere to an implicit state machine for FIPS202 whereby an initialized FIPS202 context is always in one of the following states:

- Absorbing
- Squeezing
- Reset

A call to `init()` sets the state to `Absorbing` (from any input state), a call to `absorb` retains the `Absorbing` state, a call to `absorb_once` moves from `Absorbing` to `Squeezing`, and calls to `squeezeblocks` move from `Squeezing` to itself. Finally, `reset` moves from `Squeezing` to `Reset` (note that implementations will likely allow `reset()` from any initialized state, but mlkem-native does not make use of such paths).

We previously did not check that mlkem-native adhered to this discipline.

This commit extends the custom-FIPS202 example examples/custom_fips202, wrapping the tiny-SHA3 context in a struct additionally including an explicit state. This state is transitions as above in the glue code, and we also add assertions checking the incoming state.