### PR TITLE
CI: Switch from pqcp-arm64/pqcp-x64 runners to free Github runners

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64]
+        system: [ubuntu-latest, ubuntu-24.04-arm]
     name: Linting
     runs-on: ${{ matrix.system }}
     steps:
@@ -30,7 +30,7 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
@@ -41,7 +41,7 @@ jobs:
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'aarch64'
              }}
     name: Quickcheck (${{ matrix.target.name }})
@@ -64,7 +64,7 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
@@ -72,7 +72,7 @@ jobs:
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'aarch64'
              }}
     name: Quickcheck ACVP (${{ matrix.target.name }}, ${{ matrix.acvp-version }})
@@ -89,9 +89,9 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
@@ -102,7 +102,7 @@ jobs:
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'aarch64'
              }}
     name: Quickcheck bench (${{ matrix.target.name }})
@@ -138,14 +138,14 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'aarch64'
              }}
     name: Quickcheck C90 (${{ matrix.target.name }})
@@ -206,7 +206,7 @@ jobs:
     name: Quickcheck lib
     strategy:
       matrix:
-        system: [macos-latest, macos-15-intel, ubuntu-latest, pqcp-arm64]
+        system: [macos-latest, macos-15-intel, ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -217,7 +217,7 @@ jobs:
     name: Examples
     strategy:
       matrix:
-        system: [macos-latest, macos-15-intel, ubuntu-latest, pqcp-arm64]
+        system: [macos-latest, macos-15-intel, ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -268,7 +268,7 @@ jobs:
              name: Simplified
            - arg: '--no-simplify'
              name: Unmodified
-    runs-on: pqcp-arm64
+    runs-on: ubuntu-24.04-arm
     name: AArch64 dev backend (${{ matrix.backend.name }}, ${{ matrix.simplify.name }})
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -302,7 +302,7 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,42 +26,42 @@ jobs:
            arch: mac
            mode: native
            nix_shell: ci
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (aarch64)'
            arch: aarch64
            mode: native
            nix_shell: ci
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (aarch64)'
            arch: x86_64
            mode: cross-x86_64
            nix_shell: ci-cross-x86_64
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (aarch64)'
            arch: riscv64
            mode: cross-riscv64
            nix_shell: ci-cross-riscv64
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (aarch64)'
            arch: riscv32
            mode: cross-riscv32
            nix_shell: ci-cross-riscv32
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (ppc64le)'
            arch: ppc64le
            mode: cross-ppc64le
            nix_shell: ci-cross-ppc64le
-         - runner: pqcp-x64
+         - runner: ubuntu-latest
            name: 'ubuntu-latest (x86_64)'
            arch: x86_64
            mode: native
            nix_shell: ci
-         - runner: pqcp-x64
+         - runner: ubuntu-latest
            name: 'ubuntu-latest (x86_64)'
            arch: aarch64
            mode: cross-aarch64
            nix_shell: ci-cross-aarch64
-         - runner: pqcp-x64
+         - runner: ubuntu-latest
            name: 'ubuntu-latest (x86_64)'
            arch: aarch64_be
            mode: cross-aarch64_be
@@ -69,7 +69,7 @@ jobs:
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (aarch64)',
                arch: aarch64,
                mode: native,
@@ -77,7 +77,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (aarch64)',
                arch: x86_64,
                mode: cross-x86_64,
@@ -85,7 +85,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (aarch64)',
                arch: riscv64,
                mode: cross-riscv64,
@@ -93,7 +93,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (aarch64)',
                arch: riscv32,
                mode: cross-riscv32,
@@ -101,7 +101,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (ppc64le)',
                arch: ppc64le,
                mode: cross-ppc64le,
@@ -109,7 +109,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-x64,
+               runner: ubuntu-latest,
                name: 'ubuntu-latest (x86_64)',
                arch: x86_64,
                mode: native,
@@ -117,7 +117,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-x64,
+               runner: ubuntu-latest,
                name: 'ubuntu-latest (x86_64)',
                arch: aarch64,
                mode: cross-aarch64,
@@ -125,7 +125,7 @@ jobs:
              }}
           - {external: true,
              target: {
-               runner: pqcp-x64,
+               runner: ubuntu-latest,
                name: 'ubuntu-latest (x86_64)',
                arch: aarch64_be,
                mode: cross-aarch64_be,
@@ -202,7 +202,7 @@ jobs:
       matrix:
         cflags: [ "-O0", "-Os", "-O3" ]
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
@@ -412,9 +412,9 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-          - runner: pqcp-x64
+          - runner: ubuntu-latest
             name: x86_64
-          - runner: pqcp-arm64
+          - runner: ubuntu-24.04-arm
             name: aarch64
         cflags: ['-O3', '-Os']
         exclude:
@@ -445,19 +445,19 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'ubuntu-latest (aarch64)'
-         - runner: pqcp-x64
+         - runner: ubuntu-latest
            name: 'ubuntu-latest (x86_64)'
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'ubuntu-latest (aarch64)',
              }}
           - {external: true,
              target: {
-               runner: pqcp-x64,
+               runner: ubuntu-latest,
                name: 'ubuntu-latest (x86_64)',
              }}
     runs-on: ${{ matrix.target.runner }}
