### PR TITLE
Replace `/bin/bash` by `/usr/bin/env bash`

### DIFF
--- a/META.sh
+++ b/META.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
 # Helper script to query META.yml

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 	run_size_512 run_size_768 run_size_1024 run_size \
 	host_info
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 .DEFAULT_GOAL := build
 
 all: build

--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -88,7 +88,7 @@ CBMC_STARTER_KIT_VERSION = CBMC starter kit 2.11
 # results that are hard to explain.  Dependency handling in this
 # Makefile.common may not be perfect.
 
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 
 default: report
 

--- a/proofs/cbmc/lib/z3_bv_sort
+++ b/proofs/cbmc/lib/z3_bv_sort
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 z3 rewriter.bv_sort_ac=true "$@"

--- a/proofs/cbmc/lib/z3_smt_only
+++ b/proofs/cbmc/lib/z3_smt_only
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 z3 tactic.default_tactic=smt "$@"

--- a/proofs/cbmc/proof_guide.md
+++ b/proofs/cbmc/proof_guide.md
@@ -365,14 +365,14 @@ e.g. to improve proof performance, you can create a small wrapper script and pas
 An example of such a script is [lib/z3_smt_only](lib/z3_smt_only) which looks like this:
 
 ```
-#!/bin/bash
+#!/usr/bin/env bash
 z3 tactic.default_tactic=smt "$@"
 ```
 
 There is also a script [lib/z3_bv_sort](lib/z3_bv_sort) which looks like this:
 
 ```
-#!/bin/bash
+#!/usr/bin/env bash
 z3 rewriter.bv_sort_ac "$@"
 ```
 


### PR DESCRIPTION
The mlkem-native package fails to build on NixOS, because NixOS does not provide `/bin/bash` by default.

On NixOS, the recommended approach is to use `/usr/bin/env bash` because this makes it easier to install different versions of `bash` on the same system. (By letting `PATH` decide which binary to execute.) Note that `/usr/bin/env bash` is also the recommended approach on MacOS to use a newer `bash` version than the system-provided one.

I see that `/usr/bin/env bash` and `/usr/bin/env python3` are already used in 18 locations (see for example: [proofs/cbmc/list_proofs.sh](https://github.com/pq-code-package/mlkem-native/blob/main/proofs/cbmc/list_proofs.sh)). Therefore, I'm proposing to replace the remaining instances of `/bin/bash` to `/usr/bin/env bash`. So, this change not only fixes builds on NixOS, but is also more consistent.