### PR TITLE
tests/CBMC: Specify parameter set with -k/--mlkem-parameter-set

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -53,5 +53,5 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           echo "::group::cbmc_${{ inputs.mlkem_k }}"
-          tests cbmc --k ${{ inputs.mlkem_k }} --per-proof-timeout 1800;
+          tests cbmc --mlkem-parameter-set ${{ inputs.mlkem_k }} --per-proof-timeout 1800;
           echo "::endgroup::"

--- a/scripts/tests
+++ b/scripts/tests
@@ -931,7 +931,7 @@ class Tests:
             if p.returncode != 0:
                 self.fail(f"CBMC proofs for k={mlkem_k}")
 
-        k = self.args.k
+        k = self.args.mlkem_parameter_set
         if k == "ALL":
             run_cbmc("2")
             run_cbmc("3")
@@ -1269,7 +1269,8 @@ def cli():
     )
 
     cbmc_parser.add_argument(
-        "--k",
+        "-k",
+        "--mlkem-parameter-set",
         help="Value of MLKEM_K, determining the parameter set",
         choices=["2", "3", "4", "ALL"],
         type=str.upper,


### PR DESCRIPTION
Switching short-form from `--k` to `-k` and adding long-form `--mlkem-parameter-set`.