### PR TITLE
ci_ec2_reusable: Set ec2-volume-size also on re-try

### DIFF
--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -132,6 +132,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
           ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
           subnet-id: subnet-07b2729e5e065962f
           security-group-id: sg-0ab2e297196c8c381


### PR DESCRIPTION
https://github.com/pq-code-package/mlkem-native/pull/1250 added a volume size argument to ci_ec2_reusable, but it is only used for the first attempt to start the instance.
If that fails, the retry will fall back to the default volume size which may very well be 8 GiB which is doomed to fail.