### PR TITLE
Allow the public header to work in C++ mode.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,6 +17,7 @@ IncludeBlocks: Preserve
 # as "attributes" so they don't get increasingly indented line after line
 BreakBeforeBraces: Allman
 InsertBraces: true
+IndentExternBlock: NoIndent
 WhitespaceSensitiveMacros: ['__contract__', '__loop__', 'MLK_RV64V_ABS_BOUNDS16' ]
 Macros:
  # Make this artifically long to avoid function bodies after short contracts

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -183,6 +183,11 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /*************************************************
  * Name:        crypto_kem_keypair_derand
  *
@@ -376,6 +381,10 @@ MLK_API_QUALIFIER
 MLK_API_MUST_CHECK_RETURN_VALUE
 int MLK_API_NAMESPACE(check_sk)(
     const uint8_t sk[MLKEM_SECRETKEYBYTES(MLK_CONFIG_API_PARAMETER_SET)]);
+
+#ifdef __cplusplus
+}
+#endif
 
 /****************************** SUPERCOP API *********************************/
 


### PR DESCRIPTION
Without this, includes of the header must be wrapped in `extern "C"`, which then causes problems if the config header includes headers that expect to be included in C or C++ mode.