### PR TITLE
CBMC: Add and prove x86_64 backend contracts

### DIFF
--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -7,66 +7,183 @@
 
 #include "../../../common.h"
 
-#include <immintrin.h>
 #include <stdint.h>
 #include "consts.h"
 
 #define MLK_AVX2_REJ_UNIFORM_BUFLEN \
   (3 * 168) /* REJ_UNIFORM_NBLOCKS * SHAKE128_RATE */
 
-#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
-MLK_MUST_CHECK_RETURN_VALUE
-uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
-                             const uint8_t *table);
-
 #define mlk_rej_uniform_table MLK_NAMESPACE(rej_uniform_table)
 extern const uint8_t mlk_rej_uniform_table[];
 
+#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
+MLK_MUST_CHECK_RETURN_VALUE
+uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
+                             const uint8_t *table)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_rej_uniform.ml. */
+__contract__(
+    requires(buflen % 12 == 0)
+    requires(memory_no_alias(buf, buflen))
+    requires(table == mlk_rej_uniform_table)
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+    ensures(return_value <= MLKEM_N)
+    ensures(array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
+);
+
 #define mlk_ntt_avx2 MLK_NAMESPACE(ntt_avx2)
-void mlk_ntt_avx2(int16_t *r, const int16_t *mlk_qdata);
+void mlk_ntt_avx2(int16_t *r, const int16_t *qdata)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_ntt.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  requires(array_abs_bound(r, 0, MLKEM_N, 8192))
+  requires(qdata == mlk_qdata)
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  /* check-magic: off */
+  ensures(array_abs_bound(r, 0, MLKEM_N, 23595))
+  /* check-magic: on */
+);
 
 #define mlk_invntt_avx2 MLK_NAMESPACE(invntt_avx2)
-void mlk_invntt_avx2(int16_t *r, const int16_t *mlk_qdata);
+void mlk_invntt_avx2(int16_t *r, const int16_t *qdata)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_intt.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  requires(qdata == mlk_qdata)
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  /* check-magic: off */
+  ensures(array_abs_bound(r, 0, MLKEM_N, 26632))
+  /* check-magic: on */
+);
 
 #define mlk_nttunpack_avx2 MLK_NAMESPACE(nttunpack_avx2)
-void mlk_nttunpack_avx2(int16_t *r);
+void mlk_nttunpack_avx2(int16_t *r)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_unpack.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  requires(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  /* Output is a permutation of input: every output coefficient
+   * is some input coefficient */
+  ensures(forall(i, 0, MLKEM_N, exists(j, 0, MLKEM_N,
+    r[i] == old(*(int16_t (*)[MLKEM_N])r)[j])))
+);
 
 #define mlk_reduce_avx2 MLK_NAMESPACE(reduce_avx2)
