### PR TITLE
CI: Add OpenTitan integration test 

### DIFF
--- a/.github/actions/setup-opentitan/action.yml
+++ b/.github/actions/setup-opentitan/action.yml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: Setup OpenTitan
+description: Setup OpenTitan for testing
+
+inputs:
+  expo-repository:
+    description: 'Expo repository to clone'
+    required: false
+    default: 'https://github.com/zerorisc/expo'
+  expo-commit:
+    description: 'Expo commit to checkout'
+    required: false
+    default: 'master'
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch expo repository
+      shell: bash
+      run: |
+        # Ensure HOME is set for self-hosted runners
+        echo "HOME=${HOME:-/home/runner}" >> $GITHUB_ENV
+
+        git clone ${{ inputs.expo-repository }}
+        cd expo
+        git checkout ${{ inputs.expo-commit }}
+
+        # Remember expo directory
+        echo EXPO_DIR="$GITHUB_WORKSPACE/expo" >> $GITHUB_ENV
+
+    - name: Install OpenTitan dependencies
+      shell: bash
+      run: |
+        sudo apt update
+        cd expo
+        sed -e '/^#/d' -e '/libncursesw5/d' ./apt-requirements.txt | xargs sudo apt install -y
+        # Install runtime dependencies needed by tools
+        sudo apt install -y gcc g++ libtinfo5 srecord pkg-config libudev-dev libssl-dev \
+          libftdi1-dev libelf-dev zlib1g-dev
+        pip3 install --user -r python-requirements.txt --require-hashes
+
+    - name: Cache Verilator
+      id: cache-verilator
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: /tools/verilator/4.210
+        key: verilator-4.210-ubuntu22-${{ runner.os }}
+
+    - name: Install Verilator
+      if: steps.cache-verilator.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # Install build-time dependencies for Verilator
+        sudo apt install -y make autoconf bison flex libfl-dev gcc-11 g++-11
+
+        # Build and install Verilator
+        export VERILATOR_VERSION=4.210
+        git clone https://github.com/verilator/verilator.git
+        cd verilator
+        git checkout v$VERILATOR_VERSION
+        autoconf
+        CC=gcc-11 CXX=g++-11 ./configure --prefix=/tools/verilator/$VERILATOR_VERSION
+        CC=gcc-11 CXX=g++-11 make -j$(nproc)
+        sudo CC=gcc-11 CXX=g++-11 make install
+
+    - name: Add Verilator to PATH
+      shell: bash
+      run: |
+        echo "/tools/verilator/4.210/bin" >> $GITHUB_PATH
+
+    - name: Set Bazel cache directory
+      shell: bash
+      run: |
+        echo "BAZEL_CACHE_DIR=/home/runner/bazel_cache" >> $GITHUB_ENV
+
+    - name: Test Verilator setup and build cache
+      shell: bash
+      run: |
+        cd $EXPO_DIR
+        # Run UART smoketest to verify setup
+        ./bazelisk.sh test \
+          --test_output=streamed \
+          --disk_cache=$BAZEL_CACHE_DIR \
+          //sw/device/tests:uart_smoketest_sim_verilator

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -57,6 +57,14 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/integration-liboqs.yml
     secrets: inherit
+  opentitan_integration:
+    name: OpenTitan
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: [ base ]
+    uses: ./.github/workflows/integration-opentitan.yml
+    secrets: inherit
   awslc_integration_fixed:
     name: AWS-LC (873ca6f2)
     permissions:

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+name: OpenTitan
+permissions:
+  contents: read
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
+  AWS_REGION: us-east-1
+  AMI_UBUNTU_22_04_X86_64: ami-0bbdd8c17ed981ef9
+
+jobs:
+  start-ec2-runner:
+    name: Start EC2 instance
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # Make this step non-cancellable to avoid orphaned instances
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@5ae8cda66fc6f3bae4e633ad93e6e61a061376bb # v2.4.2
+        with:
+          mode: start
+          github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          ec2-image-id: ${{ env.AMI_UBUNTU_22_04_X86_64 }}
+          ec2-instance-type: c6i.2xlarge
+          ec2-volume-size: 32
+          subnet-id: subnet-07b2729e5e065962f
+          security-group-id: sg-0ab2e297196c8c381
+
+  opentitan_test:
+    name: OpenTitan ML-KEM Test (verilator)
+    needs: start-ec2-runner
+    runs-on: ${{ needs.start-ec2-runner.outputs.label }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup-opentitan
+        with:
+          # TODO: switch to upstream once merged
+          expo-repository: https://github.com/mkannwischer/expo
+          expo-commit: 8c1fdb65ca6ff026c446cdefb106d08fd43ba7e9
+
+      - name: Patch mlkem-native dependency
+        run: |
+          cd $EXPO_DIR
+
+          # Calculate sha256 of mlkem-native at the new commit
+          SHA256=$(curl -sL "https://github.com/$GITHUB_REPOSITORY/archive/$GITHUB_SHA.tar.gz" | sha256sum | cut -d' ' -f1)
+
+          # Update the extensions.bzl file with new commit and sha256
+          sed -i \
+            -e "s|sha256 = \"[^\"]*\"|sha256 = \"$SHA256\"|" \
+            -e "s|strip_prefix = \"mlkem-native-[^\"]*\"|strip_prefix = \"mlkem-native-$GITHUB_SHA\"|" \
+            -e "s|archive/[^/]*.tar.gz|archive/$GITHUB_SHA.tar.gz|" \
+            third_party/mlkem_native/extensions.bzl
+
+          # Show the changes
+          echo "=== Patched extensions.bzl ==="
+          cat third_party/mlkem_native/extensions.bzl
+
+      - name: Run mlkem functest
+        run: |
+          cd $EXPO_DIR
+          # Run the test
+          ./bazelisk.sh test \
+            --test_output=streamed \
+            --disk_cache=$BAZEL_CACHE_DIR \
+            //sw/device/tests/crypto:mlkem_functest_sim_verilator
+
+  stop-ec2-runner:
+    name: Stop EC2 instance
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs:
+      - start-ec2-runner
+      - opentitan_test # required to wait when the main job is done
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # required to stop the runner even if errors occur
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@5ae8cda66fc6f3bae4e633ad93e6e61a061376bb # v2.4.2
+        with:
+          mode: stop
+          github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          label: ${{ needs.start-ec2-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-ec2-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
This commit adds an OpenTiten integration test to our CI which clones
OpenTitan, updates the mlkem-native dependency to the current commit, and runs
the ML-KEM tests using verilator.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1242

OpenTitan requires an old version of verilator (4.210) which is compiled from
source taking around 5-10 minutes. We cache it (80 MiB) in the Github cache
to speed-up CI.

Another expensive step is the initial compilation of the hardware simulation.
Verilator commonly takes 10-15 minutes. Usually this is cached in the bazel
cache such that subsequent tests are much faster.
I considered caching this which would speed-up CI by around 10-15 minutes,
but require 3 GiB of caching. We are already tight in Github cache, so at this
point, I don't think we can afford it.