### PR TITLE
Revert proofs of scalar_[de]compress_d* to use SMT back-end

### DIFF
--- a/proofs/cbmc/scalar_compress_d1/Makefile
+++ b/proofs/cbmc/scalar_compress_d1/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_compress_d1
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_compress_d10/Makefile
+++ b/proofs/cbmc/scalar_compress_d10/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_compress_d10
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_compress_d11/Makefile
+++ b/proofs/cbmc/scalar_compress_d11/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_compress_d11
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_compress_d4/Makefile
+++ b/proofs/cbmc/scalar_compress_d4/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_compress_d4
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_compress_d5/Makefile
+++ b/proofs/cbmc/scalar_compress_d5/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_compress_d5
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_decompress_d10/Makefile
+++ b/proofs/cbmc/scalar_decompress_d10/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_decompress_d10
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_decompress_d11/Makefile
+++ b/proofs/cbmc/scalar_decompress_d11/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_decompress_d11
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_decompress_d4/Makefile
+++ b/proofs/cbmc/scalar_decompress_d4/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_decompress_d4
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on

--- a/proofs/cbmc/scalar_decompress_d5/Makefile
+++ b/proofs/cbmc/scalar_decompress_d5/Makefile
@@ -23,10 +23,7 @@ CHECK_FUNCTION_CONTRACTS=mlk_scalar_decompress_d5
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
+CBMCFLAGS=--smt2
 
 # Uncomment this to see what commands litani is running...
 #VERBOSE=on


### PR DESCRIPTION
Fixes #1363 

Revert these proofs to use the CBMC SMT back-end.

BMC Issue 8303 meant that these proofs originally used the SAT back-end. This issue was fixed long ago, so we can revert these proofs to use the SMT back-end now, at least for consistency. It also removes the SAT back-end from our dependencies.

Proof times remain largely unchanged and, at a few seconds per function, will not affect the overall CI time.
Actual proof times will be posted below.
