### PR TITLE
autogen: Only consider tracked files

### DIFF
--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1405,18 +1405,24 @@ def get_files(pattern, strip_mlkem=False):
     def normalize(f):
         return f.removeprefix("mlkem/") if strip_mlkem else f
 
-    fs_files = {
-        str(p)
-        for p in pathlib.Path().glob(pattern)
-        if p.is_file() and not p.is_symlink()
-    }
-    cache_files = {f for f in _file_cache.keys() if pathlib.Path(f).match(pattern)}
+    fs_files = {f for f in get_all_files() if pathlib.Path(f).is_file()}
+    cache_files = set(_file_cache.keys())
+
+    # Convert glob pattern to compiled regex
+    pattern = pattern.replace(".", r"\.")
+    pattern = pattern.replace("**/", "<<<DOUBLESTAR>>>")
+    pattern = pattern.replace("*", "[^/]*")
+    pattern = pattern.replace("<<<DOUBLESTAR>>>", "(?:.*/)?")
+    regexp = re.compile(f"^{pattern}$")
 
     # Remove files which are scheduled to be deleted
     res = list(
         map(
             normalize,
-            filter(lambda f: read_file(f) is not None, fs_files | cache_files),
+            filter(
+                lambda f: regexp.match(f) and (read_file(f) is not None),
+                fs_files | cache_files,
+            ),
         )
     )
 


### PR DESCRIPTION
This commit further improves the performance of scripts/autogen by having it consider only files tracked by git.

Originally, this was not possible since we could create new files directly in the file system but wanted later steps in autogen to pick them up for further modification.

Now that we hold back any FS write operations until the end of autogen and instead work on an internal file cache, this problem goes away, and we can use 'git ls-files' exclusively for file listing.

A slight nuisance arises as we can no longer use pathlib.Path().glob() for pattern matching, and the corresponding operation PurePath.full_match seems to available since Python 3.13 only. We hence opt for a slightly hacky implementation which manually transfers the glob pattern into a regexp first.