### PR TITLE
CI/CBMC: Report CBMC runtimes and warn about regressions

### DIFF
--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -51,7 +51,17 @@ runs:
             EOF
       - name: Run CBMC proofs (MLKEM_K=${{ inputs.mlkem_k }})
         shell: ${{ env.SHELL }}
+        env:
+          GH_TOKEN: ${{ inputs.gh_token }}
         run: |
           echo "::group::cbmc_${{ inputs.mlkem_k }}"
-          tests cbmc --mlkem-parameter-set ${{ inputs.mlkem_k }} --per-proof-timeout 1800;
+          tests cbmc --mlkem-parameter-set ${{ inputs.mlkem_k }} --per-proof-timeout 1800 --output-result-json ${{ github.workspace }}/cbmc_result_k${{ inputs.mlkem_k }}.json || cbmc_failed=true
           echo "::endgroup::"
+          python3 ${{ github.action_path }}/report.py \
+            --results-json "${{ github.workspace }}/cbmc_result_k${{ inputs.mlkem_k }}.json" \
+            --mlkem-k "${{ inputs.mlkem_k }}" \
+            --min-runtime 20 \
+            --regression-threshold 1.5 \
+            --gh-pages-branch gh-pages \
+            --data-dir dev/cbmc
+          if [ "$cbmc_failed" = "true" ]; then exit 1; fi

