### PR TITLE
autogen: fix print for narrow terminals

### DIFF
--- a/scripts/autogen
+++ b/scripts/autogen
@@ -202,10 +202,16 @@ BLUE = "\033[94m"
 BOLD = "\033[1m"
 NORMAL = "\033[0m"
 
+# Set terminal width, fallback to default on systems where none is present.
+try:
+    TERMINAL_WIDTH = os.get_terminal_size().columns
+except OSError:
+    TERMINAL_WIDTH = 160
+
 
 def clear_status_line():
     """Clear any existing status line by overwriting with spaces and returning to start of line"""
-    print(f"\r{' ' * 160}", end="", flush=True)
+    print(f"\r{' ' * TERMINAL_WIDTH}", end="", flush=True)
 
 
 def status_update(task, msg):


### PR DESCRIPTION
This commit replaces the hardcoded width of 160 in `clear_status_line`
with the width of ones terminal window. This resolves the issue in which
we see autogen generate large amounts of new lines for narrow terminals
(width <160). In case we are running on a system with a non-interactive
shell (e.g. some of the CI runners) we fall back to the default.

Signed-off-by: Andreas Hatziiliou <andreas.hatziiliou@savoirfairelinux.com>
