### PR TITLE
HOL-Light: Allow interactive use of hol.sh in the hol_light shell

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -49,6 +49,22 @@ jobs:
           nix-shell: 'hol_light'
           script: |
             autogen --update-hol-light-bytecode --dry-run
+  hol_light_interactive:
+    name: HOL-Light interactive shell test
+    runs-on: pqcp-arm64
+    needs: [ hol_light_bytecode ]
+    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-shell
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          nix-shell: 'hol_light'
+          script: |
+            make -C proofs/hol_light/arm mlkem/mlkem_poly_tobytes.o
+            echo 'needs "proofs/mlkem_poly_tobytes.ml";;' | hol.sh
   hol_light_proofs:
     needs: [ hol_light_bytecode ]
     strategy:

--- a/flake.nix
+++ b/flake.nix
@@ -91,11 +91,18 @@
                 inherit (pkgs) gcc-arm-embedded qemu coreutils python3 git;
               };
           };
-          devShells.hol_light = util.mkShell {
+
+          devShells.hol_light = (util.mkShell {
             packages = builtins.attrValues {
               inherit (config.packages) linters hol_light s2n_bignum;
             };
-          };
+          }).overrideAttrs (old: {
+            shellHook = ''
+              export PATH=$PWD/scripts:$PATH
+              # Set PROOF_DIR_ARM based on where we entered the shell
+              export PROOF_DIR_ARM="$PWD/proofs/hol_light/arm"
+            '';
+          });
           devShells.ci = util.mkShell {
             packages = builtins.attrValues { inherit (config.packages) linters toolchains_native; };
           };

--- a/nix/hol_light/0005-Configure-hol-sh-for-mlkem-native.patch
+++ b/nix/hol_light/0005-Configure-hol-sh-for-mlkem-native.patch
@@ -4,7 +4,7 @@ index 1311255..8b2bc36 100755
 --- a/hol_4.14.sh
 +++ b/hol_4.14.sh
 @@ -5,7 +5,7 @@ export HOLLIGHT_DIR=__DIR__
- 
+
  if [ "$#" -eq 1 ]; then
    if [ "$1" == "-pp" ]; then
 -    echo "camlp5r pa_lexer.cmo pa_extend.cmo q_MLast.cmo -I "__DIR__" pa_j.cmo"
@@ -12,12 +12,27 @@ index 1311255..8b2bc36 100755
      exit 0
    elif [ "$1" == "-dir" ]; then
      echo "${HOLLIGHT_DIR}"
+@@ -32,4 +32,13 @@ if [ "${HOL_ML_PATH}" == "" ]; then
+   HOL_ML_PATH="${HOLLIGHT_DIR}/hol.ml"
+ fi
+
+-${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR}
++# Add site-lib directory for topfind
++SITELIB=$(dirname $(ocamlfind query findlib 2>/dev/null) 2>/dev/null)
++
++# Set HOLLIGHT_LOAD_PATH to include S2N_BIGNUM_DIR and mlkem-native proofs
++export HOLLIGHT_LOAD_PATH="${S2N_BIGNUM_DIR}:${PROOF_DIR_ARM}:${HOLLIGHT_LOAD_PATH}"
++
++# Change to mlkem-native proofs directory if set, so define_from_elf can find object files
++[ -n "${PROOF_DIR_ARM}" ] && cd "${PROOF_DIR_ARM}"
++
++${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR} ${SITELIB:+-I "$SITELIB"}
 diff --git a/hol_4.sh b/hol_4.sh
 index 0aaa5c7..5adaf4c 100755
 --- a/hol_4.sh
 +++ b/hol_4.sh
 @@ -5,7 +5,7 @@ export HOLLIGHT_DIR=__DIR__
- 
+
  if [ "$#" -eq 1 ]; then
    if [ "$1" == "-pp" ]; then
 -    echo "camlp5r pa_lexer.cmo pa_extend.cmo q_MLast.cmo -I "__DIR__" pa_j.cmo"
@@ -28,6 +43,6 @@ index 0aaa5c7..5adaf4c 100755
 @@ -32,4 +32,4 @@ if [ "${HOL_ML_PATH}" == "" ]; then
    HOL_ML_PATH="${HOLLIGHT_DIR}/hol.ml"
  fi
