### PR TITLE
Add test for failing dynamic allocation

### DIFF
--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -66,6 +66,7 @@ source code and documentation.
   - [test/custom_zeroize_config.h](test/custom_zeroize_config.h)
   - [test/no_asm_config.h](test/no_asm_config.h)
   - [test/serial_fips202_config.h](test/serial_fips202_config.h)
+  - [test/test_alloc_config.h](test/test_alloc_config.h)
 
 ### `FIPS202`
 
@@ -126,6 +127,7 @@ source code and documentation.
   - [test/custom_zeroize_config.h](test/custom_zeroize_config.h)
   - [test/no_asm_config.h](test/no_asm_config.h)
   - [test/serial_fips202_config.h](test/serial_fips202_config.h)
+  - [test/test_alloc_config.h](test/test_alloc_config.h)
 
 ### `HYBRID`
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-.PHONY: func kat acvp stack \
-	func_512 kat_512 acvp_512 stack_512 \
-	func_768 kat_768 acvp_768 stack_768 \
-	func_1024 kat_1024 acvp_1024 stack_1024 \
-	run_func run_kat run_acvp run_stack \
-	run_func_512 run_kat_512 run_stack_512 \
-	run_func_768 run_kat_768 run_stack_768 \
-	run_func_1024 run_kat_1024 run_stack_1024 \
+.PHONY: func kat acvp stack alloc \
+	func_512 kat_512 acvp_512 stack_512 alloc_512 \
+	func_768 kat_768 acvp_768 stack_768 alloc_768 \
+	func_1024 kat_1024 acvp_1024 stack_1024 alloc_1024 \
+	run_func run_kat run_acvp run_stack run_alloc \
+	run_func_512 run_kat_512 run_stack_512 run_alloc_512 \
+	run_func_768 run_kat_768 run_stack_768 run_alloc_768 \
+	run_func_1024 run_kat_1024 run_stack_1024 run_alloc_1024 \
 	bench_512 bench_768 bench_1024 bench \
 	run_bench_512 run_bench_768 run_bench_1024 run_bench \
 	bench_components_512 bench_components_768 bench_components_1024 bench_components \
@@ -47,7 +47,7 @@ quickcheck: test
 build: func kat acvp
 	$(Q)echo "  Everything builds fine!"
 
-test: run_kat run_func run_acvp run_unit
+test: run_kat run_func run_acvp run_unit run_alloc
 	$(Q)echo "  Everything checks fine!"
 
 # Detect available SHA256 command
@@ -139,6 +139,22 @@ run_stack_768: stack_768
 run_stack_1024: stack_1024
 	$(Q)python3 scripts/stack $(MLKEM1024_DIR)/bin/test_stack1024 --build-dir $(MLKEM1024_DIR) $(STACK_ANALYSIS_FLAGS)
 run_stack: run_stack_512 run_stack_768 run_stack_1024
+
+alloc_512: $(MLKEM512_DIR)/bin/test_alloc512
+	$(Q)echo "  ALLOC      ML-KEM-512:   $^"
+alloc_768: $(MLKEM768_DIR)/bin/test_alloc768
+	$(Q)echo "  ALLOC      ML-KEM-768:   $^"
+alloc_1024: $(MLKEM1024_DIR)/bin/test_alloc1024
+	$(Q)echo "  ALLOC      ML-KEM-1024:  $^"
+alloc: alloc_512 alloc_768 alloc_1024
+
+run_alloc_512: alloc_512
+	$(W) $(MLKEM512_DIR)/bin/test_alloc512
+run_alloc_768: alloc_768
+	$(W) $(MLKEM768_DIR)/bin/test_alloc768
+run_alloc_1024: alloc_1024
+	$(W) $(MLKEM1024_DIR)/bin/test_alloc1024
+run_alloc: run_alloc_512 run_alloc_768 run_alloc_1024
 
 lib: $(BUILD_DIR)/libmlkem.a $(BUILD_DIR)/libmlkem512.a $(BUILD_DIR)/libmlkem768.a $(BUILD_DIR)/libmlkem1024.a
 

--- a/mlkem/src/indcpa.c
+++ b/mlkem/src/indcpa.c
@@ -455,13 +455,13 @@ int mlk_indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
 cleanup:
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(buf, uint8_t, 2 * MLKEM_SYMBYTES);
-  MLK_FREE(coins_with_domain_separator, uint8_t, MLKEM_SYMBYTES + 1);
-  MLK_FREE(a, mlk_polymat, 1);
-  MLK_FREE(e, mlk_polyvec, 1);
-  MLK_FREE(pkpv, mlk_polyvec, 1);
-  MLK_FREE(skpv, mlk_polyvec, 1);
   MLK_FREE(skpv_cache, mlk_polyvec_mulcache, 1);
+  MLK_FREE(skpv, mlk_polyvec, 1);
+  MLK_FREE(pkpv, mlk_polyvec, 1);
+  MLK_FREE(e, mlk_polyvec, 1);
+  MLK_FREE(a, mlk_polymat, 1);
+  MLK_FREE(coins_with_domain_separator, uint8_t, MLKEM_SYMBYTES + 1);
+  MLK_FREE(buf, uint8_t, 2 * MLKEM_SYMBYTES);
   return ret;
 }
 
@@ -554,16 +554,16 @@ int mlk_indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
 cleanup:
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(seed, uint8_t, MLKEM_SYMBYTES);
-  MLK_FREE(at, mlk_polymat, 1);
-  MLK_FREE(sp, mlk_polyvec, 1);
-  MLK_FREE(pkpv, mlk_polyvec, 1);
-  MLK_FREE(ep, mlk_polyvec, 1);
-  MLK_FREE(b, mlk_polyvec, 1);
-  MLK_FREE(v, mlk_poly, 1);
-  MLK_FREE(k, mlk_poly, 1);
-  MLK_FREE(epp, mlk_poly, 1);
   MLK_FREE(sp_cache, mlk_polyvec_mulcache, 1);
