### PR TITLE
Fix pointer cleanup on dynamic allocation failure

### DIFF
--- a/mlkem/src/common.h
+++ b/mlkem/src/common.h
@@ -187,12 +187,15 @@
 /* Custom allocation */
 
 #define MLK_ALLOC(v, T, N) MLK_CUSTOM_ALLOC(v, T, N)
-#define MLK_FREE(v, T, N)            \
-  do                                 \
-  {                                  \
-    mlk_zeroize(v, sizeof(T) * (N)); \
-    MLK_CUSTOM_FREE(v, T, N);        \
-    v = NULL;                        \
+#define MLK_FREE(v, T, N)              \
+  do                                   \
+  {                                    \
+    if (v != NULL)                     \
+    {                                  \
+      mlk_zeroize(v, sizeof(T) * (N)); \
+      MLK_CUSTOM_FREE(v, T, N);        \
+      v = NULL;                        \
+    }                                  \
   } while (0)
 
 #endif /* MLK_CONFIG_CUSTOM_ALLOC_FREE */


### PR DESCRIPTION
When using a custom alloc/free implementation, allocation may fail, in which case the cleanup section needs to zeroize and free those pointers there were successfully allocated, and skip those for which allocation failed. This skipping of failed allocations is not implemented correctly and would lead to a null pointer dereference.

This commit fixes this.

This highlights the need to cover custom alloc/free in CBMC, which we currently don't. Of course, we cannot know what exact custom implementation a consumer uses, but we should strive to cover at least a standard alloc/free based one.