### PR TITLE
Remove redundant nmake rule for legacy test path

### DIFF
--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -35,10 +35,6 @@ OPT = 0
     @if NOT EXIST $(MLKEM512_BUILD_DIR)\mlkem\fips202 mkdir $(MLKEM512_BUILD_DIR)\mlkem\fips202
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=512 /c /Fo$(MLKEM512_BUILD_DIR)\mlkem\fips202\ $<
 
-{test}.c{$(MLKEM512_BUILD_DIR)\test}.obj::
-    @if NOT EXIST $(MLKEM512_BUILD_DIR)\test mkdir $(MLKEM512_BUILD_DIR)\test
-    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=512 /c /Fo$(MLKEM512_BUILD_DIR)\test\ $<
-
 {test\src}.c{$(MLKEM512_BUILD_DIR)\test}.obj::
     @if NOT EXIST $(MLKEM512_BUILD_DIR)\test mkdir $(MLKEM512_BUILD_DIR)\test
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=512 /c /Fo$(MLKEM512_BUILD_DIR)\test\ $<
@@ -52,10 +48,6 @@ OPT = 0
     @if NOT EXIST $(MLKEM768_BUILD_DIR)\mlkem\fips202 mkdir $(MLKEM768_BUILD_DIR)\mlkem\fips202
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=768 /c /Fo$(MLKEM768_BUILD_DIR)\mlkem\fips202\ $<
 
-{test}.c{$(MLKEM768_BUILD_DIR)\test}.obj::
-    @if NOT EXIST $(MLKEM768_BUILD_DIR)\test mkdir $(MLKEM768_BUILD_DIR)\test
-    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=768 /c /Fo$(MLKEM768_BUILD_DIR)\test\ $<
-
 {test\src}.c{$(MLKEM768_BUILD_DIR)\test}.obj::
     @if NOT EXIST $(MLKEM768_BUILD_DIR)\test mkdir $(MLKEM768_BUILD_DIR)\test
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=768 /c /Fo$(MLKEM768_BUILD_DIR)\test\ $<
@@ -68,10 +60,6 @@ OPT = 0
 {mlkem\src\fips202}.c{$(MLKEM1024_BUILD_DIR)\mlkem\fips202}.obj::
     @if NOT EXIST $(MLKEM1024_BUILD_DIR)\mlkem\fips202 mkdir $(MLKEM1024_BUILD_DIR)\mlkem\fips202
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=1024 /c /Fo$(MLKEM1024_BUILD_DIR)\mlkem\fips202\ $<
-
-{test}.c{$(MLKEM1024_BUILD_DIR)\test}.obj::
-    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\test mkdir $(MLKEM1024_BUILD_DIR)\test
-    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=1024 /c /Fo$(MLKEM1024_BUILD_DIR)\test\ $<
 
 {test\src}.c{$(MLKEM1024_BUILD_DIR)\test}.obj::
     @if NOT EXIST $(MLKEM1024_BUILD_DIR)\test mkdir $(MLKEM1024_BUILD_DIR)\test


### PR DESCRIPTION
- This PR removes a redundant nmake rule in mlkem-native that is no longer required after the test source directory cleanup (https://github.com/pq-code-package/mlkem-native/pull/1416).

While porting the changes from PR #1416 to mldsa-native (https://github.com/pq-code-package/mldsa-native/pull/846), we noticed that the nmake file also required cleanup. The same issue was present in mlkem-native, so this PR addresses it.