+  MLK_FREE(epp, mlk_poly, 1);
+  MLK_FREE(k, mlk_poly, 1);
+  MLK_FREE(v, mlk_poly, 1);
+  MLK_FREE(b, mlk_polyvec, 1);
+  MLK_FREE(ep, mlk_polyvec, 1);
+  MLK_FREE(pkpv, mlk_polyvec, 1);
+  MLK_FREE(sp, mlk_polyvec, 1);
+  MLK_FREE(at, mlk_polymat, 1);
+  MLK_FREE(seed, uint8_t, MLKEM_SYMBYTES);
   return ret;
 }
 
@@ -604,11 +604,11 @@ int mlk_indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
 cleanup:
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(b, mlk_polyvec, 1);
-  MLK_FREE(skpv, mlk_polyvec, 1);
-  MLK_FREE(v, mlk_poly, 1);
-  MLK_FREE(sb, mlk_poly, 1);
   MLK_FREE(b_cache, mlk_polyvec_mulcache, 1);
+  MLK_FREE(sb, mlk_poly, 1);
+  MLK_FREE(v, mlk_poly, 1);
+  MLK_FREE(skpv, mlk_polyvec, 1);
+  MLK_FREE(b, mlk_polyvec, 1);
   return ret;
 }
 

--- a/mlkem/src/kem.c
+++ b/mlkem/src/kem.c
@@ -64,8 +64,8 @@ int crypto_kem_check_pk(const uint8_t pk[MLKEM_INDCCA_PUBLICKEYBYTES])
 cleanup:
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(p, mlk_polyvec, 1);
   MLK_FREE(p_reencoded, uint8_t, MLKEM_POLYVECBYTES);
+  MLK_FREE(p, mlk_polyvec, 1);
   return ret;
 }
 
@@ -177,9 +177,9 @@ cleanup:
 
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(ct, uint8_t, MLKEM_INDCCA_CIPHERTEXTBYTES);
-  MLK_FREE(ss_enc, uint8_t, MLKEM_SSBYTES);
   MLK_FREE(ss_dec, uint8_t, MLKEM_SSBYTES);
+  MLK_FREE(ss_enc, uint8_t, MLKEM_SSBYTES);
+  MLK_FREE(ct, uint8_t, MLKEM_INDCCA_CIPHERTEXTBYTES);
   return ret;
 }
 #else  /* MLK_CONFIG_KEYGEN_PCT */
@@ -305,8 +305,8 @@ int crypto_kem_enc_derand(uint8_t ct[MLKEM_INDCCA_CIPHERTEXTBYTES],
 cleanup:
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(buf, uint8_t, 2 * MLKEM_SYMBYTES);
   MLK_FREE(kr, uint8_t, 2 * MLKEM_SYMBYTES);
+  MLK_FREE(buf, uint8_t, 2 * MLKEM_SYMBYTES);
   return ret;
 }
 
@@ -402,9 +402,9 @@ int crypto_kem_dec(uint8_t ss[MLKEM_SSBYTES],
 cleanup:
   /* Specification: Partially implements
    * @[FIPS203, Section 3.3, Destruction of intermediate values] */
-  MLK_FREE(buf, uint8_t, 2 * MLKEM_SYMBYTES);
-  MLK_FREE(kr, uint8_t, 2 * MLKEM_SYMBYTES);
   MLK_FREE(tmp, uint8_t, MLKEM_SYMBYTES + MLKEM_INDCCA_CIPHERTEXTBYTES);
+  MLK_FREE(kr, uint8_t, 2 * MLKEM_SYMBYTES);
+  MLK_FREE(buf, uint8_t, 2 * MLKEM_SYMBYTES);
 
   return ret;
 }

--- a/test/configs.yml
+++ b/test/configs.yml
@@ -425,3 +425,21 @@ configs:
           #endif /* !__ASSEMBLER__ */
       MLK_CONFIG_FILE:
         comment: "/* No need to set this -- we _are_ already in a custom config */"
+
+  - path: test/test_alloc_config.h
+    description: "Using custom allocation that can be made fail at specific invocation"
+    defines:
+      MLK_CONFIG_NAMESPACE_PREFIX: mlk
+      MLK_CONFIG_KEYGEN_PCT: true
+      MLK_CONFIG_CUSTOM_ALLOC_FREE:
+        content: |
+          #define MLK_CONFIG_CUSTOM_ALLOC_FREE
+          #if !defined(__ASSEMBLER__)
+          #include <stdlib.h>
+          void * custom_alloc(size_t sz, const char *file, int line, const char *var, const char *type);
+          void custom_free(void *p, size_t sz, const char *file, int line, const char *var, const char *type);
+          #define MLK_CUSTOM_ALLOC(v, T, N) T *v = custom_alloc(sizeof(T)*(N), __FILE__, __LINE__, #v, #T)
+          #define MLK_CUSTOM_FREE(v, T, N) custom_free(v, sizeof(T)*(N), __FILE__, __LINE__, #v, #T)
+          #endif /* !__ASSEMBLER__ */
+      MLK_CONFIG_FILE:
+        comment: "/* No need to set this -- we _are_ already in a custom config */"

--- a/test/mk/rules.mk
+++ b/test/mk/rules.mk
@@ -81,3 +81,33 @@ $(BUILD_DIR)/mlkem1024/unit/%.S.o: %.S $(CONFIG)
 	$(Q)echo "  AS      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BUILD_DIR)/mlkem512/alloc/%.c.o: %.c $(CONFIG)
+	$(Q)echo "  CC      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BUILD_DIR)/mlkem512/alloc/%.S.o: %.S $(CONFIG)
+	$(Q)echo "  AS      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BUILD_DIR)/mlkem768/alloc/%.c.o: %.c $(CONFIG)
+	$(Q)echo "  CC      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BUILD_DIR)/mlkem768/alloc/%.S.o: %.S $(CONFIG)
+	$(Q)echo "  AS      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BUILD_DIR)/mlkem1024/alloc/%.c.o: %.c $(CONFIG)
+	$(Q)echo "  CC      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
+
+$(BUILD_DIR)/mlkem1024/alloc/%.S.o: %.S $(CONFIG)
+	$(Q)echo "  AS      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<