-void mlk_reduce_avx2(int16_t *r);
+void mlk_reduce_avx2(int16_t *r)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_reduce.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))
+);
 
 #define mlk_poly_mulcache_compute_avx2 MLK_NAMESPACE(poly_mulcache_compute_avx2)
 void mlk_poly_mulcache_compute_avx2(int16_t *out, const int16_t *in,
-                                    const int16_t *mlk_qdata);
+                                    const int16_t *qdata)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_mulcache_compute.ml */
+__contract__(
+  requires(memory_no_alias(out, sizeof(int16_t) * (MLKEM_N / 2)))
+  requires(memory_no_alias(in, sizeof(int16_t) * MLKEM_N))
+  requires(qdata == mlk_qdata)
+  assigns(memory_slice(out, sizeof(int16_t) * (MLKEM_N / 2)))
+  ensures(array_abs_bound(out, 0, MLKEM_N/2, MLKEM_Q))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
+    requires(array_abs_bound(a, 0, 2 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
+    requires(array_abs_bound(a, 0, 3 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
+    requires(array_abs_bound(a, 0, 4 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_ntttobytes_avx2 MLK_NAMESPACE(ntttobytes_avx2)
-void mlk_ntttobytes_avx2(uint8_t *r, const int16_t *a);
+void mlk_ntttobytes_avx2(uint8_t *r, const int16_t *a)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_tobytes.ml.
+ */
+__contract__(
+  requires(memory_no_alias(r, MLKEM_POLYBYTES))
+  requires(memory_no_alias(a, sizeof(int16_t) * MLKEM_N))
+  requires(array_bound(a, 0, MLKEM_N, 0, MLKEM_Q))
+  assigns(memory_slice(r, MLKEM_POLYBYTES))
+);
 
 #define mlk_nttfrombytes_avx2 MLK_NAMESPACE(nttfrombytes_avx2)
-void mlk_nttfrombytes_avx2(int16_t *r, const uint8_t *a);
+void mlk_nttfrombytes_avx2(int16_t *r, const uint8_t *a)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_frombytes.ml.
+ */
+__contract__(
+  requires(memory_no_alias(a, MLKEM_POLYBYTES))
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+);
 
 #define mlk_tomont_avx2 MLK_NAMESPACE(tomont_avx2)
-void mlk_tomont_avx2(int16_t *r);
+void mlk_tomont_avx2(int16_t *r)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_tomont.ml.
+ */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  ensures(array_abs_bound(r, 0, MLKEM_N, MLKEM_Q))
+);
 
 #define mlk_poly_compress_d4_avx2 MLK_NAMESPACE(poly_compress_d4_avx2)
 void mlk_poly_compress_d4_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],

--- a/mlkem/src/cbmc.h
+++ b/mlkem/src/cbmc.h
@@ -94,7 +94,7 @@
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==> (predicate)   \
   }
 
-#define EXISTS(qvar, qvar_lb, qvar_ub, predicate)         \
+#define exists(qvar, qvar_lb, qvar_ub, predicate)         \
   __CPROVER_exists                                              \
   {                                                             \
     unsigned qvar;                                              \

--- a/mlkem/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/src/native/x86_64/src/arith_native_x86_64.h
@@ -7,66 +7,183 @@
 
 #include "../../../common.h"
 
-#include <immintrin.h>
 #include <stdint.h>
 #include "consts.h"
 
 #define MLK_AVX2_REJ_UNIFORM_BUFLEN \
   (3 * 168) /* REJ_UNIFORM_NBLOCKS * SHAKE128_RATE */
 
-#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
-MLK_MUST_CHECK_RETURN_VALUE
-uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
-                             const uint8_t *table);
-
 #define mlk_rej_uniform_table MLK_NAMESPACE(rej_uniform_table)
 extern const uint8_t mlk_rej_uniform_table[];
 
+#define mlk_rej_uniform_asm MLK_NAMESPACE(rej_uniform_asm)
+MLK_MUST_CHECK_RETURN_VALUE
+uint64_t mlk_rej_uniform_asm(int16_t *r, const uint8_t *buf, unsigned buflen,
+                             const uint8_t *table)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_rej_uniform.ml. */
+__contract__(
+    requires(buflen % 12 == 0)
+    requires(memory_no_alias(buf, buflen))
+    requires(table == mlk_rej_uniform_table)
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+    ensures(return_value <= MLKEM_N)
+    ensures(array_bound(r, 0, (unsigned) return_value, 0, MLKEM_Q))
+);
+
 #define mlk_ntt_avx2 MLK_NAMESPACE(ntt_avx2)
-void mlk_ntt_avx2(int16_t *r, const int16_t *mlk_qdata);
+void mlk_ntt_avx2(int16_t *r, const int16_t *qdata)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_ntt.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  requires(array_abs_bound(r, 0, MLKEM_N, 8192))
+  requires(qdata == mlk_qdata)
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  /* check-magic: off */
+  ensures(array_abs_bound(r, 0, MLKEM_N, 23595))
+  /* check-magic: on */
+);
 
 #define mlk_invntt_avx2 MLK_NAMESPACE(invntt_avx2)
-void mlk_invntt_avx2(int16_t *r, const int16_t *mlk_qdata);
+void mlk_invntt_avx2(int16_t *r, const int16_t *qdata)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_intt.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  requires(qdata == mlk_qdata)
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  /* check-magic: off */
+  ensures(array_abs_bound(r, 0, MLKEM_N, 26632))
+  /* check-magic: on */
+);
 
 #define mlk_nttunpack_avx2 MLK_NAMESPACE(nttunpack_avx2)
-void mlk_nttunpack_avx2(int16_t *r);
+void mlk_nttunpack_avx2(int16_t *r)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_unpack.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  requires(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  /* Output is a permutation of input: every output coefficient
+   * is some input coefficient */
+  ensures(forall(i, 0, MLKEM_N, exists(j, 0, MLKEM_N,
+    r[i] == old(*(int16_t (*)[MLKEM_N])r)[j])))
+);
 
 #define mlk_reduce_avx2 MLK_NAMESPACE(reduce_avx2)
-void mlk_reduce_avx2(int16_t *r);
+void mlk_reduce_avx2(int16_t *r)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_reduce.ml */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))
+);
 
 #define mlk_poly_mulcache_compute_avx2 MLK_NAMESPACE(poly_mulcache_compute_avx2)
 void mlk_poly_mulcache_compute_avx2(int16_t *out, const int16_t *in,
-                                    const int16_t *mlk_qdata);
+                                    const int16_t *qdata)
+/* This must be kept in sync with the HOL-Light specification
+ * in proofs/hol_light/x86_64/proofs/mlkem_mulcache_compute.ml */
+__contract__(
+  requires(memory_no_alias(out, sizeof(int16_t) * (MLKEM_N / 2)))
+  requires(memory_no_alias(in, sizeof(int16_t) * MLKEM_N))
+  requires(qdata == mlk_qdata)
+  assigns(memory_slice(out, sizeof(int16_t) * (MLKEM_N / 2)))
+  ensures(array_abs_bound(out, 0, MLKEM_N/2, MLKEM_Q))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k2(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 2 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 2 * (MLKEM_N / 2)))
+    requires(array_abs_bound(a, 0, 2 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k3(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 3 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 3 * (MLKEM_N / 2)))
+    requires(array_abs_bound(a, 0, 3 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 \
   MLK_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4)
 void mlk_polyvec_basemul_acc_montgomery_cached_asm_k4(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
-                                                      const int16_t *b_cache);
+                                                      const int16_t *b_cache)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml.
+ */
+__contract__(
+    requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+    requires(memory_no_alias(a, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b, sizeof(int16_t) * 4 * MLKEM_N))
+    requires(memory_no_alias(b_cache, sizeof(int16_t) * 4 * (MLKEM_N / 2)))
+    requires(array_abs_bound(a, 0, 4 * MLKEM_N, MLKEM_UINT12_LIMIT + 1))
+    assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+);
 
 #define mlk_ntttobytes_avx2 MLK_NAMESPACE(ntttobytes_avx2)
-void mlk_ntttobytes_avx2(uint8_t *r, const int16_t *a);
+void mlk_ntttobytes_avx2(uint8_t *r, const int16_t *a)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_tobytes.ml.
+ */
+__contract__(
+  requires(memory_no_alias(r, MLKEM_POLYBYTES))
+  requires(memory_no_alias(a, sizeof(int16_t) * MLKEM_N))
+  requires(array_bound(a, 0, MLKEM_N, 0, MLKEM_Q))
+  assigns(memory_slice(r, MLKEM_POLYBYTES))
+);
 
 #define mlk_nttfrombytes_avx2 MLK_NAMESPACE(nttfrombytes_avx2)
-void mlk_nttfrombytes_avx2(int16_t *r, const uint8_t *a);
+void mlk_nttfrombytes_avx2(int16_t *r, const uint8_t *a)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_frombytes.ml.
+ */
+__contract__(
+  requires(memory_no_alias(a, MLKEM_POLYBYTES))
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_UINT12_LIMIT))
+);
 
 #define mlk_tomont_avx2 MLK_NAMESPACE(tomont_avx2)
