### PR TITLE
HOL-Light: Add proof for x86_64 inverse NTT

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -189,6 +189,8 @@ jobs:
           # Dependencies on {name}.{S,ml} are implicit
           - name: mlkem_ntt
             needs: ["mlkem_specs.ml", "mlkem_zetas.ml"]
+          - name: mlkem_intt
+            needs: ["mlkem_specs.ml", "mlkem_zetas.ml"]
           - name: mlkem_poly_basemul_acc_montgomery_cached_k2
             needs: ["mlkem_specs.ml"]
           - name: mlkem_poly_basemul_acc_montgomery_cached_k3

--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -27,6 +27,7 @@ source code and documentation.
   - [dev/x86_64/src/ntt.S](dev/x86_64/src/ntt.S)
   - [mlkem/src/native/x86_64/src/intt.S](mlkem/src/native/x86_64/src/intt.S)
   - [mlkem/src/native/x86_64/src/ntt.S](mlkem/src/native/x86_64/src/ntt.S)
+  - [proofs/hol_light/x86/mlkem/mlkem_intt.S](proofs/hol_light/x86/mlkem/mlkem_intt.S)
   - [proofs/hol_light/x86/mlkem/mlkem_ntt.S](proofs/hol_light/x86/mlkem/mlkem_ntt.S)
 
 ### `FIPS140_3_IG`
@@ -260,6 +261,7 @@ source code and documentation.
   - [mlkem/src/native/x86_64/src/nttunpack.S](mlkem/src/native/x86_64/src/nttunpack.S)
   - [mlkem/src/native/x86_64/src/reduce.S](mlkem/src/native/x86_64/src/reduce.S)
   - [mlkem/src/native/x86_64/src/tomont.S](mlkem/src/native/x86_64/src/tomont.S)
+  - [proofs/hol_light/x86/mlkem/mlkem_intt.S](proofs/hol_light/x86/mlkem/mlkem_intt.S)
   - [proofs/hol_light/x86/mlkem/mlkem_ntt.S](proofs/hol_light/x86/mlkem/mlkem_ntt.S)
 
 ### `SLOTHY`

--- a/proofs/hol_light/README.md
+++ b/proofs/hol_light/README.md
@@ -102,6 +102,7 @@ The NTT and invNTT functions are super-optimized using [SLOTHY](https://github.c
 The following x86_64 assembly routines used in mlkem-native are covered:
 - ML-KEM Arithmetic:
   * x86_64 forward NTT: [mlkem_ntt.S](x86/mlkem/mlkem_ntt.S)
+  * x86_64 inverse NTT: [mlkem_intt.S](x86/mlkem/mlkem_intt.S)
   * x86_64 base multiplications: [mlkem_poly_basemul_acc_montgomery_cached_k2.S](x86/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.S) [mlkem_poly_basemul_acc_montgomery_cached_k3.S](x86/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.S) [mlkem_poly_basemul_acc_montgomery_cached_k4.S](x86/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.S)
 
 <!--- bibliography --->

--- a/proofs/hol_light/common/mlkem_specs.ml
+++ b/proofs/hol_light/common/mlkem_specs.ml
@@ -44,6 +44,23 @@ let avx2_ntt_order = define
  `avx2_ntt_order i =
     bitreverse7(64 * (i DIV 64) + ((i MOD 64) DIV 16) + 4 * (i MOD 16))`;;
 
+let avx2_ntt_order' = define
+ `avx2_ntt_order' i =
+    let j = bitreverse7 i in
+    (64 * (j DIV 64) + 16 * (j MOD 4) + (j MOD 64) DIV 4)`;;
+
+let avx2_reorder = define
+ `avx2_reorder i =
+    let r = (i DIV 16) MOD 2
+    and q = 16 * (i DIV 32) + i MOD 16 in
+    2 * avx2_ntt_order q + r`;;
+
+let avx2_reorder' = define
+ `avx2_reorder' i =
+    let r = i MOD 2
+    and q = avx2_ntt_order'(i DIV 2) in
+    (q DIV 16) * 32 + r * 16 + q MOD 16`;;
+
 (* ------------------------------------------------------------------------- *)
 (* Conversion of each element of an array to Montgomery form with B = 2^16.  *)
 (* ------------------------------------------------------------------------- *)
@@ -91,6 +108,14 @@ let avx2_forward_ntt = define
                        &17 pow ((2 * avx2_ntt_order q + 1) * j))
     rem &3329`;;
 
+let avx2_inverse_ntt = define
+ `avx2_inverse_ntt f k =
+    (&512 * isum (0..127)
+                 (\j. f(avx2_ntt_order' j DIV 16 * 32 +
+                        k MOD 2 * 16 +
+                        avx2_ntt_order' j MOD 16) *
+                      &1175 pow ((2 * j + 1) * k DIV 2)))
+    rem &3329`;;
 (* ------------------------------------------------------------------------- *)
 (* Show how these relate to the "pure" ones.                                 *)
 (* ------------------------------------------------------------------------- *)
@@ -109,6 +134,26 @@ let INVERSE_NTT = prove
   REWRITE_TAC[ARITH_RULE `(2 * x + i MOD 2) DIV 2 = x`] THEN
   REWRITE_TAC[MOD_MULT_ADD; MOD_MOD_REFL] THEN
   MAP_EVERY X_GEN_TAC [`a:num->int`; `i:num`] THEN
+  CONV_TAC INT_REM_DOWN_CONV THEN REWRITE_TAC[INT_MUL_ASSOC] THEN
+  ONCE_REWRITE_TAC[GSYM INT_MUL_REM] THEN CONV_TAC INT_REDUCE_CONV);;
+
+let AVX2_FORWARD_NTT = prove
+ (`avx2_forward_ntt = reorder avx2_reorder o pure_forward_ntt`,
+  REWRITE_TAC[FUN_EQ_THM; o_DEF; avx2_reorder; reorder] THEN
+  REWRITE_TAC[avx2_forward_ntt; pure_forward_ntt] THEN
+  MAP_EVERY X_GEN_TAC [`x:num->int`; `k:num`] THEN
+  CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN
+  SIMP_TAC[MOD_MULT_ADD; DIV_MULT_ADD; ARITH_EQ; MOD_MOD_REFL] THEN
+  REWRITE_TAC[ARITH_RULE `x MOD 2 DIV 2 = 0`; ADD_CLAUSES]);;
+
+let AVX2_INVERSE_NTT = prove
+ (`avx2_inverse_ntt = tomont_3329 o pure_inverse_ntt o reorder avx2_reorder'`,
+  REWRITE_TAC[FUN_EQ_THM; o_DEF; avx2_reorder'; reorder] THEN
+  REWRITE_TAC[avx2_inverse_ntt; pure_inverse_ntt; tomont_3329] THEN
+  REWRITE_TAC[ARITH_RULE `(2 * x + i MOD 2) DIV 2 = x`] THEN
+  REWRITE_TAC[MOD_MULT_ADD; MOD_MOD_REFL] THEN
+  MAP_EVERY X_GEN_TAC [`x:num->int`; `k:num`] THEN
+  CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN
   CONV_TAC INT_REM_DOWN_CONV THEN REWRITE_TAC[INT_MUL_ASSOC] THEN
   ONCE_REWRITE_TAC[GSYM INT_MUL_REM] THEN CONV_TAC INT_REDUCE_CONV);;
 
@@ -172,6 +217,25 @@ let INVERSE_NTT_ALT = prove
   CONV_TAC INT_REM_DOWN_CONV THEN
   AP_THM_TAC THEN AP_TERM_TAC THEN CONV_TAC INT_ARITH);;
 
+let AVX2_INVERSE_NTT_ALT = prove
+ (`avx2_inverse_ntt f k =
+    isum (0..127)
+      (\j. f(avx2_ntt_order' j DIV 16 * 32 +
+             k MOD 2 * 16 +
+             avx2_ntt_order' j MOD 16) *
+           (&512 *
+            (&1175 pow ((2 * j + 1) * k DIV 2)) rem &3329)
+           rem &3329) rem &3329`,
+  REWRITE_TAC[avx2_inverse_ntt; GSYM ISUM_LMUL] THEN
+  MATCH_MP_TAC (REWRITE_RULE[] (ISPEC
+      `(\x y. x rem &3329 = y rem &3329)` ISUM_RELATED)) THEN
+  REWRITE_TAC[INT_REM_EQ; FINITE_NUMSEG; INT_CONG_ADD] THEN
+  X_GEN_TAC `i:num` THEN DISCH_TAC THEN
+  REWRITE_TAC[GSYM INT_OF_NUM_REM; GSYM INT_OF_NUM_CLAUSES;
+              GSYM INT_REM_EQ] THEN
+  CONV_TAC INT_REM_DOWN_CONV THEN
+  AP_THM_TAC THEN AP_TERM_TAC THEN CONV_TAC INT_ARITH);;
+
 let FORWARD_NTT_CONV =
   GEN_REWRITE_CONV I [FORWARD_NTT_ALT] THENC
   LAND_CONV EXPAND_ISUM_CONV THENC
@@ -185,6 +249,12 @@ let AVX2_NTT_ORDER_CLAUSES = end_itlist CONJ (map
  (GEN_REWRITE_CONV I [avx2_ntt_order] THENC DEPTH_CONV WORD_NUM_RED_CONV THENC
   GEN_REWRITE_CONV I [BITREVERSE7_CLAUSES])
  (map (curry mk_comb `avx2_ntt_order` o mk_small_numeral) (0--127)));;
+
+let AVX2_NTT_ORDER_CLAUSES' = end_itlist CONJ (map
+ (GEN_REWRITE_CONV I [avx2_ntt_order'] THENC DEPTH_CONV WORD_NUM_RED_CONV THENC
+ DEPTH_CONV let_CONV THENC
+ GEN_REWRITE_CONV ONCE_DEPTH_CONV [BITREVERSE7_CLAUSES] THENC NUM_REDUCE_CONV)
+ (map (curry mk_comb `avx2_ntt_order'` o mk_small_numeral) (0--127)));;
 
 let AVX2_FORWARD_NTT_CONV =
   GEN_REWRITE_CONV I [AVX2_FORWARD_NTT_ALT] THENC
@@ -201,6 +271,16 @@ let INVERSE_NTT_CONV =
   LAND_CONV EXPAND_ISUM_CONV THENC
   DEPTH_CONV NUM_RED_CONV THENC
   GEN_REWRITE_CONV ONCE_DEPTH_CONV [BITREVERSE7_CLAUSES] THENC
