### PR TITLE
Remove unused CBMC tools

### DIFF
--- a/proofs/cbmc/lib/print_tool_versions.py
+++ b/proofs/cbmc/lib/print_tool_versions.py
@@ -14,8 +14,6 @@ _TOOLS = [
     "cadical",
     "cbmc",
     "cbmc-viewer",
-    "cbmc-starter-kit-update",
-    "kissat",
     "litani",
 ]
 


### PR DESCRIPTION
Both kissat and cbmc-starter-kit-update are not used and not installed by mlkem-native, so there is no
point trying to report their version number.

This removes 2 spurious warnings from the CBMC logs.