--- a/test/test_alloc.c
+++ b/test/test_alloc.c
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Expose declaration of allocator (normally internal) */
+#define MLK_BUILD_INTERNAL
+#include "../mlkem/mlkem_native.h"
+#include "notrandombytes/notrandombytes.h"
+
+/*
+ * This test checks that
+ * - we handle allocator failures correctly, propagating MLK_ERR_OUT_OF_MEMORY
+ *   and cleaning up all memory, and
+ * - we leak no memory, and
+ * - we always de-allocate in the reverse order of allocation, thereby
+ *   allowing the use of a bump allocator.
+ *
+ * This is done through a custom bump allocator and tracking of in-flight
+ * allocations.
+ */
+
+/*
+ * Allocation tracker
+ *
+ * Simple stack of in-flight allocations that's used to test that there are
+ * no leaks and that we free in reverse order than we allocate. (The absence
+ * of leaks is also checked through the address sanitizer)
+ */
+
+typedef struct
+{
+  void *addr;
+  size_t size;
+  const char *file;
+  int line;
+  const char *var;
+  const char *type;
+} alloc_info_t;
+
+#define MLK_MAX_IN_FLIGHT_ALLOCS 100
+static alloc_info_t alloc_stack[MLK_MAX_IN_FLIGHT_ALLOCS];
+static int alloc_stack_top = 0;
+
+static void alloc_tracker_push(void *addr, size_t size, const char *file,
+                               int line, const char *var, const char *type)
+{
+  if (alloc_stack_top >= MLK_MAX_IN_FLIGHT_ALLOCS)
+  {
+    fprintf(stderr, "ERROR: Allocation stack overflow\n");
+    exit(1);
+  }
+  alloc_stack[alloc_stack_top].addr = addr;
+  alloc_stack[alloc_stack_top].size = size;
+  alloc_stack[alloc_stack_top].file = file;
+  alloc_stack[alloc_stack_top].line = line;
+  alloc_stack[alloc_stack_top].var = var;
+  alloc_stack[alloc_stack_top].type = type;
+  alloc_stack_top++;
+}
+
+static void alloc_tracker_pop(void *addr, size_t size, const char *file,
+                              int line, const char *var)
+{
+  alloc_info_t *top;
+  if (alloc_stack_top == 0)
+  {
+    fprintf(
+        stderr,
+        "ERROR: Attempting to free %s at %s:%d but allocation stack is empty\n",
+        var, file, line);
+    exit(1);
+  }
+
+  top = &alloc_stack[alloc_stack_top - 1];
+  if (top->addr != addr || top->size != size)
+  {
+    fprintf(stderr,
+            "ERROR: Free order violation at %s:%d\n"
+            "  Attempting to free: %s (addr=%p, sz %d)\n"
+            "  Expected to free:   %s (addr=%p, sz %d) allocated at %s:%d\n",
+            file, line, var, addr, (int)size, top->var, top->addr,
+            (int)top->size, top->file, top->line);
+    exit(1);
+  }
+
+  alloc_stack_top--;
+}
+
+/*
+ * Bump allocator
+ *
+ * A simple stack-like allocator. We can use it since freeing happens in
+ * reverse order to allocation.
+ */
+
+#define MLK_BUMP_ALLOC_SIZE (24 * 1024) /* 24KB buffer */
+static uint8_t *bump_buffer = NULL;     /* Base address */
+static size_t bump_offset = 0;          /* Watermark */
+static size_t bump_high_mark = 0;       /* High watermark */
+
+static void *bump_alloc(size_t sz)
+{
+  /* Align to 32 bytes */
+  size_t aligned_sz = (sz + 31) & ~((size_t)31);
+  void *p;
+
+  if (sz > MLK_BUMP_ALLOC_SIZE ||
+      aligned_sz > MLK_BUMP_ALLOC_SIZE - bump_offset)
+  {
+    return NULL;
+  }
+
+  p = bump_buffer + bump_offset;
+  bump_offset += aligned_sz;
+
+  if (bump_offset > bump_high_mark)
+  {
+    bump_high_mark = bump_offset;
+  }
+
+  return p;
+}
+
+static int bump_free(void *p)
+{
+  if (p == NULL)
+  {
+    return 0;
+  }
+
+  /* Check that p is within the bump buffer */
+  if (p < (void *)bump_buffer || p >= (void *)(bump_buffer + bump_offset))
+  {
+    return -1;
+  }
+
+  /* Reset bump offset to the freed address */
+  bump_offset = (size_t)((uint8_t *)p - bump_buffer);
+  return 0;
+}
+
+int alloc_counter = 0;
+int fail_on_counter = -1;
+int print_debug_info = 0;
+
+static void reset_all(void)
+{
+  randombytes_reset();
+  alloc_counter = 0;
+  alloc_stack_top = 0;
+  bump_offset = 0;
+  fail_on_counter = -1;
+}
+
+void *custom_alloc(size_t sz, const char *file, int line, const char *var,
+                   const char *type)
+{
+  void *p = NULL;
+  if (alloc_counter++ == fail_on_counter)
+  {
+    return NULL;
+  }
+
+  p = bump_alloc(sz);
+  if (p == NULL)
+  {
+    fprintf(stderr,
+            "ERROR: Bump allocator (%d bytes) ran out of memory. "
+            "%s *%s (%d bytes) at %s:%d\n",
+            (int)MLK_BUMP_ALLOC_SIZE, type, var, (int)sz, file, line);
+    exit(1);
+  }
+
+  alloc_tracker_push(p, sz, file, line, var, type);
+
+  if (print_debug_info == 1)
+  {
+    fprintf(stderr, "Alloc #%d: %s %s (%d bytes) at %s:%d\n", alloc_counter + 1,
+            type, var, (int)sz, file, line);
+  }
+
+  return p;
+}
+
+void custom_free(void *p, size_t sz, const char *file, int line,
+                 const char *var, const char *type)
+{
+  (void)sz;
+  (void)type;
+
+  if (p != NULL)
+  {
+    alloc_tracker_pop(p, sz, file, line, var);
+  }
+
+  if (bump_free(p) != 0)
+  {
+    fprintf(stderr, "ERROR: Free failed: %s %s (%d bytes) at %s:%d\n", type,
+            var, (int)sz, file, line);
+    exit(1);
+  }
+}
+
+#define TEST_ALLOC_FAILURE(test_name, call)                                   \
+  do                                                                          \
+  {                                                                           \
+    int num_allocs, i, rc;                                                    \
+    /* First pass: count allocations */                                       \
+    bump_high_mark = 0;                                                       \
+    reset_all();                                                              \
+    rc = call;                                                                \
+    if (rc != 0)                                                              \
+    {                                                                         \
+      fprintf(stderr, "ERROR: %s failed with %d in counting pass\n",          \
+              test_name, rc);                                                 \
+      return 1;                                                               \
+    }                                                                         \
+    if (alloc_stack_top != 0)                                                 \
+    {                                                                         \
+      fprintf(stderr, "ERROR: %s leaked %d allocation(s) in counting pass\n", \
+              test_name, alloc_stack_top);                                    \
+      return 1;                                                               \
+    }                                                                         \
+    num_allocs = alloc_counter;                                               \
+    /* Second pass: test each allocation failure */                           \
+    for (i = 0; i < num_allocs; i++)                                          \
+    {                                                                         \
+      reset_all();                                                            \
+      fail_on_counter = i;                                                    \
+      rc = call;                                                              \
+      if (rc != MLK_ERR_OUT_OF_MEMORY)                                        \
+      {                                                                       \
+        int rc2;                                                              \
+        /* Re-run dry-run and print debug info */                             \
+        print_debug_info = 1;                                                 \
+        reset_all();                                                          \
+        rc2 = call;                                                           \
+        (void)rc2;                                                            \
+        if (rc == 0)                                                          \
+        {                                                                     \
+          fprintf(stderr,                                                     \
+                  "ERROR: %s unexpectedly succeeded when allocation %d/%d "   \
+                  "was instrumented to fail\n",                               \
+                  test_name, i + 1, num_allocs);                              \
+        }                                                                     \
+        else                                                                  \
+        {                                                                     \
+          fprintf(stderr,                                                     \
+                  "ERROR: %s failed with wrong error code %d "                \
+                  "(expected %d) when allocation %d/%d was instrumented "     \
+                  "to fail\n",                                                \
+                  test_name, rc, MLK_ERR_OUT_OF_MEMORY, i + 1, num_allocs);   \
+        }                                                                     \
+        return 1;                                                             \
+      }                                                                       \
+      if (alloc_stack_top != 0)                                               \
+      {                                                                       \
+        fprintf(stderr,                                                       \
+                "ERROR: %s leaked %d allocation(s) when allocation %d/%d "    \
+                "was instrumented to fail\n",                                 \
+                test_name, alloc_stack_top, i + 1, num_allocs);               \
+        return 1;                                                             \
+      }                                                                       \
+      if (bump_offset != 0)                                                   \
+      {                                                                       \
+        fprintf(stderr,                                                       \
+                "ERROR: %s leaked %d bytes when allocation %d/%d "            \
+                "was instrumented to fail\n",                                 \
+                test_name, (int)bump_offset, i + 1, num_allocs);              \
+        return 1;                                                             \
+      }                                                                       \
+    }                                                                         \
+    printf(                                                                   \
+        "Allocation test for %s PASSED.\n"                                    \
+        "  Max dynamic allocation: %d bytes\n",                               \
+        test_name, (int)bump_high_mark);                                      \
+  } while (0)
+
+static int test_keygen_alloc_failure(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+
+  TEST_ALLOC_FAILURE("crypto_kem_keypair", crypto_kem_keypair(pk, sk));
+  return 0;
+}
+
+static int test_enc_alloc_failure(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key[CRYPTO_BYTES];
+
+  /* Generate valid keypair first */
+  reset_all();
+  if (crypto_kem_keypair(pk, sk) != 0)
+  {
+    fprintf(stderr, "ERROR: crypto_kem_keypair failed in enc test setup\n");
+    return 1;
+  }
+
+  TEST_ALLOC_FAILURE("crypto_kem_enc", crypto_kem_enc(ct, key, pk));
+  return 0;
+}
+
+static int test_dec_alloc_failure(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key_enc[CRYPTO_BYTES];
+  uint8_t key_dec[CRYPTO_BYTES];
+
+  /* Generate valid keypair and ciphertext first */
+  reset_all();
+  if (crypto_kem_keypair(pk, sk) != 0)
+  {
+    fprintf(stderr, "ERROR: crypto_kem_keypair failed in dec test setup\n");
+    return 1;
+  }
+
+  if (crypto_kem_enc(ct, key_enc, pk) != 0)
+  {
+    fprintf(stderr, "ERROR: crypto_kem_enc failed in dec test setup\n");
+    return 1;
+  }
+
+  TEST_ALLOC_FAILURE("crypto_kem_dec", crypto_kem_dec(key_dec, ct, sk));
+  return 0;
+}
+
+static int test_check_pk_alloc_failure(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+
+  reset_all();
+  if (crypto_kem_keypair(pk, sk) != 0)
+  {
+    fprintf(stderr,
+            "ERROR: crypto_kem_keypair failed in check_pk test setup\n");
+    return 1;
+  }
+
+  TEST_ALLOC_FAILURE("crypto_kem_check_pk", crypto_kem_check_pk(pk));
+  return 0;
+}
+
+static int test_check_sk_alloc_failure(void)
+{
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+
+  reset_all();
+  if (crypto_kem_keypair(pk, sk) != 0)
+  {
+    fprintf(stderr,
+            "ERROR: crypto_kem_keypair failed in check_sk test setup\n");
+    return 1;
+  }
+
+  TEST_ALLOC_FAILURE("crypto_kem_check_sk", crypto_kem_check_sk(sk));
+  return 0;
+}
+
+int main(void)
+{
+  uint8_t bump_buffer_storage[MLK_BUMP_ALLOC_SIZE];
+  bump_buffer = bump_buffer_storage;
+
+  if (test_keygen_alloc_failure() != 0)
+  {
+    return 1;
+  }
+
+  if (test_enc_alloc_failure() != 0)
+  {
+    return 1;
+  }
+
+  if (test_dec_alloc_failure() != 0)
+  {
+    return 1;
+  }
+
+  if (test_check_pk_alloc_failure() != 0)
+  {
+    return 1;
+  }
+
+  if (test_check_sk_alloc_failure() != 0)
+  {
+    return 1;
+  }
+
+  return 0;
+}

