### PR TITLE
CI/CBMC: Allow dropping level-agnostic functions for ML-KEM-768/1024 proofs

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -19,6 +19,9 @@ inputs:
   mlkem_k:
     description: "Security level for ML-KEM (2,3,4)"
     default: "2"
+  may_omit_level_agnostic:
+    description: "Whether level-agnostic proofs may be skipped"
+    default: 'false'
   gh_token:
     description: Github access token to use
     required: true
@@ -52,5 +55,5 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           echo "::group::cbmc_${{ inputs.mlkem_k }}"
-          tests cbmc --k ${{ inputs.mlkem_k }};
+          tests cbmc --k ${{ inputs.mlkem_k }} ${{ inputs.may_omit_level_agnostic == 'true' && '--may-omit-level-agnostic' || '' }}
           echo "::endgroup::"

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -23,10 +23,8 @@ jobs:
       compile_mode: native
       opt: no_opt
       lint: false
-      verbose: true
-      functest: true
-      kattest: false
-      acvptest: false
+      verbose: false
+      test: false
       cbmc: true
       cbmc_mlkem_k: 2
     secrets: inherit
@@ -46,11 +44,10 @@ jobs:
       opt: no_opt
       lint: false
       verbose: true
-      functest: true
-      kattest: false
-      acvptest: false
+      test: false
       cbmc: true
       cbmc_mlkem_k: 3
+      cbmc_may_omit_level_agnostic: true
     secrets: inherit
   cbmc_k4:
     name: CBMC (ML-KEM-1024)
@@ -68,9 +65,8 @@ jobs:
       opt: no_opt
       lint: false
       verbose: true
-      functest: true
-      kattest: false
-      acvptest: false
+      test: false
       cbmc: true
       cbmc_mlkem_k: 4
+      cbmc_may_omit_level_agnostic: true
     secrets: inherit

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -69,6 +69,9 @@ on:
       cbmc_mlkem_k:
         type: string
         default: 2
+      cbmc_may_omit_level_agnostic:
+        type: boolean
+        default: false
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
   AWS_REGION: us-east-1
@@ -188,6 +191,7 @@ jobs:
           nix-shell: ci-cbmc
           nix-verbose: ${{ inputs.verbose }}
           mlkem_k: ${{ inputs.cbmc_mlkem_k }}
+          may_omit_level_agnostic: ${{ inputs.cbmc_may_omit_level_agnostic }}
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
       - name: SLOTHY
         if: ${{ inputs.slothy }}

--- a/scripts/tests
+++ b/scripts/tests
@@ -19,10 +19,58 @@ import json
 
 from enum import Enum
 from functools import reduce
+from pathlib import Path
 
 #
 # Some utility functions
 #
+
+
+def list_cbmc_proofs(may_omit_level_agnostic=False):
+    cmd_str = ["./proofs/cbmc/list_proofs.sh"]
+    p = subprocess.run(cmd_str, capture_output=True, universal_newlines=False)
+    proofs = list(filter(lambda s: s.strip() != "", p.stdout.decode().split("\n")))
+
+    if may_omit_level_agnostic is False:
+        return proofs
+
+    # Listing exactly which functions are level-specific vs. level-agnostic
+    # is not obvious, and we cannot risk falsely declaring functions to be
+    # level-generic. We therefore only list some core files which we are know
+    # to only include level specific functionality.
+    some_k_agnostic_sources = [
+        "sampling.h",
+        "sampling.c",
+        "poly.h",
+        "poly.c",
+        "sys.h",
+        "verify.h",
+        "compress.h",
+        "compress.c",
+        "fips202/fips202.h",
+        "fips202/fips202.c",
+        "fips202/fips202x4.c",
+        "fips202/fips202x4.h",
+        "fips202/keccakf1600.h",
+        "fips202/keccakf1600.c",
+    ]
+
+    contract_pattern = re.compile(r"(\w+)\s*\([^)]*\)\s*\n?\s*__contract__")
+
+    k_generic_funcs = []
+    for src_file in some_k_agnostic_sources:
+        filepath = Path("mlkem/src") / src_file
+        with open(filepath) as f:
+            content = f.read()
+
+        # Verify k-agnostic files don't use MLK_NAMESPACE_K
+        assert "MLK_NAMESPACE_K" not in content
+
+        for match in contract_pattern.finditer(content):
+            funcname = match.group(1).removeprefix("mlk_")
+            k_generic_funcs.append(funcname)
+
+    return list([x for x in proofs if x not in k_generic_funcs])
 
 
 def dict2str(dict):
@@ -822,14 +870,12 @@ class Tests:
 
     def cbmc(self):
 
-        def list_proofs():
-            cmd_str = ["./proofs/cbmc/list_proofs.sh"]
-            p = subprocess.run(cmd_str, capture_output=True, universal_newlines=False)
-            proofs = filter(lambda s: s.strip() != "", p.stdout.decode().split("\n"))
-            return list(proofs)
+        # Filter by --may-omit-level-agnostic if requested
+        all_proofs = list_cbmc_proofs(self.args.may_omit_level_agnostic)
 
+        # If --list-functions, print and exit
         if self.args.list_functions:
-            for p in list_proofs():
+            for p in all_proofs:
                 print(p)
             exit(0)
 
@@ -879,8 +925,8 @@ class Tests:
                     log.info(f"   SUCCESS (after {dur}s)")
 
         def run_cbmc(mlkem_k):
-            all_proofs = list_proofs()
             proofs = all_proofs
+
             if self.args.start_with is not None:
                 try:
                     idx = proofs.index(self.args.start_with)
@@ -1290,6 +1336,13 @@ def cli():
         "-l",
         "--list-functions",
         help="Don't run any proofs, but list all functions for which CBMC proofs are available",
+        action="store_true",
+        default=False,
+    )
+
+    cbmc_parser.add_argument(
+        "--may-omit-level-agnostic",
+        help="Allow dropping of level-agnostic proofs; can save time when running proofs for all security levels",
         action="store_true",
         default=False,
     )


### PR DESCRIPTION
This commit modifies the CBMC CI to not check proofs of level-independent
functionality three times for MLKEM-{512,768,1024}.

Rather than trying to find out exactly which functions are level-independent
vs. level-agnostic, we only list a few files which we are sure only to include
level-agnostic functionality, and exclude the functions whose contracts is
declared in those files. We then skip the proofs for those functions in the
CBMC CI runs for MLKEM-768 and MLKEM-1024. By default, however, `tests cbmc`
continues to run all proofs.

We also drop functionality tests from the CBMC CI runs.