### PR TITLE
Unit test: remove duplicate NTT test

### DIFF
--- a/test/test_unit.c
+++ b/test/test_unit.c
@@ -303,13 +303,6 @@ static int test_native_ntt(void)
   int16_t test_data[MLKEM_N];
   int pos, i;
 
-  /* Use a more complex test that will expose the bug */
-  for (i = 0; i < NUM_RANDOM_TESTS; i++)
-  {
-    generate_i16_array_ranged(test_data, MLKEM_N, -MLKEM_Q + 1, MLKEM_Q);
-    CHECK(test_ntt_core(test_data, "ntt_complex") == 0);
-  }
-
   generate_i16_array_zeros(test_data, MLKEM_N);
   CHECK(test_ntt_core(test_data, "ntt_zeros") == 0);
 


### PR DESCRIPTION
- This PR remove the duplicate unit test pattern in `test_native_ntt` function, there are two test loop namely "ntt_complex" and "ntt_random", appear to be identical, this commit remove "ntt_complex". only the random one kept.