### PR TITLE
Mingw-w64: Add 14.2.0 and 15.2.0

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mingw-version: [5.4.0, 11.2.0, 12.2.0, 13.2.0]
+        mingw-version: [5.4.0, 11.2.0, 12.2.0, 13.2.0, 14.2.0, 15.2.0]
     name: Quickcheck (Mingw-w64 ${{ matrix.mingw-version }})
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
https://community.chocolatey.org/packages/mingw has finally been updated with new versions of Mingw-w64. This commit adds 14.2.0 and 15.2.0 to the tests.