### PR TITLE
Correct example Makefile licenses to Apache-2.0 OR ISC OR MIT

### DIFF
--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/basic_deterministic/Makefile
+++ b/examples/basic_deterministic/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/bring_your_own_fips202/Makefile
+++ b/examples/bring_your_own_fips202/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/bring_your_own_fips202_static/Makefile
+++ b/examples/bring_your_own_fips202_static/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/custom_backend/Makefile
+++ b/examples/custom_backend/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/monolithic_build/Makefile
+++ b/examples/monolithic_build/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/monolithic_build_multilevel/Makefile
+++ b/examples/monolithic_build_multilevel/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/monolithic_build_multilevel_native/Makefile
+++ b/examples/monolithic_build_multilevel_native/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/monolithic_build_native/Makefile
+++ b/examples/monolithic_build_native/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean size
 .DEFAULT_GOAL := all

--- a/examples/multilevel_build/Makefile
+++ b/examples/multilevel_build/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean mlkem512_objs mlkem768_objs mlkem1024_objs mlkem_objs size size_objs
 .DEFAULT_GOAL := all

--- a/examples/multilevel_build_native/Makefile
+++ b/examples/multilevel_build_native/Makefile
@@ -1,4 +1,5 @@
-# (SPDX-License-Identifier: CC-BY-4.0)
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 .PHONY: build run clean mlkem512_objs mlkem768_objs mlkem1024_objs mlkem_objs size size_objs
 .DEFAULT_GOAL := all


### PR DESCRIPTION
The example Makefiles were incorrectly listing a CC-BY license that we commonly use for documentation, but as they are code they should be Apache-2.0 OR ISC OR MIT.
This commit relicenses them as Apache-2.0 OR ISC OR MIT.