### PR TITLE
Speed up `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,16 @@ endif
 
 W := $(EXEC_WRAPPER)
 
+BUILD_DIR ?= test/build
+
+# Skip includes for clean target
+ifneq ($(MAKECMDGOALS),clean)
 include test/mk/config.mk
 include test/mk/compiler.mk
 include test/mk/auto.mk
 include test/mk/components.mk
 include test/mk/rules.mk
+endif
 
 quickcheck: test
 
@@ -228,17 +233,27 @@ else
 	@echo "No specific feature detection available for $(ARCH)"
 endif
 
-clean:
-	-$(RM) -rf *.gcno *.gcda *.lcov *.o *.so
-	-$(RM) -rf $(BUILD_DIR)
-	-make clean -C examples/bring_your_own_fips202 >/dev/null
-	-make clean -C examples/bring_your_own_fips202_static >/dev/null
-	-make clean -C examples/custom_backend >/dev/null
-	-make clean -C examples/basic >/dev/null
-	-make clean -C examples/basic_deterministic >/dev/null
-	-make clean -C examples/monolithic_build >/dev/null
-	-make clean -C examples/monolithic_build_native >/dev/null
-	-make clean -C examples/monolithic_build_multilevel >/dev/null
-	-make clean -C examples/monolithic_build_multilevel_native >/dev/null
-	-make clean -C examples/multilevel_build >/dev/null
-	-make clean -C examples/multilevel_build_native >/dev/null
+EXAMPLE_DIRS := \
+	examples/bring_your_own_fips202 \
+	examples/bring_your_own_fips202_static \
+	examples/custom_backend \
+	examples/basic \
+	examples/basic_deterministic \
+	examples/monolithic_build \
+	examples/monolithic_build_native \
+	examples/monolithic_build_multilevel \
+	examples/monolithic_build_multilevel_native \
+	examples/multilevel_build \
+	examples/multilevel_build_native
+
+EXAMPLE_CLEAN_TARGETS := $(EXAMPLE_DIRS:%=clean-%)
+
+.PHONY: $(EXAMPLE_CLEAN_TARGETS)
+
+$(EXAMPLE_CLEAN_TARGETS): clean-%:
+	@echo "  CLEAN   $*"
+	-@$(MAKE) clean -C $* >/dev/null
+
+clean: $(EXAMPLE_CLEAN_TARGETS)
+	@echo "  RM      $(BUILD_DIR)"
+	-@$(RM) -rf $(BUILD_DIR)

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -80,14 +80,14 @@ $(MLKEM1024_DIR)/bin/%: CFLAGS += -DMLK_CONFIG_PARAMETER_SET=1024
 
 # Link tests with respective library (except test_unit which includes sources directly)
 define ADD_SOURCE
-$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(BUILD_DIR) -l$(1)
-$(BUILD_DIR)/$(1)/bin/$(2)$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/$(2).c.o $(BUILD_DIR)/lib$(1).a
+$(BUILD_DIR)/$(1)/bin/$(2)$(subst mlkem,,$(1)): LDLIBS += -L$(BUILD_DIR) -l$(1)
+$(BUILD_DIR)/$(1)/bin/$(2)$(subst mlkem,,$(1)): $(BUILD_DIR)/$(1)/test/$(2).c.o $(BUILD_DIR)/lib$(1).a
 endef
 
 # Special rule for test_unit - link against unit libraries with exposed internal functions
 define ADD_SOURCE_UNIT
-$(BUILD_DIR)/$(1)/bin/test_unit$(shell echo $(1) | tr -d -c 0-9): LDLIBS += -L$(BUILD_DIR) -l$(1)_unit
-$(BUILD_DIR)/$(1)/bin/test_unit$(shell echo $(1) | tr -d -c 0-9): $(BUILD_DIR)/$(1)/test/test_unit.c.o $(BUILD_DIR)/lib$(1)_unit.a $(call MAKE_OBJS, $(BUILD_DIR)/$(1), $(wildcard test/notrandombytes/*.c))
+$(BUILD_DIR)/$(1)/bin/test_unit$(subst mlkem,,$(1)): LDLIBS += -L$(BUILD_DIR) -l$(1)_unit
+$(BUILD_DIR)/$(1)/bin/test_unit$(subst mlkem,,$(1)): $(BUILD_DIR)/$(1)/test/test_unit.c.o $(BUILD_DIR)/lib$(1)_unit.a $(call MAKE_OBJS, $(BUILD_DIR)/$(1), $(wildcard test/notrandombytes/*.c))
 endef
 
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -91,8 +91,6 @@ $(foreach var,$(RETAINED_VARS),$(eval $(call CAPTURE_VAR,$(var))))
 CYCLES ?=
 OPT ?= 1
 
-BUILD_DIR ?= test/build
-
 MAKE_OBJS = $(2:%=$(1)/%.o)
 OBJS = $(call MAKE_OBJS,$(BUILD_DIR),$(1))
 


### PR DESCRIPTION
* Resolves https://github.com/pq-code-package/mlkem-native/issues/1349

A plain `make clean` would previously take >3s, primarily because of an unnecessary use of dozens of shell invocations that could be replaced by a mere `subst` inside `make`.

Also, skip the bulk of the makefiles when cleaning, and align the output format of `make clean` with that of other targets.