- 
+
 -${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -I `camlp5 -where` camlp5o.cma -init ${HOL_ML_PATH} -safe-string -I ${HOLLIGHT_DIR}
 +${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -I $(camlp5 -where) camlp5o.cma -init ${HOL_ML_PATH} -safe-string -I ${HOLLIGHT_DIR}

--- a/nix/hol_light/0006-Add-findlib-to-ocaml-hol.patch
+++ b/nix/hol_light/0006-Add-findlib-to-ocaml-hol.patch
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+diff --git a/Makefile b/Makefile
+index abc1234..def5678 100644
+--- a/Makefile
++++ b/Makefile
+@@ -100,7 +100,7 @@ hol.sh: pa_j.cmo ${HOLSRC} bignum.cmo hol_loader.cmo update_database.ml
+ 	if [ `uname` = "Linux" ] || [ `uname` = "Darwin" ] ; then \
+ 		if [ ${OCAML_UNARY_VERSION} = "5" ] || [ ${OCAML_VERSION} = "4.14" ] ; then \
+-			ocamlfind ocamlmktop -package zarith -o ocaml-hol zarith.cma bignum.cmo hol_loader.cmo ; \
++			ocamlfind ocamlmktop -package zarith,findlib -o ocaml-hol zarith.cma bignum.cmo hol_loader.cmo ; \
+ 			sed "s^__DIR__^`pwd`^g; s^__USE_MODULE__^$(HOLLIGHT_USE_MODULE)^g" hol_4.14.sh > hol.sh ; \
+ 		else \
+ 			ocamlmktop -o ocaml-hol nums.cma bignum.cmo hol_loader.cmo ; \

--- a/nix/hol_light/default.nix
+++ b/nix/hol_light/default.nix
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-{ hol_light, fetchFromGitHub, writeText, ... }:
+{ hol_light, fetchFromGitHub, writeText, ocamlPackages, ledit, ... }:
 hol_light.overrideAttrs (old: {
   setupHook = writeText "setup-hook.sh" ''
     export HOLDIR="$1/lib/hol_light"
     export HOLLIGHT_DIR="$1/lib/hol_light"
+    export PATH="$1/lib/hol_light:$PATH"
   '';
   version = "unstable-2025-09-22";
   src = fetchFromGitHub {
@@ -13,8 +14,11 @@ hol_light.overrideAttrs (old: {
     rev = "bed58fa74649fa74015176f8f90e77f7af5cf8e3";
     hash = "sha256-QDubbUUChvv04239BdcKPSU+E2gdSzqAWfAETK2Xtg0=";
   };
-  patches = [ ./0005-Fix-hollight-path.patch ];
-  propagatedBuildInputs = old.propagatedBuildInputs ++ old.nativeBuildInputs;
+  patches = [
+    ./0005-Configure-hol-sh-for-mlkem-native.patch
+    ./0006-Add-findlib-to-ocaml-hol.patch
+  ];
+  propagatedBuildInputs = old.propagatedBuildInputs ++ old.nativeBuildInputs ++ [ ocamlPackages.pcre2 ledit ];
   buildPhase = ''
     HOLLIGHT_USE_MODULE=1 make hol.sh
     patchShebangs hol.sh


### PR DESCRIPTION
Previously, while compiling and running the HOL-Light proofs in `nix develop .#hol_light` worked, trying to start the interactive shell `hol.sh` for proof development would fail. This required proof developers to install HOL-Light and s2n-bignum locally, both inconvenient and error proone because one would need to keep that local version and the nix version in sync.

This commit adjusts the nix flake to setup HOL-Light in such a way that hol.sh can be used interactively inside the `hol_light` shell.

Now, when you enter the shell via `nix develop .#hol_light`, the interactive shell `hol.sh` is in the PATH, and within it, both s2n-bignum and proofs/hol_light/arm are added to HOL-Light's own search path (`load_path`). In particular, you can do

```
  needs "arm/proofs/base.ml";;
```

to load the s2n-bignum base sources, or

```
  needs "proofs/mlkem_poly_tobytes.ml";;
```

or similar, to test a proof script.

The CI is extended to exercise the interactive shell, running one of the faster proofs -- mlkem_poly_tobytes.ml -- interactively.