### PR TITLE
CBMC: Call `mlk_randombytes` by contract

### DIFF
--- a/proofs/cbmc/crypto_kem_enc/Makefile
+++ b/proofs/cbmc/crypto_kem_enc/Makefile
@@ -20,7 +20,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/kem.c
 
 CHECK_FUNCTION_CONTRACTS=mlk_enc
-USE_FUNCTION_CONTRACTS=mlk_enc_derand randombytes mlk_zeroize
+USE_FUNCTION_CONTRACTS=mlk_enc_derand mlk_randombytes mlk_zeroize
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 

--- a/proofs/cbmc/crypto_kem_keypair/Makefile
+++ b/proofs/cbmc/crypto_kem_keypair/Makefile
@@ -20,7 +20,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/kem.c
 
 CHECK_FUNCTION_CONTRACTS=mlk_keypair
-USE_FUNCTION_CONTRACTS=mlk_keypair_derand randombytes mlk_zeroize
+USE_FUNCTION_CONTRACTS=mlk_keypair_derand mlk_randombytes mlk_zeroize
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 


### PR DESCRIPTION
We previously missed to rename `randombytes` -> `mlk_randombytes` in two USE_FUNCTION_CONTRACTS clauses in the CBMC proofs for crypto_kem_enc and crypto_kem_keypair. In consequence, CBMC would inline mlk_randombytes, which forwards to `randombytes` which has no contract attached to it. Being asked to call `randombytes` by contract, CBMC would create an empty contract rather than failing (it's unclear if this is desirable).

In consequence, the CBMC proofs previously did not check the validity of the output buffer passed to `mlk_randombytes`.

This commit fixes the issue by changing `randombytes` to `mlk_randombytes` in the CBMC Makefiles for crypto_kem_{enc,keypair}.