### PR TITLE
CI: Enable gcc15 tests on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,7 @@ jobs:
            examples: true
          - name: gcc-15
            shell: ci_gcc15
-           # TODO: Add this once gcc15 is supported in nix on aarch64-Darwin
-           darwin: False
+           darwin: True
            c17: True
            c23: True
            opt: all

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757068644,
-        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+        "lastModified": 1767116409,
+        "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+        "rev": "cad22e7d996aea55ecab064e84834289143e44a0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
                 gcc48 = pkgs-2405.gcc48;
                 gcc49 = pkgs-2405.gcc49;
                 gcc7 = pkgs-2405.gcc7;
+                gcc15 = pkgs-unstable.gcc15;
                 clang_21 = pkgs-unstable.clang_21;
                 zig_0_15 = pkgs-unstable.zig_0_15;
               })


### PR DESCRIPTION
gcc15 on Arm MacOS finally got fixed in nixpkgs.
This commit updates nixpkgs-unstable, takes gcc15 from it, and enables gcc15 tests on MacOS in CI.

- Resolves #1356 