### PR TITLE
CI: Do not use npx in lint-markdown-link

### DIFF
--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -15,4 +15,5 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Check markdown links
       run: |
-        find . -name '*.md' -print0 | xargs -0 -P16 -n1 npx -y markdown-link-check@3.14.2 -q
+        npm install -g markdown-link-check@3.14.2
+        find . -name '*.md' -print0 | xargs -0 -P16 -n1 markdown-link-check -q


### PR DESCRIPTION
We keep seeing spurious failures of the lint-markdown-link job in CI:

```
SyntaxError: Unexpected end of input
    at wrapSafe (node:internal/modules/cjs/loader:1464:18)
    at Module._compile (node:internal/modules/cjs/loader:1495:20)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
    at Module.require (node:internal/modules/cjs/loader:1289:19)
    at require (node:internal/modules/helpers:182:18)
    at Object.<anonymous> (/home/runner/.npm/_npx/e03bf6f7009cd48e/node_modules/undici/lib/dispatcher/client.js:6:14)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
```

Those are potentially caused by race conditions in npx. This commit splits off a separate installation step which should solve the problem - it also eliminates npx as it's no longer needed.