### PR TITLE
Refactor: move acvp test source and data into test/acvp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 test/build
 __pycache__/
 # Downloaded ACVP test data
-test/.acvp-data/
+test/acvp/.acvp-data/

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ run_unit_1024: unit_1024
 run_unit: run_unit_512 run_unit_768 run_unit_1024
 
 run_acvp: acvp
-	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/acvp_client.py $(if $(ACVP_VERSION),--version $(ACVP_VERSION))
+	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/acvp/acvp_client.py $(if $(ACVP_VERSION),--version $(ACVP_VERSION))
 
 func_512:  $(MLKEM512_DIR)/bin/test_mlkem512
 	$(Q)echo "  FUNC       ML-KEM-512:   $^"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [dev/README.md](dev/README.md) for more details.
 
 mlkem-native is tested against all official ACVP ML-KEM test vectors[^ACVP].
 
-You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP client](./test/acvp_client.py) directly:
+You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP client](./test/acvp/acvp_client.py) directly:
 
 ```bash
 # Using the tests script
@@ -109,15 +109,15 @@ You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP 
 ./scripts/tests acvp --version v1.1.0.41
 
 # Using the ACVP client directly
-python3 ./test/acvp_client.py
-python3 ./test/acvp_client.py --version v1.1.0.41
+python3 ./test/acvp/acvp_client.py
+python3 ./test/acvp/acvp_client.py --version v1.1.0.41
 
 # Using specific ACVP test vector files (downloaded from the ACVP-Server)
-# python3 ./test/acvp_client.py -p {PROMPT}.json -e {EXPECTED_RESULT}.json
+# python3 ./test/acvp/acvp_client.py -p {PROMPT}.json -e {EXPECTED_RESULT}.json
 # For example, assuming you have run the above
-python3 ./test/acvp_client.py \
-  -p ./test/.acvp-data/v1.1.0.41/files/ML-KEM-keyGen-FIPS203/prompt.json \
-  -e ./test/.acvp-data/v1.1.0.41/files/ML-KEM-keyGen-FIPS203/expectedResults.json
+python3 ./test/acvp/acvp_client.py \
+  -p ./test/acvp/.acvp-data/v1.1.0.41/files/ML-KEM-keyGen-FIPS203/prompt.json \
+  -e ./test/acvp/.acvp-data/v1.1.0.41/files/ML-KEM-keyGen-FIPS203/expectedResults.json
 ```
 
 ## Benchmarking

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -33,7 +33,7 @@ def download_acvp_files(version):
     ]
 
     # Create directory structure
-    data_dir = Path(f"test/.acvp-data/{version}/files")
+    data_dir = Path(f"test/acvp/.acvp-data/{version}/files")
     data_dir.mkdir(parents=True, exist_ok=True)
 
     for file_path in files_to_download:
@@ -76,7 +76,7 @@ def loadAcvpData(prompt, expectedResults):
 
 def loadDefaultAcvpData(version):
 
-    data_dir = f"test/.acvp-data/{version}/files"
+    data_dir = f"test/acvp/.acvp-data/{version}/files"
     acvp_jsons_for_version = [
         (
             f"{data_dir}/ML-KEM-keyGen-FIPS203/prompt.json",

--- a/test/acvp/acvp_mlkem.c
+++ b/test/acvp/acvp_mlkem.c
@@ -6,9 +6,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../mlkem/src/common.h"
+#include "../../mlkem/src/common.h"
 
-#include "../mlkem/src/kem.h"
+#include "../../mlkem/src/kem.h"
 
 #define USAGE \
   "acvp_mlkem{lvl} [encapDecap|keyGen] [AFT|VAL] {test specific arguments}"

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -120,7 +120,7 @@ endef
 
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
 	$(foreach test,$(ACVP_TESTS), \
-		$(eval $(call ADD_SOURCE,$(scheme),$(test),)) \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),acvp/)) \
 	) \
 	$(foreach test,$(BENCH_TESTS), \
 		$(eval $(call ADD_SOURCE,$(scheme),$(test),)) \


### PR DESCRIPTION
- Resolves: #1367
- Based on: #1401 

- This PR move acvp source and data from `test/` to `test/acvp`