### PR TITLE
CBMC: Use polyvec_permute contract in polymat_permute proof

### DIFF
--- a/proofs/cbmc/polymat_permute_bitrev_to_custom/Makefile
+++ b/proofs/cbmc/polymat_permute_bitrev_to_custom/Makefile
@@ -19,7 +19,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/indcpa.c
 
 CHECK_FUNCTION_CONTRACTS=mlk_polymat_permute_bitrev_to_custom
-USE_FUNCTION_CONTRACTS=
+USE_FUNCTION_CONTRACTS=mlk_polyvec_permute_bitrev_to_custom
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 


### PR DESCRIPTION
The mlk_polymat_permute_bitrev_to_custom was split up into two parts to work around CBMC performance issues when proving it on top of the native backend.
However, it was forgotten to call mlk_polyvec_permute_bitrev_to_custom (which is proven for both the C and native backend) in the mlk_polymat_permute_bitrev_to_custom proof.
As a consequence, mlk_polymat_permute_bitrev_to_custom wasn't actually proven for the native backend, as the C version was inlined. This commit closes that gap by calling it by contract.