### PR TITLE
Fix mlk_poly_tobytes_native comment

### DIFF
--- a/mlkem/src/native/api.h
+++ b/mlkem/src/native/api.h
@@ -346,7 +346,7 @@ __contract__(
  *
  * Arguments:   INPUT:
  *              - a: const pointer to input polynomial,
- *                with each coefficient in the range -Q+1 .. Q-1
+ *                with each coefficient in the range 0 .. Q-1
  *              OUTPUT
  *              - r: pointer to output byte array
  *                   (of MLKEM_POLYBYTES bytes)


### PR DESCRIPTION
Tiny fix for `mlk_poly_tobytes_native` comment.