@@ -501,14 +501,14 @@ jobs:
         external:
          - ${{ github.repository_owner != 'pq-code-package' }}
         target:
-         - runner: pqcp-arm64
+         - runner: ubuntu-24.04-arm
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
         exclude:
           - {external: true,
              target: {
-               runner: pqcp-arm64,
+               runner: ubuntu-24.04-arm,
                name: 'aarch64'
              }}
     name: Check API consistency
@@ -681,7 +681,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64]
+        system: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.system }}
     name: Check autogenerated files
     steps:
@@ -695,7 +695,7 @@ jobs:
             python3 ./scripts/autogen --dry-run --force-cross
       - uses: ./.github/actions/setup-shell
         # Building the HOL-Light bytecode currently requires native compilation
-        if: ${{ matrix.system == 'pqcp-arm64' }}
+        if: ${{ matrix.system == 'ubuntu-24.04-arm' }}
         with:
           nix-shell: 'hol_light'
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        system: [ubuntu-latest, pqcp-arm64]
+        system: [ubuntu-latest, ubuntu-24.04-arm]
         nix-shell:
           - ci_valgrind-varlat_clang14
           - ci_valgrind-varlat_clang15

--- a/.github/workflows/integration-awslc.yml
+++ b/.github/workflows/integration-awslc.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64]
+        system: [ubuntu-latest, ubuntu-24.04-arm]
         fips: [0,1]
     name: AWS-LC FIPS test (${{ matrix.system }}, FIPS=${{ matrix.fips }})
     runs-on: ${{ matrix.system }}
@@ -73,7 +73,7 @@ jobs:
       max-parallel: 16
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64]
+        system: [ubuntu-latest, ubuntu-24.04-arm]
         test:
           - name: Debug mode
             flags: -DENABLE_DILITHIUM=ON
@@ -127,7 +127,7 @@ jobs:
       max-parallel: 8
       fail-fast: false
       matrix:
-        system: [ubuntu-latest, pqcp-arm64, macos-latest, macos-15-intel]
+        system: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
         test:
           - name: Prefix+Debug
             flags:

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -25,10 +25,10 @@ jobs:
             name: C
             flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           # AArch64
-          - system: pqcp-arm64
+          - system: ubuntu-24.04-arm
             name: Auto
             flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=auto -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
-          - system: pqcp-arm64
+          - system: ubuntu-24.04-arm
             name: C
             flags: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
     name: Build (${{ matrix.name }}, ${{ matrix.system }})


### PR DESCRIPTION
We spend considerable $ on the pqcp-arm64 runners. Initially we introduced those as there were no free Arm64 runners yet, but those are now publicly avilable and we should use the free runners as much as possible. This commit switches everything except the HOL-Light workflows to the free runners.