### PR TITLE
HOL-Light: Speed up NTT/INTT proofs

### DIFF
--- a/proofs/hol_light/arm/proofs/mlkem_intt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_intt.ml
@@ -655,7 +655,7 @@ let MLKEM_INTT_CORRECT = prove
   (*** Simulate all the way to the end, in effect unrolling loops ***)
 
   MAP_UNTIL_TARGET_PC (fun n -> ARM_STEPS_TAC MLKEM_INTT_EXEC [n] THEN
-            (SIMD_SIMPLIFY_TAC [barred; barmul]))
+            (SIMD_SIMPLIFY_ABBREV_TAC[barred; barmul] []))
             1 THEN
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
@@ -666,19 +666,28 @@ let MLKEM_INTT_CORRECT = prove
    CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
    check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 
-  (*** Turn the conclusion into an explicit conjunction and split it up ***)
+  (*** Expand and substitute in the conclusion we want to prove ***)
 
   CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN REWRITE_TAC[INT_ABS_BOUNDS] THEN
   GEN_REWRITE_TAC (BINDER_CONV o RAND_CONV) [GSYM I_THM] THEN
   CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV) THEN
   ASM_REWRITE_TAC[I_THM; WORD_ADD_0] THEN DISCARD_STATE_TAC "s1153" THEN
+
+  (*** Perform congruence and bound propagation and finish ***)
+
+  W(fun (asl,w) ->
+    let lfn = undefined
+    and asms =
+      map snd (filter (is_local_definition [barred; barmul] o concl o snd)
+              asl) in
+    let lfn' = LOCAL_CONGBOUND_RULE lfn (rev asms) in
+
   REPEAT(W(fun (asl,w) ->
      if length(conjuncts w) > 3 then CONJ_TAC else NO_TAC)) THEN
 
-  (*** Get congruences and bounds for the result digits and finish ***)
-
-  (W(MP_TAC o CONGBOUND_RULE o rand o lhand o rator o lhand o snd) THEN
-    MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
+     W(MP_TAC o ASM_CONGBOUND_RULE lfn' o
+      rand o lhand o rator o lhand o snd) THEN
+   (MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
      [MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
       CONV_TAC(ONCE_DEPTH_CONV INVERSE_NTT_CONV) THEN
       REWRITE_TAC[GSYM INT_REM_EQ; o_THM] THEN CONV_TAC INT_REM_DOWN_CONV THEN
@@ -689,7 +698,7 @@ let MLKEM_INTT_CORRECT = prove
       MATCH_MP_TAC(INT_ARITH
        `l':int <= l /\ u <= u'
         ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
-      CONV_TAC INT_REDUCE_CONV]));;
+      CONV_TAC INT_REDUCE_CONV])));;
 
 (*** Subroutine form, somewhat messy elaboration of the usual wrapper ***)
 

--- a/proofs/hol_light/arm/proofs/mlkem_ntt.ml
+++ b/proofs/hol_light/arm/proofs/mlkem_ntt.ml
@@ -590,7 +590,7 @@ let MLKEM_NTT_CORRECT = prove
   (*** Simulate all the way to the end, in effect unrolling loops ***)
 
   MAP_UNTIL_TARGET_PC (fun n -> ARM_STEPS_TAC MLKEM_NTT_EXEC [n] THEN
-             (SIMD_SIMPLIFY_TAC [barmul])) 1 THEN
+             (SIMD_SIMPLIFY_ABBREV_TAC[barmul] [])) 1 THEN
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
   (*** Reverse the restructuring by splitting the 128-bit words up ***)
@@ -600,23 +600,28 @@ let MLKEM_NTT_CORRECT = prove
     CONV_RULE(READ_MEMORY_SPLIT_CONV 3) o
     check (can (term_match [] `read qqq s:int128 = xxx`) o concl))) THEN
 
-  (*** Turn the conclusion into an explicit conjunction and split it up ***)
+  (*** Expand and substitute in the conclusion we want to prove ***)
 
   DISCH_TAC THEN
   CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN REWRITE_TAC[INT_ABS_BOUNDS] THEN
   GEN_REWRITE_TAC (BINDER_CONV o RAND_CONV) [GSYM I_THM] THEN
   CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV) THEN
   ASM_REWRITE_TAC[I_THM; WORD_ADD_0] THEN DISCARD_STATE_TAC "s904" THEN
-  REPEAT(W(fun (asl,w) ->
-     if length(conjuncts w) > 3 then CONJ_TAC else NO_TAC)) THEN
 
-  (*** Get congruences and bounds for the result digits and finish ***)
+  (*** Perform congruence and bound propagation and finish ***)
 
-  FIRST_X_ASSUM(MP_TAC o CONV_RULE EXPAND_CASES_CONV) THEN
-  POP_ASSUM_LIST(K ALL_TAC) THEN
-  DISCH_THEN(fun aboth ->
-    W(MP_TAC o GEN_CONGBOUND_RULE (CONJUNCTS aboth) o
-      rand o lhand o rator o lhand o snd)) THEN
+  W(fun (asl,w) ->
+    let lfn = PROCESS_BOUND_ASSUMPTIONS
+      (CONJUNCTS(tryfind (CONV_RULE EXPAND_CASES_CONV o snd) asl))
+    and asms =
+      map snd (filter (is_local_definition [barmul] o concl o snd) asl) in
+    let lfn' = LOCAL_CONGBOUND_RULE lfn (rev asms) in
+
+    REPEAT(W(fun (asl,w) ->
+      if length(conjuncts w) > 3 then CONJ_TAC else NO_TAC)) THEN
+
+    W(MP_TAC o ASM_CONGBOUND_RULE lfn' o
+        rand o lhand o rator o lhand o snd) THEN
   (MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
      [MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
       CONV_TAC(ONCE_DEPTH_CONV FORWARD_NTT_CONV) THEN
@@ -628,7 +633,7 @@ let MLKEM_NTT_CORRECT = prove
       MATCH_MP_TAC(INT_ARITH
        `l':int <= l /\ u <= u'
         ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
-      CONV_TAC INT_REDUCE_CONV]));;
+      CONV_TAC INT_REDUCE_CONV])));;
 
 (*** Subroutine form, somewhat messy elaboration of the usual wrapper ***)
 