+  DEPTH_CONV NUM_RED_CONV THENC
+  GEN_REWRITE_CONV DEPTH_CONV [INT_OF_NUM_POW; INT_OF_NUM_REM] THENC
+  ONCE_DEPTH_CONV EXP_MOD_CONV THENC INT_REDUCE_CONV;;
+
+let AVX2_INVERSE_NTT_CONV =
+  GEN_REWRITE_CONV I [AVX2_INVERSE_NTT_ALT] THENC
+  NUM_REDUCE_CONV THENC ONCE_DEPTH_CONV let_CONV THENC
+  LAND_CONV EXPAND_ISUM_CONV THENC
+  DEPTH_CONV NUM_RED_CONV THENC
+  GEN_REWRITE_CONV ONCE_DEPTH_CONV [AVX2_NTT_ORDER_CLAUSES'] THENC
   DEPTH_CONV NUM_RED_CONV THENC
   GEN_REWRITE_CONV DEPTH_CONV [INT_OF_NUM_POW; INT_OF_NUM_REM] THENC
   ONCE_DEPTH_CONV EXP_MOD_CONV THENC INT_REDUCE_CONV;;
@@ -543,7 +623,7 @@ let CONGBOUND_BARRED_X86 = prove
  (`!a a' l u.
         ((ival a == a') (mod &3329) /\ l <= ival a /\ ival a <= u)
         ==> (ival(barred_x86 a) == a') (mod &3329) /\
-            &0 <= ival(barred_x86 a) /\ ival(barred_x86 a) < &6658`,
+            &0 <= ival(barred_x86 a) /\ ival(barred_x86 a) <= &6657`,
   REPEAT GEN_TAC THEN STRIP_TAC THEN REWRITE_TAC[barred_x86] THEN
   REWRITE_TAC[WORD_BLAST
    `word_ishr (word_subword (x:int32) (16,16):int16) 10 =

--- a/proofs/hol_light/x86/Makefile
+++ b/proofs/hol_light/x86/Makefile
@@ -63,7 +63,8 @@ endif
 OBJ = mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.o \
       mlkem/mlkem_poly_basemul_acc_montgomery_cached_k3.o \
       mlkem/mlkem_poly_basemul_acc_montgomery_cached_k4.o \
-      mlkem/mlkem_ntt.o
+      mlkem/mlkem_ntt.o \
+      mlkem/mlkem_intt.o
 
 # Build object files from assembly sources
 $(OBJ): %.o : %.S

--- a/proofs/hol_light/x86/mlkem/mlkem_intt.S
+++ b/proofs/hol_light/x86/mlkem/mlkem_intt.S
@@ -1,0 +1,717 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/* References
+ * ==========
+ *
+ * - [AVX2_NTT]
+ *   Faster AVX2 optimized NTT multiplication for Ring-LWE lattice cryptography.
+ *   Gregor Seiler
+ *   https://eprint.iacr.org/2018/039
+ *
+ * - [REF_AVX2]
+ *   CRYSTALS-Kyber optimized AVX2 implementation
+ *   Bos, Ducas, Kiltz, Lepoint, Lyubashevsky, Schanck, Schwabe, Seiler, Stehlé
+ *   https://github.com/pq-crystals/kyber/tree/main/avx2
+ */
+
+/*
+ * This file is derived from the public domain
+ * AVX2 Kyber implementation @[REF_AVX2].
+ *
+ * The core ideas behind the implementation are described in @[AVX2_NTT].
+ *
+ * Changes:
+ * - Different placement of modular reductions to simplify
+ *   reasoning of non-overflow
+ */
+
+
+/*
+ * WARNING: This file is auto-derived from the mlkem-native source file
+ *   dev/x86_64/src/intt.S using scripts/simpasm. Do not modify it directly.
+ */
+
+#if defined(__ELF__)
+.section .note.GNU-stack,"",@progbits
+#endif
+
+.text
+.balign 4
+#ifdef __APPLE__
+.global _PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2
+_PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2:
+#else
+.global PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2
+PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2:
+#endif
+
+        .cfi_startproc
+        endbr64
+        movl	$0xd010d01, %eax        # imm = 0xD010D01
+        vmovd	%eax, %xmm0
+        vpbroadcastd	%xmm0, %ymm0
+        movl	$0xd8a1d8a1, %eax       # imm = 0xD8A1D8A1
+        vmovd	%eax, %xmm2
+        vpbroadcastd	%xmm2, %ymm2
+        movl	$0x5a105a1, %eax        # imm = 0x5A105A1
+        vmovd	%eax, %xmm3
+        vpbroadcastd	%xmm3, %ymm3
+        vmovdqa	(%rdi), %ymm4
+        vmovdqa	0x40(%rdi), %ymm6
+        vmovdqa	0x20(%rdi), %ymm5
+        vmovdqa	0x60(%rdi), %ymm7
+        vpmullw	%ymm2, %ymm4, %ymm12
+        vpmulhw	%ymm3, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm4, %ymm4
+        vpmullw	%ymm2, %ymm6, %ymm12
+        vpmulhw	%ymm3, %ymm6, %ymm6
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm6, %ymm6
+        vpmullw	%ymm2, %ymm5, %ymm12
+        vpmulhw	%ymm3, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm5, %ymm5
+        vpmullw	%ymm2, %ymm7, %ymm12
+        vpmulhw	%ymm3, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm7, %ymm7
+        vmovdqa	0x80(%rdi), %ymm8
+        vmovdqa	0xc0(%rdi), %ymm10
+        vmovdqa	0xa0(%rdi), %ymm9
+        vmovdqa	0xe0(%rdi), %ymm11
+        vpmullw	%ymm2, %ymm8, %ymm12
+        vpmulhw	%ymm3, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm8, %ymm8
+        vpmullw	%ymm2, %ymm10, %ymm12
+        vpmulhw	%ymm3, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm10, %ymm10
+        vpmullw	%ymm2, %ymm9, %ymm12
+        vpmulhw	%ymm3, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm9, %ymm9
+        vpmullw	%ymm2, %ymm11, %ymm12
+        vpmulhw	%ymm3, %ymm11, %ymm11
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm11, %ymm11
+        vpermq	$0x4e, 0x3a0(%rsi), %ymm15 # ymm15 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x360(%rsi), %ymm1 # ymm1 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x3c0(%rsi), %ymm2 # ymm2 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x380(%rsi), %ymm3 # ymm3 = mem[2,3,0,1]
+        vmovdqa	(%rsi), %ymm12
+        vpshufb	%ymm12, %ymm15, %ymm15
+        vpshufb	%ymm12, %ymm1, %ymm1
+        vpshufb	%ymm12, %ymm2, %ymm2
+        vpshufb	%ymm12, %ymm3, %ymm3
+        vpsubw	%ymm4, %ymm6, %ymm12
+        vpaddw	%ymm6, %ymm4, %ymm4
+        vpsubw	%ymm5, %ymm7, %ymm13
+        vpmullw	%ymm15, %ymm12, %ymm6
+        vpaddw	%ymm7, %ymm5, %ymm5
+        vpsubw	%ymm8, %ymm10, %ymm14
+        vpmullw	%ymm15, %ymm13, %ymm7
+        vpaddw	%ymm10, %ymm8, %ymm8
+        vpsubw	%ymm9, %ymm11, %ymm15
+        vpmullw	%ymm1, %ymm14, %ymm10
+        vpaddw	%ymm11, %ymm9, %ymm9
+        vpmullw	%ymm1, %ymm15, %ymm11
+        vpmulhw	%ymm2, %ymm12, %ymm12
+        vpmulhw	%ymm2, %ymm13, %ymm13
+        vpmulhw	%ymm3, %ymm14, %ymm14
+        vpmulhw	%ymm3, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm6, %ymm6
+        vpmulhw	%ymm0, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm6, %ymm12, %ymm6
+        vpsubw	%ymm7, %ymm13, %ymm7
+        vpsubw	%ymm10, %ymm14, %ymm10
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpermq	$0x4e, 0x320(%rsi), %ymm2 # ymm2 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x340(%rsi), %ymm3 # ymm3 = mem[2,3,0,1]
+        vmovdqa	(%rsi), %ymm1
+        vpshufb	%ymm1, %ymm2, %ymm2
+        vpshufb	%ymm1, %ymm3, %ymm3
+        vpsubw	%ymm4, %ymm8, %ymm12
+        vpaddw	%ymm8, %ymm4, %ymm4
+        vpsubw	%ymm5, %ymm9, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm8
+        vpaddw	%ymm9, %ymm5, %ymm5
+        vpsubw	%ymm6, %ymm10, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm9
+        vpaddw	%ymm10, %ymm6, %ymm6
+        vpsubw	%ymm7, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm10
+        vpaddw	%ymm11, %ymm7, %ymm7
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm3, %ymm12, %ymm12
+        vpmulhw	%ymm3, %ymm13, %ymm13
+        vpmulhw	%ymm3, %ymm14, %ymm14
+        vpmulhw	%ymm3, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm8, %ymm12, %ymm8
+        vpsubw	%ymm9, %ymm13, %ymm9
+        vpsubw	%ymm10, %ymm14, %ymm10
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpslld	$0x10, %ymm5, %ymm3
+        vpblendw	$0xaa, %ymm3, %ymm4, %ymm3 # ymm3 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7],ymm4[8],ymm3[9],ymm4[10],ymm3[11],ymm4[12],ymm3[13],ymm4[14],ymm3[15]
+        vpsrld	$0x10, %ymm4, %ymm4
+        vpblendw	$0xaa, %ymm5, %ymm4, %ymm5 # ymm5 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7],ymm4[8],ymm5[9],ymm4[10],ymm5[11],ymm4[12],ymm5[13],ymm4[14],ymm5[15]
+        vpslld	$0x10, %ymm7, %ymm4
+        vpblendw	$0xaa, %ymm4, %ymm6, %ymm4 # ymm4 = ymm6[0],ymm4[1],ymm6[2],ymm4[3],ymm6[4],ymm4[5],ymm6[6],ymm4[7],ymm6[8],ymm4[9],ymm6[10],ymm4[11],ymm6[12],ymm4[13],ymm6[14],ymm4[15]
+        vpsrld	$0x10, %ymm6, %ymm6
+        vpblendw	$0xaa, %ymm7, %ymm6, %ymm7 # ymm7 = ymm6[0],ymm7[1],ymm6[2],ymm7[3],ymm6[4],ymm7[5],ymm6[6],ymm7[7],ymm6[8],ymm7[9],ymm6[10],ymm7[11],ymm6[12],ymm7[13],ymm6[14],ymm7[15]
+        vpslld	$0x10, %ymm9, %ymm6
+        vpblendw	$0xaa, %ymm6, %ymm8, %ymm6 # ymm6 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7],ymm8[8],ymm6[9],ymm8[10],ymm6[11],ymm8[12],ymm6[13],ymm8[14],ymm6[15]
+        vpsrld	$0x10, %ymm8, %ymm8
+        vpblendw	$0xaa, %ymm9, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm9[1],ymm8[2],ymm9[3],ymm8[4],ymm9[5],ymm8[6],ymm9[7],ymm8[8],ymm9[9],ymm8[10],ymm9[11],ymm8[12],ymm9[13],ymm8[14],ymm9[15]
+        vpslld	$0x10, %ymm11, %ymm8
+        vpblendw	$0xaa, %ymm8, %ymm10, %ymm8 # ymm8 = ymm10[0],ymm8[1],ymm10[2],ymm8[3],ymm10[4],ymm8[5],ymm10[6],ymm8[7],ymm10[8],ymm8[9],ymm10[10],ymm8[11],ymm10[12],ymm8[13],ymm10[14],ymm8[15]
+        vpsrld	$0x10, %ymm10, %ymm10
+        vpblendw	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7],ymm10[8],ymm11[9],ymm10[10],ymm11[11],ymm10[12],ymm11[13],ymm10[14],ymm11[15]
+        vmovdqa	0x20(%rsi), %ymm12
+        vpermd	0x2e0(%rsi), %ymm12, %ymm2
+        vpermd	0x300(%rsi), %ymm12, %ymm10
+        vpsubw	%ymm3, %ymm5, %ymm12
+        vpaddw	%ymm5, %ymm3, %ymm3
+        vpsubw	%ymm4, %ymm7, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm5
+        vpaddw	%ymm7, %ymm4, %ymm4
+        vpsubw	%ymm6, %ymm9, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm7
+        vpaddw	%ymm9, %ymm6, %ymm6
+        vpsubw	%ymm8, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm9
+        vpaddw	%ymm11, %ymm8, %ymm8
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm10, %ymm12, %ymm12
+        vpmulhw	%ymm10, %ymm13, %ymm13
+        vpmulhw	%ymm10, %ymm14, %ymm14
+        vpmulhw	%ymm10, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm5, %ymm12, %ymm5
+        vpsubw	%ymm7, %ymm13, %ymm7
+        vpsubw	%ymm9, %ymm14, %ymm9
+        vpsubw	%ymm11, %ymm15, %ymm11
+        movl	$0x4ebf4ebf, %eax       # imm = 0x4EBF4EBF
+        vmovd	%eax, %xmm1
+        vpbroadcastd	%xmm1, %ymm1
+        vpmulhw	%ymm1, %ymm3, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm3, %ymm3
+        vmovsldup	%ymm4, %ymm10   # ymm10 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm10, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm8, %ymm3    # ymm3 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm6, %ymm3 # ymm3 = ymm6[0],ymm3[1],ymm6[2],ymm3[3],ymm6[4],ymm3[5],ymm6[6],ymm3[7]
+        vpsrlq	$0x20, %ymm6, %ymm6
+        vpblendd	$0xaa, %ymm8, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm8[1],ymm6[2],ymm8[3],ymm6[4],ymm8[5],ymm6[6],ymm8[7]
+        vmovsldup	%ymm7, %ymm6    # ymm6 = ymm7[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vmovsldup	%ymm11, %ymm5   # ymm5 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm9, %ymm5 # ymm5 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
+        vpsrlq	$0x20, %ymm9, %ymm9
+        vpblendd	$0xaa, %ymm11, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
+        vpermq	$0x1b, 0x2a0(%rsi), %ymm2 # ymm2 = mem[3,2,1,0]
+        vpermq	$0x1b, 0x2c0(%rsi), %ymm9 # ymm9 = mem[3,2,1,0]
+        vpsubw	%ymm10, %ymm4, %ymm12
+        vpaddw	%ymm4, %ymm10, %ymm10
+        vpsubw	%ymm3, %ymm8, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm4
+        vpaddw	%ymm8, %ymm3, %ymm3
+        vpsubw	%ymm6, %ymm7, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm8
+        vpaddw	%ymm7, %ymm6, %ymm6
+        vpsubw	%ymm5, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm7
+        vpaddw	%ymm11, %ymm5, %ymm5
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm9, %ymm12, %ymm12
+        vpmulhw	%ymm9, %ymm13, %ymm13
+        vpmulhw	%ymm9, %ymm14, %ymm14
+        vpmulhw	%ymm9, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm4, %ymm12, %ymm4
+        vpsubw	%ymm8, %ymm13, %ymm8
+        vpsubw	%ymm7, %ymm14, %ymm7
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpmulhw	%ymm1, %ymm10, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm10, %ymm10
+        vpunpcklqdq	%ymm3, %ymm10, %ymm9 # ymm9 = ymm10[0],ymm3[0],ymm10[2],ymm3[2]
+        vpunpckhqdq	%ymm3, %ymm10, %ymm3 # ymm3 = ymm10[1],ymm3[1],ymm10[3],ymm3[3]
+        vpunpcklqdq	%ymm5, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm5[0],ymm6[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm6, %ymm5 # ymm5 = ymm6[1],ymm5[1],ymm6[3],ymm5[3]
+        vpunpcklqdq	%ymm8, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm8[0],ymm4[2],ymm8[2]
+        vpunpckhqdq	%ymm8, %ymm4, %ymm8 # ymm8 = ymm4[1],ymm8[1],ymm4[3],ymm8[3]
+        vpunpcklqdq	%ymm11, %ymm7, %ymm4 # ymm4 = ymm7[0],ymm11[0],ymm7[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm7, %ymm11 # ymm11 = ymm7[1],ymm11[1],ymm7[3],ymm11[3]
+        vpermq	$0x4e, 0x260(%rsi), %ymm2 # ymm2 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x280(%rsi), %ymm7 # ymm7 = mem[2,3,0,1]
+        vpsubw	%ymm9, %ymm3, %ymm12
+        vpaddw	%ymm3, %ymm9, %ymm9
+        vpsubw	%ymm10, %ymm5, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm3
+        vpaddw	%ymm5, %ymm10, %ymm10
+        vpsubw	%ymm6, %ymm8, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm5
+        vpaddw	%ymm8, %ymm6, %ymm6
+        vpsubw	%ymm4, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm8
+        vpaddw	%ymm11, %ymm4, %ymm4
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm7, %ymm12, %ymm12
+        vpmulhw	%ymm7, %ymm13, %ymm13
+        vpmulhw	%ymm7, %ymm14, %ymm14
+        vpmulhw	%ymm7, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm3, %ymm3
+        vpmulhw	%ymm0, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm3, %ymm12, %ymm3
+        vpsubw	%ymm5, %ymm13, %ymm5
+        vpsubw	%ymm8, %ymm14, %ymm8
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpmulhw	%ymm1, %ymm9, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm9, %ymm9
+        vperm2i128	$0x20, %ymm10, %ymm9, %ymm7 # ymm7 = ymm9[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm9, %ymm10 # ymm10 = ymm9[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm4, %ymm6, %ymm9 # ymm9 = ymm6[0,1],ymm4[0,1]
+        vperm2i128	$0x31, %ymm4, %ymm6, %ymm4 # ymm4 = ymm6[2,3],ymm4[2,3]
+        vperm2i128	$0x20, %ymm5, %ymm3, %ymm6 # ymm6 = ymm3[0,1],ymm5[0,1]
+        vperm2i128	$0x31, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[2,3],ymm5[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm8, %ymm3 # ymm3 = ymm8[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm8, %ymm11 # ymm11 = ymm8[2,3],ymm11[2,3]
+        vmovdqa	0x220(%rsi), %ymm2
+        vmovdqa	0x240(%rsi), %ymm8
+        vpsubw	%ymm7, %ymm10, %ymm12
+        vpaddw	%ymm10, %ymm7, %ymm7
+        vpsubw	%ymm9, %ymm4, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm10
+        vpaddw	%ymm4, %ymm9, %ymm9
+        vpsubw	%ymm6, %ymm5, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm4
+        vpaddw	%ymm5, %ymm6, %ymm6
+        vpsubw	%ymm3, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm5
+        vpaddw	%ymm11, %ymm3, %ymm3
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm8, %ymm12, %ymm12
+        vpmulhw	%ymm8, %ymm13, %ymm13
+        vpmulhw	%ymm8, %ymm14, %ymm14
+        vpmulhw	%ymm8, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm10, %ymm12, %ymm10
+        vpsubw	%ymm4, %ymm13, %ymm4
+        vpsubw	%ymm5, %ymm14, %ymm5
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpmulhw	%ymm1, %ymm7, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm7, %ymm7
+        vmovdqa	%ymm7, (%rdi)
+        vmovdqa	%ymm9, 0x20(%rdi)
+        vmovdqa	%ymm6, 0x40(%rdi)
+        vmovdqa	%ymm3, 0x60(%rdi)
+        vmovdqa	%ymm10, 0x80(%rdi)
+        vmovdqa	%ymm4, 0xa0(%rdi)
+        vmovdqa	%ymm5, 0xc0(%rdi)
+        vmovdqa	%ymm11, 0xe0(%rdi)
+        movl	$0xd8a1d8a1, %eax       # imm = 0xD8A1D8A1
+        vmovd	%eax, %xmm2
+        vpbroadcastd	%xmm2, %ymm2
+        movl	$0x5a105a1, %eax        # imm = 0x5A105A1
+        vmovd	%eax, %xmm3
+        vpbroadcastd	%xmm3, %ymm3
+        vmovdqa	0x100(%rdi), %ymm4
+        vmovdqa	0x140(%rdi), %ymm6
+        vmovdqa	0x120(%rdi), %ymm5
+        vmovdqa	0x160(%rdi), %ymm7
+        vpmullw	%ymm2, %ymm4, %ymm12
+        vpmulhw	%ymm3, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm4, %ymm4
+        vpmullw	%ymm2, %ymm6, %ymm12
+        vpmulhw	%ymm3, %ymm6, %ymm6
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm6, %ymm6
+        vpmullw	%ymm2, %ymm5, %ymm12
+        vpmulhw	%ymm3, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm5, %ymm5
+        vpmullw	%ymm2, %ymm7, %ymm12
+        vpmulhw	%ymm3, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm7, %ymm7
+        vmovdqa	0x180(%rdi), %ymm8
+        vmovdqa	0x1c0(%rdi), %ymm10
+        vmovdqa	0x1a0(%rdi), %ymm9
+        vmovdqa	0x1e0(%rdi), %ymm11
+        vpmullw	%ymm2, %ymm8, %ymm12
+        vpmulhw	%ymm3, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm8, %ymm8
+        vpmullw	%ymm2, %ymm10, %ymm12
+        vpmulhw	%ymm3, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm10, %ymm10
+        vpmullw	%ymm2, %ymm9, %ymm12
+        vpmulhw	%ymm3, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm9, %ymm9
+        vpmullw	%ymm2, %ymm11, %ymm12
+        vpmulhw	%ymm3, %ymm11, %ymm11
+        vpmulhw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm11, %ymm11
+        vpermq	$0x4e, 0x1e0(%rsi), %ymm15 # ymm15 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x1a0(%rsi), %ymm1 # ymm1 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x200(%rsi), %ymm2 # ymm2 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x1c0(%rsi), %ymm3 # ymm3 = mem[2,3,0,1]
+        vmovdqa	(%rsi), %ymm12
+        vpshufb	%ymm12, %ymm15, %ymm15
+        vpshufb	%ymm12, %ymm1, %ymm1
+        vpshufb	%ymm12, %ymm2, %ymm2
+        vpshufb	%ymm12, %ymm3, %ymm3
+        vpsubw	%ymm4, %ymm6, %ymm12
+        vpaddw	%ymm6, %ymm4, %ymm4
+        vpsubw	%ymm5, %ymm7, %ymm13
+        vpmullw	%ymm15, %ymm12, %ymm6
+        vpaddw	%ymm7, %ymm5, %ymm5
+        vpsubw	%ymm8, %ymm10, %ymm14
+        vpmullw	%ymm15, %ymm13, %ymm7
+        vpaddw	%ymm10, %ymm8, %ymm8
+        vpsubw	%ymm9, %ymm11, %ymm15
+        vpmullw	%ymm1, %ymm14, %ymm10
+        vpaddw	%ymm11, %ymm9, %ymm9
+        vpmullw	%ymm1, %ymm15, %ymm11
+        vpmulhw	%ymm2, %ymm12, %ymm12
+        vpmulhw	%ymm2, %ymm13, %ymm13
+        vpmulhw	%ymm3, %ymm14, %ymm14
+        vpmulhw	%ymm3, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm6, %ymm6
+        vpmulhw	%ymm0, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm6, %ymm12, %ymm6
+        vpsubw	%ymm7, %ymm13, %ymm7
+        vpsubw	%ymm10, %ymm14, %ymm10
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpermq	$0x4e, 0x160(%rsi), %ymm2 # ymm2 = mem[2,3,0,1]
+        vpermq	$0x4e, 0x180(%rsi), %ymm3 # ymm3 = mem[2,3,0,1]
+        vmovdqa	(%rsi), %ymm1
+        vpshufb	%ymm1, %ymm2, %ymm2
+        vpshufb	%ymm1, %ymm3, %ymm3
+        vpsubw	%ymm4, %ymm8, %ymm12
+        vpaddw	%ymm8, %ymm4, %ymm4
+        vpsubw	%ymm5, %ymm9, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm8
+        vpaddw	%ymm9, %ymm5, %ymm5
+        vpsubw	%ymm6, %ymm10, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm9
+        vpaddw	%ymm10, %ymm6, %ymm6
+        vpsubw	%ymm7, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm10
+        vpaddw	%ymm11, %ymm7, %ymm7
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm3, %ymm12, %ymm12
+        vpmulhw	%ymm3, %ymm13, %ymm13
+        vpmulhw	%ymm3, %ymm14, %ymm14
+        vpmulhw	%ymm3, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm8, %ymm12, %ymm8
+        vpsubw	%ymm9, %ymm13, %ymm9
+        vpsubw	%ymm10, %ymm14, %ymm10
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpslld	$0x10, %ymm5, %ymm3
+        vpblendw	$0xaa, %ymm3, %ymm4, %ymm3 # ymm3 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7],ymm4[8],ymm3[9],ymm4[10],ymm3[11],ymm4[12],ymm3[13],ymm4[14],ymm3[15]
+        vpsrld	$0x10, %ymm4, %ymm4
+        vpblendw	$0xaa, %ymm5, %ymm4, %ymm5 # ymm5 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7],ymm4[8],ymm5[9],ymm4[10],ymm5[11],ymm4[12],ymm5[13],ymm4[14],ymm5[15]
+        vpslld	$0x10, %ymm7, %ymm4
+        vpblendw	$0xaa, %ymm4, %ymm6, %ymm4 # ymm4 = ymm6[0],ymm4[1],ymm6[2],ymm4[3],ymm6[4],ymm4[5],ymm6[6],ymm4[7],ymm6[8],ymm4[9],ymm6[10],ymm4[11],ymm6[12],ymm4[13],ymm6[14],ymm4[15]
+        vpsrld	$0x10, %ymm6, %ymm6
+        vpblendw	$0xaa, %ymm7, %ymm6, %ymm7 # ymm7 = ymm6[0],ymm7[1],ymm6[2],ymm7[3],ymm6[4],ymm7[5],ymm6[6],ymm7[7],ymm6[8],ymm7[9],ymm6[10],ymm7[11],ymm6[12],ymm7[13],ymm6[14],ymm7[15]
+        vpslld	$0x10, %ymm9, %ymm6
+        vpblendw	$0xaa, %ymm6, %ymm8, %ymm6 # ymm6 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7],ymm8[8],ymm6[9],ymm8[10],ymm6[11],ymm8[12],ymm6[13],ymm8[14],ymm6[15]
+        vpsrld	$0x10, %ymm8, %ymm8
+        vpblendw	$0xaa, %ymm9, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm9[1],ymm8[2],ymm9[3],ymm8[4],ymm9[5],ymm8[6],ymm9[7],ymm8[8],ymm9[9],ymm8[10],ymm9[11],ymm8[12],ymm9[13],ymm8[14],ymm9[15]
+        vpslld	$0x10, %ymm11, %ymm8
+        vpblendw	$0xaa, %ymm8, %ymm10, %ymm8 # ymm8 = ymm10[0],ymm8[1],ymm10[2],ymm8[3],ymm10[4],ymm8[5],ymm10[6],ymm8[7],ymm10[8],ymm8[9],ymm10[10],ymm8[11],ymm10[12],ymm8[13],ymm10[14],ymm8[15]
+        vpsrld	$0x10, %ymm10, %ymm10
+        vpblendw	$0xaa, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7],ymm10[8],ymm11[9],ymm10[10],ymm11[11],ymm10[12],ymm11[13],ymm10[14],ymm11[15]
+        vmovdqa	0x20(%rsi), %ymm12
+        vpermd	0x120(%rsi), %ymm12, %ymm2
+        vpermd	0x140(%rsi), %ymm12, %ymm10
+        vpsubw	%ymm3, %ymm5, %ymm12
+        vpaddw	%ymm5, %ymm3, %ymm3
+        vpsubw	%ymm4, %ymm7, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm5
+        vpaddw	%ymm7, %ymm4, %ymm4
+        vpsubw	%ymm6, %ymm9, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm7
+        vpaddw	%ymm9, %ymm6, %ymm6
+        vpsubw	%ymm8, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm9
+        vpaddw	%ymm11, %ymm8, %ymm8
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm10, %ymm12, %ymm12
+        vpmulhw	%ymm10, %ymm13, %ymm13
+        vpmulhw	%ymm10, %ymm14, %ymm14
+        vpmulhw	%ymm10, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm5, %ymm12, %ymm5
+        vpsubw	%ymm7, %ymm13, %ymm7
+        vpsubw	%ymm9, %ymm14, %ymm9
+        vpsubw	%ymm11, %ymm15, %ymm11
+        movl	$0x4ebf4ebf, %eax       # imm = 0x4EBF4EBF
+        vmovd	%eax, %xmm1
+        vpbroadcastd	%xmm1, %ymm1
+        vpmulhw	%ymm1, %ymm3, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm3, %ymm3
+        vmovsldup	%ymm4, %ymm10   # ymm10 = ymm4[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm10, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
+        vpsrlq	$0x20, %ymm3, %ymm3
+        vpblendd	$0xaa, %ymm4, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+        vmovsldup	%ymm8, %ymm3    # ymm3 = ymm8[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm3, %ymm6, %ymm3 # ymm3 = ymm6[0],ymm3[1],ymm6[2],ymm3[3],ymm6[4],ymm3[5],ymm6[6],ymm3[7]
+        vpsrlq	$0x20, %ymm6, %ymm6
+        vpblendd	$0xaa, %ymm8, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm8[1],ymm6[2],ymm8[3],ymm6[4],ymm8[5],ymm6[6],ymm8[7]
+        vmovsldup	%ymm7, %ymm6    # ymm6 = ymm7[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm6, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+        vpsrlq	$0x20, %ymm5, %ymm5
+        vpblendd	$0xaa, %ymm7, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm7[1],ymm5[2],ymm7[3],ymm5[4],ymm7[5],ymm5[6],ymm7[7]
+        vmovsldup	%ymm11, %ymm5   # ymm5 = ymm11[0,0,2,2,4,4,6,6]
+        vpblendd	$0xaa, %ymm5, %ymm9, %ymm5 # ymm5 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
+        vpsrlq	$0x20, %ymm9, %ymm9
+        vpblendd	$0xaa, %ymm11, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
+        vpermq	$0x1b, 0xe0(%rsi), %ymm2 # ymm2 = mem[3,2,1,0]
+        vpermq	$0x1b, 0x100(%rsi), %ymm9 # ymm9 = mem[3,2,1,0]
+        vpsubw	%ymm10, %ymm4, %ymm12
+        vpaddw	%ymm4, %ymm10, %ymm10
+        vpsubw	%ymm3, %ymm8, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm4
+        vpaddw	%ymm8, %ymm3, %ymm3
+        vpsubw	%ymm6, %ymm7, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm8
+        vpaddw	%ymm7, %ymm6, %ymm6
+        vpsubw	%ymm5, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm7
+        vpaddw	%ymm11, %ymm5, %ymm5
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm9, %ymm12, %ymm12
+        vpmulhw	%ymm9, %ymm13, %ymm13
+        vpmulhw	%ymm9, %ymm14, %ymm14
+        vpmulhw	%ymm9, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm7, %ymm7
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm4, %ymm12, %ymm4
+        vpsubw	%ymm8, %ymm13, %ymm8
+        vpsubw	%ymm7, %ymm14, %ymm7
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpmulhw	%ymm1, %ymm10, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm10, %ymm10
+        vpunpcklqdq	%ymm3, %ymm10, %ymm9 # ymm9 = ymm10[0],ymm3[0],ymm10[2],ymm3[2]
+        vpunpckhqdq	%ymm3, %ymm10, %ymm3 # ymm3 = ymm10[1],ymm3[1],ymm10[3],ymm3[3]
+        vpunpcklqdq	%ymm5, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm5[0],ymm6[2],ymm5[2]
+        vpunpckhqdq	%ymm5, %ymm6, %ymm5 # ymm5 = ymm6[1],ymm5[1],ymm6[3],ymm5[3]
+        vpunpcklqdq	%ymm8, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm8[0],ymm4[2],ymm8[2]
+        vpunpckhqdq	%ymm8, %ymm4, %ymm8 # ymm8 = ymm4[1],ymm8[1],ymm4[3],ymm8[3]
+        vpunpcklqdq	%ymm11, %ymm7, %ymm4 # ymm4 = ymm7[0],ymm11[0],ymm7[2],ymm11[2]
+        vpunpckhqdq	%ymm11, %ymm7, %ymm11 # ymm11 = ymm7[1],ymm11[1],ymm7[3],ymm11[3]
+        vpermq	$0x4e, 0xa0(%rsi), %ymm2 # ymm2 = mem[2,3,0,1]
+        vpermq	$0x4e, 0xc0(%rsi), %ymm7 # ymm7 = mem[2,3,0,1]
+        vpsubw	%ymm9, %ymm3, %ymm12
+        vpaddw	%ymm3, %ymm9, %ymm9
+        vpsubw	%ymm10, %ymm5, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm3
+        vpaddw	%ymm5, %ymm10, %ymm10
+        vpsubw	%ymm6, %ymm8, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm5
+        vpaddw	%ymm8, %ymm6, %ymm6
+        vpsubw	%ymm4, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm8
+        vpaddw	%ymm11, %ymm4, %ymm4
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm7, %ymm12, %ymm12
+        vpmulhw	%ymm7, %ymm13, %ymm13
+        vpmulhw	%ymm7, %ymm14, %ymm14
+        vpmulhw	%ymm7, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm3, %ymm3
+        vpmulhw	%ymm0, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm3, %ymm12, %ymm3
+        vpsubw	%ymm5, %ymm13, %ymm5
+        vpsubw	%ymm8, %ymm14, %ymm8
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpmulhw	%ymm1, %ymm9, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm9, %ymm9
+        vperm2i128	$0x20, %ymm10, %ymm9, %ymm7 # ymm7 = ymm9[0,1],ymm10[0,1]
+        vperm2i128	$0x31, %ymm10, %ymm9, %ymm10 # ymm10 = ymm9[2,3],ymm10[2,3]
+        vperm2i128	$0x20, %ymm4, %ymm6, %ymm9 # ymm9 = ymm6[0,1],ymm4[0,1]
+        vperm2i128	$0x31, %ymm4, %ymm6, %ymm4 # ymm4 = ymm6[2,3],ymm4[2,3]
+        vperm2i128	$0x20, %ymm5, %ymm3, %ymm6 # ymm6 = ymm3[0,1],ymm5[0,1]
+        vperm2i128	$0x31, %ymm5, %ymm3, %ymm5 # ymm5 = ymm3[2,3],ymm5[2,3]
+        vperm2i128	$0x20, %ymm11, %ymm8, %ymm3 # ymm3 = ymm8[0,1],ymm11[0,1]
+        vperm2i128	$0x31, %ymm11, %ymm8, %ymm11 # ymm11 = ymm8[2,3],ymm11[2,3]
+        vmovdqa	0x60(%rsi), %ymm2
+        vmovdqa	0x80(%rsi), %ymm8
+        vpsubw	%ymm7, %ymm10, %ymm12
+        vpaddw	%ymm10, %ymm7, %ymm7
+        vpsubw	%ymm9, %ymm4, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm10
+        vpaddw	%ymm4, %ymm9, %ymm9
+        vpsubw	%ymm6, %ymm5, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm4
+        vpaddw	%ymm5, %ymm6, %ymm6
+        vpsubw	%ymm3, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm5
+        vpaddw	%ymm11, %ymm3, %ymm3
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm8, %ymm12, %ymm12
+        vpmulhw	%ymm8, %ymm13, %ymm13
+        vpmulhw	%ymm8, %ymm14, %ymm14
+        vpmulhw	%ymm8, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm4, %ymm4
+        vpmulhw	%ymm0, %ymm5, %ymm5
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm10, %ymm12, %ymm10
+        vpsubw	%ymm4, %ymm13, %ymm4
+        vpsubw	%ymm5, %ymm14, %ymm5
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vpmulhw	%ymm1, %ymm7, %ymm12
+        vpsraw	$0xa, %ymm12, %ymm12
+        vpmullw	%ymm0, %ymm12, %ymm12
+        vpsubw	%ymm12, %ymm7, %ymm7
+        vmovdqa	%ymm7, 0x100(%rdi)
+        vmovdqa	%ymm9, 0x120(%rdi)
+        vmovdqa	%ymm6, 0x140(%rdi)
+        vmovdqa	%ymm3, 0x160(%rdi)
+        vmovdqa	%ymm10, 0x180(%rdi)
+        vmovdqa	%ymm4, 0x1a0(%rdi)
+        vmovdqa	%ymm5, 0x1c0(%rdi)
+        vmovdqa	%ymm11, 0x1e0(%rdi)
+        vmovdqa	(%rdi), %ymm4
+        vmovdqa	0x100(%rdi), %ymm8
+        vmovdqa	0x20(%rdi), %ymm5
+        vmovdqa	0x120(%rdi), %ymm9
+        vpbroadcastq	0x40(%rsi), %ymm2
+        vmovdqa	0x40(%rdi), %ymm6
+        vmovdqa	0x140(%rdi), %ymm10
+        vmovdqa	0x60(%rdi), %ymm7
+        vmovdqa	0x160(%rdi), %ymm11
+        vpbroadcastq	0x48(%rsi), %ymm3
+        vpsubw	%ymm4, %ymm8, %ymm12
+        vpaddw	%ymm8, %ymm4, %ymm4
+        vpsubw	%ymm5, %ymm9, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm8
+        vpaddw	%ymm9, %ymm5, %ymm5
+        vpsubw	%ymm6, %ymm10, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm9
+        vpaddw	%ymm10, %ymm6, %ymm6
+        vpsubw	%ymm7, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm10
+        vpaddw	%ymm11, %ymm7, %ymm7
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm3, %ymm12, %ymm12
+        vpmulhw	%ymm3, %ymm13, %ymm13
+        vpmulhw	%ymm3, %ymm14, %ymm14
+        vpmulhw	%ymm3, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm8, %ymm12, %ymm8
+        vpsubw	%ymm9, %ymm13, %ymm9
+        vpsubw	%ymm10, %ymm14, %ymm10
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vmovdqa	%ymm4, (%rdi)
+        vmovdqa	%ymm5, 0x20(%rdi)
+        vmovdqa	%ymm6, 0x40(%rdi)
+        vmovdqa	%ymm7, 0x60(%rdi)
+        vmovdqa	%ymm8, 0x100(%rdi)
+        vmovdqa	%ymm9, 0x120(%rdi)
+        vmovdqa	%ymm10, 0x140(%rdi)
+        vmovdqa	%ymm11, 0x160(%rdi)
+        vmovdqa	0x80(%rdi), %ymm4
+        vmovdqa	0x180(%rdi), %ymm8
+        vmovdqa	0xa0(%rdi), %ymm5
+        vmovdqa	0x1a0(%rdi), %ymm9
+        vpbroadcastq	0x40(%rsi), %ymm2
+        vmovdqa	0xc0(%rdi), %ymm6
+        vmovdqa	0x1c0(%rdi), %ymm10
+        vmovdqa	0xe0(%rdi), %ymm7
+        vmovdqa	0x1e0(%rdi), %ymm11
+        vpbroadcastq	0x48(%rsi), %ymm3
+        vpsubw	%ymm4, %ymm8, %ymm12
+        vpaddw	%ymm8, %ymm4, %ymm4
+        vpsubw	%ymm5, %ymm9, %ymm13
+        vpmullw	%ymm2, %ymm12, %ymm8
+        vpaddw	%ymm9, %ymm5, %ymm5
+        vpsubw	%ymm6, %ymm10, %ymm14
+        vpmullw	%ymm2, %ymm13, %ymm9
+        vpaddw	%ymm10, %ymm6, %ymm6
+        vpsubw	%ymm7, %ymm11, %ymm15
+        vpmullw	%ymm2, %ymm14, %ymm10
+        vpaddw	%ymm11, %ymm7, %ymm7
+        vpmullw	%ymm2, %ymm15, %ymm11
+        vpmulhw	%ymm3, %ymm12, %ymm12
+        vpmulhw	%ymm3, %ymm13, %ymm13
+        vpmulhw	%ymm3, %ymm14, %ymm14
+        vpmulhw	%ymm3, %ymm15, %ymm15
+        vpmulhw	%ymm0, %ymm8, %ymm8
+        vpmulhw	%ymm0, %ymm9, %ymm9
+        vpmulhw	%ymm0, %ymm10, %ymm10
+        vpmulhw	%ymm0, %ymm11, %ymm11
+        vpsubw	%ymm8, %ymm12, %ymm8
+        vpsubw	%ymm9, %ymm13, %ymm9
+        vpsubw	%ymm10, %ymm14, %ymm10
+        vpsubw	%ymm11, %ymm15, %ymm11
+        vmovdqa	%ymm4, 0x80(%rdi)
+        vmovdqa	%ymm5, 0xa0(%rdi)
+        vmovdqa	%ymm6, 0xc0(%rdi)
+        vmovdqa	%ymm7, 0xe0(%rdi)
+        vmovdqa	%ymm8, 0x180(%rdi)
+        vmovdqa	%ymm9, 0x1a0(%rdi)
+        vmovdqa	%ymm10, 0x1c0(%rdi)
+        vmovdqa	%ymm11, 0x1e0(%rdi)
+        retq
+        .cfi_endproc

--- a/proofs/hol_light/x86/proofs/dump_bytecode.ml
+++ b/proofs/hol_light/x86/proofs/dump_bytecode.ml
@@ -9,6 +9,10 @@ print_string "=== bytecode start: x86/mlkem/mlkem_ntt.o ===\n";;
 print_literal_from_elf "x86/mlkem/mlkem_ntt.o";;
 print_string "==== bytecode end =====================================\n\n";;
 
+print_string "=== bytecode start: x86/mlkem/mlkem_intt.o ===\n";;
+print_literal_from_elf "x86/mlkem/mlkem_intt.o";;
+print_string "==== bytecode end =====================================\n\n";;
+
 print_string "=== bytecode start: x86/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.o ===\n";;
 print_literal_from_elf "x86/mlkem/mlkem_poly_basemul_acc_montgomery_cached_k2.o";;
 print_string "==== bytecode end =====================================\n\n";;

--- a/proofs/hol_light/x86/proofs/mlkem_intt.ml
+++ b/proofs/hol_light/x86/proofs/mlkem_intt.ml
@@ -1,0 +1,1226 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+needs "x86/proofs/base.ml";;
+needs "common/mlkem_specs.ml";;
+needs "x86/proofs/mlkem_zetas.ml";;
+
+(* print_literal_from_elf "x86/mlkem/mlkem_intt.o";; *)
+
+let mlkem_intt_mc = define_assert_from_elf "mlkem_intt_mc" "x86/mlkem/mlkem_intt.o"
+(*** BYTECODE START ***)
+[
+  0xf3; 0x0f; 0x1e; 0xfa;  (* ENDBR64 *)
+  0xb8; 0x01; 0x0d; 0x01; 0x0d;
+                           (* MOV (% eax) (Imm32 (word 218172673)) *)
+  0xc5; 0xf9; 0x6e; 0xc0;  (* VMOVD (%_% xmm0) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xc0;
+                           (* VPBROADCASTD (%_% ymm0) (%_% xmm0) *)
+  0xb8; 0xa1; 0xd8; 0xa1; 0xd8;
+                           (* MOV (% eax) (Imm32 (word 3634485409)) *)
+  0xc5; 0xf9; 0x6e; 0xd0;  (* VMOVD (%_% xmm2) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xd2;
+                           (* VPBROADCASTD (%_% ymm2) (%_% xmm2) *)
+  0xb8; 0xa1; 0x05; 0xa1; 0x05;
+                           (* MOV (% eax) (Imm32 (word 94438817)) *)
+  0xc5; 0xf9; 0x6e; 0xd8;  (* VMOVD (%_% xmm3) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xdb;
+                           (* VPBROADCASTD (%_% ymm3) (%_% xmm3) *)
+  0xc5; 0xfd; 0x6f; 0x27;  (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,0))) *)
+  0xc5; 0xfd; 0x6f; 0x77; 0x40;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,64))) *)
+  0xc5; 0xfd; 0x6f; 0x6f; 0x20;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,32))) *)
+  0xc5; 0xfd; 0x6f; 0x7f; 0x60;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,96))) *)
+  0xc5; 0x5d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm4) (%_% ymm2) *)
+  0xc5; 0xdd; 0xe5; 0xe3;  (* VPMULHW (%_% ymm4) (%_% ymm4) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x5d; 0xf9; 0xe4;
+                           (* VPSUBW (%_% ymm4) (%_% ymm4) (%_% ymm12) *)
+  0xc5; 0x4d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm6) (%_% ymm2) *)
+  0xc5; 0xcd; 0xe5; 0xf3;  (* VPMULHW (%_% ymm6) (%_% ymm6) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x4d; 0xf9; 0xf4;
+                           (* VPSUBW (%_% ymm6) (%_% ymm6) (%_% ymm12) *)
+  0xc5; 0x55; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm5) (%_% ymm2) *)
+  0xc5; 0xd5; 0xe5; 0xeb;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x55; 0xf9; 0xec;
+                           (* VPSUBW (%_% ymm5) (%_% ymm5) (%_% ymm12) *)
+  0xc5; 0x45; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm7) (%_% ymm2) *)
+  0xc5; 0xc5; 0xe5; 0xfb;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x45; 0xf9; 0xfc;
+                           (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,128))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,192))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,160))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,224))) *)
+  0xc5; 0x3d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm8) (%_% ymm2) *)
+  0xc5; 0x3d; 0xe5; 0xc3;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x3d; 0xf9; 0xc4;
+                           (* VPSUBW (%_% ymm8) (%_% ymm8) (%_% ymm12) *)
+  0xc5; 0x2d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm10) (%_% ymm2) *)
+  0xc5; 0x2d; 0xe5; 0xd3;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x2d; 0xf9; 0xd4;
+                           (* VPSUBW (%_% ymm10) (%_% ymm10) (%_% ymm12) *)
+  0xc5; 0x35; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm9) (%_% ymm2) *)
+  0xc5; 0x35; 0xe5; 0xcb;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x35; 0xf9; 0xcc;
+                           (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
+  0xc5; 0x25; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm11) (%_% ymm2) *)
+  0xc5; 0x25; 0xe5; 0xdb;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x25; 0xf9; 0xdc;
+                           (* VPSUBW (%_% ymm11) (%_% ymm11) (%_% ymm12) *)
+  0xc4; 0x63; 0xfd; 0x00; 0xbe; 0xa0; 0x03; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm15) (Memop Word256 (%% (rsi,928))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x8e; 0x60; 0x03; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm1) (Memop Word256 (%% (rsi,864))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0xc0; 0x03; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,960))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x9e; 0x80; 0x03; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm3) (Memop Word256 (%% (rsi,896))) (Imm8 (word 78)) *)
+  0xc5; 0x7d; 0x6f; 0x26;  (* VMOVDQA (%_% ymm12) (Memop Word256 (%% (rsi,0))) *)
+  0xc4; 0x42; 0x05; 0x00; 0xfc;
+                           (* VPSHUFB (%_% ymm15) (%_% ymm15) (%_% ymm12) *)
+  0xc4; 0xc2; 0x75; 0x00; 0xcc;
+                           (* VPSHUFB (%_% ymm1) (%_% ymm1) (%_% ymm12) *)
+  0xc4; 0xc2; 0x6d; 0x00; 0xd4;
+                           (* VPSHUFB (%_% ymm2) (%_% ymm2) (%_% ymm12) *)
+  0xc4; 0xc2; 0x65; 0x00; 0xdc;
+                           (* VPSHUFB (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
+  0xc5; 0x4d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm12) (%_% ymm6) (%_% ymm4) *)
+  0xc5; 0xdd; 0xfd; 0xe6;  (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0x45; 0xf9; 0xed;  (* VPSUBW (%_% ymm13) (%_% ymm7) (%_% ymm5) *)
+  0xc4; 0xc1; 0x1d; 0xd5; 0xf7;
+                           (* VPMULLW (%_% ymm6) (%_% ymm12) (%_% ymm15) *)
+  0xc5; 0xd5; 0xfd; 0xef;  (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm7) *)
+  0xc4; 0x41; 0x2d; 0xf9; 0xf0;
+                           (* VPSUBW (%_% ymm14) (%_% ymm10) (%_% ymm8) *)
+  0xc4; 0xc1; 0x15; 0xd5; 0xff;
+                           (* VPMULLW (%_% ymm7) (%_% ymm13) (%_% ymm15) *)
+  0xc4; 0x41; 0x3d; 0xfd; 0xc2;
+                           (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x25; 0xf9; 0xf9;
+                           (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm9) *)
+  0xc5; 0x0d; 0xd5; 0xd1;  (* VPMULLW (%_% ymm10) (%_% ymm14) (%_% ymm1) *)
+  0xc4; 0x41; 0x35; 0xfd; 0xcb;
+                           (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xd9;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm1) *)
+  0xc5; 0x1d; 0xe5; 0xe2;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0x15; 0xe5; 0xea;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm2) *)
+  0xc5; 0x0d; 0xe5; 0xf3;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm3) *)
+  0xc5; 0x05; 0xe5; 0xfb;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm3) *)
+  0xc5; 0xcd; 0xe5; 0xf0;  (* VPMULHW (%_% ymm6) (%_% ymm6) (%_% ymm0) *)
+  0xc5; 0xc5; 0xe5; 0xf8;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm6) (%_% ymm12) (%_% ymm6) *)
+  0xc5; 0x95; 0xf9; 0xff;  (* VPSUBW (%_% ymm7) (%_% ymm13) (%_% ymm7) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0x20; 0x03; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,800))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x9e; 0x40; 0x03; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm3) (Memop Word256 (%% (rsi,832))) (Imm8 (word 78)) *)
+  0xc5; 0xfd; 0x6f; 0x0e;  (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,0))) *)
+  0xc4; 0xe2; 0x6d; 0x00; 0xd1;
+                           (* VPSHUFB (%_% ymm2) (%_% ymm2) (%_% ymm1) *)
+  0xc4; 0xe2; 0x65; 0x00; 0xd9;
+                           (* VPSHUFB (%_% ymm3) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x3d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0xc1; 0x5d; 0xfd; 0xe0;
+                           (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc5; 0x35; 0xf9; 0xed;  (* VPSUBW (%_% ymm13) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x1d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0xc1; 0x55; 0xfd; 0xe9;
+                           (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc5; 0x2d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm10) (%_% ymm6) *)
+  0xc5; 0x15; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf2;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc5; 0x25; 0xf9; 0xff;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm7) *)
+  0xc5; 0x0d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x45; 0xfd; 0xfb;
+                           (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc5; 0x1d; 0xe5; 0xe3;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm3) *)
+  0xc5; 0x15; 0xe5; 0xeb;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm3) *)
+  0xc5; 0x0d; 0xe5; 0xf3;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm3) *)
+  0xc5; 0x05; 0xe5; 0xfb;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm3) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xc8;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc4; 0x41; 0x1d; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x41; 0x15; 0xf9; 0xc9;
+                           (* VPSUBW (%_% ymm9) (%_% ymm13) (%_% ymm9) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0xe5; 0x72; 0xf5; 0x10;
+                           (* VPSLLD (%_% ymm3) (%_% ymm5) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x5d; 0x0e; 0xdb; 0xaa;
+                           (* VPBLENDW (%_% ymm3) (%_% ymm4) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc5; 0xdd; 0x72; 0xd4; 0x10;
+                           (* VPSRLD (%_% ymm4) (%_% ymm4) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x5d; 0x0e; 0xed; 0xaa;
+                           (* VPBLENDW (%_% ymm5) (%_% ymm4) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc5; 0xdd; 0x72; 0xf7; 0x10;
+                           (* VPSLLD (%_% ymm4) (%_% ymm7) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x4d; 0x0e; 0xe4; 0xaa;
+                           (* VPBLENDW (%_% ymm4) (%_% ymm6) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc5; 0xcd; 0x72; 0xd6; 0x10;
+                           (* VPSRLD (%_% ymm6) (%_% ymm6) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x4d; 0x0e; 0xff; 0xaa;
+                           (* VPBLENDW (%_% ymm7) (%_% ymm6) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x4d; 0x72; 0xf1; 0x10;
+                           (* VPSLLD (%_% ymm6) (%_% ymm9) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x3d; 0x0e; 0xf6; 0xaa;
+                           (* VPBLENDW (%_% ymm6) (%_% ymm8) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x3d; 0x72; 0xd0; 0x10;
+                           (* VPSRLD (%_% ymm8) (%_% ymm8) (Imm8 (word 16)) *)
+  0xc4; 0x43; 0x3d; 0x0e; 0xc9; 0xaa;
+                           (* VPBLENDW (%_% ymm9) (%_% ymm8) (%_% ymm9) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x3d; 0x72; 0xf3; 0x10;
+                           (* VPSLLD (%_% ymm8) (%_% ymm11) (Imm8 (word 16)) *)
+  0xc4; 0x43; 0x2d; 0x0e; 0xc0; 0xaa;
+                           (* VPBLENDW (%_% ymm8) (%_% ymm10) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x2d; 0x72; 0xd2; 0x10;
+                           (* VPSRLD (%_% ymm10) (%_% ymm10) (Imm8 (word 16)) *)
+  0xc4; 0x43; 0x2d; 0x0e; 0xdb; 0xaa;
+                           (* VPBLENDW (%_% ymm11) (%_% ymm10) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc5; 0x7d; 0x6f; 0x66; 0x20;
+                           (* VMOVDQA (%_% ymm12) (Memop Word256 (%% (rsi,32))) *)
+  0xc4; 0xe2; 0x1d; 0x36; 0x96; 0xe0; 0x02; 0x00; 0x00;
+                           (* VPERMD (%_% ymm2) (%_% ymm12) (Memop Word256 (%% (rsi,736))) *)
+  0xc4; 0x62; 0x1d; 0x36; 0x96; 0x00; 0x03; 0x00; 0x00;
+                           (* VPERMD (%_% ymm10) (%_% ymm12) (Memop Word256 (%% (rsi,768))) *)
+  0xc5; 0x55; 0xf9; 0xe3;  (* VPSUBW (%_% ymm12) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xe5; 0xfd; 0xdd;  (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0x45; 0xf9; 0xec;  (* VPSUBW (%_% ymm13) (%_% ymm7) (%_% ymm4) *)
+  0xc5; 0x9d; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0xdd; 0xfd; 0xe7;  (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm7) *)
+  0xc5; 0x35; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm9) (%_% ymm6) *)
+  0xc5; 0x95; 0xd5; 0xfa;  (* VPMULLW (%_% ymm7) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf1;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm9) *)
+  0xc4; 0x41; 0x25; 0xf9; 0xf8;
+                           (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm8) *)
+  0xc5; 0x0d; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0x41; 0x3d; 0xfd; 0xc3;
+                           (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x41; 0x1d; 0xe5; 0xe2;
+                           (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x41; 0x15; 0xe5; 0xea;
+                           (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm10) *)
+  0xc4; 0x41; 0x0d; 0xe5; 0xf2;
+                           (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xe5; 0xfa;
+                           (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm10) *)
+  0xc5; 0xd5; 0xe5; 0xe8;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0xc5; 0xe5; 0xf8;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xc8;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xed;  (* VPSUBW (%_% ymm5) (%_% ymm12) (%_% ymm5) *)
+  0xc5; 0x95; 0xf9; 0xff;  (* VPSUBW (%_% ymm7) (%_% ymm13) (%_% ymm7) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xc9;
+                           (* VPSUBW (%_% ymm9) (%_% ymm14) (%_% ymm9) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xb8; 0xbf; 0x4e; 0xbf; 0x4e;
+                           (* MOV (% eax) (Imm32 (word 1321160383)) *)
+  0xc5; 0xf9; 0x6e; 0xc8;  (* VMOVD (%_% xmm1) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xc9;
+                           (* VPBROADCASTD (%_% ymm1) (%_% xmm1) *)
+  0xc5; 0x65; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm3) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x65; 0xf9; 0xdc;
+                           (* VPSUBW (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
+  0xc5; 0x7e; 0x12; 0xd4;  (* VMOVSLDUP (%_% ymm10) (%_% ymm4) *)
+  0xc4; 0x43; 0x65; 0x02; 0xd2; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm3) (%_% ymm10) (Imm8 (word 170)) *)
+  0xc5; 0xe5; 0x73; 0xd3; 0x20;
+                           (* VPSRLQ (%_% ymm3) (%_% ymm3) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm3) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xd8;
+                           (* VMOVSLDUP (%_% ymm3) (%_% ymm8) *)
+  0xc4; 0xe3; 0x4d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm6) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc5; 0xcd; 0x73; 0xd6; 0x20;
+                           (* VPSRLQ (%_% ymm6) (%_% ymm6) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x4d; 0x02; 0xc0; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm6) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xf7;  (* VMOVSLDUP (%_% ymm6) (%_% ymm7) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xf6; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm5) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc5; 0xd5; 0x73; 0xd5; 0x20;
+                           (* VPSRLQ (%_% ymm5) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xff; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm5) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xeb;
+                           (* VMOVSLDUP (%_% ymm5) (%_% ymm11) *)
+  0xc4; 0xe3; 0x35; 0x02; 0xed; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm9) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x35; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm9) (%_% ymm9) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x35; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm9) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0xa0; 0x02; 0x00; 0x00; 0x1b;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,672))) (Imm8 (word 27)) *)
+  0xc4; 0x63; 0xfd; 0x00; 0x8e; 0xc0; 0x02; 0x00; 0x00; 0x1b;
+                           (* VPERMQ (%_% ymm9) (Memop Word256 (%% (rsi,704))) (Imm8 (word 27)) *)
+  0xc4; 0x41; 0x5d; 0xf9; 0xe2;
+                           (* VPSUBW (%_% ymm12) (%_% ymm4) (%_% ymm10) *)
+  0xc5; 0x2d; 0xfd; 0xd4;  (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm4) *)
+  0xc5; 0x3d; 0xf9; 0xeb;  (* VPSUBW (%_% ymm13) (%_% ymm8) (%_% ymm3) *)
+  0xc5; 0x9d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm4) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0xc1; 0x65; 0xfd; 0xd8;
+                           (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm8) *)
+  0xc5; 0x45; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm7) (%_% ymm6) *)
+  0xc5; 0x15; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm13) (%_% ymm2) *)
+  0xc5; 0xcd; 0xfd; 0xf7;  (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm7) *)
+  0xc5; 0x25; 0xf9; 0xfd;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm5) *)
+  0xc5; 0x8d; 0xd5; 0xfa;  (* VPMULLW (%_% ymm7) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x55; 0xfd; 0xeb;
+                           (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x41; 0x1d; 0xe5; 0xe1;
+                           (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x41; 0x15; 0xe5; 0xe9;
+                           (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm9) *)
+  0xc4; 0x41; 0x0d; 0xe5; 0xf1;
+                           (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm9) *)
+  0xc4; 0x41; 0x05; 0xe5; 0xf9;
+                           (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm9) *)
+  0xc5; 0xdd; 0xe5; 0xe0;  (* VPMULHW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0xc5; 0xe5; 0xf8;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm4) (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x41; 0x15; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm13) (%_% ymm8) *)
+  0xc5; 0x8d; 0xf9; 0xff;  (* VPSUBW (%_% ymm7) (%_% ymm14) (%_% ymm7) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0x2d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x2d; 0xf9; 0xd4;
+                           (* VPSUBW (%_% ymm10) (%_% ymm10) (%_% ymm12) *)
+  0xc5; 0x2d; 0x6c; 0xcb;  (* VPUNPCKLQDQ (%_% ymm9) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0xad; 0x6d; 0xdb;  (* VPUNPCKHQDQ (%_% ymm3) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0x4d; 0x6c; 0xd5;  (* VPUNPCKLQDQ (%_% ymm10) (%_% ymm6) (%_% ymm5) *)
+  0xc5; 0xcd; 0x6d; 0xed;  (* VPUNPCKHQDQ (%_% ymm5) (%_% ymm6) (%_% ymm5) *)
+  0xc4; 0xc1; 0x5d; 0x6c; 0xf0;
+                           (* VPUNPCKLQDQ (%_% ymm6) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x5d; 0x6d; 0xc0;
+                           (* VPUNPCKHQDQ (%_% ymm8) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x45; 0x6c; 0xe3;
+                           (* VPUNPCKLQDQ (%_% ymm4) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x45; 0x6d; 0xdb;
+                           (* VPUNPCKHQDQ (%_% ymm11) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0x60; 0x02; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,608))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0xbe; 0x80; 0x02; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm7) (Memop Word256 (%% (rsi,640))) (Imm8 (word 78)) *)
+  0xc4; 0x41; 0x65; 0xf9; 0xe1;
+                           (* VPSUBW (%_% ymm12) (%_% ymm3) (%_% ymm9) *)
+  0xc5; 0x35; 0xfd; 0xcb;  (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm3) *)
+  0xc4; 0x41; 0x55; 0xf9; 0xea;
+                           (* VPSUBW (%_% ymm13) (%_% ymm5) (%_% ymm10) *)
+  0xc5; 0x9d; 0xd5; 0xda;  (* VPMULLW (%_% ymm3) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0x2d; 0xfd; 0xd5;  (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm5) *)
+  0xc5; 0x3d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm8) (%_% ymm6) *)
+  0xc5; 0x95; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf0;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm8) *)
+  0xc5; 0x25; 0xf9; 0xfc;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm4) *)
+  0xc5; 0x0d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x5d; 0xfd; 0xe3;
+                           (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc5; 0x1d; 0xe5; 0xe7;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm7) *)
+  0xc5; 0x15; 0xe5; 0xef;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm7) *)
+  0xc5; 0x0d; 0xe5; 0xf7;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm7) *)
+  0xc5; 0x05; 0xe5; 0xff;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm7) *)
+  0xc5; 0xe5; 0xe5; 0xd8;  (* VPMULHW (%_% ymm3) (%_% ymm3) (%_% ymm0) *)
+  0xc5; 0xd5; 0xe5; 0xe8;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xdb;  (* VPSUBW (%_% ymm3) (%_% ymm12) (%_% ymm3) *)
+  0xc5; 0x95; 0xf9; 0xed;  (* VPSUBW (%_% ymm5) (%_% ymm13) (%_% ymm5) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm14) (%_% ymm8) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0x35; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x35; 0xf9; 0xcc;
+                           (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
+  0xc4; 0xc3; 0x35; 0x46; 0xfa; 0x20;
+                           (* VPERM2I128 (%_% ymm7) (%_% ymm9) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x35; 0x46; 0xd2; 0x31;
+                           (* VPERM2I128 (%_% ymm10) (%_% ymm9) (%_% ymm10) (Imm8 (word 49)) *)
+  0xc4; 0x63; 0x4d; 0x46; 0xcc; 0x20;
+                           (* VPERM2I128 (%_% ymm9) (%_% ymm6) (%_% ymm4) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x4d; 0x46; 0xe4; 0x31;
+                           (* VPERM2I128 (%_% ymm4) (%_% ymm6) (%_% ymm4) (Imm8 (word 49)) *)
+  0xc4; 0xe3; 0x65; 0x46; 0xf5; 0x20;
+                           (* VPERM2I128 (%_% ymm6) (%_% ymm3) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x46; 0xed; 0x31;
+                           (* VPERM2I128 (%_% ymm5) (%_% ymm3) (%_% ymm5) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x3d; 0x46; 0xdb; 0x20;
+                           (* VPERM2I128 (%_% ymm3) (%_% ymm8) (%_% ymm11) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x3d; 0x46; 0xdb; 0x31;
+                           (* VPERM2I128 (%_% ymm11) (%_% ymm8) (%_% ymm11) (Imm8 (word 49)) *)
+  0xc5; 0xfd; 0x6f; 0x96; 0x20; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,544))) *)
+  0xc5; 0x7d; 0x6f; 0x86; 0x40; 0x02; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rsi,576))) *)
+  0xc5; 0x2d; 0xf9; 0xe7;  (* VPSUBW (%_% ymm12) (%_% ymm10) (%_% ymm7) *)
+  0xc4; 0xc1; 0x45; 0xfd; 0xfa;
+                           (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm10) *)
+  0xc4; 0x41; 0x5d; 0xf9; 0xe9;
+                           (* VPSUBW (%_% ymm13) (%_% ymm4) (%_% ymm9) *)
+  0xc5; 0x1d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0x35; 0xfd; 0xcc;  (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm4) *)
+  0xc5; 0x55; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm5) (%_% ymm6) *)
+  0xc5; 0x95; 0xd5; 0xe2;  (* VPMULLW (%_% ymm4) (%_% ymm13) (%_% ymm2) *)
+  0xc5; 0xcd; 0xfd; 0xf5;  (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm5) *)
+  0xc5; 0x25; 0xf9; 0xfb;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm3) *)
+  0xc5; 0x8d; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x65; 0xfd; 0xdb;
+                           (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x41; 0x1d; 0xe5; 0xe0;
+                           (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x41; 0x15; 0xe5; 0xe8;
+                           (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm8) *)
+  0xc4; 0x41; 0x0d; 0xe5; 0xf0;
+                           (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm8) *)
+  0xc4; 0x41; 0x05; 0xe5; 0xf8;
+                           (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm8) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0xdd; 0xe5; 0xe0;  (* VPMULHW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
+  0xc5; 0xd5; 0xe5; 0xe8;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc4; 0x41; 0x1d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm12) (%_% ymm10) *)
+  0xc5; 0x95; 0xf9; 0xe4;  (* VPSUBW (%_% ymm4) (%_% ymm13) (%_% ymm4) *)
+  0xc5; 0x8d; 0xf9; 0xed;  (* VPSUBW (%_% ymm5) (%_% ymm14) (%_% ymm5) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0x45; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm7) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x45; 0xf9; 0xfc;
+                           (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
+  0xc5; 0xfd; 0x7f; 0x3f;  (* VMOVDQA (Memop Word256 (%% (rdi,0))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x4f; 0x20;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,32))) (%_% ymm9) *)
+  0xc5; 0xfd; 0x7f; 0x77; 0x40;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,64))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0x5f; 0x60;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,96))) (%_% ymm3) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,128))) (%_% ymm10) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,160))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,192))) (%_% ymm5) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,224))) (%_% ymm11) *)
+  0xb8; 0xa1; 0xd8; 0xa1; 0xd8;
+                           (* MOV (% eax) (Imm32 (word 3634485409)) *)
+  0xc5; 0xf9; 0x6e; 0xd0;  (* VMOVD (%_% xmm2) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xd2;
+                           (* VPBROADCASTD (%_% ymm2) (%_% xmm2) *)
+  0xb8; 0xa1; 0x05; 0xa1; 0x05;
+                           (* MOV (% eax) (Imm32 (word 94438817)) *)
+  0xc5; 0xf9; 0x6e; 0xd8;  (* VMOVD (%_% xmm3) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xdb;
+                           (* VPBROADCASTD (%_% ymm3) (%_% xmm3) *)
+  0xc5; 0xfd; 0x6f; 0xa7; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,256))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,320))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,288))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,352))) *)
+  0xc5; 0x5d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm4) (%_% ymm2) *)
+  0xc5; 0xdd; 0xe5; 0xe3;  (* VPMULHW (%_% ymm4) (%_% ymm4) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x5d; 0xf9; 0xe4;
+                           (* VPSUBW (%_% ymm4) (%_% ymm4) (%_% ymm12) *)
+  0xc5; 0x4d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm6) (%_% ymm2) *)
+  0xc5; 0xcd; 0xe5; 0xf3;  (* VPMULHW (%_% ymm6) (%_% ymm6) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x4d; 0xf9; 0xf4;
+                           (* VPSUBW (%_% ymm6) (%_% ymm6) (%_% ymm12) *)
+  0xc5; 0x55; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm5) (%_% ymm2) *)
+  0xc5; 0xd5; 0xe5; 0xeb;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x55; 0xf9; 0xec;
+                           (* VPSUBW (%_% ymm5) (%_% ymm5) (%_% ymm12) *)
+  0xc5; 0x45; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm7) (%_% ymm2) *)
+  0xc5; 0xc5; 0xe5; 0xfb;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x45; 0xf9; 0xfc;
+                           (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,384))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,448))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,416))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,480))) *)
+  0xc5; 0x3d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm8) (%_% ymm2) *)
+  0xc5; 0x3d; 0xe5; 0xc3;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x3d; 0xf9; 0xc4;
+                           (* VPSUBW (%_% ymm8) (%_% ymm8) (%_% ymm12) *)
+  0xc5; 0x2d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm10) (%_% ymm2) *)
+  0xc5; 0x2d; 0xe5; 0xd3;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x2d; 0xf9; 0xd4;
+                           (* VPSUBW (%_% ymm10) (%_% ymm10) (%_% ymm12) *)
+  0xc5; 0x35; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm9) (%_% ymm2) *)
+  0xc5; 0x35; 0xe5; 0xcb;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x35; 0xf9; 0xcc;
+                           (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
+  0xc5; 0x25; 0xd5; 0xe2;  (* VPMULLW (%_% ymm12) (%_% ymm11) (%_% ymm2) *)
+  0xc5; 0x25; 0xe5; 0xdb;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm3) *)
+  0xc5; 0x1d; 0xe5; 0xe0;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x25; 0xf9; 0xdc;
+                           (* VPSUBW (%_% ymm11) (%_% ymm11) (%_% ymm12) *)
+  0xc4; 0x63; 0xfd; 0x00; 0xbe; 0xe0; 0x01; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm15) (Memop Word256 (%% (rsi,480))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x8e; 0xa0; 0x01; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm1) (Memop Word256 (%% (rsi,416))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0x00; 0x02; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,512))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x9e; 0xc0; 0x01; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm3) (Memop Word256 (%% (rsi,448))) (Imm8 (word 78)) *)
+  0xc5; 0x7d; 0x6f; 0x26;  (* VMOVDQA (%_% ymm12) (Memop Word256 (%% (rsi,0))) *)
+  0xc4; 0x42; 0x05; 0x00; 0xfc;
+                           (* VPSHUFB (%_% ymm15) (%_% ymm15) (%_% ymm12) *)
+  0xc4; 0xc2; 0x75; 0x00; 0xcc;
+                           (* VPSHUFB (%_% ymm1) (%_% ymm1) (%_% ymm12) *)
+  0xc4; 0xc2; 0x6d; 0x00; 0xd4;
+                           (* VPSHUFB (%_% ymm2) (%_% ymm2) (%_% ymm12) *)
+  0xc4; 0xc2; 0x65; 0x00; 0xdc;
+                           (* VPSHUFB (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
+  0xc5; 0x4d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm12) (%_% ymm6) (%_% ymm4) *)
+  0xc5; 0xdd; 0xfd; 0xe6;  (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm6) *)
+  0xc5; 0x45; 0xf9; 0xed;  (* VPSUBW (%_% ymm13) (%_% ymm7) (%_% ymm5) *)
+  0xc4; 0xc1; 0x1d; 0xd5; 0xf7;
+                           (* VPMULLW (%_% ymm6) (%_% ymm12) (%_% ymm15) *)
+  0xc5; 0xd5; 0xfd; 0xef;  (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm7) *)
+  0xc4; 0x41; 0x2d; 0xf9; 0xf0;
+                           (* VPSUBW (%_% ymm14) (%_% ymm10) (%_% ymm8) *)
+  0xc4; 0xc1; 0x15; 0xd5; 0xff;
+                           (* VPMULLW (%_% ymm7) (%_% ymm13) (%_% ymm15) *)
+  0xc4; 0x41; 0x3d; 0xfd; 0xc2;
+                           (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm10) *)
+  0xc4; 0x41; 0x25; 0xf9; 0xf9;
+                           (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm9) *)
+  0xc5; 0x0d; 0xd5; 0xd1;  (* VPMULLW (%_% ymm10) (%_% ymm14) (%_% ymm1) *)
+  0xc4; 0x41; 0x35; 0xfd; 0xcb;
+                           (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xd9;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm1) *)
+  0xc5; 0x1d; 0xe5; 0xe2;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0x15; 0xe5; 0xea;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm2) *)
+  0xc5; 0x0d; 0xe5; 0xf3;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm3) *)
+  0xc5; 0x05; 0xe5; 0xfb;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm3) *)
+  0xc5; 0xcd; 0xe5; 0xf0;  (* VPMULHW (%_% ymm6) (%_% ymm6) (%_% ymm0) *)
+  0xc5; 0xc5; 0xe5; 0xf8;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm6) (%_% ymm12) (%_% ymm6) *)
+  0xc5; 0x95; 0xf9; 0xff;  (* VPSUBW (%_% ymm7) (%_% ymm13) (%_% ymm7) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0x60; 0x01; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,352))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x9e; 0x80; 0x01; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm3) (Memop Word256 (%% (rsi,384))) (Imm8 (word 78)) *)
+  0xc5; 0xfd; 0x6f; 0x0e;  (* VMOVDQA (%_% ymm1) (Memop Word256 (%% (rsi,0))) *)
+  0xc4; 0xe2; 0x6d; 0x00; 0xd1;
+                           (* VPSHUFB (%_% ymm2) (%_% ymm2) (%_% ymm1) *)
+  0xc4; 0xe2; 0x65; 0x00; 0xd9;
+                           (* VPSHUFB (%_% ymm3) (%_% ymm3) (%_% ymm1) *)
+  0xc5; 0x3d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0xc1; 0x5d; 0xfd; 0xe0;
+                           (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc5; 0x35; 0xf9; 0xed;  (* VPSUBW (%_% ymm13) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x1d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0xc1; 0x55; 0xfd; 0xe9;
+                           (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc5; 0x2d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm10) (%_% ymm6) *)
+  0xc5; 0x15; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf2;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc5; 0x25; 0xf9; 0xff;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm7) *)
+  0xc5; 0x0d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x45; 0xfd; 0xfb;
+                           (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc5; 0x1d; 0xe5; 0xe3;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm3) *)
+  0xc5; 0x15; 0xe5; 0xeb;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm3) *)
+  0xc5; 0x0d; 0xe5; 0xf3;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm3) *)
+  0xc5; 0x05; 0xe5; 0xfb;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm3) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xc8;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc4; 0x41; 0x1d; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x41; 0x15; 0xf9; 0xc9;
+                           (* VPSUBW (%_% ymm9) (%_% ymm13) (%_% ymm9) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0xe5; 0x72; 0xf5; 0x10;
+                           (* VPSLLD (%_% ymm3) (%_% ymm5) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x5d; 0x0e; 0xdb; 0xaa;
+                           (* VPBLENDW (%_% ymm3) (%_% ymm4) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc5; 0xdd; 0x72; 0xd4; 0x10;
+                           (* VPSRLD (%_% ymm4) (%_% ymm4) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x5d; 0x0e; 0xed; 0xaa;
+                           (* VPBLENDW (%_% ymm5) (%_% ymm4) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc5; 0xdd; 0x72; 0xf7; 0x10;
+                           (* VPSLLD (%_% ymm4) (%_% ymm7) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x4d; 0x0e; 0xe4; 0xaa;
+                           (* VPBLENDW (%_% ymm4) (%_% ymm6) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc5; 0xcd; 0x72; 0xd6; 0x10;
+                           (* VPSRLD (%_% ymm6) (%_% ymm6) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x4d; 0x0e; 0xff; 0xaa;
+                           (* VPBLENDW (%_% ymm7) (%_% ymm6) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x4d; 0x72; 0xf1; 0x10;
+                           (* VPSLLD (%_% ymm6) (%_% ymm9) (Imm8 (word 16)) *)
+  0xc4; 0xe3; 0x3d; 0x0e; 0xf6; 0xaa;
+                           (* VPBLENDW (%_% ymm6) (%_% ymm8) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x3d; 0x72; 0xd0; 0x10;
+                           (* VPSRLD (%_% ymm8) (%_% ymm8) (Imm8 (word 16)) *)
+  0xc4; 0x43; 0x3d; 0x0e; 0xc9; 0xaa;
+                           (* VPBLENDW (%_% ymm9) (%_% ymm8) (%_% ymm9) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x3d; 0x72; 0xf3; 0x10;
+                           (* VPSLLD (%_% ymm8) (%_% ymm11) (Imm8 (word 16)) *)
+  0xc4; 0x43; 0x2d; 0x0e; 0xc0; 0xaa;
+                           (* VPBLENDW (%_% ymm8) (%_% ymm10) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x2d; 0x72; 0xd2; 0x10;
+                           (* VPSRLD (%_% ymm10) (%_% ymm10) (Imm8 (word 16)) *)
+  0xc4; 0x43; 0x2d; 0x0e; 0xdb; 0xaa;
+                           (* VPBLENDW (%_% ymm11) (%_% ymm10) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc5; 0x7d; 0x6f; 0x66; 0x20;
+                           (* VMOVDQA (%_% ymm12) (Memop Word256 (%% (rsi,32))) *)
+  0xc4; 0xe2; 0x1d; 0x36; 0x96; 0x20; 0x01; 0x00; 0x00;
+                           (* VPERMD (%_% ymm2) (%_% ymm12) (Memop Word256 (%% (rsi,288))) *)
+  0xc4; 0x62; 0x1d; 0x36; 0x96; 0x40; 0x01; 0x00; 0x00;
+                           (* VPERMD (%_% ymm10) (%_% ymm12) (Memop Word256 (%% (rsi,320))) *)
+  0xc5; 0x55; 0xf9; 0xe3;  (* VPSUBW (%_% ymm12) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xe5; 0xfd; 0xdd;  (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm5) *)
+  0xc5; 0x45; 0xf9; 0xec;  (* VPSUBW (%_% ymm13) (%_% ymm7) (%_% ymm4) *)
+  0xc5; 0x9d; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0xdd; 0xfd; 0xe7;  (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm7) *)
+  0xc5; 0x35; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm9) (%_% ymm6) *)
+  0xc5; 0x95; 0xd5; 0xfa;  (* VPMULLW (%_% ymm7) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf1;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm9) *)
+  0xc4; 0x41; 0x25; 0xf9; 0xf8;
+                           (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm8) *)
+  0xc5; 0x0d; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0x41; 0x3d; 0xfd; 0xc3;
+                           (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x41; 0x1d; 0xe5; 0xe2;
+                           (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm10) *)
+  0xc4; 0x41; 0x15; 0xe5; 0xea;
+                           (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm10) *)
+  0xc4; 0x41; 0x0d; 0xe5; 0xf2;
+                           (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xe5; 0xfa;
+                           (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm10) *)
+  0xc5; 0xd5; 0xe5; 0xe8;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0xc5; 0xe5; 0xf8;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xc8;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xed;  (* VPSUBW (%_% ymm5) (%_% ymm12) (%_% ymm5) *)
+  0xc5; 0x95; 0xf9; 0xff;  (* VPSUBW (%_% ymm7) (%_% ymm13) (%_% ymm7) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xc9;
+                           (* VPSUBW (%_% ymm9) (%_% ymm14) (%_% ymm9) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xb8; 0xbf; 0x4e; 0xbf; 0x4e;
+                           (* MOV (% eax) (Imm32 (word 1321160383)) *)
+  0xc5; 0xf9; 0x6e; 0xc8;  (* VMOVD (%_% xmm1) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xc9;
+                           (* VPBROADCASTD (%_% ymm1) (%_% xmm1) *)
+  0xc5; 0x65; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm3) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x65; 0xf9; 0xdc;
+                           (* VPSUBW (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
+  0xc5; 0x7e; 0x12; 0xd4;  (* VMOVSLDUP (%_% ymm10) (%_% ymm4) *)
+  0xc4; 0x43; 0x65; 0x02; 0xd2; 0xaa;
+                           (* VPBLENDD (%_% ymm10) (%_% ymm3) (%_% ymm10) (Imm8 (word 170)) *)
+  0xc5; 0xe5; 0x73; 0xd3; 0x20;
+                           (* VPSRLQ (%_% ymm3) (%_% ymm3) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x02; 0xe4; 0xaa;
+                           (* VPBLENDD (%_% ymm4) (%_% ymm3) (%_% ymm4) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xd8;
+                           (* VMOVSLDUP (%_% ymm3) (%_% ymm8) *)
+  0xc4; 0xe3; 0x4d; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm3) (%_% ymm6) (%_% ymm3) (Imm8 (word 170)) *)
+  0xc5; 0xcd; 0x73; 0xd6; 0x20;
+                           (* VPSRLQ (%_% ymm6) (%_% ymm6) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x4d; 0x02; 0xc0; 0xaa;
+                           (* VPBLENDD (%_% ymm8) (%_% ymm6) (%_% ymm8) (Imm8 (word 170)) *)
+  0xc5; 0xfe; 0x12; 0xf7;  (* VMOVSLDUP (%_% ymm6) (%_% ymm7) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xf6; 0xaa;
+                           (* VPBLENDD (%_% ymm6) (%_% ymm5) (%_% ymm6) (Imm8 (word 170)) *)
+  0xc5; 0xd5; 0x73; 0xd5; 0x20;
+                           (* VPSRLQ (%_% ymm5) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x55; 0x02; 0xff; 0xaa;
+                           (* VPBLENDD (%_% ymm7) (%_% ymm5) (%_% ymm7) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x7e; 0x12; 0xeb;
+                           (* VMOVSLDUP (%_% ymm5) (%_% ymm11) *)
+  0xc4; 0xe3; 0x35; 0x02; 0xed; 0xaa;
+                           (* VPBLENDD (%_% ymm5) (%_% ymm9) (%_% ymm5) (Imm8 (word 170)) *)
+  0xc4; 0xc1; 0x35; 0x73; 0xd1; 0x20;
+                           (* VPSRLQ (%_% ymm9) (%_% ymm9) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x35; 0x02; 0xdb; 0xaa;
+                           (* VPBLENDD (%_% ymm11) (%_% ymm9) (%_% ymm11) (Imm8 (word 170)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0xe0; 0x00; 0x00; 0x00; 0x1b;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,224))) (Imm8 (word 27)) *)
+  0xc4; 0x63; 0xfd; 0x00; 0x8e; 0x00; 0x01; 0x00; 0x00; 0x1b;
+                           (* VPERMQ (%_% ymm9) (Memop Word256 (%% (rsi,256))) (Imm8 (word 27)) *)
+  0xc4; 0x41; 0x5d; 0xf9; 0xe2;
+                           (* VPSUBW (%_% ymm12) (%_% ymm4) (%_% ymm10) *)
+  0xc5; 0x2d; 0xfd; 0xd4;  (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm4) *)
+  0xc5; 0x3d; 0xf9; 0xeb;  (* VPSUBW (%_% ymm13) (%_% ymm8) (%_% ymm3) *)
+  0xc5; 0x9d; 0xd5; 0xe2;  (* VPMULLW (%_% ymm4) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0xc1; 0x65; 0xfd; 0xd8;
+                           (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm8) *)
+  0xc5; 0x45; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm7) (%_% ymm6) *)
+  0xc5; 0x15; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm13) (%_% ymm2) *)
+  0xc5; 0xcd; 0xfd; 0xf7;  (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm7) *)
+  0xc5; 0x25; 0xf9; 0xfd;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm5) *)
+  0xc5; 0x8d; 0xd5; 0xfa;  (* VPMULLW (%_% ymm7) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x55; 0xfd; 0xeb;
+                           (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x41; 0x1d; 0xe5; 0xe1;
+                           (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm9) *)
+  0xc4; 0x41; 0x15; 0xe5; 0xe9;
+                           (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm9) *)
+  0xc4; 0x41; 0x0d; 0xe5; 0xf1;
+                           (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm9) *)
+  0xc4; 0x41; 0x05; 0xe5; 0xf9;
+                           (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm9) *)
+  0xc5; 0xdd; 0xe5; 0xe0;  (* VPMULHW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0xc5; 0xe5; 0xf8;  (* VPMULHW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm4) (%_% ymm12) (%_% ymm4) *)
+  0xc4; 0x41; 0x15; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm13) (%_% ymm8) *)
+  0xc5; 0x8d; 0xf9; 0xff;  (* VPSUBW (%_% ymm7) (%_% ymm14) (%_% ymm7) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0x2d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm10) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x2d; 0xf9; 0xd4;
+                           (* VPSUBW (%_% ymm10) (%_% ymm10) (%_% ymm12) *)
+  0xc5; 0x2d; 0x6c; 0xcb;  (* VPUNPCKLQDQ (%_% ymm9) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0xad; 0x6d; 0xdb;  (* VPUNPCKHQDQ (%_% ymm3) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0x4d; 0x6c; 0xd5;  (* VPUNPCKLQDQ (%_% ymm10) (%_% ymm6) (%_% ymm5) *)
+  0xc5; 0xcd; 0x6d; 0xed;  (* VPUNPCKHQDQ (%_% ymm5) (%_% ymm6) (%_% ymm5) *)
+  0xc4; 0xc1; 0x5d; 0x6c; 0xf0;
+                           (* VPUNPCKLQDQ (%_% ymm6) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0x41; 0x5d; 0x6d; 0xc0;
+                           (* VPUNPCKHQDQ (%_% ymm8) (%_% ymm4) (%_% ymm8) *)
+  0xc4; 0xc1; 0x45; 0x6c; 0xe3;
+                           (* VPUNPCKLQDQ (%_% ymm4) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0x41; 0x45; 0x6d; 0xdb;
+                           (* VPUNPCKHQDQ (%_% ymm11) (%_% ymm7) (%_% ymm11) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0x96; 0xa0; 0x00; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm2) (Memop Word256 (%% (rsi,160))) (Imm8 (word 78)) *)
+  0xc4; 0xe3; 0xfd; 0x00; 0xbe; 0xc0; 0x00; 0x00; 0x00; 0x4e;
+                           (* VPERMQ (%_% ymm7) (Memop Word256 (%% (rsi,192))) (Imm8 (word 78)) *)
+  0xc4; 0x41; 0x65; 0xf9; 0xe1;
+                           (* VPSUBW (%_% ymm12) (%_% ymm3) (%_% ymm9) *)
+  0xc5; 0x35; 0xfd; 0xcb;  (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm3) *)
+  0xc4; 0x41; 0x55; 0xf9; 0xea;
+                           (* VPSUBW (%_% ymm13) (%_% ymm5) (%_% ymm10) *)
+  0xc5; 0x9d; 0xd5; 0xda;  (* VPMULLW (%_% ymm3) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0x2d; 0xfd; 0xd5;  (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm5) *)
+  0xc5; 0x3d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm8) (%_% ymm6) *)
+  0xc5; 0x95; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf0;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm8) *)
+  0xc5; 0x25; 0xf9; 0xfc;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm4) *)
+  0xc5; 0x0d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x5d; 0xfd; 0xe3;
+                           (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc5; 0x1d; 0xe5; 0xe7;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm7) *)
+  0xc5; 0x15; 0xe5; 0xef;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm7) *)
+  0xc5; 0x0d; 0xe5; 0xf7;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm7) *)
+  0xc5; 0x05; 0xe5; 0xff;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm7) *)
+  0xc5; 0xe5; 0xe5; 0xd8;  (* VPMULHW (%_% ymm3) (%_% ymm3) (%_% ymm0) *)
+  0xc5; 0xd5; 0xe5; 0xe8;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0x9d; 0xf9; 0xdb;  (* VPSUBW (%_% ymm3) (%_% ymm12) (%_% ymm3) *)
+  0xc5; 0x95; 0xf9; 0xed;  (* VPSUBW (%_% ymm5) (%_% ymm13) (%_% ymm5) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm14) (%_% ymm8) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0x35; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm9) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0x41; 0x35; 0xf9; 0xcc;
+                           (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
+  0xc4; 0xc3; 0x35; 0x46; 0xfa; 0x20;
+                           (* VPERM2I128 (%_% ymm7) (%_% ymm9) (%_% ymm10) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x35; 0x46; 0xd2; 0x31;
+                           (* VPERM2I128 (%_% ymm10) (%_% ymm9) (%_% ymm10) (Imm8 (word 49)) *)
+  0xc4; 0x63; 0x4d; 0x46; 0xcc; 0x20;
+                           (* VPERM2I128 (%_% ymm9) (%_% ymm6) (%_% ymm4) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x4d; 0x46; 0xe4; 0x31;
+                           (* VPERM2I128 (%_% ymm4) (%_% ymm6) (%_% ymm4) (Imm8 (word 49)) *)
+  0xc4; 0xe3; 0x65; 0x46; 0xf5; 0x20;
+                           (* VPERM2I128 (%_% ymm6) (%_% ymm3) (%_% ymm5) (Imm8 (word 32)) *)
+  0xc4; 0xe3; 0x65; 0x46; 0xed; 0x31;
+                           (* VPERM2I128 (%_% ymm5) (%_% ymm3) (%_% ymm5) (Imm8 (word 49)) *)
+  0xc4; 0xc3; 0x3d; 0x46; 0xdb; 0x20;
+                           (* VPERM2I128 (%_% ymm3) (%_% ymm8) (%_% ymm11) (Imm8 (word 32)) *)
+  0xc4; 0x43; 0x3d; 0x46; 0xdb; 0x31;
+                           (* VPERM2I128 (%_% ymm11) (%_% ymm8) (%_% ymm11) (Imm8 (word 49)) *)
+  0xc5; 0xfd; 0x6f; 0x56; 0x60;
+                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rsi,96))) *)
+  0xc5; 0x7d; 0x6f; 0x86; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rsi,128))) *)
+  0xc5; 0x2d; 0xf9; 0xe7;  (* VPSUBW (%_% ymm12) (%_% ymm10) (%_% ymm7) *)
+  0xc4; 0xc1; 0x45; 0xfd; 0xfa;
+                           (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm10) *)
+  0xc4; 0x41; 0x5d; 0xf9; 0xe9;
+                           (* VPSUBW (%_% ymm13) (%_% ymm4) (%_% ymm9) *)
+  0xc5; 0x1d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm12) (%_% ymm2) *)
+  0xc5; 0x35; 0xfd; 0xcc;  (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm4) *)
+  0xc5; 0x55; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm5) (%_% ymm6) *)
+  0xc5; 0x95; 0xd5; 0xe2;  (* VPMULLW (%_% ymm4) (%_% ymm13) (%_% ymm2) *)
+  0xc5; 0xcd; 0xfd; 0xf5;  (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm5) *)
+  0xc5; 0x25; 0xf9; 0xfb;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm3) *)
+  0xc5; 0x8d; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x65; 0xfd; 0xdb;
+                           (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc4; 0x41; 0x1d; 0xe5; 0xe0;
+                           (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x41; 0x15; 0xe5; 0xe8;
+                           (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm8) *)
+  0xc4; 0x41; 0x0d; 0xe5; 0xf0;
+                           (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm8) *)
+  0xc4; 0x41; 0x05; 0xe5; 0xf8;
+                           (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm8) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0xdd; 0xe5; 0xe0;  (* VPMULHW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
+  0xc5; 0xd5; 0xe5; 0xe8;  (* VPMULHW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc4; 0x41; 0x1d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm12) (%_% ymm10) *)
+  0xc5; 0x95; 0xf9; 0xe4;  (* VPSUBW (%_% ymm4) (%_% ymm13) (%_% ymm4) *)
+  0xc5; 0x8d; 0xf9; 0xed;  (* VPSUBW (%_% ymm5) (%_% ymm14) (%_% ymm5) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0x45; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm7) (%_% ymm1) *)
+  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
+                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
+  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc4; 0xc1; 0x45; 0xf9; 0xfc;
+                           (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,256))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,288))) (%_% ymm9) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,320))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0x9f; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,352))) (%_% ymm3) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,384))) (%_% ymm10) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,416))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,448))) (%_% ymm5) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,480))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0x27;  (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,0))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,256))) *)
+  0xc5; 0xfd; 0x6f; 0x6f; 0x20;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,32))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,288))) *)
+  0xc4; 0xe2; 0x7d; 0x59; 0x56; 0x40;
+                           (* VPBROADCASTQ (%_% ymm2) (Memop Quadword (%% (rsi,64))) *)
+  0xc5; 0xfd; 0x6f; 0x77; 0x40;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,64))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,320))) *)
+  0xc5; 0xfd; 0x6f; 0x7f; 0x60;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,96))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,352))) *)
+  0xc4; 0xe2; 0x7d; 0x59; 0x5e; 0x48;
+                           (* VPBROADCASTQ (%_% ymm3) (Memop Quadword (%% (rsi,72))) *)
+  0xc5; 0x3d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0xc1; 0x5d; 0xfd; 0xe0;
+                           (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc5; 0x35; 0xf9; 0xed;  (* VPSUBW (%_% ymm13) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x1d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0xc1; 0x55; 0xfd; 0xe9;
+                           (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc5; 0x2d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm10) (%_% ymm6) *)
+  0xc5; 0x15; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf2;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc5; 0x25; 0xf9; 0xff;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm7) *)
+  0xc5; 0x0d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x45; 0xfd; 0xfb;
+                           (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc5; 0x1d; 0xe5; 0xe3;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm3) *)
+  0xc5; 0x15; 0xe5; 0xeb;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm3) *)
+  0xc5; 0x0d; 0xe5; 0xf3;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm3) *)
+  0xc5; 0x05; 0xe5; 0xfb;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm3) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xc8;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc4; 0x41; 0x1d; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x41; 0x15; 0xf9; 0xc9;
+                           (* VPSUBW (%_% ymm9) (%_% ymm13) (%_% ymm9) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0xfd; 0x7f; 0x27;  (* VMOVDQA (Memop Word256 (%% (rdi,0))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0x6f; 0x20;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,32))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0x77; 0x40;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,64))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0x7f; 0x60;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,96))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,256))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,288))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,320))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,352))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0xa7; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,128))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,384))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,160))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,416))) *)
+  0xc4; 0xe2; 0x7d; 0x59; 0x56; 0x40;
+                           (* VPBROADCASTQ (%_% ymm2) (Memop Quadword (%% (rsi,64))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,192))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,448))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,224))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,480))) *)
+  0xc4; 0xe2; 0x7d; 0x59; 0x5e; 0x48;
+                           (* VPBROADCASTQ (%_% ymm3) (Memop Quadword (%% (rsi,72))) *)
+  0xc5; 0x3d; 0xf9; 0xe4;  (* VPSUBW (%_% ymm12) (%_% ymm8) (%_% ymm4) *)
+  0xc4; 0xc1; 0x5d; 0xfd; 0xe0;
+                           (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm8) *)
+  0xc5; 0x35; 0xf9; 0xed;  (* VPSUBW (%_% ymm13) (%_% ymm9) (%_% ymm5) *)
+  0xc5; 0x1d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm12) (%_% ymm2) *)
+  0xc4; 0xc1; 0x55; 0xfd; 0xe9;
+                           (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm9) *)
+  0xc5; 0x2d; 0xf9; 0xf6;  (* VPSUBW (%_% ymm14) (%_% ymm10) (%_% ymm6) *)
+  0xc5; 0x15; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm13) (%_% ymm2) *)
+  0xc4; 0xc1; 0x4d; 0xfd; 0xf2;
+                           (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm10) *)
+  0xc5; 0x25; 0xf9; 0xff;  (* VPSUBW (%_% ymm15) (%_% ymm11) (%_% ymm7) *)
+  0xc5; 0x0d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm14) (%_% ymm2) *)
+  0xc4; 0xc1; 0x45; 0xfd; 0xfb;
+                           (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm11) *)
+  0xc5; 0x05; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm15) (%_% ymm2) *)
+  0xc5; 0x1d; 0xe5; 0xe3;  (* VPMULHW (%_% ymm12) (%_% ymm12) (%_% ymm3) *)
+  0xc5; 0x15; 0xe5; 0xeb;  (* VPMULHW (%_% ymm13) (%_% ymm13) (%_% ymm3) *)
+  0xc5; 0x0d; 0xe5; 0xf3;  (* VPMULHW (%_% ymm14) (%_% ymm14) (%_% ymm3) *)
+  0xc5; 0x05; 0xe5; 0xfb;  (* VPMULHW (%_% ymm15) (%_% ymm15) (%_% ymm3) *)
+  0xc5; 0x3d; 0xe5; 0xc0;  (* VPMULHW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xc8;  (* VPMULHW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xd0;  (* VPMULHW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xd8;  (* VPMULHW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc4; 0x41; 0x1d; 0xf9; 0xc0;
+                           (* VPSUBW (%_% ymm8) (%_% ymm12) (%_% ymm8) *)
+  0xc4; 0x41; 0x15; 0xf9; 0xc9;
+                           (* VPSUBW (%_% ymm9) (%_% ymm13) (%_% ymm9) *)
+  0xc4; 0x41; 0x0d; 0xf9; 0xd2;
+                           (* VPSUBW (%_% ymm10) (%_% ymm14) (%_% ymm10) *)
+  0xc4; 0x41; 0x05; 0xf9; 0xdb;
+                           (* VPSUBW (%_% ymm11) (%_% ymm15) (%_% ymm11) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,128))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,160))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,192))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,224))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,384))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,416))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,448))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,480))) (%_% ymm11) *)
+  0xc3                     (* RET *)
+];;
+(*** BYTECODE END ***)
+
+let mlkem_intt_tmc = define_trimmed "mlkem_intt_tmc" mlkem_intt_mc;;
+let MLKEM_INTT_TMC_EXEC = X86_MK_CORE_EXEC_RULE mlkem_intt_tmc;;
+
+let MLKEM_INTT_CORRECT = prove
+  (`!a zetas (zetas_list:int16 list) x pc.
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc, 3341) (a, 512) /\
+    nonoverlapping (word pc, 3341) (zetas, 1248) /\
+    nonoverlapping (a, 512) (zetas, 1248)
+    ==> ensures x86
+          (\s. bytes_loaded s (word pc) (BUTLAST mlkem_intt_tmc) /\
+              read RIP s = word pc /\
+              C_ARGUMENTS [a; zetas] s /\
+              wordlist_from_memory(zetas, 624) s = MAP (iword: int -> 16 word) qdata_full /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add a (word(2 * i)))) s = x i))
+          (\s. read RIP s = word(pc + 3341) /\
+              (!i. i < 256
+                        ==> let zi =
+                      read(memory :> bytes16(word_add a (word(2 * i)))) s in
+                      (ival zi == avx2_inverse_ntt (ival o x) i) (mod &3329) /\
+                      abs(ival zi) <= &26632))
+          (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI  ,,
+           MAYCHANGE [ZMM0; ZMM1; ZMM2; ZMM3; ZMM4; ZMM5; ZMM6; ZMM7; ZMM8;
+                      ZMM9; ZMM10; ZMM11; ZMM12; ZMM13; ZMM14; ZMM15] ,,
+           MAYCHANGE [RAX] ,, MAYCHANGE SOME_FLAGS ,,
+           MAYCHANGE [memory :> bytes(a, 512)])`,
+
+  MAP_EVERY X_GEN_TAC
+   [`a:int64`; `zetas:int64`; `zetas_list:int16 list`; `x:num->int16`; `pc:num`] THEN
+  REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
+              NONOVERLAPPING_CLAUSES; ALL] THEN
+
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV EXPAND_CASES_CONV))) THEN
+  CONV_TAC NUM_REDUCE_CONV THEN
+  REPEAT STRIP_TAC THEN
+
+  REWRITE_TAC [SOME_FLAGS; fst MLKEM_INTT_TMC_EXEC] THEN
+
+  GHOST_INTRO_TAC `init_ymm0:int256` `read YMM0` THEN
+  GHOST_INTRO_TAC `init_ymm1:int256` `read YMM1` THEN
+  GHOST_INTRO_TAC `init_ymm2:int256` `read YMM2` THEN
+  GHOST_INTRO_TAC `init_ymm3:int256` `read YMM3` THEN
+
+  ENSURES_INIT_TAC "s0" THEN
+
+  MEMORY_256_FROM_16_TAC "a" 16 THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN
+  DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 a) s = x`] THEN
+  CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
+
+
+  FIRST_X_ASSUM(MP_TAC o CONV_RULE (LAND_CONV WORDLIST_FROM_MEMORY_CONV)) THEN
+  REWRITE_TAC[qdata_full; MAP; CONS_11] THEN
+  STRIP_TAC THEN
+
+  MP_TAC(end_itlist CONJ (map (fun n -> READ_MEMORY_MERGE_CONV 4
+            (subst[mk_small_numeral(32*n),`n:num`]
+                  `read (memory :> bytes256(word_add zetas (word n))) s0`))
+            (0--38))) THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN
+  DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 a) s = x`] THEN
+  CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
+
+  FIRST_ASSUM(MP_TAC o check
+   (can (term_match [] `read (memory :> bytes256 (word_add zetas (word 64))) s0 = xxx`) o concl)) THEN
+  CONV_TAC(LAND_CONV(READ_MEMORY_SPLIT_CONV 2)) THEN
+  CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
+
+  MAP_EVERY (fun n -> X86_STEPS_TAC MLKEM_INTT_TMC_EXEC [n] THEN
+                      SIMD_SIMPLIFY_TAC[ntt_montmul; ntt_montmul_add; ntt_montmul_sub; barred_x86])
+        (1--663) THEN
+
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+
+  REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
+  CONV_RULE(SIMD_SIMPLIFY_CONV[]) o
+  CONV_RULE(READ_MEMORY_SPLIT_CONV 4) o
+  check (can (term_match [] `read qqq s:int256 = xxx`) o concl))) THEN
+
+  CONV_TAC(TOP_DEPTH_CONV EXPAND_CASES_CONV) THEN
+  CONV_TAC(DEPTH_CONV NUM_MULT_CONV THENC
+           DEPTH_CONV NUM_ADD_CONV) THEN
+  REWRITE_TAC[INT_ABS_BOUNDS; WORD_ADD_0] THEN
+  ASM_REWRITE_TAC[WORD_ADD_0] THEN
+
+  ASM_REWRITE_TAC[] THEN DISCARD_STATE_TAC "s663" THEN
+
+  REWRITE_TAC[WORD_BLAST `word_subword (x:int32) (0, 32) = x`] THEN
+  REWRITE_TAC[WORD_BLAST `word_subword (x:int64) (0, 64) = x`] THEN
+  REWRITE_TAC[WORD_BLAST
+   `word_subword (word_ushr (word_join (h:int16) (l:int16):int32) 16) (0, 16) = h`] THEN
+  REWRITE_TAC[WORD_BLAST
+   `word_subword (word_ushr (word_join (h:int32) (l:int32):int64) 32) (0, 32) = h`] THEN
+  REWRITE_TAC[WORD_BLAST
+    `word_subword (word_ushr (word_join (h:int32) (l:int32):int64) 32) (0, 16):int16 =
+     word_subword h (0, 16)`] THEN
+  REWRITE_TAC[WORD_BLAST
+    `word_subword (word_ushr (word_join (h:int32) (l:int32):int64) 32) (16, 16):int16 =
+     word_subword h (16, 16)`] THEN
+  REWRITE_TAC[WORD_BLAST
+    `word_subword (word_shl (word_subword (x:int32) (0, 32):int32) 16:int32) (16, 16):int16 =
+     word_subword x (0, 16)`] THEN
+  REWRITE_TAC[WORD_BLAST
+    `word_subword (word_shl (word_subword (x:int32) (0, 32):int32) 16:int32) (16, 16):int16 =
+     word_subword x (0, 16)`] THEN
+  REWRITE_TAC[WORD_BLAST
+    `word_subword (word_shl (x:int32) 16:int32) (16, 16):int16 =
+     word_subword x (0, 16)`] THEN
+  CONV_TAC(TOP_DEPTH_CONV WORD_SIMPLE_SUBWORD_CONV) THEN
+
+  CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
+  REWRITE_TAC[GSYM CONJ_ASSOC] THEN
+  REPEAT(GEN_REWRITE_TAC I
+   [TAUT `p /\ q /\ r /\ s <=> (p /\ q /\ r) /\ s`] THEN CONJ_TAC) THEN
+  POP_ASSUM_LIST(K ALL_TAC) THEN
+  (W(MP_TAC o CONGBOUND_RULE o rand o lhand o rator o lhand o snd) THEN
+   MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
+   [REWRITE_TAC[INVERSE_MOD_CONV `inverse_mod 3329 65536`] THEN
+    MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
+    CONV_TAC(ONCE_DEPTH_CONV AVX2_INVERSE_NTT_CONV) THEN
+    REWRITE_TAC[GSYM INT_REM_EQ; o_THM] THEN CONV_TAC INT_REM_DOWN_CONV THEN
+    REWRITE_TAC[INT_REM_EQ] THEN
+    REWRITE_TAC[REAL_INT_CONGRUENCE; INT_OF_NUM_EQ; ARITH_EQ] THEN
+    REWRITE_TAC[GSYM REAL_OF_INT_CLAUSES] THEN
+    CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN REAL_INTEGER_TAC;
+    MATCH_MP_TAC(INT_ARITH
+     `l':int <= l /\ u <= u'
+      ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
+    CONV_TAC INT_REDUCE_CONV])
+);;
+
+let MLKEM_INTT_NOIBT_SUBROUTINE_CORRECT  = prove
+  (`!a zetas (zetas_list:int16 list) x pc stackpointer returnaddress.
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc, LENGTH mlkem_intt_tmc) (a, 512) /\
+    nonoverlapping (word pc, LENGTH mlkem_intt_tmc) (zetas, 1248) /\
+    nonoverlapping (a, 512) (zetas, 1248) /\
+    nonoverlapping (a, 512) (stackpointer, 8) /\
+    nonoverlapping (zetas, 1248) (stackpointer, 8)
+    ==> ensures x86
+          (\s. bytes_loaded s (word pc) mlkem_intt_tmc /\
+              read RIP s = word pc /\
+              read RSP s = stackpointer /\
+              read (memory :> bytes64 stackpointer) s = returnaddress /\
+              C_ARGUMENTS [a; zetas] s /\
+              wordlist_from_memory(zetas, 624) s = MAP (iword: int -> 16 word) qdata_full /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add a (word(2 * i)))) s = x i))
+          (\s. read RIP s = returnaddress /\
+               read RSP s = word_add stackpointer (word 8) /\
+              (!i. i < 256
+                        ==> let zi =
+                      read(memory :> bytes16(word_add a (word(2 * i)))) s in
+                      (ival zi == avx2_inverse_ntt (ival o x) i) (mod &3329) /\
+                      abs(ival zi) <= &26632))
+          (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+           MAYCHANGE [memory :> bytes(a, 512)])`,
+  let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
+  CONV_TAC TWEAK_CONV THEN
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_intt_tmc (CONV_RULE TWEAK_CONV MLKEM_INTT_CORRECT));;
+
+let MLKEM_INTT_SUBROUTINE_CORRECT  = prove
+  (`!a zetas (zetas_list:int16 list) x pc stackpointer returnaddress.
+    aligned 32 a /\
+    aligned 32 zetas /\
+    nonoverlapping (word pc, LENGTH mlkem_intt_mc) (a, 512) /\
+    nonoverlapping (word pc, LENGTH mlkem_intt_mc) (zetas, 1248) /\
+    nonoverlapping (a, 512) (zetas, 1248) /\
+    nonoverlapping (a, 512) (stackpointer, 8) /\
+    nonoverlapping (zetas, 1248) (stackpointer, 8)
+    ==> ensures x86
+          (\s. bytes_loaded s (word pc) mlkem_intt_mc /\
+              read RIP s = word pc /\
+              read RSP s = stackpointer /\
+              read (memory :> bytes64 stackpointer) s = returnaddress /\
+              C_ARGUMENTS [a; zetas] s /\
+              wordlist_from_memory(zetas, 624) s = MAP (iword: int -> 16 word) qdata_full /\
+              (!i. i < 256 ==> read(memory :> bytes16(word_add a (word(2 * i)))) s = x i))
+          (\s. read RIP s = returnaddress /\
+               read RSP s = word_add stackpointer (word 8) /\
+              (!i. i < 256
+                        ==> let zi =
+                      read(memory :> bytes16(word_add a (word(2 * i)))) s in
+                      (ival zi == avx2_inverse_ntt (ival o x) i) (mod &3329) /\
+                      abs(ival zi) <= &26632))
+          (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+           MAYCHANGE [memory :> bytes(a, 512)])`,
+  let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
+  CONV_TAC TWEAK_CONV THEN
+  MATCH_ACCEPT_TAC(ADD_IBT_RULE
+  (CONV_RULE TWEAK_CONV MLKEM_INTT_NOIBT_SUBROUTINE_CORRECT)));;

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2413,6 +2413,13 @@ def gen_hol_light_asm():
             "-Imlkem/src/native/x86_64/src -Imlkem/src/common.h -mavx2 -mbmi2 -msse4 -fcf-protection=full",
             "x86",
         ),
+        (
+            "intt.S",
+            "mlkem_intt.S",
+            "dev/x86_64/src",
+            "-Imlkem/src/native/x86_64/src -Imlkem/src/common.h -mavx2 -mbmi2 -msse4 -fcf-protection=full",
+            "x86",
+        ),
     ]
 
     if platform.machine().lower() in ["arm64", "aarch64"]:


### PR DESCRIPTION
This commit adds the HOL-Light correctness proof of the x86_64 inverse NTT by @dkostic.

- Ported from https://github.com/awslabs/s2n-bignum/pull/315
- Resolves https://github.com/pq-code-package/mlkem-native/issues/1373
- Depends on #1374 

It also adds autogeneration of the embedded byte code and the constant twiddle factor array (qdata).
CBMC proofs that the contract implied by the HOL-Light proofs also fulfills the api.h contracts is not yet added - we will do that as a part of https://github.com/pq-code-package/mlkem-native/issues/1335.