### PR TITLE
Use mlkem_native.h from stack and acvp tests

### DIFF
--- a/test/acvp/acvp_mlkem.c
+++ b/test/acvp/acvp_mlkem.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include "../../mlkem/src/common.h"
 
-#include "../../mlkem/src/kem.h"
+#include "../../mlkem/mlkem_native.h"
 
 #define USAGE \
   "acvp_mlkem{lvl} [encapDecap|keyGen] [AFT|VAL] {test specific arguments}"
@@ -133,11 +133,11 @@ static void print_hex(const char *name, const unsigned char *raw, size_t len)
 }
 
 static void acvp_mlkem_encapDecp_AFT_encapsulation(
-    unsigned char const ek[MLKEM_INDCCA_PUBLICKEYBYTES],
+    unsigned char const ek[CRYPTO_PUBLICKEYBYTES],
     unsigned char const m[MLKEM_SYMBYTES])
 {
-  unsigned char ct[MLKEM_INDCCA_CIPHERTEXTBYTES];
-  unsigned char ss[MLKEM_SSBYTES];
+  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
+  unsigned char ss[CRYPTO_BYTES];
 
   CHECK(crypto_kem_enc_derand(ct, ss, ek, m) == 0);
 
@@ -146,10 +146,10 @@ static void acvp_mlkem_encapDecp_AFT_encapsulation(
 }
 
 static void acvp_mlkem_encapDecp_VAL_decapsulation(
-    unsigned char const dk[MLKEM_INDCCA_SECRETKEYBYTES],
-    unsigned char const c[MLKEM_INDCCA_CIPHERTEXTBYTES])
+    unsigned char const dk[CRYPTO_SECRETKEYBYTES],
+    unsigned char const c[CRYPTO_CIPHERTEXTBYTES])
 {
-  unsigned char ss[MLKEM_SSBYTES];
+  unsigned char ss[CRYPTO_BYTES];
 
   CHECK(crypto_kem_dec(ss, c, dk) == 0);
 
@@ -157,7 +157,7 @@ static void acvp_mlkem_encapDecp_VAL_decapsulation(
 }
 
 static void acvp_mlkem_encapDecp_VAL_encapsulationKeyCheck(
-    unsigned char const ek[MLKEM_INDCCA_PUBLICKEYBYTES])
+    unsigned char const ek[CRYPTO_PUBLICKEYBYTES])
 {
   int rc = 0;
   rc = (crypto_kem_check_pk(ek) == 0) ? 1 : 0;
@@ -165,7 +165,7 @@ static void acvp_mlkem_encapDecp_VAL_encapsulationKeyCheck(
 }
 
 static void acvp_mlkem_encapDecp_VAL_decapsulationKeyCheck(
-    unsigned char const dk[MLKEM_INDCCA_SECRETKEYBYTES])
+    unsigned char const dk[CRYPTO_SECRETKEYBYTES])
 {
   int rc = 0;
   rc = (crypto_kem_check_sk(dk) == 0) ? 1 : 0;
@@ -175,8 +175,8 @@ static void acvp_mlkem_encapDecp_VAL_decapsulationKeyCheck(
 static void acvp_mlkem_keyGen_AFT(unsigned char const z[MLKEM_SYMBYTES],
                                   unsigned char const d[MLKEM_SYMBYTES])
 {
-  unsigned char ek[MLKEM_INDCCA_PUBLICKEYBYTES];
-  unsigned char dk[MLKEM_INDCCA_SECRETKEYBYTES];
+  unsigned char ek[CRYPTO_PUBLICKEYBYTES];
+  unsigned char dk[CRYPTO_SECRETKEYBYTES];
 
   unsigned char zd[2 * MLKEM_SYMBYTES];
   memcpy(zd, d, MLKEM_SYMBYTES);
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
       {
         case encapsulation:
         {
-          unsigned char ek[MLKEM_INDCCA_PUBLICKEYBYTES];
+          unsigned char ek[CRYPTO_PUBLICKEYBYTES];
           unsigned char m[MLKEM_SYMBYTES];
           /* Encapsulation only for "AFT" */
           if (type != AFT)
@@ -305,8 +305,8 @@ int main(int argc, char *argv[])
         }
         case decapsulation:
         {
-          unsigned char dk[MLKEM_INDCCA_SECRETKEYBYTES];
-          unsigned char c[MLKEM_INDCCA_CIPHERTEXTBYTES];
+          unsigned char dk[CRYPTO_SECRETKEYBYTES];
+          unsigned char c[CRYPTO_CIPHERTEXTBYTES];
           /* Decapsulation only for "VAL" */
           if (type != VAL)
           {
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
         }
         case encapsulationKeyCheck:
         {
-          unsigned char ek[MLKEM_INDCCA_PUBLICKEYBYTES];
+          unsigned char ek[CRYPTO_PUBLICKEYBYTES];
           /* encapsulationKeyCheck only for "VAL" */
           if (type != VAL || argc == 0)
           {
@@ -359,7 +359,7 @@ int main(int argc, char *argv[])
         }
         case decapsulationKeyCheck:
         {
-          unsigned char dk[MLKEM_INDCCA_SECRETKEYBYTES];
+          unsigned char dk[CRYPTO_SECRETKEYBYTES];
           /* Encapsulation only for "VAL" */
           if (type != VAL || argc == 0)
           {

--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -6,12 +6,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "kem.h"
+#include "mlkem_native.h"
 
 static void test_keygen_only(void)
 {
-  unsigned char pk[MLKEM_INDCCA_PUBLICKEYBYTES];
-  unsigned char sk[MLKEM_INDCCA_SECRETKEYBYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
 
   /* Only call keypair - this is what we're measuring */
   /* Uses the notrandombytes implementation for deterministic randomness */
@@ -21,9 +21,9 @@ static void test_keygen_only(void)
 
 static void test_encaps_only(void)
 {
-  unsigned char pk[MLKEM_INDCCA_PUBLICKEYBYTES] = {0};
-  unsigned char ct[MLKEM_INDCCA_CIPHERTEXTBYTES];
-  unsigned char ss[MLKEM_SSBYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES] = {0};
+  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
+  unsigned char ss[CRYPTO_BYTES];
 
   /* Only call encaps - this is what we're measuring */
   /* pk is zero-initialized (invalid key, but OK for stack measurement) */
@@ -33,9 +33,9 @@ static void test_encaps_only(void)
 
 static void test_decaps_only(void)
 {
-  unsigned char sk[MLKEM_INDCCA_SECRETKEYBYTES] = {0};
-  unsigned char ct[MLKEM_INDCCA_CIPHERTEXTBYTES] = {0};
-  unsigned char ss[MLKEM_SSBYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES] = {0};
+  unsigned char ct[CRYPTO_CIPHERTEXTBYTES] = {0};
+  unsigned char ss[CRYPTO_BYTES];
 
   /* Only call decaps - this is what we're measuring */
   /* sk and ct are zero-initialized (invalid, but OK for stack measurement) */


### PR DESCRIPTION
This commit modifes the stack and ACVP tests to use the public header mlkem_native.h instead of the internal header kem.h.