### PR TITLE
CBMC: add functional spec for mlk_ct_cmov_zero

### DIFF
--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -407,11 +407,14 @@ __contract__(
   requires(len <= MLK_MAX_BUFFER_SIZE)
   requires(memory_no_alias(r, len))
   requires(memory_no_alias(x, len))
-  assigns(memory_slice(r, len)))
+  assigns(memory_slice(r, len))
+  ensures(forall(i, 0, len, (r[i] == (b == 0 ? x[i] : old(r)[i])))))
 {
   size_t i;
   for (i = 0; i < len; i++)
-  __loop__(invariant(i <= len))
+  __loop__(
+    invariant(i <= len)
+    invariant(forall(k, 0, i, r[k] == (b == 0 ? x[k] : loop_entry(r)[k]))))
   {
     r[i] = mlk_ct_sel_uint8(r[i], x[i], b);
   }

--- a/proofs/cbmc/ct_cmov_zero/Makefile
+++ b/proofs/cbmc/ct_cmov_zero/Makefile
@@ -26,7 +26,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--bitwuzla
 
 FUNCTION_NAME = mlk_ct_cmov_zero
 
@@ -37,7 +37,7 @@ FUNCTION_NAME = mlk_ct_cmov_zero
 # EXPENSIVE = true
 
 # This function is large enough to need...
-CBMC_OBJECT_BITS = 8
+CBMC_OBJECT_BITS = 10
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file


### PR DESCRIPTION
- Resolves: #1330 
- This PR add functional specification for `mlk_ct_cmov_zero`:
- Adding following in `__contract__`:
```
  assigns(memory_slice(r, len)))
  assigns(memory_slice(r, len))
```
- And add following in `loop`:
```
    invariant(forall(k, 0, i, r[k] == (b == 0 ? x[k] : loop_entry(r)[k]))))
```
Really appreciate for @mkannwischer 's help.
