### PR TITLE
CBMC: Allow specification of per-proof timeouts

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -53,5 +53,5 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           echo "::group::cbmc_${{ inputs.mlkem_k }}"
-          tests cbmc --k ${{ inputs.mlkem_k }};
+          tests cbmc --k ${{ inputs.mlkem_k }} --per-proof-timeout 1800;
           echo "::endgroup::"

--- a/scripts/tests
+++ b/scripts/tests
@@ -857,6 +857,8 @@ class Tests:
                             "run-cbmc-proofs.py",
                             "--summarize",
                             "--no-coverage",
+                            "--per-proof-timeout",
+                            str(self.args.per_proof_timeout),
                             "-p",
                             func,
                         ]
@@ -911,7 +913,15 @@ class Tests:
                 return
             envvars = {"MLKEM_K": mlkem_k}
             p = subprocess.run(
-                ["python3", "run-cbmc-proofs.py", "--summarize", "--no-coverage", "-p"]
+                [
+                    "python3",
+                    "run-cbmc-proofs.py",
+                    "--summarize",
+                    "--no-coverage",
+                    "--per-proof-timeout",
+                    str(self.args.per_proof_timeout),
+                    "-p",
+                ]
                 + proofs
                 + self.make_j(),
                 cwd="proofs/cbmc",
@@ -1285,6 +1295,13 @@ def cli():
         help="Timeout for individual CBMC proofs, in seconds",
         type=int,
         default=3600,
+    )
+
+    cbmc_parser.add_argument(
+        "--per-proof-timeout",
+        help="Timeout for each individual CBMC proof passed to run-cbmc-proofs.py, in seconds (default: 1800)",
+        type=int,
+        default=1800,
     )
 
     cbmc_parser.add_argument(


### PR DESCRIPTION
This commit adds support for per-proof timeouts in CBMC proofs to prevent CI from running for hours on failing or slow proofs. The implementation leverages Litani's existing timeout mechanism via the CBMC_TIMEOUT environment variable.

Add --per-proof-timeout argument to run-cbmc-proofs.py (default: 1800s) Pass timeout to Litani via CBMC_TIMEOUT environment variable Modify lib/summarize.py to detect timeout_reached flag and display "timeout" instead.  Add --per-proof-timeout argument to tests cbmc command Set explicit 30-minute timeout in CI workflow

* Port of https://github.com/pq-code-package/mldsa-native/pull/734