### PR TITLE
CI: Switch to r8g.xlarge for CBMC proofs

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -17,9 +17,9 @@ jobs:
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-512)
-      ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
+      ec2_instance_type: r8g.xlarge
+      ec2_ami: ubuntu-latest (aarch64)
+      ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
       lint: false
@@ -39,9 +39,9 @@ jobs:
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-768)
-      ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
+      ec2_instance_type: r8g.xlarge
+      ec2_ami: ubuntu-latest (aarch64)
+      ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
       lint: false
@@ -61,9 +61,9 @@ jobs:
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-1024)
-      ec2_instance_type: c7g.4xlarge
-      ec2_ami: ubuntu-latest (custom AMI)
-      ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
+      ec2_instance_type: r8g.xlarge
+      ec2_ami: ubuntu-latest (aarch64)
+      ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
       lint: false

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -22,6 +22,9 @@ on:
         type: string
         description: AMI ID
         default: ami-096ea6a12ea24a797
+      ec2_volume_size:
+        type: string
+        default: ""
       cflags:
         type: string
         description: Custom CFLAGS for compilation
@@ -111,6 +114,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
           ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
           subnet-id: subnet-07b2729e5e065962f
           security-group-id: sg-0ab2e297196c8c381


### PR DESCRIPTION
The r instances have a higher Memory/vCPU ratio and are therefore
more suited for the memory-hungry CBMC tests. Specifically, r8g.xlarge
has the same RAM as c7g.4xlarge, a newer generation Graviton core,
and at the time of writing currently comes at a lower price point.

Therefore, this commit modifies the CBMC CI job to use r8g.xlarge
instances instead of c7g.4xlarge.