--- a/.github/actions/cbmc/report.py
+++ b/.github/actions/cbmc/report.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+"""CBMC proof results reporter for GitHub Actions."""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import tempfile
+from collections import namedtuple
+
+# GitHub context
+GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
+GITHUB_REF = os.environ.get("GITHUB_REF", "")
+GITHUB_SHA = os.environ.get("GITHUB_SHA", "")[:7]
+
+COMMENT_TAG = "cbmc-report"
+
+# Status symbols
+OK = "✅"
+WARN = "⚠️"
+FAIL = "❌"
+
+ProofResult = namedtuple(
+    "ProofResult", ["name", "status", "current", "previous", "change"]
+)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="CBMC proof results reporter")
+    parser.add_argument("--results-json", required=True)
+    parser.add_argument("--mlkem-k", required=True, choices=["2", "3", "4"])
+    parser.add_argument("--min-runtime", type=int, default=20)
+    parser.add_argument("--regression-threshold", type=float, default=1.5)
+    parser.add_argument("--gh-pages-branch", default="gh-pages")
+    parser.add_argument("--data-dir", default="dev/cbmc")
+    return parser.parse_args()
+
+
+def get_pr_number():
+    """Get PR number from GitHub event."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path or not os.path.exists(event_path):
+        return None
+    with open(event_path) as f:
+        event = json.load(f)
+    return event.get("pull_request", {}).get("number")
+
+
+def fetch_baseline(cfg):
+    """Fetch baseline data from gh-pages branch."""
+    baseline_file = f"{cfg.data_dir}/mlkem-{cfg.param_set}.json"
+    subprocess.run(
+        ["git", "fetch", "origin", cfg.gh_pages_branch, "--depth=1"],
+        capture_output=True,
+    )
+    result = subprocess.run(
+        ["git", "show", f"origin/{cfg.gh_pages_branch}:{baseline_file}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return json.loads(result.stdout)
+    return None
+
+
+def render_table(rows):
+    """Render a markdown table from ProofResult rows."""
+    lines = [
+        "| Proof | Status | Current | Previous | Change |",
+        "|-------|--------|---------|----------|--------|",
+    ]
+    lines.extend(
+        f"| `{r.name}` | {r.status} | {r.current} | {r.previous} | {r.change} |"
+        for r in rows
+    )
+    return lines
+
+
+def classify_proof(r, baseline_runtimes, cfg):
+    """Classify a single proof result, returning (ProofResult, is_alert)."""
+    name = r["name"]
+    base = baseline_runtimes.get(name, {})
+    base_val, base_failed = base.get("value"), base.get("status") == "failed"
+
+    if r.get("status") == "failed":
+        prev = "failed" if base_failed else (f"{base_val}s" if base_val else "-")
+        return ProofResult(name, FAIL, "-", prev, "-"), True
+
+    cur_val = r["value"]
+    if base_failed:
+        return ProofResult(name, OK, f"{cur_val}s", "failed", "fixed"), False
+    if base_val is None:
+        return ProofResult(name, OK, f"{cur_val}s", "-", "new"), False
+
+    ratio = cur_val / base_val if base_val > 0 else 1
+    change = f"{(ratio - 1) * 100:+.0f}%" if base_val > 0 else "-"
+    is_regression = cur_val >= cfg.min_runtime and ratio >= cfg.regression_threshold
+    status = WARN if is_regression else OK
+    return (
+        ProofResult(name, status, f"{cur_val}s", f"{base_val}s", change),
+        is_regression,
+    )
+
+
+def build_comment(current, baseline, cfg):
+    """Build the PR comment markdown."""
+    baseline_runtimes = {r["name"]: r for r in (baseline or {}).get("runtimes", [])}
+    alerts, all_rows = [], []
+
+    for r in current.get("runtimes", []):
+        result, is_alert = classify_proof(r, baseline_runtimes, cfg)
+        all_rows.append(result)
+        if is_alert:
+            alerts.append(result)
+
+    def sort_key(r):
+        return -1 if r.current == "-" else -int(r.current.rstrip("s"))
+
+    all_rows.sort(key=sort_key)
+
+    lines = [
+        f"<!-- {COMMENT_TAG}(start): mlkem-{cfg.param_set} -->",
+        f"## CBMC Results (ML-KEM-{cfg.param_set})",
+        "",
+    ]
+
+    if alerts:
+        lines += [f"{WARN} **Attention Required**", ""] + render_table(alerts) + [""]
+
+    total = current.get("summary", {}).get("total", len(all_rows))
+    lines += (
+        [
+            "<details>",
+            f"<summary>Full Results ({total} proofs)</summary>",
+            "",
+        ]
+        + render_table(all_rows)
+        + [
+            "",
+            "</details>",
+            "",
+            f"<!-- {COMMENT_TAG}(end): mlkem-{cfg.param_set} -->",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def post_or_update_comment(pr_number, body, cfg):
+    """Post or update PR comment."""
+    tag = f"<!-- {COMMENT_TAG}(start): mlkem-{cfg.param_set} -->"
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{GITHUB_REPOSITORY}/issues/{pr_number}/comments",
+            "--jq",
+            f'.[] | select(.body | startswith("{tag}")) | .id',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    existing_id = (
+        result.stdout.strip().split("\n")[0]
+        if result.returncode == 0 and result.stdout.strip()
+        else None
+    )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(body)
+        tmp_path = f.name
+
+    try:
+        if existing_id:
+            subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{GITHUB_REPOSITORY}/issues/comments/{existing_id}",
+                    "-X",
+                    "PATCH",
+                    "-F",
+                    f"body=@{tmp_path}",
+                ],
+                check=True,
+            )
+            print(f"Updated existing comment {existing_id}")
+        else:
+            subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{GITHUB_REPOSITORY}/issues/{pr_number}/comments",
+                    "-X",
+                    "POST",
+                    "-F",
+                    f"body=@{tmp_path}",
+                ],
+                check=True,
+            )
+            print("Created new comment")
+    finally:
+        os.unlink(tmp_path)
+
+
+def push_to_gh_pages(current, cfg):
+    """Push results to gh-pages branch using GitHub Contents API."""
+    file_path = f"{cfg.data_dir}/mlkem-{cfg.param_set}.json"
+    content_b64 = base64.b64encode(json.dumps(current, indent=2).encode()).decode()
+
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{GITHUB_REPOSITORY}/contents/{file_path}?ref={cfg.gh_pages_branch}",
+            "--jq",
+            ".sha",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    sha = result.stdout.strip() if result.returncode == 0 else ""
+
+    cmd = [
+        "gh",
+        "api",
+        f"repos/{GITHUB_REPOSITORY}/contents/{file_path}",
+        "-X",
+        "PUT",
+        "-F",
+        f"message=Update CBMC results for ML-KEM-{cfg.param_set} ({GITHUB_SHA})",
+        "-F",
+        f"content={content_b64}",
+        "-F",
+        f"branch={cfg.gh_pages_branch}",
+    ]
+    if sha:
+        cmd.extend(["-F", f"sha={sha}"])
+
+    subprocess.run(cmd, check=True)
+    print(f"Pushed results to {cfg.gh_pages_branch}")
+
+
+def main():
+    args = get_args()
+    args.param_set = {"2": "512", "3": "768", "4": "1024"}[args.mlkem_k]
+
+    with open(args.results_json) as f:
+        current = json.load(f)
+    baseline = fetch_baseline(args)
+
+    pr_number = get_pr_number()
+    if pr_number:
+        post_or_update_comment(pr_number, build_comment(current, baseline, args), args)
+    elif GITHUB_REF in ("refs/heads/main", "refs/heads/master"):
+        push_to_gh_pages(current, args)
+    else:
+        print(f"Not a PR and not main branch ({GITHUB_REF}), skipping")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      pull-requests: 'write'
     needs: [ base, nix ]
     uses: ./.github/workflows/cbmc.yml
     secrets: inherit

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      pull-requests: 'write'
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-512)
@@ -35,6 +36,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      pull-requests: 'write'
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-768)
@@ -55,6 +57,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      pull-requests: 'write'
     uses: ./.github/workflows/ci_ec2_reusable.yml
     with:
       name: CBMC (MLKEM-1024)

--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
             packages = builtins.attrValues { inherit (config.packages) toolchains_native; };
           };
           devShells.ci-cbmc = util.mkShell {
-            packages = builtins.attrValues { inherit (config.packages) cbmc toolchains_native; };
+            packages = builtins.attrValues { inherit (config.packages) cbmc toolchains_native; } ++ [ pkgs.gh ];
           };
           devShells.ci-slothy = util.mkShell {
             packages = builtins.attrValues { inherit (config.packages) slothy linters toolchains_native; };

--- a/proofs/cbmc/run-cbmc-proofs.py
+++ b/proofs/cbmc/run-cbmc-proofs.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 import uuid
 
-from lib.summarize import print_proof_results
+from lib.summarize import print_proof_results, export_result_json
 
 
 DESCRIPTION = "Configure and run all CBMC proofs in parallel"
@@ -188,6 +188,11 @@ def get_args():
             "default": 1800,
             "help": "timeout for each individual proof in seconds (default: 1800)",
         },
+        {
+            "flags": ["--output-result-json"],
+            "metavar": "FILE",
+            "help": "path to export result JSON",
+        },
     ]:
         flags = arg.pop("flags")
         pars.add_argument(*flags, **arg)
@@ -243,7 +248,7 @@ def get_proof_dirs(proof_root, proof_list, marker_file):
         sys.exit(1)
 
 
-def run_build(litani, jobs, fail_on_proof_failure, summarize):
+def run_build(litani, jobs, fail_on_proof_failure, summarize, output_result_json=None):
     cmd = [str(litani), "run-build"]
     if jobs:
         cmd.extend(["-j", str(jobs)])
@@ -261,6 +266,7 @@ def run_build(litani, jobs, fail_on_proof_failure, summarize):
         sys.exit(1)
 
     if summarize:
+        export_result_json(output_result_json, out_file)
         print_proof_results(out_file)
         out_file.unlink()
 
@@ -531,7 +537,11 @@ async def main():  # pylint: disable=too-many-locals
 
     if not args.no_standalone:
         run_build(
-            litani, args.parallel_jobs, args.fail_on_proof_failure, args.summarize
+            litani,
+            args.parallel_jobs,
+            args.fail_on_proof_failure,
+            args.summarize,
+            args.output_result_json,
         )
 
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -935,7 +935,7 @@ class Tests:
                 run_cbmc_single_step(mlkem_k, proofs)
                 return
             envvars = {"MLKEM_K": mlkem_k}
-            p = subprocess.run(
+            cmd = (
                 [
                     "python3",
                     "run-cbmc-proofs.py",
@@ -946,7 +946,12 @@ class Tests:
                     "-p",
                 ]
                 + proofs
-                + self.make_j(),
+                + self.make_j()
+            )
+            if self.args.output_result_json:
+                cmd.extend(["--output-result-json", self.args.output_result_json])
+            p = subprocess.run(
+                cmd,
                 cwd="proofs/cbmc",
                 env=os.environ.copy() | envvars,
             )
@@ -1364,6 +1369,12 @@ def cli():
         help="Don't run any proofs, but list all functions for which CBMC proofs are available",
         action="store_true",
         default=False,
+    )
+
+    cbmc_parser.add_argument(
+        "--output-result-json",
+        help="Path to export result JSON",
+        default=None,
     )
 
     # hol_light arguments


### PR DESCRIPTION
This commit adds to the CBMC CI action another step which, for PRs,
- emits one comment per security level showing the CBMC runtimes
  and the relative slowdown/speedup compares to the last run on `main`
- warns about severe proof regressions (>50% for now) and failures.

Comments are updated when the CI is run multiple times on the same PR.

* Resolves #1322 