--- a/proofs/hol_light/common/mlkem_specs.ml
+++ b/proofs/hol_light/common/mlkem_specs.ml
@@ -957,9 +957,7 @@ let CONCL_BOUNDS_RULE =
 let SIDE_ELIM_RULE th =
   MP th (EQT_ELIM(DIMINDEX_INT_REDUCE_CONV(lhand(concl th))));;
 
-let GEN_CONGBOUND_RULE aboths =
-  let lfn = PROCESS_BOUND_ASSUMPTIONS aboths in
-  let rec rule tm =
+let rec ASM_CONGBOUND_RULE lfn tm =
     try apply lfn tm with Failure _ ->
     match tm with
       Comb(Const("word",_),n) when is_numeral n ->
@@ -972,60 +970,76 @@ let GEN_CONGBOUND_RULE aboths =
         let th2 = WORD_RED_CONV(lhand(lhand(snd(strip_forall(concl th1))))) in
         SUBS[SYM th0] (MATCH_MP th1 th2)
     | Comb(Comb(Const("barmul",_),kb),t) ->
-        let ktm,btm = dest_pair kb and th0 = rule t in
+        let ktm,btm = dest_pair kb and th0 = ASM_CONGBOUND_RULE lfn t in
         let th0' = WEAKEN_INTCONG_RULE (num 3329) th0 in
         let th1 = SPECL [ktm;btm] (MATCH_MP CONGBOUND_BARMUL th0') in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
     | Comb(Comb(Const("montmul_x86",_),ltm),rtm) ->
-        let lth = WEAKEN_INTCONG_RULE (num 3329) (rule ltm)
-        and rth = WEAKEN_INTCONG_RULE (num 3329) (rule rtm) in
+        let lth = WEAKEN_INTCONG_RULE (num 3329) (ASM_CONGBOUND_RULE lfn ltm)
+        and rth = WEAKEN_INTCONG_RULE (num 3329) (ASM_CONGBOUND_RULE lfn rtm) in
         let th1 = MATCH_MP CONGBOUND_MONTMUL_X86
                    (UNIFY_INTCONG_RULE lth rth) in
         CONCL_BOUNDS_RULE(th1)
     | Comb(Const("barred",_),t) ->
-        let th1 = WEAKEN_INTCONG_RULE (num 3329) (rule t) in
+        let th1 = WEAKEN_INTCONG_RULE (num 3329) (ASM_CONGBOUND_RULE lfn t) in
         MATCH_MP CONGBOUND_BARRED th1
     | Comb(Const("barred_x86",_),t) ->
-        let th1 = WEAKEN_INTCONG_RULE (num 3329) (rule t) in
+        let th1 = WEAKEN_INTCONG_RULE (num 3329) (ASM_CONGBOUND_RULE lfn t) in
         MATCH_MP CONGBOUND_BARRED_X86 th1
     | Comb(Const("montred",_),t) ->
-        let th1 = WEAKEN_INTCONG_RULE (num 3329) (rule t) in
+        let th1 = WEAKEN_INTCONG_RULE (num 3329) (ASM_CONGBOUND_RULE lfn t) in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE(MATCH_MP CONGBOUND_MONTRED th1))
     | Comb(Comb(Const("ntt_montmul",_),ab),t) ->
