### PR TITLE
tests: Run check-namespace script also for tests all

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -796,6 +796,15 @@ class Tests:
             if unit is True:
                 self._compile_schemes(TEST_TYPES.UNIT, opt)
 
+            if self.args.check_namespace is True:
+                p = subprocess.run(
+                    ["python3", "check-namespace"],
+                    stdout=subprocess.DEVNULL if not self.args.verbose else None,
+                    cwd="scripts",
+                )
+                if p.returncode != 0:
+                    self.fail(f"Namespacing failed for opt={opt}")
+
             if self.args.run is False:
                 return
 


### PR DESCRIPTION
Currently the check-namespacing script is only run when tests func --check-namespace
is called

For
tests all, the --check-namespace has no effect.

This commit fixes that by adding the namespace check to the all test as well.

This is important as we only run the all target in CI.