-void mlk_tomont_avx2(int16_t *r);
+void mlk_tomont_avx2(int16_t *r)
+/* This must be kept in sync with the HOL-Light specification in
+ * proofs/hol_light/x86_64/proofs/mlkem_tomont.ml.
+ */
+__contract__(
+  requires(memory_no_alias(r, sizeof(int16_t) * MLKEM_N))
+  assigns(memory_slice(r, sizeof(int16_t) * MLKEM_N))
+  ensures(array_abs_bound(r, 0, MLKEM_N, MLKEM_Q))
+);
 
 #define mlk_poly_compress_d4_avx2 MLK_NAMESPACE(poly_compress_d4_avx2)
 void mlk_poly_compress_d4_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],

--- a/proofs/cbmc/intt_native_x86_64/Makefile
+++ b/proofs/cbmc/intt_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = intt_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = intt_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly.c $(SRCDIR)/mlkem/src/native/x86_64/src/consts.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_intt_native
+USE_FUNCTION_CONTRACTS=mlk_invntt_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = intt_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/intt_native_x86_64/intt_native_x86_64_harness.c
+++ b/proofs/cbmc/intt_native_x86_64/intt_native_x86_64_harness.c
@@ -1,0 +1,16 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+int mlk_intt_native(int16_t data[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r;
+  int t;
+  t = mlk_intt_native(r);
+}

--- a/proofs/cbmc/ntt_native_x86_64/Makefile
+++ b/proofs/cbmc/ntt_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = ntt_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = ntt_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly.c $(SRCDIR)/mlkem/src/native/x86_64/src/consts.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_ntt_native
+USE_FUNCTION_CONTRACTS=mlk_ntt_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = ntt_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/ntt_native_x86_64/ntt_native_x86_64_harness.c
+++ b/proofs/cbmc/ntt_native_x86_64/ntt_native_x86_64_harness.c
@@ -1,0 +1,16 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+int mlk_ntt_native(int16_t data[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r;
+  int t;
+  t = mlk_ntt_native(r);
+}

--- a/proofs/cbmc/nttunpack_native_x86_64/Makefile
+++ b/proofs/cbmc/nttunpack_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = nttunpack_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = nttunpack_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/indcpa.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_permute_bitrev_to_custom
+USE_FUNCTION_CONTRACTS=mlk_nttunpack_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = nttunpack_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/nttunpack_native_x86_64/nttunpack_native_x86_64_harness.c
+++ b/proofs/cbmc/nttunpack_native_x86_64/nttunpack_native_x86_64_harness.c
@@ -1,0 +1,20 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "cbmc.h"
+#include "params.h"
+
+void mlk_poly_permute_bitrev_to_custom(int16_t p[MLKEM_N]);
+
+void harness(void)
+{
+  {
+    /* Dummy use of `free` to work around CBMC issue #8814. */
+    free(NULL);
+  }
+  int16_t *r;
+  mlk_poly_permute_bitrev_to_custom(r);
+}

--- a/proofs/cbmc/poly_frombytes_native_x86_64/Makefile
+++ b/proofs/cbmc/poly_frombytes_native_x86_64/Makefile
@@ -1,0 +1,55 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_frombytes_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_frombytes_native_x86_64
+
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/compress.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_frombytes_native
+USE_FUNCTION_CONTRACTS=mlk_nttfrombytes_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
+FUNCTION_NAME = poly_frombytes_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_frombytes_native_x86_64/poly_frombytes_native_x86_64_harness.c
+++ b/proofs/cbmc/poly_frombytes_native_x86_64/poly_frombytes_native_x86_64_harness.c
@@ -1,0 +1,16 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include "compress.h"
+
+int mlk_poly_frombytes_native(int16_t r[MLKEM_N],
+                              const uint8_t a[MLKEM_POLYBYTES]);
+
+void harness(void)
+{
+  uint16_t *r;
+  uint8_t *a;
+  int t;
+  t = mlk_poly_frombytes_native(r, a);
+}

--- a/proofs/cbmc/poly_mulcache_compute_native_x86_64/Makefile
+++ b/proofs/cbmc/poly_mulcache_compute_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_mulcache_compute_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_mulcache_compute_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly.c  $(SRCDIR)/mlkem/src/native/x86_64/src/consts.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_mulcache_compute_native
+USE_FUNCTION_CONTRACTS=mlk_poly_mulcache_compute_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_mulcache_compute_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_mulcache_compute_native_x86_64/poly_mulcache_compute_native_x86_64_harness.c
+++ b/proofs/cbmc/poly_mulcache_compute_native_x86_64/poly_mulcache_compute_native_x86_64_harness.c
@@ -1,0 +1,17 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+int mlk_poly_mulcache_compute_native(int16_t cache[MLKEM_N / 2],
+                                     const int16_t mlk_poly[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r, *c;
+  int t;
+  t = mlk_poly_mulcache_compute_native(c, r);
+}

--- a/proofs/cbmc/poly_reduce_native_x86_64/Makefile
+++ b/proofs/cbmc/poly_reduce_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_reduce_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_reduce_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_reduce_native
+USE_FUNCTION_CONTRACTS=mlk_reduce_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_reduce_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_reduce_native_x86_64/poly_reduce_native_x86_64_harness.c
+++ b/proofs/cbmc/poly_reduce_native_x86_64/poly_reduce_native_x86_64_harness.c
@@ -1,0 +1,16 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+int mlk_poly_reduce_native(int16_t data[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r;
+  int t;
+  t = mlk_poly_reduce_native(r);
+}

--- a/proofs/cbmc/poly_tobytes_native_x86_64/Makefile
+++ b/proofs/cbmc/poly_tobytes_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_tobytes_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_tobytes_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_tobytes_native
+USE_FUNCTION_CONTRACTS=mlk_ntttobytes_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_tobytes_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_tobytes_native_x86_64/poly_tobytes_native_x86_64_harness.c
+++ b/proofs/cbmc/poly_tobytes_native_x86_64/poly_tobytes_native_x86_64_harness.c
@@ -1,0 +1,18 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+int mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
+                            const int16_t a[MLKEM_N]);
+
+void harness(void)
+{
+  uint8_t *r;
+  int16_t *a;
+  int t;
+  t = mlk_poly_tobytes_native(r, a);
+}

--- a/proofs/cbmc/poly_tomont_native_x86_64/Makefile
+++ b/proofs/cbmc/poly_tomont_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_tomont_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_tomont_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_poly_tomont_native
+USE_FUNCTION_CONTRACTS=mlk_tomont_avx2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = poly_tomont_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/poly_tomont_native_x86_64/poly_tomont_native_x86_64_harness.c
+++ b/proofs/cbmc/poly_tomont_native_x86_64/poly_tomont_native_x86_64_harness.c
@@ -1,0 +1,16 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+#include "params.h"
+
+int mlk_poly_tomont_native(int16_t p[MLKEM_N]);
+
+void harness(void)
+{
+  int16_t *r;
+  int t;
+  t = mlk_poly_tomont_native(r);
+}

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_x86_64/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_basemul_acc_montgomery_cached_k2_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_basemul_acc_montgomery_cached_k2_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS -DMLK_CONFIG_MULTILEVEL -DMLK_CONFIG_MULTILEVEL_WITH_SHARED
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly_k.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_k2_native
+USE_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_asm_k2 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvec_basemul_acc_montgomery_cached_k2_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_x86_64/polyvec_basemul_acc_montgomery_cached_k2_native_x86_64_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k2_native_x86_64/polyvec_basemul_acc_montgomery_cached_k2_native_x86_64_harness.c
@@ -1,0 +1,22 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+#include "cbmc.h"
+#include "common.h"
+
+int mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
+    int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
+    const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)]);
+
+void harness(void)
+{
+  int16_t *r;
+  const int16_t *a;
+  const int16_t *b;
+  const int16_t *b_cache;
+  int t;
+  t = mlk_polyvec_basemul_acc_montgomery_cached_k2_native(r, a, b, b_cache);
+}

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_x86_64/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_basemul_acc_montgomery_cached_k3_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_basemul_acc_montgomery_cached_k3_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS -DMLK_CONFIG_MULTILEVEL -DMLK_CONFIG_MULTILEVEL_WITH_SHARED
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly_k.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_k3_native
+USE_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_asm_k3 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvec_basemul_acc_montgomery_cached_k3_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_x86_64/polyvec_basemul_acc_montgomery_cached_k3_native_x86_64_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k3_native_x86_64/polyvec_basemul_acc_montgomery_cached_k3_native_x86_64_harness.c
@@ -1,0 +1,21 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+#include "cbmc.h"
+#include "common.h"
+
+int mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
+    int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
+    const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)]);
+void harness(void)
+{
+  int16_t *r;
+  const int16_t *a;
+  const int16_t *b;
+  const int16_t *b_cache;
+  int t;
+  t = mlk_polyvec_basemul_acc_montgomery_cached_k3_native(r, a, b, b_cache);
+}

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_x86_64/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = polyvec_basemul_acc_montgomery_cached_k4_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = polyvec_basemul_acc_montgomery_cached_k4_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS -DMLK_CONFIG_MULTILEVEL -DMLK_CONFIG_MULTILEVEL_WITH_SHARED
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly_k.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_k4_native
+USE_FUNCTION_CONTRACTS=mlk_polyvec_basemul_acc_montgomery_cached_asm_k4 mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = polyvec_basemul_acc_montgomery_cached_k4_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_x86_64/polyvec_basemul_acc_montgomery_cached_k4_native_x86_64_harness.c
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached_k4_native_x86_64/polyvec_basemul_acc_montgomery_cached_k4_native_x86_64_harness.c
@@ -1,0 +1,22 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+
+#include "cbmc.h"
+#include "common.h"
+
+int mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
+    int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
+    const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)]);
+
+void harness(void)
+{
+  int16_t *r;
+  const int16_t *a;
+  const int16_t *b;
+  const int16_t *b_cache;
+  int t;
+  t = mlk_polyvec_basemul_acc_montgomery_cached_k4_native(r, a, b, b_cache);
+}

