### PR TITLE
test_alloc: Align bump buffer

### DIFF
--- a/test/test_alloc.c
+++ b/test/test_alloc.c
@@ -9,6 +9,7 @@
 /* Expose declaration of allocator (normally internal) */
 #define MLK_BUILD_INTERNAL
 #include "../mlkem/mlkem_native.h"
+#include "../mlkem/src/common.h"
 #include "notrandombytes/notrandombytes.h"
 
 /*
@@ -370,7 +371,7 @@ static int test_check_sk_alloc_failure(void)
 
 int main(void)
 {
-  uint8_t bump_buffer_storage[MLK_BUMP_ALLOC_SIZE];
+  MLK_ALIGN uint8_t bump_buffer_storage[MLK_BUMP_ALLOC_SIZE];
   bump_buffer = bump_buffer_storage;
 
   if (test_keygen_alloc_failure() != 0)


### PR DESCRIPTION
test/test_alloc.c uses a custom bump allocator. While all allocation sizes are aligned to multiples of 32 bytes, the allocation buffer itself can be unaligned. This can crash the test on systems with alignment requirement, such as x86+AVX2.

This is not an issue in the actual implementation, which uses appropriate alignment constraints: See the default implementation of MLK_ALLOC in src/common.h.