-        let atm,btm = dest_pair ab and th0 = rule t in
+        let atm,btm = dest_pair ab and th0 = ASM_CONGBOUND_RULE lfn t in
         let th0' = WEAKEN_INTCONG_RULE (num 3329) th0 in
         let th1 = SPECL [atm;btm] (MATCH_MP CONGBOUND_NTT_MONTMUL th0') in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
     | Comb(Const("word_sx",_),t) ->
-        let th0 = rule t in
+        let th0 = ASM_CONGBOUND_RULE lfn t in
         let tyin = type_match
          (type_of(rator(rand(lhand(funpow 4 rand (snd(dest_forall
             (concl CONGBOUND_WORD_SX)))))))) (type_of(rator tm)) [] in
         let th1 = MATCH_MP (INST_TYPE tyin CONGBOUND_WORD_SX) th0 in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
     | Comb(Const("word_neg",_),t) ->
-        let th0 = rule t in
+        let th0 = ASM_CONGBOUND_RULE lfn t in
         let th1 = MATCH_MP CONGBOUND_WORD_NEG th0 in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
     | Comb(Comb(Const("word_add",_),ltm),rtm) ->
-        let lth = rule ltm and rth = rule rtm in
+        let lth = ASM_CONGBOUND_RULE lfn ltm
+        and rth = ASM_CONGBOUND_RULE lfn rtm in
         let th1 = MATCH_MP CONGBOUND_WORD_ADD (UNIFY_INTCONG_RULE lth rth) in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
     | Comb(Comb(Const("word_sub",_),ltm),rtm) ->
-        let lth = rule ltm and rth = rule rtm in
+        let lth = ASM_CONGBOUND_RULE lfn ltm
+        and rth = ASM_CONGBOUND_RULE lfn rtm in
         let th1 = MATCH_MP CONGBOUND_WORD_SUB (UNIFY_INTCONG_RULE lth rth) in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
     | Comb(Comb(Const("word_mul",_),ltm),rtm) ->
-        let lth = rule ltm and rth = rule rtm in
+        let lth = ASM_CONGBOUND_RULE lfn ltm
+        and rth = ASM_CONGBOUND_RULE lfn rtm in
         let th1 = MATCH_MP CONGBOUND_WORD_MUL (UNIFY_INTCONG_RULE lth rth) in
         CONCL_BOUNDS_RULE(SIDE_ELIM_RULE th1)
-    | _ -> CONCL_BOUNDS_RULE(ISPEC tm CONGBOUND_ATOM) in
-  rule;;
+    | _ -> CONCL_BOUNDS_RULE(ISPEC tm CONGBOUND_ATOM);;
+
+let GEN_CONGBOUND_RULE aboths =
+  ASM_CONGBOUND_RULE (PROCESS_BOUND_ASSUMPTIONS aboths);;
 
 let CONGBOUND_RULE = GEN_CONGBOUND_RULE [];;
 
+let rec LOCAL_CONGBOUND_RULE lfn asms =
+  match asms with
+    [] -> lfn
+  | th::ths ->
+      let bod,var = dest_eq (concl th) in
+      let th1 = ASM_CONGBOUND_RULE lfn bod in
+      let th2 = SUBS[th] th1 in
+      let lfn' = (var |-> th2) lfn in
+      LOCAL_CONGBOUND_RULE lfn' ths;;
+
 (* ------------------------------------------------------------------------- *)
-(* Simplify SIMD cruft and fold abbreviations when encountered.              *)
+(* Simplify SIMD cruft and fold relevant definitions when encountered.       *)
+(* The ABBREV form also introduces abbreviations for relevant subterms.      *)
 (* ------------------------------------------------------------------------- *)
 
 let SIMD_SIMPLIFY_CONV unfold_defs =
@@ -1042,3 +1056,31 @@ let SIMD_SIMPLIFY_TAC unfold_defs =
    (ASSUME_TAC o
     CONV_RULE(RAND_CONV (SIMD_SIMPLIFY_CONV unfold_defs)) o
     check (simdable o concl)));;
