### PR TITLE
Minor clean-up of mlk_rej_uniform_native contract

### DIFF
--- a/mlkem/src/native/api.h
+++ b/mlkem/src/native/api.h
@@ -413,8 +413,10 @@ __contract__(
   requires(memory_no_alias(r, sizeof(int16_t) * len))
   requires(memory_no_alias(buf, buflen))
   assigns(memory_slice(r, sizeof(int16_t) * len))
-  ensures(return_value == MLK_NATIVE_FUNC_FALLBACK || (0 <= return_value && return_value <= len))
-  ensures(return_value != -1 ==> array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
+  ensures(return_value != MLK_NATIVE_FUNC_FALLBACK
+	      ==> (0 <= return_value && return_value <= len))
+  ensures(return_value != MLK_NATIVE_FUNC_FALLBACK
+	      ==> array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
 );
 #endif /* MLK_USE_NATIVE_REJ_UNIFORM */
 


### PR DESCRIPTION
Fixes single instance of -1 that should be MLK_NATIVE_FUNC_FALLBACK.