### PR TITLE
Linting: Detect outdated BIBLIOGRAPHY.md

### DIFF
--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2830,7 +2830,7 @@ def gen_citations(dry_run=False):
                 "Add a citation or remove from BIBLIOGRAPHY.yml."
             )
 
-    gen_bib_file(bibliography, dry_run=False)
+    gen_bib_file(bibliography, dry_run=dry_run)
 
 
 def extract_bytecode_from_output(output_text):


### PR DESCRIPTION
- This PR ported from mldsa-native PR: https://github.com/pq-code-package/mldsa-native/pull/568
- During PR https://github.com/pq-code-package/mldsa-native/pull/567, we notice that the CI will not rising error if there are missing reference in BIBLIOGRAPHY.md, the detail described in [mldsa-native PR#567](https://github.com/pq-code-package/mldsa-native/pull/567).
- This PR fixes the issue where the dry_run argument was not working in the `gen_bib_file()` function. As a result, the CI now rising error correctly when reference missing update in `BIBLIOGRAPHY.md`.