--- a/test/test_alloc_config.h
+++ b/test/test_alloc_config.h
@@ -1,0 +1,703 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/* References
+ * ==========
+ *
+ * - [FIPS140_3_IG]
+ *   Implementation Guidance for FIPS 140-3 and the Cryptographic Module
+ *   Validation Program
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-ig-announcements
+ *
+ * - [FIPS203]
+ *   FIPS 203 Module-Lattice-Based Key-Encapsulation Mechanism Standard
+ *   National Institute of Standards and Technology
+ *   https://csrc.nist.gov/pubs/fips/203/final
+ */
+
+/*
+ * WARNING: This file is auto-generated from scripts/autogen
+ *          in the mlkem-native repository.
+ *          Do not modify it directly.
+ */
+
+/*
+ * Test configuration: Using custom allocation that can be made fail at specific
+ * invocation
+ *
+ * This configuration differs from the default mlkem/mlkem_native_config.h in
+ * the following places:
+ *   - MLK_CONFIG_NAMESPACE_PREFIX
+ *   - MLK_CONFIG_KEYGEN_PCT
+ *   - MLK_CONFIG_CUSTOM_ALLOC_FREE
+ */
+
+
+#ifndef MLK_CONFIG_H
+#define MLK_CONFIG_H
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_PARAMETER_SET
+ *
+ * Description: Specifies the parameter set for ML-KEM
+ *              - MLK_CONFIG_PARAMETER_SET=512 corresponds to ML-KEM-512
+ *              - MLK_CONFIG_PARAMETER_SET=768 corresponds to ML-KEM-768
+ *              - MLK_CONFIG_PARAMETER_SET=1024 corresponds to ML-KEM-1024
+ *
+ *              If you want to support multiple parameter sets, build the
+ *              library multiple times and set MLK_CONFIG_MULTILEVEL_BUILD.
+ *              See MLK_CONFIG_MULTILEVEL_BUILD for how to do this while
+ *              minimizing code duplication.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#ifndef MLK_CONFIG_PARAMETER_SET
+#define MLK_CONFIG_PARAMETER_SET \
+  768 /* Change this for different security strengths */
+#endif
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_FILE
+ *
+ * Description: If defined, this is a header that will be included instead
+ *              of the default configuration file mlkem/mlkem_native_config.h.
+ *
+ *              When you need to build mlkem-native in multiple configurations,
+ *              using varying MLK_CONFIG_FILE can be more convenient
+ *              then configuring everything through CFLAGS.
+ *
+ *              To use, MLK_CONFIG_FILE _must_ be defined prior
+ *              to the inclusion of any mlkem-native headers. For example,
+ *              it can be set by passing `-DMLK_CONFIG_FILE="..."`
+ *              on the command line.
+ *
+ *****************************************************************************/
+/* No need to set this -- we _are_ already in a custom config */
+/* #define MLK_CONFIG_FILE "mlkem_native_config.h" */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_NAMESPACE_PREFIX
+ *
+ * Description: The prefix to use to namespace global symbols from mlkem/.
+ *
+ *              In a multi-level build, level-dependent symbols will
+ *              additionally be prefixed with the parameter set (512/768/1024).
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLK_CONFIG_NAMESPACE_PREFIX mlk
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_MULTILEVEL_BUILD
+ *
+ * Description: Set this if the build is part of a multi-level build supporting
+ *              multiple parameter sets.
+ *
+ *              If you need only a single parameter set, keep this unset.
+ *
+ *              To build mlkem-native with support for all parameter sets,
+ *              build it three times -- once per parameter set -- and set the
+ *              option MLK_CONFIG_MULTILEVEL_WITH_SHARED for exactly one of
+ *              them, and MLK_CONFIG_MULTILEVEL_NO_SHARED for the others.
+ *              MLK_CONFIG_MULTILEVEL_BUILD should be set for all of them.
+ *
+ *              See examples/multilevel_build for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_MULTILEVEL_BUILD */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_EXTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of mlkem-native's
+ *              public API.
+ *
+ *              The primary use case for this option are single-CU builds
+ *              where the public API exposed by mlkem-native is wrapped by
+ *              another API in the consuming application. In this case,
+ *              even mlkem-native's public API can be marked `static`.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_EXTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_NO_RANDOMIZED_API
+ *
+ * Description: If this option is set, mlkem-native will be built without the
+ *              randomized API functions (crypto_kem_keypair and
+ *              crypto_kem_enc).
+ *              This allows users to build mlkem-native without providing a
+ *              randombytes() implementation if they only need the
+ *              deterministic API
+ *              (crypto_kem_keypair_derand, crypto_kem_enc_derand,
+ *              crypto_kem_dec).
+ *
+ *              NOTE: This option is incompatible with MLK_CONFIG_KEYGEN_PCT
+ *              as the current PCT implementation requires crypto_kem_enc().
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_NO_RANDOMIZED_API */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_NO_SUPERCOP
+ *
+ * Description: By default, mlkem_native.h exposes the mlkem-native API in the
+ *              SUPERCOP naming convention (crypto_kem_xxx). If you don't need
+ *              this, set MLK_CONFIG_NO_SUPERCOP.
+ *
+ *              NOTE: You must set this for a multi-level build as the SUPERCOP
+ *              naming does not disambiguate between the parameter sets.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_NO_SUPERCOP */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CONSTANTS_ONLY
+ *
+ * Description: If you only need the size constants (MLKEM_PUBLICKEYBYTES, etc.)
+ *              but no function declarations, set MLK_CONFIG_CONSTANTS_ONLY.
+ *
+ *              This only affects the public header mlkem_native.h, not
+ *              the implementation.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CONSTANTS_ONLY */
+
+/******************************************************************************
+ *
+ * Build-only configuration options
+ *
+ * The remaining configurations are build-options only.
+ * They do not affect the API described in mlkem_native.h.
+ *
+ *****************************************************************************/
+
+#if defined(MLK_BUILD_INTERNAL)
+/******************************************************************************
+ * Name:        MLK_CONFIG_MULTILEVEL_WITH_SHARED
+ *
+ * Description: This is for multi-level builds of mlkem-native only. If you
+ *              need only a single parameter set, keep this unset.
+ *
+ *              If this is set, all MLK_CONFIG_PARAMETER_SET-independent
+ *              code will be included in the build, including code needed only
+ *              for other parameter sets.
+ *
+ *              Example: mlk_poly_cbd3 is only needed for
+ *              MLK_CONFIG_PARAMETER_SET == 512. Yet, if this option is set
+ *              for a build with MLK_CONFIG_PARAMETER_SET == 768/1024, it
+ *              would be included.
+ *
+ *              To build mlkem-native with support for all parameter sets,
+ *              build it three times -- once per parameter set -- and set the
+ *              option MLK_CONFIG_MULTILEVEL_WITH_SHARED for exactly one of
+ *              them, and MLK_CONFIG_MULTILEVEL_NO_SHARED for the others.
+ *              MLK_CONFIG_MULTILEVEL_BUILD should be set for all of them.
+ *
+ *              See examples/multilevel_build for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_MULTILEVEL_WITH_SHARED */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_MULTILEVEL_NO_SHARED
+ *
+ * Description: This is for multi-level builds of mlkem-native only. If you
+ *              need only a single parameter set, keep this unset.
+ *
+ *              If this is set, no MLK_CONFIG_PARAMETER_SET-independent code
+ *              will be included in the build.
+ *
+ *              To build mlkem-native with support for all parameter sets,
+ *              build it three times -- once per parameter set -- and set the
+ *              option MLK_CONFIG_MULTILEVEL_WITH_SHARED for exactly one of
+ *              them, and MLK_CONFIG_MULTILEVEL_NO_SHARED for the others.
+ *              MLK_CONFIG_MULTILEVEL_BUILD should be set for all of them.
+ *
+ *              See examples/multilevel_build for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_MULTILEVEL_NO_SHARED */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+ *
+ * Description: This is only relevant for single compilation unit (SCU)
+ *              builds of mlkem-native. In this case, it determines whether
+ *              directives defined in parameter-set-independent headers should
+ *              be #undef'ined or not at the of the SCU file. This is needed
+ *              in multilevel builds.
+ *
+ *              See examples/multilevel_build_native for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
+ *
+ * Description: Determines whether an native arithmetic backend should be used.
+ *
+ *              The arithmetic backend covers performance critical functions
+ *              such as the number-theoretic transform (NTT).
+ *
+ *              If this option is unset, the C backend will be used.
+ *
+ *              If this option is set, the arithmetic backend to be use is
+ *              determined by MLK_CONFIG_ARITH_BACKEND_FILE: If the latter is
+ *              unset, the default backend for your the target architecture
+ *              will be used. If set, it must be the name of a backend metadata
+ *              file.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if !defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)
+/* #define MLK_CONFIG_USE_NATIVE_BACKEND_ARITH */
+#endif
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_ARITH_BACKEND_FILE
+ *
+ * Description: The arithmetic backend to use.
+ *
+ *              If MLK_CONFIG_USE_NATIVE_BACKEND_ARITH is unset, this option
+ *              is ignored.
+ *
+ *              If MLK_CONFIG_USE_NATIVE_BACKEND_ARITH is set, this option must
+ *              either be undefined or the filename of an arithmetic backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH) && \
+    !defined(MLK_CONFIG_ARITH_BACKEND_FILE)
+#define MLK_CONFIG_ARITH_BACKEND_FILE "native/meta.h"
+#endif
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202
+ *
+ * Description: Determines whether an native FIPS202 backend should be used.
+ *
+ *              The FIPS202 backend covers 1x/2x/4x-fold Keccak-f1600, which is
+ *              the performance bottleneck of SHA3 and SHAKE.
+ *
+ *              If this option is unset, the C backend will be used.
+ *
+ *              If this option is set, the FIPS202 backend to be use is
+ *              determined by MLK_CONFIG_FIPS202_BACKEND_FILE: If the latter is
+ *              unset, the default backend for your the target architecture
+ *              will be used. If set, it must be the name of a backend metadata
+ *              file.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if !defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202)
+/* #define MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 */
+#endif
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_FIPS202_BACKEND_FILE
+ *
+ * Description: The FIPS-202 backend to use.
+ *
+ *              If MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 is set, this option
+ *              must either be undefined or the filename of a FIPS202 backend.
+ *              If unset, the default backend will be used.
+ *
+ *              This can be set using CFLAGS.
+ *
+ *****************************************************************************/
+#if defined(MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202) && \
+    !defined(MLK_CONFIG_FIPS202_BACKEND_FILE)
+#define MLK_CONFIG_FIPS202_BACKEND_FILE "fips202/native/auto.h"
+#endif
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_FIPS202_CUSTOM_HEADER
+ *
+ * Description: Custom header to use for FIPS-202
+ *
+ *              This should only be set if you intend to use a custom
+ *              FIPS-202 implementation, different from the one shipped
+ *              with mlkem-native.
+ *
+ *              If set, it must be the name of a file serving as the
+ *              replacement for mlkem/fips202/fips202.h, and exposing
+ *              the same API (see FIPS202.md).
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_FIPS202_CUSTOM_HEADER "SOME_FILE.h" */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_FIPS202X4_CUSTOM_HEADER
+ *
+ * Description: Custom header to use for FIPS-202-X4
+ *
+ *              This should only be set if you intend to use a custom
+ *              FIPS-202 implementation, different from the one shipped
+ *              with mlkem-native.
+ *
+ *              If set, it must be the name of a file serving as the
+ *              replacement for mlkem/fips202/fips202x4.h, and exposing
+ *              the same API (see FIPS202.md).
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_FIPS202X4_CUSTOM_HEADER "SOME_FILE.h" */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CUSTOM_ZEROIZE
+ *
+ * Description: In compliance with @[FIPS203, Section 3.3], mlkem-native
+ *              zeroizes intermediate stack buffers before returning from
+ *              function calls.
+ *
+ *              Set this option and define `mlk_zeroize` if you want to
+ *              use a custom method to zeroize intermediate stack buffers.
+ *              The default implementation uses SecureZeroMemory on Windows
+ *              and a memset + compiler barrier otherwise. If neither of those
+ *              is available on the target platform, compilation will fail,
+ *              and you will need to use MLK_CONFIG_CUSTOM_ZEROIZE to provide
+ *              a custom implementation of `mlk_zeroize()`.
+ *
+ *              WARNING:
+ *              The explicit stack zeroization conducted by mlkem-native
+ *              reduces the likelihood of data leaking on the stack, but
+ *              does not eliminate it! The C standard makes no guarantee about
+ *              where a compiler allocates structures and whether/where it makes
+ *              copies of them. Also, in addition to entire structures, there
+ *              may also be potentially exploitable leakage of individual values
+ *              on the stack.
+ *
+ *              If you need bullet-proof zeroization of the stack, you need to
+ *              consider additional measures instead of of what this feature
+ *              provides. In this case, you can set mlk_zeroize to a no-op.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CUSTOM_ZEROIZE
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "src/sys.h"
+   static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
+ *
+ * Description: mlkem-native does not provide a secure randombytes
+ *              implementation. Such an implementation has to provided by the
+ *              consumer.
+ *
+ *              If this option is not set, mlkem-native expects a function
+ *              void randombytes(uint8_t *out, size_t outlen).
+ *
+ *              Set this option and define `mlk_randombytes` if you want to
+ *              use a custom method to sample randombytes with a different name
+ *              or signature.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CUSTOM_RANDOMBYTES
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "src/sys.h"
+   static MLK_INLINE void mlk_randombytes(uint8_t *ptr, size_t len)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CUSTOM_CAPABILITY_FUNC
+ *
+ * Description: mlkem-native backends may rely on specific hardware features.
+ *              Those backends will only be included in an mlkem-native build
+ *              if support for the respective features is enabled at
+ *              compile-time. However, when building for a heteroneous set
+ *              of CPUs to run the resulting binary/library on, feature
+ *              detection at _runtime_ is needed to decided whether a backend
+ *              can be used or not.
+ *
+ *              Set this option and define `mlk_sys_check_capability` if you
+ *              want to use a custom method to dispatch between implementations.
+ *
+ *              If this option is not set, mlkem-native uses compile-time
+ *              feature detection only to decide which backend to use.
+ *
+ *              If you compile mlkem-native on a system with different
+ *              capabilities than the system that the resulting binary/library
+ *              will be run on, you must use this option.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CUSTOM_CAPABILITY_FUNC
+   static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
+   __contract__(
+     ensures(return_value == 0 || return_value == 1)
+   )
+   {
+       ... your implementation ...
+   }
+*/
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CUSTOM_ALLOC_FREE [EXPERIMENTAL]
+ *
+ * Description: Set this option and define `MLK_CUSTOM_ALLOC` and
+ *              `MLK_CUSTOM_FREE` if you want to use custom allocation for
+ *              large local structures or buffers.
+ *
+ *              By default, all buffers/structures are allocated on the stack.
+ *              If this option is set, most of them will be allocated via
+ *              MLK_CUSTOM_ALLOC.
+ *
+ *              Parameters to MLK_CUSTOM_ALLOC:
+ *              - T* v: Target pointer to declare.
+ *              - T: Type of structure to be allocated
+ *              - N: Number of elements to be allocated.
+ *
+ *              Parameters to MLK_CUSTOM_FREE:
+ *              - T* v: Target pointer to free. May be NULL.
+ *              - T: Type of structure to be freed.
+ *              - N: Number of elements to be freed.
+ *
+ *              WARNING: This option is experimental!
+ *              Its scope, configuration and function/macro signatures may
+ *              change at any time. We expect a stable API for v2.
+ *
+ *              NOTE: Even if this option is set, some allocations further down
+ *              the call stack will still be made from the stack, consuming up
+ *              to 3KB of stack space. Those will likely be added to the scope
+ *              of this option in the future.
+ *
+ *              NOTE: MLK_CUSTOM_ALLOC need not guarantee a successful
+ *              allocation nor include error handling. Upon failure, the
+ *              target pointer should simply be set to NULL. The calling
+ *              code will handle this case and invoke MLK_CUSTOM_FREE.
+ *
+ *****************************************************************************/
+#define MLK_CONFIG_CUSTOM_ALLOC_FREE
+#if !defined(__ASSEMBLER__)
+#include <stdlib.h>
+void *custom_alloc(size_t sz, const char *file, int line, const char *var,
+                   const char *type);
+void custom_free(void *p, size_t sz, const char *file, int line,
+                 const char *var, const char *type);
+#define MLK_CUSTOM_ALLOC(v, T, N) \
+  T *v = custom_alloc(sizeof(T) * (N), __FILE__, __LINE__, #v, #T)
+#define MLK_CUSTOM_FREE(v, T, N) \
+  custom_free(v, sizeof(T) * (N), __FILE__, __LINE__, #v, #T)
+#endif /* !__ASSEMBLER__ */
+
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CUSTOM_MEMCPY
+ *
+ * Description: Set this option and define `mlk_memcpy` if you want to
+ *              use a custom method to copy memory instead of the standard
+ *              library memcpy function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memcpy function:
+ *              void *mlk_memcpy(void *dest, const void *src, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CUSTOM_MEMCPY
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "src/sys.h"
+   static MLK_INLINE void *mlk_memcpy(void *dest, const void *src, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CUSTOM_MEMSET
+ *
+ * Description: Set this option and define `mlk_memset` if you want to
+ *              use a custom method to set memory instead of the standard
+ *              library memset function.
+ *
+ *              The custom implementation must have the same signature and
+ *              behavior as the standard memset function:
+ *              void *mlk_memset(void *s, int c, size_t n)
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CUSTOM_MEMSET
+   #if !defined(__ASSEMBLER__)
+   #include <stdint.h>
+   #include "src/sys.h"
+   static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
+   {
+       ... your implementation ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_INTERNAL_API_QUALIFIER */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_CT_TESTING_ENABLED
+ *
+ * Description: If set, mlkem-native annotates data as secret / public using
+ *              valgrind's annotations VALGRIND_MAKE_MEM_UNDEFINED and
+ *              VALGRIND_MAKE_MEM_DEFINED, enabling various checks for secret-
+ *              dependent control flow of variable time execution (depending
+ *              on the exact version of valgrind installed).
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_CT_TESTING_ENABLED */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_NO_ASM
+ *
+ * Description: If this option is set, mlkem-native will be built without
+ *              use of native code or inline assembly.
+ *
+ *              By default, inline assembly is used to implement value barriers.
+ *              Without inline assembly, mlkem-native will use a global volatile
+ *              'opt blocker' instead; see verify.h.
+ *
+ *              Inline assembly is also used to implement a secure zeroization
+ *              function on non-Windows platforms. If this option is set and
+ *              the target platform is not Windows, you MUST set
+ *              MLK_CONFIG_CUSTOM_ZEROIZE and provide a custom zeroization
+ *              function.
+ *
+ *              If this option is set, MLK_CONFIG_USE_NATIVE_BACKEND_FIPS202 and
+ *              and MLK_CONFIG_USE_NATIVE_BACKEND_ARITH will be ignored, and no
+ *              native backends will be used.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_NO_ASM */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_NO_ASM_VALUE_BARRIER
+ *
+ * Description: If this option is set, mlkem-native will be built without
+ *              use of native code or inline assembly for value barriers.
+ *
+ *              By default, inline assembly (if available) is used to implement
+ *              value barriers.
+ *              Without inline assembly, mlkem-native will use a global volatile
+ *              'opt blocker' instead; see verify.h.
+ *
+ *****************************************************************************/
+/* #define MLk_CONFIG_NO_ASM_VALUE_BARRIER */
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_KEYGEN_PCT
+ *
+ * Description: Compliance with @[FIPS140_3_IG, p.87] requires a
+ *              Pairwise Consistency Test (PCT) to be carried out on a freshly
+ *              generated keypair before it can be exported.
+ *
+ *              Set this option if such a check should be implemented.
+ *              In this case, crypto_kem_keypair_derand and crypto_kem_keypair
+ *              will return a non-zero error code if the PCT failed.
+ *
+ *              NOTE: This feature will drastically lower the performance of
+ *              key generation.
+ *
+ *****************************************************************************/
+#define MLK_CONFIG_KEYGEN_PCT
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+ *
+ * Description: If this option is set, the user must provide a runtime
+ *              function `static inline int mlk_break_pct() { ... }` to
+ *              indicate whether the PCT should be made fail.
+ *
+ *              This option only has an effect if MLK_CONFIG_KEYGEN_PCT is set.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
+   #if !defined(__ASSEMBLER__)
+   #include "src/sys.h"
+   static MLK_INLINE int mlk_break_pct(void)
+   {
+       ... return 0/1 depending on whether PCT should be broken ...
+   }
+   #endif
+*/
+
+/******************************************************************************
+ * Name:        MLK_CONFIG_SERIAL_FIPS202_ONLY
+ *
+ * Description: Set this to use a FIPS202 implementation with global state
+ *              that supports only one active Keccak computation at a time
+ *              (e.g. some hardware accelerators).
+ *
+ *              If this option is set, batched Keccak operations are
+ *              disabled for rejection sampling during matrix generation.
+ *              Instead, matrix entries will be generated one at a time.
+ *
+ *              This allows offloading Keccak computations to a hardware
+ *              accelerator that holds only a single Keccak state locally,
+ *              rather than requiring support for batched (4x) Keccak states.
+ *
+ *              NOTE: Depending on the target CPU, disabling batched Keccak
+ *              may reduce performance when using software FIPS202
+ *              implementations. Only enable this when you have to.
+ *
+ *****************************************************************************/
+/* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
+
+/*************************  Config internals  ********************************/
+
+#endif /* MLK_BUILD_INTERNAL */
+
+/* Default namespace
+ *
+ * Don't change this. If you need a different namespace, re-define
+ * MLK_CONFIG_NAMESPACE_PREFIX above instead, and remove the following.
+ *
+ * The default MLKEM namespace is
+ *
+ *   PQCP_MLKEM_NATIVE_MLKEM<LEVEL>_
+ *
+ * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
+ */
+
+#if MLK_CONFIG_PARAMETER_SET == 512
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
+#elif MLK_CONFIG_PARAMETER_SET == 768
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768
+#elif MLK_CONFIG_PARAMETER_SET == 1024
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM1024
+#endif
+
+#endif /* !MLK_CONFIG_H */


### PR DESCRIPTION
* Based on #1405 
* Resolves #1404 

```
Tests the top-level API correctly handles allocation failures by:
- Returning MLK_ERR_OUT_OF_MEMORY on allocation failure
- Cleaning up all allocated memory (no leaks)
- Freeing in LIFO order (enabling bump allocator use)

Uses custom bump allocator with LIFO tracking to systematically inject
failures at each allocation point and verify error handling.
```