### PR TITLE
mk: Fix global setting of CFLAGS (fix benchmarking)

### DIFF
--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -30,8 +30,7 @@ CC_AR  := $(CROSS_PREFIX)$(CC_AR)
 #################
 # Common config #
 #################
-
-override CFLAGS := \
+CFLAGS := \
 	-Wall \
 	-Wextra \
 	-Werror=unused-result \


### PR DESCRIPTION
ce37b3f1295bae5fab36da6cda23ca89bbd76023 added support for passing CFLAGS both as environment vaariables and make arguments. However, this disabled the various CFLAGS += invocation extending CFLAGS throughout our Makefile.
This, for example, disabled our benchmarking as the cycle counting method was not correctly passed.
This PR reverts that commit. 