### PR TITLE
CBMC: Fix native Armv8.4-A Keccak proofs on x86

### DIFF
--- a/mlkem/src/sys.h
+++ b/mlkem/src/sys.h
@@ -217,15 +217,10 @@
 /* System capability enumeration */
 typedef enum
 {
-#if defined(MLK_SYS_X86_64)
-  MLK_SYS_CAP_AVX2
-#elif defined(MLK_SYS_AARCH64)
+  /* x86_64 */
+  MLK_SYS_CAP_AVX2,
+  /* AArch64 */
   MLK_SYS_CAP_SHA3
-#else
-  /* C90 does not allow empty enums, so use a dummy value
-   * for architectures other than AArch64 and x86_64. */
-  MLK_SYS_CAP_DUMMY
-#endif
 } mlk_sys_cap;
 
 #if !defined(MLK_CONFIG_CUSTOM_CAPABILITY_FUNC)


### PR DESCRIPTION
Currently the CBMC proofs for the 3 native aarch64 versions of Keccak using SHA-3 instructions are failing as the MLK_SYS_CAP_SHA3 symbol is not defined on an x86 system.

This commit fixes this by defining the mlk_sys_cap entries unconditional.
~For clarity they are now prefixed with the platform:~
 ~MLK_SYS_CAP_AVX2 -> MLK_SYS_CAP_X86_64_AVX2~
 ~MLK_SYS_CAP_SHA3 -> MLK_SYS_CAP_AARCH64_SHA3~
 
 I've un-done the last change as this is strictly speaking a change of public API (it breaks the AWS-LC integration) - that's not worth it imo.

- Resolves #1318 