### PR TITLE
Examples: Remove MLK_CONFIG_NO_SUPERCOP from multi-level header

### DIFF
--- a/examples/monolithic_build_multilevel/mlkem_native_all.h
+++ b/examples/monolithic_build_multilevel/mlkem_native_all.h
@@ -6,8 +6,6 @@
 #if !defined(MLK_ALL_H)
 #define MLK_ALL_H
 
-#define MLK_CONFIG_NO_SUPERCOP
-
 /* API for MLKEM-512 */
 #define MLK_CONFIG_PARAMETER_SET 512
 #include <mlkem_native.h>


### PR DESCRIPTION
`MLK_CONFIG_NO_SUPERCOP` is already set in the configuration file; it should not be set again in mlkem_native_all.h.