+
+let is_local_definition unfold_defs =
+  let pats = map (lhand o snd o strip_forall o concl) unfold_defs in
+  let pam t = exists (fun p -> can(term_match [] p) t) pats in
+  fun tm -> is_eq tm && is_var(rand tm) && pam(lhand tm);;
+
+let AUTO_ABBREV_TAC tm =
+  let gv = genvar(type_of tm) in
+  ABBREV_TAC(mk_eq(gv,tm));;
+
+let SIMD_SIMPLIFY_ABBREV_TAC =
+  let arm_simdable =
+    can (term_match [] `read X (s:armstate):int128 = whatever`)
+  and x86_simdable =
+    can (term_match [] `read X (s:x86state):int256 = whatever`) in
+  let simdable tm = arm_simdable tm || x86_simdable tm in
+  fun unfold_defs unfold_aux ->
+    let pats = map (lhand o snd o strip_forall o concl) unfold_defs in
+    let pam t = exists (fun p -> can(term_match [] p) t) pats in
+    let ttac th (asl,w) =
+      let th' = CONV_RULE(RAND_CONV
+                 (SIMD_SIMPLIFY_CONV (unfold_defs @ unfold_aux))) th in
+      let asms =
+        map snd (filter (is_local_definition unfold_defs o concl o snd) asl) in
+      let th'' = GEN_REWRITE_RULE (RAND_CONV o TOP_DEPTH_CONV) asms th' in
+      let tms = sort free_in (find_terms pam (rand(concl th''))) in
+      (MP_TAC th'' THEN MAP_EVERY AUTO_ABBREV_TAC tms THEN DISCH_TAC) (asl,w) in
+  TRY(FIRST_X_ASSUM(ttac o check (simdable o concl)));;

--- a/proofs/hol_light/x86/proofs/mlkem_intt.ml
+++ b/proofs/hol_light/x86/proofs/mlkem_intt.ml
@@ -1102,7 +1102,8 @@ let MLKEM_INTT_CORRECT = prove
   CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
 
   MAP_EVERY (fun n -> X86_STEPS_TAC MLKEM_INTT_TMC_EXEC [n] THEN
-                      SIMD_SIMPLIFY_TAC[ntt_montmul; ntt_montmul_add; ntt_montmul_sub; barred_x86])
+                      SIMD_SIMPLIFY_ABBREV_TAC[ntt_montmul; barred_x86]
+                              [ntt_montmul_add; ntt_montmul_sub])
         (1--663) THEN
 
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
@@ -1119,6 +1120,13 @@ let MLKEM_INTT_CORRECT = prove
   ASM_REWRITE_TAC[WORD_ADD_0] THEN
 
   ASM_REWRITE_TAC[] THEN DISCARD_STATE_TAC "s663" THEN
