### PR TITLE
Refactor: Move benchmarking sources to test/bench/

### DIFF
--- a/test/bench/bench_components_mlkem.c
+++ b/test/bench/bench_components_mlkem.c
@@ -7,16 +7,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../mlkem/src/kem.h"
-#include "../mlkem/src/randombytes.h"
-#include "../mlkem/src/sampling.h"
+#include "../../mlkem/src/kem.h"
+#include "../../mlkem/src/randombytes.h"
+#include "../../mlkem/src/sampling.h"
 #include "hal.h"
 
-#include "../mlkem/src/fips202/fips202.h"
-#include "../mlkem/src/fips202/keccakf1600.h"
-#include "../mlkem/src/indcpa.h"
-#include "../mlkem/src/poly.h"
-#include "../mlkem/src/poly_k.h"
+#include "../../mlkem/src/fips202/fips202.h"
+#include "../../mlkem/src/fips202/keccakf1600.h"
+#include "../../mlkem/src/indcpa.h"
+#include "../../mlkem/src/poly.h"
+#include "../../mlkem/src/poly_k.h"
 
 #define NWARMUP 50
 #define NITERATIONS 300

--- a/test/bench/bench_mlkem.c
+++ b/test/bench/bench_mlkem.c
@@ -7,11 +7,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../mlkem/src/common.h"
-#include "../mlkem/src/randombytes.h"
+#include "../../mlkem/src/common.h"
+#include "../../mlkem/src/randombytes.h"
 #include "hal.h"
 
-#include "../mlkem/mlkem_native.h"
+#include "../../mlkem/mlkem_native.h"
 
 #define NWARMUP 50
 #define NITERATIONS 300

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -103,7 +103,7 @@ $(MLKEM1024_DIR)/bin/%: CFLAGS += -DMLK_CONFIG_PARAMETER_SET=1024
 # Link tests with respective library (except test_unit which includes sources directly)
 define ADD_SOURCE
 $(BUILD_DIR)/$(1)/bin/$(2)$(subst mlkem,,$(1)): LDLIBS += -L$(BUILD_DIR) -l$(1)
-$(BUILD_DIR)/$(1)/bin/$(2)$(subst mlkem,,$(1)): $(BUILD_DIR)/$(1)/test/$(3)$(2).c.o $(BUILD_DIR)/lib$(1).a
+$(BUILD_DIR)/$(1)/bin/$(2)$(subst mlkem,,$(1)): $(BUILD_DIR)/$(1)/test/$(3)/$(2).c.o $(BUILD_DIR)/lib$(1).a
 endef
 
 # Special rule for test_unit - link against unit libraries with exposed internal functions
@@ -120,13 +120,13 @@ endef
 
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
 	$(foreach test,$(ACVP_TESTS), \
-		$(eval $(call ADD_SOURCE,$(scheme),$(test),acvp/)) \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),acvp)) \
 	) \
 	$(foreach test,$(BENCH_TESTS), \
-		$(eval $(call ADD_SOURCE,$(scheme),$(test),)) \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),bench)) \
 	) \
 	$(foreach test,$(BASIC_TESTS), \
-		$(eval $(call ADD_SOURCE,$(scheme),$(test),src/)) \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),src)) \
 	) \
 	$(eval $(call ADD_SOURCE_UNIT,$(scheme))) \
 	$(eval $(call ADD_SOURCE_ALLOC,$(scheme))) \


### PR DESCRIPTION
- Resolves: #1368
- Based on: #1414

- This PR move the bench functional and test files from `test/` to `test/bench/`