### PR TITLE
Make: Support CFLAGS as both env var and make argument

### DIFF
--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -30,7 +30,8 @@ CC_AR  := $(CROSS_PREFIX)$(CC_AR)
 #################
 # Common config #
 #################
-CFLAGS := \
+
+override CFLAGS := \
 	-Wall \
 	-Wextra \
 	-Werror=unused-result \


### PR DESCRIPTION
We usually pass arguments to make through environment variables: CFLAGS="-std=c11" make quickcheck

It currently does not work to pass it as a make argument: make quickcheck CFLAGS="-std=c11"

This commit fixes that and extends the C90 CI to test both variants.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1315