+
+  W(fun (asl,w) ->
+     let asms =
+        map snd (filter (is_local_definition
+          [ntt_montmul; barred_x86] o concl o snd) asl) in
+     MP_TAC(end_itlist CONJ (rev asms)) THEN
+     MAP_EVERY (fun t -> UNDISCH_THEN (concl t) (K ALL_TAC)) asms) THEN
 
   REWRITE_TAC[WORD_BLAST `word_subword (x:int32) (0, 32) = x`] THEN
   REWRITE_TAC[WORD_BLAST `word_subword (x:int64) (0, 64) = x`] THEN
@@ -1143,13 +1151,22 @@ let MLKEM_INTT_CORRECT = prove
      word_subword x (0, 16)`] THEN
   CONV_TAC(TOP_DEPTH_CONV WORD_SIMPLE_SUBWORD_CONV) THEN
 
+  STRIP_TAC THEN
+
   CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
   REWRITE_TAC[GSYM CONJ_ASSOC] THEN
-  REPEAT(GEN_REWRITE_TAC I
-   [TAUT `p /\ q /\ r /\ s <=> (p /\ q /\ r) /\ s`] THEN CONJ_TAC) THEN
-  POP_ASSUM_LIST(K ALL_TAC) THEN
-  (W(MP_TAC o CONGBOUND_RULE o rand o lhand o rator o lhand o snd) THEN
-   MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
+
+  W(fun (asl,w) ->
+    let lfn = undefined
+    and asms =
+      map snd (filter (is_local_definition [ntt_montmul; barred_x86] o concl o snd) asl) in
+    let lfn' = LOCAL_CONGBOUND_RULE lfn (rev asms) in
+
+    REPEAT(GEN_REWRITE_TAC I
+     [TAUT `p /\ q /\ r /\ s <=> (p /\ q /\ r) /\ s`] THEN CONJ_TAC) THEN
+
+    W(MP_TAC o ASM_CONGBOUND_RULE lfn' o rand o lhand o rator o lhand o snd) THEN
+   (MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
    [REWRITE_TAC[INVERSE_MOD_CONV `inverse_mod 3329 65536`] THEN
     MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
     CONV_TAC(ONCE_DEPTH_CONV AVX2_INVERSE_NTT_CONV) THEN
@@ -1161,7 +1178,7 @@ let MLKEM_INTT_CORRECT = prove
     MATCH_MP_TAC(INT_ARITH
      `l':int <= l /\ u <= u'
       ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
-    CONV_TAC INT_REDUCE_CONV])
+    CONV_TAC INT_REDUCE_CONV]))
 );;
 
 let MLKEM_INTT_NOIBT_SUBROUTINE_CORRECT  = prove

--- a/proofs/hol_light/x86/proofs/mlkem_ntt.ml
+++ b/proofs/hol_light/x86/proofs/mlkem_ntt.ml
@@ -1114,7 +1114,7 @@ let MLKEM_NTT_CORRECT = prove
   CONV_TAC(LAND_CONV WORD_REDUCE_CONV) THEN STRIP_TAC THEN
 
   MAP_EVERY (fun n -> X86_STEPS_TAC MLKEM_NTT_TMC_EXEC [n] THEN
-                      SIMD_SIMPLIFY_TAC[ntt_montmul; ntt_montmul_add; ntt_montmul_sub])
+                      SIMD_SIMPLIFY_ABBREV_TAC[ntt_montmul] [ntt_montmul_add; ntt_montmul_sub])
         (1--587) THEN
   ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
@@ -1130,6 +1130,12 @@ let MLKEM_NTT_CORRECT = prove
   ASM_REWRITE_TAC[WORD_ADD_0]  THEN
 
   ASM_REWRITE_TAC[] THEN DISCARD_STATE_TAC "s587" THEN
+
+  W(fun (asl,w) ->
+     let asms =
+        map snd (filter (is_local_definition [ntt_montmul] o concl o snd) asl) in
+     MP_TAC(end_itlist CONJ (rev asms)) THEN
+     MAP_EVERY (fun t -> UNDISCH_THEN (concl t) (K ALL_TAC)) asms) THEN
 
   REWRITE_TAC[WORD_BLAST `word_subword (x:int32) (0, 32) = x`] THEN
   REWRITE_TAC[WORD_BLAST `word_subword (x:int64) (0, 64) = x`] THEN
