### PR TITLE
CONTRIBUTING.md: Add instructions for Debian

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 We welcome contributors who can help us build mlkem-native. If you are interested, please contact us, or volunteer for
 any of the open issues. Here are some things to get you started.
 
-### nix setup
+### Nix (Recommended)
 
 We specify the development environment for mlkem-native using `nix`. If you want to help develop mlkem-native, please
 use `nix`. We recommend using the latest Nix version provided by the [nix installer
@@ -16,26 +16,29 @@ All the development and build dependencies are specified in [flake.nix](flake.ni
 nix develop --experimental-features 'nix-command flakes'
 ```
 
-To confirm that everything worked, try `lint` or `tests cbmc`.
+Use the `./scripts/format` and `./scripts/autogen` scripts (in your `PATH` when using `nix`) to re-format and re-generate all the files respectively. To confirm that everything worked, try `lint` or `tests cbmc`.
 
-### Coding style
+### Debian
 
-We use auto-formatting using `clang-format` as specified in [.clang-format](.clang-format). Use the `./scripts/format`
-script (in your `PATH` when using `nix`) to re-format the files accordingly.
-
-When using `Debian`, the following dependencies are needed to be installed:
+When using Debian, the following dependencies are needed to be installed:
 
 ```bash
-sudo apt install shfmt black clang-format
+sudo apt install shfmt black clang-format llvm python3-pyparsing python3-yaml
 ```
 
-When using `Debian`, `nixpkgs-fmt` is needed to be compiled from source:
+Additionally, `nixpkgs-fmt` is needed to be compiled from source:
 
 ```bash
 sudo apt install cargo
 cargo install nixpkgs-fmt
 export PATH="$PATH:~/.cargo/bin"
 ```
+
+The scripts `./scripts/format` and `./scripts/autogen` can then be used to re-format and re-generate all the files respectively.
+
+### Coding style
+
+We use auto-formatting using `clang-format` as specified in [.clang-format](.clang-format).
 
 ### Namespacing
 


### PR DESCRIPTION
Following up on #1353, this pull request add instructions to install the additional dependencies required for `scripts/format` and `scripts/autogen` on Debian and Debian-based distributions.