--- a/proofs/cbmc/rej_uniform_native_x86_64/Makefile
+++ b/proofs/cbmc/rej_uniform_native_x86_64/Makefile
@@ -1,0 +1,57 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = rej_uniform_native_x86_64_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = rej_uniform_native_x86_64
+
+# We need to set MLK_CHECK_APIS as otherwise mlkem/src/native/api.h won't be
+# included, which contains the CBMC specifications.
+DEFINES += -DMLK_CONFIG_USE_NATIVE_BACKEND_ARITH -DMLK_CONFIG_ARITH_BACKEND_FILE="\"$(SRCDIR)/mlkem/src/native/x86_64/meta.h\"" -DMLK_CHECK_APIS
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/src/sampling.c $(SRCDIR)/mlkem/src/native/x86_64/src/rej_uniform_table.c
+
+CHECK_FUNCTION_CONTRACTS=mlk_rej_uniform_native
+USE_FUNCTION_CONTRACTS=mlk_rej_uniform_asm mlk_sys_check_capability
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = rej_uniform_native_x86_64
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/src/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/src/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/proofs/cbmc/rej_uniform_native_x86_64/rej_uniform_native_x86_64_harness.c
+++ b/proofs/cbmc/rej_uniform_native_x86_64/rej_uniform_native_x86_64_harness.c
@@ -1,0 +1,20 @@
+// Copyright (c) The mlkem-native project authors
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+#include <stdint.h>
+#include "cbmc.h"
+
+
+int mlk_rej_uniform_native(int16_t *r, unsigned len, const uint8_t *buf,
+                           unsigned buflen);
+
+void harness(void)
+{
+  int16_t *r;
+  unsigned len;
+  const uint8_t *buf;
+  unsigned buflen;
+
+  mlk_rej_uniform_native(r, len, buf, buflen);
+}