@@ -1152,31 +1158,35 @@ let MLKEM_NTT_CORRECT = prove
 
   CONV_TAC(TOP_DEPTH_CONV WORD_SIMPLE_SUBWORD_CONV) THEN
 
+  STRIP_TAC THEN
+
   CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
   REWRITE_TAC[GSYM CONJ_ASSOC] THEN
+
+  W(fun (asl,w) ->
+    let lfn = PROCESS_BOUND_ASSUMPTIONS
+      (CONJUNCTS(tryfind (CONV_RULE EXPAND_CASES_CONV o snd) asl))
+    and asms =
+      map snd (filter (is_local_definition [ntt_montmul] o concl o snd) asl) in
+    let lfn' = LOCAL_CONGBOUND_RULE lfn (rev asms) in
+
   REPEAT(GEN_REWRITE_TAC I
    [TAUT `p /\ q /\ r /\ s <=> (p /\ q /\ r) /\ s`] THEN CONJ_TAC) THEN
 
-  FIRST_X_ASSUM(MP_TAC o CONV_RULE EXPAND_CASES_CONV) THEN
-  POP_ASSUM_LIST(K ALL_TAC) THEN
-  CONV_TAC(TOP_DEPTH_CONV let_CONV) THEN
-  DISCH_THEN(fun aboth ->
-    W(MP_TAC o GEN_CONGBOUND_RULE (CONJUNCTS aboth) o
-      rand o lhand o rator o lhand o snd)) THEN
-
-  (MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
-   [REWRITE_TAC[INVERSE_MOD_CONV `inverse_mod 3329 65536`] THEN
-    MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
-    CONV_TAC(ONCE_DEPTH_CONV AVX2_FORWARD_NTT_CONV) THEN
-    REWRITE_TAC[GSYM INT_REM_EQ; o_THM] THEN CONV_TAC INT_REM_DOWN_CONV THEN
-    REWRITE_TAC[INT_REM_EQ] THEN
-    REWRITE_TAC[REAL_INT_CONGRUENCE; INT_OF_NUM_EQ; ARITH_EQ] THEN
-    REWRITE_TAC[GSYM REAL_OF_INT_CLAUSES] THEN
-    CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN REAL_INTEGER_TAC;
-    MATCH_MP_TAC(INT_ARITH
-     `l':int <= l /\ u <= u'
-      ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
-    CONV_TAC INT_REDUCE_CONV])
+    W(MP_TAC o ASM_CONGBOUND_RULE lfn' o rand o lhand o rator o lhand o snd) THEN
+   (MATCH_MP_TAC MONO_AND THEN CONJ_TAC THENL
+    [REWRITE_TAC[INVERSE_MOD_CONV `inverse_mod 3329 65536`] THEN
+     MATCH_MP_TAC(REWRITE_RULE[IMP_CONJ_ALT] INT_CONG_TRANS) THEN
+     CONV_TAC(ONCE_DEPTH_CONV AVX2_FORWARD_NTT_CONV) THEN
+     REWRITE_TAC[GSYM INT_REM_EQ; o_THM] THEN CONV_TAC INT_REM_DOWN_CONV THEN
+     REWRITE_TAC[INT_REM_EQ] THEN
+     REWRITE_TAC[REAL_INT_CONGRUENCE; INT_OF_NUM_EQ; ARITH_EQ] THEN
+     REWRITE_TAC[GSYM REAL_OF_INT_CLAUSES] THEN
+     CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN REAL_INTEGER_TAC;
+     MATCH_MP_TAC(INT_ARITH
+      `l':int <= l /\ u <= u'
+       ==> l <= x /\ x <= u ==> l' <= x /\ x <= u'`) THEN
+     CONV_TAC INT_REDUCE_CONV]))
 );;
 
 let MLKEM_NTT_NOIBT_SUBROUTINE_CORRECT  = prove


### PR DESCRIPTION
This commit ports @jargh's improvements to the NTT/INTT proofs in s2n-bignum which should result in vast proof performance improvements (1.6x- 4.3x according to the PR).

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1413
- Ports https://github.com/awslabs/s2n-bignum/pull/325