--- a/proofs/hol_light/x86_64/proofs/mlkem_frombytes.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_frombytes.ml
@@ -446,6 +446,9 @@ let MLKEM_FROMBYTES_NOIBT_SUBROUTINE_CORRECT = prove(
               MAYCHANGE [RSP] ,, MAYCHANGE [memory :> bytes(r, 512)])`,
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_frombytes_tmc MLKEM_FROMBYTES_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_FROMBYTES_SUBROUTINE_CORRECT = prove(
     `!r a (l:(12 word) list) pc.
         aligned 32 a /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_intt.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_intt.ml
@@ -1213,6 +1213,9 @@ let MLKEM_INTT_NOIBT_SUBROUTINE_CORRECT  = prove
   CONV_TAC TWEAK_CONV THEN
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_intt_tmc (CONV_RULE TWEAK_CONV MLKEM_INTT_CORRECT));;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_INTT_SUBROUTINE_CORRECT  = prove
   (`!a zetas (zetas_list:int16 list) x pc stackpointer returnaddress.
     aligned 32 a /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_mulcache_compute.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_mulcache_compute.ml
@@ -267,6 +267,9 @@ let MLKEM_MULCACHE_COMPUTE_NOIBT_SUBROUTINE_CORRECT  = prove(
   CONV_TAC TWEAK_CONV THEN
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_mulcache_compute_tmc (CONV_RULE TWEAK_CONV MLKEM_MULCACHE_COMPUTE_CORRECT));;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_MULCACHE_COMPUTE_SUBROUTINE_CORRECT = prove(
  `!r a zetas (zetas_list:int16 list) x pc stackpointer returnaddress.
     aligned 32 r /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_ntt.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_ntt.ml
@@ -1222,6 +1222,9 @@ let MLKEM_NTT_NOIBT_SUBROUTINE_CORRECT  = prove
   CONV_TAC TWEAK_CONV THEN
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_ntt_tmc (CONV_RULE TWEAK_CONV MLKEM_NTT_CORRECT));;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_NTT_SUBROUTINE_CORRECT  = prove
   (`!a zetas (zetas_list:int16 list) x pc stackpointer returnaddress.
     aligned 32 a /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k2.ml
@@ -1081,6 +1081,9 @@ let MLKEM_BASEMUL_K2_NOIBT_SUBROUTINE_CORRECT = prove(
                MAYCHANGE [memory :> bytes(dst, 512)])`,
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k2_tmc MLKEM_BASEMUL_K2_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_BASEMUL_K2_SUBROUTINE_CORRECT = prove(
   `!src1 src2 src2t dst a0 b0 c0 d0 dz0 a1 b1 c1 d1 dz1 pc stackpointer returnaddress.
         aligned 32 src1 /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
@@ -1551,6 +1551,9 @@ let MLKEM_BASEMUL_K3_NOIBT_SUBROUTINE_CORRECT = prove(
                MAYCHANGE [memory :> bytes(dst, 512)])`,
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k3_tmc MLKEM_BASEMUL_K3_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_BASEMUL_K3_SUBROUTINE_CORRECT = prove(
   `!src1 src2 src2t dst a0 b0 c0 d0 dz0 a1 b1 c1 d1 dz1 a2 b2 c2 d2 dz2 pc stackpointer returnaddress.
         aligned 32 src1 /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
@@ -2028,6 +2028,9 @@ let MLKEM_BASEMUL_K4_NOIBT_SUBROUTINE_CORRECT = prove(
                MAYCHANGE [memory :> bytes(dst, 512)])`,
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k4_tmc MLKEM_BASEMUL_K4_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_BASEMUL_K4_SUBROUTINE_CORRECT = prove(
   `!src1 src2 src2t dst a0 b0 c0 d0 dz0 a1 b1 c1 d1 dz1 a2 b2 c2 d2 dz2 a3 b3 c3 d3 dz3 pc stackpointer returnaddress.
         aligned 32 src1 /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_reduce.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_reduce.ml
@@ -421,6 +421,9 @@ let MLKEM_REDUCE_NOIBT_SUBROUTINE_CORRECT = prove
                MAYCHANGE [memory :> bytes(a, 512)])`,
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_reduce_tmc MLKEM_REDUCE_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_REDUCE_SUBROUTINE_CORRECT = prove
  (`!a x pc stackpointer returnaddress.
         aligned 32 a /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_rej_uniform.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_rej_uniform.ml
@@ -781,6 +781,9 @@ let MLKEM_REJ_UNIFORM_NOIBT_SUBROUTINE_CORRECT = prove
   X86_PROMOTE_RETURN_STACK_TAC mlkem_rej_uniform_tmc
     (CONV_RULE TWEAK_CONV MLKEM_REJ_UNIFORM_CORRECT) `[]` 528);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_REJ_UNIFORM_SUBROUTINE_CORRECT = prove
  (`!res buf buflen table (inlist:(12 word)list) pc stackpointer returnaddress.
       12 divides val buflen /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_tobytes.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_tobytes.ml
@@ -404,6 +404,9 @@ let MLKEM_TOBYTES_NOIBT_SUBROUTINE_CORRECT = prove
                MAYCHANGE [memory :> bytes(r, 384)])`,
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_tobytes_tmc MLKEM_TOBYTES_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_TOBYTES_SUBROUTINE_CORRECT = prove
 (`!r a (l:int16 list) pc.
         aligned 32 a /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_tomont.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_tomont.ml
@@ -311,6 +311,9 @@ let MLKEM_TOMONT_NOIBT_SUBROUTINE_CORRECT = prove(
               MAYCHANGE [memory :> bytes(a,512)])`, 
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_tomont_tmc MLKEM_TOMONT_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_TOMONT_SUBROUTINE_CORRECT = prove(
   `!a x pc stackpointer returnaddress.
         aligned 32 a /\

--- a/proofs/hol_light/x86_64/proofs/mlkem_unpack.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_unpack.ml
@@ -384,6 +384,9 @@ let MLKEM_UNPACK_NOIBT_SUBROUTINE_CORRECT = prove(
               MAYCHANGE [memory :> bytes(a, 512)])`, 
   X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_unpack_tmc MLKEM_UNPACK_CORRECT);;
 
+(* NOTE: This must be kept in sync with the CBMC specification
+ * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
+
 let MLKEM_UNPACK_SUBROUTINE_CORRECT = prove(
     `!a (l:int16 list) pc.
         aligned 32 a /\

--- a/scripts/check-contracts
+++ b/scripts/check-contracts
@@ -45,7 +45,7 @@ def is_exception(funcname):
     if funcname == 'poly_permute_bitrev_to_custom':
         return True
 
-    if funcname.endswith("_native") or funcname.endswith("_asm"):
+    if funcname.endswith("_native") or funcname.endswith("_asm") or funcname.endswith("avx2"):
         # CBMC proofs are axiomatized against contracts of the backends
         return True
 


### PR DESCRIPTION
- Resolves: #1335 
- Rebased on #1432, tomont isn't actually use mlk_qdata.
- This PR also added proof corresponding these two hol-light: https://github.com/pq-code-package/mlkem-native/pull/1418
- This commit introduces CBMC verification for several x86-64 assembly functions. The contracts for these functions are derived from their corresponding HOL-Light correctness proofs.

- The following functions now have CBMC proofs based on their
  HOL-Light specifications:

  - polyvec_basemul_acc_montgomery_cached_asm_k2/k3/k4:
    - Pre-conditions:
      `<= &2 pow 12`(HOL_LIGHT) v.s. `MLKEM_UINT12_LIMIT + 1`(CBMC)
    - Adds a CBMC pre-condition:
      `requires(array_abs_bound(a, 0, 4 * MLKEM_N, MLKEM_UINT12_LIMIT +`
                                                                   `1))`
  - ntt_avx2:
    - Pre-condition:
      `<= &8191`(HOL_LIGHT) v.s. `8191 + 1`(CBMC)
    - Post-condition:
      `<= &23594`(HOL_LIGHT) v.s. `23594 + 1`(CBMC)
    - Adds a CBMC pre-condition:
      `requires(array_abs_bound(r, 0, MLKEM_N, 8192))`
    - Adds a CBMC post-condition:
      `ensures(array_abs_bound(r, 0, MLKEM_N, 23595))`

  - intt_avx2:
    - Post-condition:
      `<= &26631` v.s. `26631 + 1`(CBMC)
    - Adds a CBMC post-condition:
      `ensures(array_abs_bound(r, 0, MLKEM_N, 26632))`

   - reduce_avx2:
     - Post-condition:
       `< &3329`(HOL_LIGHT) v.s. `3329 == MLKEM_Q`(CBMC)
     - Adds a CBMC post-condition:
       `ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))`

   - tobytes_avx2:
     - Pre-condition:
       `(!i. i < LENGTH l ==> val(EL i l) < 3329)`(HOL_LIGHT)
       v.s.
       `MLKEM_UINT12_LIMIT`(CBMC)
     - Adds a CBMC pre-condition:
       `requires(array_bound(a, 0, MLKEM_N, 0, MLKEM_Q))`

   - frombytes_avx2:
     - Post-conditions:
       `read (memory :> bytes(a,dimindex(:32) * 12)) s0 =
                                      num_of_wordlist (l:(12 word)list)`
     - Adds a CBMC post-condition:
       `ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_UINT12_LIMIT))`

   - mlk_rej_uniform_asm:
     - This proof are reference from aarch64 one, and change requires:
       `requires(buflen % 24 == 0)` to `requires(buflen % 12 == 0)`

   - mlk_tomont_avx2:
     - Post conditions:
       `(ival z_i == (tomont_3329 (ival o x)) i) (mod &3329) /\
                        abs(ival z_i) <= &3328)`
       v.s.
       `ensures(array_abs_bound(r, 0, MLKEM_N, MLKEM_Q))`
     - Add a CBMC post-condition:
       `ensures(array_abs_bound(r, 0, MLKEM_N, 3328 + 1))`

   - mlk_poly_mulcache_compute_avx2:
     - Post conditions:
        ```
         read(memory :> bytes16(word_add r (word(2 * i)))) s in
                      (ival zi == avx2_mulcache (ival o x) i) (mod &3329) /\
                      (abs(ival zi) <= &3328))
         ```
        v.s.
        `ensures(array_abs_bound(cache, 0, MLKEM_N/2, MLKEM_Q))`
        Add a CBMC post-condition:
        `ensures(array_abs_bound(out, 0, MLKEM_N/2, 3329))`

   - mlk_nttunpack_avx2:                                                
     - Pre-condition:                                                   
       `read(memory :> bytes(a, 512)) s = num_of_wordlist (unpermute_list l)))`
       v.s.                                                             
       `requires(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))`               
     - Post-condition:                                                  
       `read(memory :> bytes(a, 512)) s = num_of_wordlist (unpermute_list l)))`            
       v.s.                                                             
       `ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))`                
     - Add CBMC pre-condition and post-condition:                       
       `requires(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))`               
       `ensures(array_bound(r, 0, MLKEM_N, 0, MLKEM_Q))`                