### PR TITLE
x86_64: Improve XKCP x4 Keccak intrinsics implementation

### DIFF
--- a/mlkem/src/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
+++ b/mlkem/src/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
@@ -70,298 +70,236 @@ static const uint64_t mlk_rho56[4] = {0x0007060504030201, 0x080F0E0D0C0B0A09,
   __m256i Ca, Ce, Ci, Co, Cu;      \
   __m256i Ca1, Ce1, Ci1, Co1, Cu1; \
   __m256i Da, De, Di, Do, Du;      \
-  __m256i Eba, Ebe, Ebi, Ebo, Ebu; \
-  __m256i Ega, Ege, Egi, Ego, Egu; \
-  __m256i Eka, Eke, Eki, Eko, Eku; \
-  __m256i Ema, Eme, Emi, Emo, Emu; \
-  __m256i Esa, Ese, Esi, Eso, Esu;
-
-#define MLK_prepareTheta                                                       \
-  Ca =                                                                         \
-      MLK_XOR256(Aba, MLK_XOR256(Aga, MLK_XOR256(Aka, MLK_XOR256(Ama, Asa)))); \
-  Ce =                                                                         \
-      MLK_XOR256(Abe, MLK_XOR256(Age, MLK_XOR256(Ake, MLK_XOR256(Ame, Ase)))); \
-  Ci =                                                                         \
-      MLK_XOR256(Abi, MLK_XOR256(Agi, MLK_XOR256(Aki, MLK_XOR256(Ami, Asi)))); \
-  Co =                                                                         \
-      MLK_XOR256(Abo, MLK_XOR256(Ago, MLK_XOR256(Ako, MLK_XOR256(Amo, Aso)))); \
-  Cu = MLK_XOR256(Abu, MLK_XOR256(Agu, MLK_XOR256(Aku, MLK_XOR256(Amu, Asu))));
-
-/*
- * --- Theta Rho Pi Chi Iota Prepare-theta
- * --- 64-bit lanes mapped to 64-bit words
- */
-#define MLK_thetaRhoPiChiIotaPrepareTheta(i, A, E)                        \
-  MLK_ROL64IN256(Ce1, Ce, 1);                                             \
-  Da = MLK_XOR256(Cu, Ce1);                                               \
-  MLK_ROL64IN256(Ci1, Ci, 1);                                             \
-  De = MLK_XOR256(Ca, Ci1);                                               \
-  MLK_ROL64IN256(Co1, Co, 1);                                             \
-  Di = MLK_XOR256(Ce, Co1);                                               \
-  MLK_ROL64IN256(Cu1, Cu, 1);                                             \
-  Do = MLK_XOR256(Ci, Cu1);                                               \
-  MLK_ROL64IN256(Ca1, Ca, 1);                                             \
-  Du = MLK_XOR256(Co, Ca1);                                               \
-                                                                          \
-  MLK_XOREQ256(A##ba, Da);                                                \
-  Bba = A##ba;                                                            \
-  MLK_XOREQ256(A##ge, De);                                                \
-  MLK_ROL64IN256(Bbe, A##ge, 44);                                         \
-  MLK_XOREQ256(A##ki, Di);                                                \
-  MLK_ROL64IN256(Bbi, A##ki, 43);                                         \
-  E##ba = MLK_XOR256(Bba, MLK_ANDNU256(Bbe, Bbi));                        \
-  MLK_XOREQ256(E##ba, MLK_CONST256_64(mlk_keccakf1600RoundConstants[i])); \
-  Ca = E##ba;                                                             \
-  MLK_XOREQ256(A##mo, Do);                                                \
-  MLK_ROL64IN256(Bbo, A##mo, 21);                                         \
-  E##be = MLK_XOR256(Bbe, MLK_ANDNU256(Bbi, Bbo));                        \
-  Ce = E##be;                                                             \
-  MLK_XOREQ256(A##su, Du);                                                \
-  MLK_ROL64IN256(Bbu, A##su, 14);                                         \
-  E##bi = MLK_XOR256(Bbi, MLK_ANDNU256(Bbo, Bbu));                        \
-  Ci = E##bi;                                                             \
-  E##bo = MLK_XOR256(Bbo, MLK_ANDNU256(Bbu, Bba));                        \
-  Co = E##bo;                                                             \
-  E##bu = MLK_XOR256(Bbu, MLK_ANDNU256(Bba, Bbe));                        \
-  Cu = E##bu;                                                             \
-                                                                          \
-  MLK_XOREQ256(A##bo, Do);                                                \
-  MLK_ROL64IN256(Bga, A##bo, 28);                                         \
-  MLK_XOREQ256(A##gu, Du);                                                \
-  MLK_ROL64IN256(Bge, A##gu, 20);                                         \
-  MLK_XOREQ256(A##ka, Da);                                                \
-  MLK_ROL64IN256(Bgi, A##ka, 3);                                          \
-  E##ga = MLK_XOR256(Bga, MLK_ANDNU256(Bge, Bgi));                        \
-  MLK_XOREQ256(Ca, E##ga);                                                \
-  MLK_XOREQ256(A##me, De);                                                \
-  MLK_ROL64IN256(Bgo, A##me, 45);                                         \
-  E##ge = MLK_XOR256(Bge, MLK_ANDNU256(Bgi, Bgo));                        \
-  MLK_XOREQ256(Ce, E##ge);                                                \
-  MLK_XOREQ256(A##si, Di);                                                \
-  MLK_ROL64IN256(Bgu, A##si, 61);                                         \
-  E##gi = MLK_XOR256(Bgi, MLK_ANDNU256(Bgo, Bgu));                        \
-  MLK_XOREQ256(Ci, E##gi);                                                \
-  E##go = MLK_XOR256(Bgo, MLK_ANDNU256(Bgu, Bga));                        \
-  MLK_XOREQ256(Co, E##go);                                                \
-  E##gu = MLK_XOR256(Bgu, MLK_ANDNU256(Bga, Bge));                        \
-  MLK_XOREQ256(Cu, E##gu);                                                \
-                                                                          \
-  MLK_XOREQ256(A##be, De);                                                \
-  MLK_ROL64IN256(Bka, A##be, 1);                                          \
-  MLK_XOREQ256(A##gi, Di);                                                \
-  MLK_ROL64IN256(Bke, A##gi, 6);                                          \
-  MLK_XOREQ256(A##ko, Do);                                                \
-  MLK_ROL64IN256(Bki, A##ko, 25);                                         \
-  E##ka = MLK_XOR256(Bka, MLK_ANDNU256(Bke, Bki));                        \
-  MLK_XOREQ256(Ca, E##ka);                                                \
-  MLK_XOREQ256(A##mu, Du);                                                \
-  MLK_ROL64IN256_8(Bko, A##mu);                                           \
-  E##ke = MLK_XOR256(Bke, MLK_ANDNU256(Bki, Bko));                        \
-  MLK_XOREQ256(Ce, E##ke);                                                \
-  MLK_XOREQ256(A##sa, Da);                                                \
-  MLK_ROL64IN256(Bku, A##sa, 18);                                         \
-  E##ki = MLK_XOR256(Bki, MLK_ANDNU256(Bko, Bku));                        \
-  MLK_XOREQ256(Ci, E##ki);                                                \
-  E##ko = MLK_XOR256(Bko, MLK_ANDNU256(Bku, Bka));                        \
-  MLK_XOREQ256(Co, E##ko);                                                \
-  E##ku = MLK_XOR256(Bku, MLK_ANDNU256(Bka, Bke));                        \
-  MLK_XOREQ256(Cu, E##ku);                                                \
-                                                                          \
-  MLK_XOREQ256(A##bu, Du);                                                \
-  MLK_ROL64IN256(Bma, A##bu, 27);                                         \
-  MLK_XOREQ256(A##ga, Da);                                                \
-  MLK_ROL64IN256(Bme, A##ga, 36);                                         \
-  MLK_XOREQ256(A##ke, De);                                                \
-  MLK_ROL64IN256(Bmi, A##ke, 10);                                         \
-  E##ma = MLK_XOR256(Bma, MLK_ANDNU256(Bme, Bmi));                        \
-  MLK_XOREQ256(Ca, E##ma);                                                \
-  MLK_XOREQ256(A##mi, Di);                                                \
-  MLK_ROL64IN256(Bmo, A##mi, 15);                                         \
-  E##me = MLK_XOR256(Bme, MLK_ANDNU256(Bmi, Bmo));                        \
-  MLK_XOREQ256(Ce, E##me);                                                \
-  MLK_XOREQ256(A##so, Do);                                                \
-  MLK_ROL64IN256_56(Bmu, A##so);                                          \
-  E##mi = MLK_XOR256(Bmi, MLK_ANDNU256(Bmo, Bmu));                        \
-  MLK_XOREQ256(Ci, E##mi);                                                \
-  E##mo = MLK_XOR256(Bmo, MLK_ANDNU256(Bmu, Bma));                        \
-  MLK_XOREQ256(Co, E##mo);                                                \
-  E##mu = MLK_XOR256(Bmu, MLK_ANDNU256(Bma, Bme));                        \
-  MLK_XOREQ256(Cu, E##mu);                                                \
-                                                                          \
-  MLK_XOREQ256(A##bi, Di);                                                \
-  MLK_ROL64IN256(Bsa, A##bi, 62);                                         \
-  MLK_XOREQ256(A##go, Do);                                                \
-  MLK_ROL64IN256(Bse, A##go, 55);                                         \
-  MLK_XOREQ256(A##ku, Du);                                                \
-  MLK_ROL64IN256(Bsi, A##ku, 39);                                         \
-  E##sa = MLK_XOR256(Bsa, MLK_ANDNU256(Bse, Bsi));                        \
-  MLK_XOREQ256(Ca, E##sa);                                                \
-  MLK_XOREQ256(A##ma, Da);                                                \
-  MLK_ROL64IN256(Bso, A##ma, 41);                                         \
-  E##se = MLK_XOR256(Bse, MLK_ANDNU256(Bsi, Bso));                        \
-  MLK_XOREQ256(Ce, E##se);                                                \
-  MLK_XOREQ256(A##se, De);                                                \
-  MLK_ROL64IN256(Bsu, A##se, 2);                                          \
-  E##si = MLK_XOR256(Bsi, MLK_ANDNU256(Bso, Bsu));                        \
-  MLK_XOREQ256(Ci, E##si);                                                \
-  E##so = MLK_XOR256(Bso, MLK_ANDNU256(Bsu, Bsa));                        \
-  MLK_XOREQ256(Co, E##so);                                                \
-  E##su = MLK_XOR256(Bsu, MLK_ANDNU256(Bsa, Bse));                        \
-  MLK_XOREQ256(Cu, E##su);
-
-
-/*
- * --- Theta Rho Pi Chi Iota
- * --- 64-bit lanes mapped to 64-bit words
- */
-#define MLK_thetaRhoPiChiIota(i, A, E)                                    \
-  MLK_ROL64IN256(Ce1, Ce, 1);                                             \
-  Da = MLK_XOR256(Cu, Ce1);                                               \
-  MLK_ROL64IN256(Ci1, Ci, 1);                                             \
-  De = MLK_XOR256(Ca, Ci1);                                               \
-  MLK_ROL64IN256(Co1, Co, 1);                                             \
-  Di = MLK_XOR256(Ce, Co1);                                               \
-  MLK_ROL64IN256(Cu1, Cu, 1);                                             \
-  Do = MLK_XOR256(Ci, Cu1);                                               \
-  MLK_ROL64IN256(Ca1, Ca, 1);                                             \
-  Du = MLK_XOR256(Co, Ca1);                                               \
-                                                                          \
-  MLK_XOREQ256(A##ba, Da);                                                \
-  Bba = A##ba;                                                            \
-  MLK_XOREQ256(A##ge, De);                                                \
-  MLK_ROL64IN256(Bbe, A##ge, 44);                                         \
-  MLK_XOREQ256(A##ki, Di);                                                \
-  MLK_ROL64IN256(Bbi, A##ki, 43);                                         \
-  E##ba = MLK_XOR256(Bba, MLK_ANDNU256(Bbe, Bbi));                        \
-  MLK_XOREQ256(E##ba, MLK_CONST256_64(mlk_keccakf1600RoundConstants[i])); \
-  MLK_XOREQ256(A##mo, Do);                                                \
-  MLK_ROL64IN256(Bbo, A##mo, 21);                                         \
-  E##be = MLK_XOR256(Bbe, MLK_ANDNU256(Bbi, Bbo));                        \
-  MLK_XOREQ256(A##su, Du);                                                \
-  MLK_ROL64IN256(Bbu, A##su, 14);                                         \
-  E##bi = MLK_XOR256(Bbi, MLK_ANDNU256(Bbo, Bbu));                        \
-  E##bo = MLK_XOR256(Bbo, MLK_ANDNU256(Bbu, Bba));                        \
-  E##bu = MLK_XOR256(Bbu, MLK_ANDNU256(Bba, Bbe));                        \
-                                                                          \
-  MLK_XOREQ256(A##bo, Do);                                                \
-  MLK_ROL64IN256(Bga, A##bo, 28);                                         \
-  MLK_XOREQ256(A##gu, Du);                                                \
-  MLK_ROL64IN256(Bge, A##gu, 20);                                         \
-  MLK_XOREQ256(A##ka, Da);                                                \
-  MLK_ROL64IN256(Bgi, A##ka, 3);                                          \
-  E##ga = MLK_XOR256(Bga, MLK_ANDNU256(Bge, Bgi));                        \
-  MLK_XOREQ256(A##me, De);                                                \
-  MLK_ROL64IN256(Bgo, A##me, 45);                                         \
-  E##ge = MLK_XOR256(Bge, MLK_ANDNU256(Bgi, Bgo));                        \
-  MLK_XOREQ256(A##si, Di);                                                \
-  MLK_ROL64IN256(Bgu, A##si, 61);                                         \
-  E##gi = MLK_XOR256(Bgi, MLK_ANDNU256(Bgo, Bgu));                        \
-  E##go = MLK_XOR256(Bgo, MLK_ANDNU256(Bgu, Bga));                        \
-  E##gu = MLK_XOR256(Bgu, MLK_ANDNU256(Bga, Bge));                        \
-                                                                          \
-  MLK_XOREQ256(A##be, De);                                                \
-  MLK_ROL64IN256(Bka, A##be, 1);                                          \
-  MLK_XOREQ256(A##gi, Di);                                                \
-  MLK_ROL64IN256(Bke, A##gi, 6);                                          \
-  MLK_XOREQ256(A##ko, Do);                                                \
-  MLK_ROL64IN256(Bki, A##ko, 25);                                         \
-  E##ka = MLK_XOR256(Bka, MLK_ANDNU256(Bke, Bki));                        \
-  MLK_XOREQ256(A##mu, Du);                                                \
-  MLK_ROL64IN256_8(Bko, A##mu);                                           \
-  E##ke = MLK_XOR256(Bke, MLK_ANDNU256(Bki, Bko));                        \
-  MLK_XOREQ256(A##sa, Da);                                                \
-  MLK_ROL64IN256(Bku, A##sa, 18);                                         \
-  E##ki = MLK_XOR256(Bki, MLK_ANDNU256(Bko, Bku));                        \
-  E##ko = MLK_XOR256(Bko, MLK_ANDNU256(Bku, Bka));                        \
-  E##ku = MLK_XOR256(Bku, MLK_ANDNU256(Bka, Bke));                        \
-                                                                          \
-  MLK_XOREQ256(A##bu, Du);                                                \
-  MLK_ROL64IN256(Bma, A##bu, 27);                                         \
-  MLK_XOREQ256(A##ga, Da);                                                \
-  MLK_ROL64IN256(Bme, A##ga, 36);                                         \
-  MLK_XOREQ256(A##ke, De);                                                \
-  MLK_ROL64IN256(Bmi, A##ke, 10);                                         \
-  E##ma = MLK_XOR256(Bma, MLK_ANDNU256(Bme, Bmi));                        \
-  MLK_XOREQ256(A##mi, Di);                                                \
-  MLK_ROL64IN256(Bmo, A##mi, 15);                                         \
-  E##me = MLK_XOR256(Bme, MLK_ANDNU256(Bmi, Bmo));                        \
-  MLK_XOREQ256(A##so, Do);                                                \
-  MLK_ROL64IN256_56(Bmu, A##so);                                          \
-  E##mi = MLK_XOR256(Bmi, MLK_ANDNU256(Bmo, Bmu));                        \
-  E##mo = MLK_XOR256(Bmo, MLK_ANDNU256(Bmu, Bma));                        \
-  E##mu = MLK_XOR256(Bmu, MLK_ANDNU256(Bma, Bme));                        \
-                                                                          \
-  MLK_XOREQ256(A##bi, Di);                                                \
-  MLK_ROL64IN256(Bsa, A##bi, 62);                                         \
-  MLK_XOREQ256(A##go, Do);                                                \
-  MLK_ROL64IN256(Bse, A##go, 55);                                         \
-  MLK_XOREQ256(A##ku, Du);                                                \
-  MLK_ROL64IN256(Bsi, A##ku, 39);                                         \
-  E##sa = MLK_XOR256(Bsa, MLK_ANDNU256(Bse, Bsi));                        \
-  MLK_XOREQ256(A##ma, Da);                                                \
-  MLK_ROL64IN256(Bso, A##ma, 41);                                         \
-  E##se = MLK_XOR256(Bse, MLK_ANDNU256(Bsi, Bso));                        \
-  MLK_XOREQ256(A##se, De);                                                \
-  MLK_ROL64IN256(Bsu, A##se, 2);                                          \
-  E##si = MLK_XOR256(Bsi, MLK_ANDNU256(Bso, Bsu));                        \
-  E##so = MLK_XOR256(Bso, MLK_ANDNU256(Bsu, Bsa));                        \
-  E##su = MLK_XOR256(Bsu, MLK_ANDNU256(Bsa, Bse));
-
+  __m256i Tba, Tbe, Tbi, Tbo, Tbu; \
+  __m256i Tga, Tge, Tgi, Tgo, Tgu; \
+  __m256i Tka, Tke, Tki, Tko, Tku; \
+  __m256i Tma, Tme, Tmi, Tmo, Tmu; \
+  __m256i Tsa, Tse, Tsi, Tso, Tsu;
 
 static MLK_ALIGN const uint64_t mlk_keccakf1600RoundConstants[24] = {
-    (uint64_t)0x0000000000000001ULL, (uint64_t)0x0000000000008082ULL,
-    (uint64_t)0x800000000000808aULL, (uint64_t)0x8000000080008000ULL,
-    (uint64_t)0x000000000000808bULL, (uint64_t)0x0000000080000001ULL,
-    (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008009ULL,
-    (uint64_t)0x000000000000008aULL, (uint64_t)0x0000000000000088ULL,
-    (uint64_t)0x0000000080008009ULL, (uint64_t)0x000000008000000aULL,
-    (uint64_t)0x000000008000808bULL, (uint64_t)0x800000000000008bULL,
-    (uint64_t)0x8000000000008089ULL, (uint64_t)0x8000000000008003ULL,
-    (uint64_t)0x8000000000008002ULL, (uint64_t)0x8000000000000080ULL,
-    (uint64_t)0x000000000000800aULL, (uint64_t)0x800000008000000aULL,
-    (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008080ULL,
-    (uint64_t)0x0000000080000001ULL, (uint64_t)0x8000000080008008ULL};
+    0x0000000000000001ULL, 0x0000000000008082ULL, 0x800000000000808aULL,
+    0x8000000080008000ULL, 0x000000000000808bULL, 0x0000000080000001ULL,
+    0x8000000080008081ULL, 0x8000000000008009ULL, 0x000000000000008aULL,
+    0x0000000000000088ULL, 0x0000000080008009ULL, 0x000000008000000aULL,
+    0x000000008000808bULL, 0x800000000000008bULL, 0x8000000000008089ULL,
+    0x8000000000008003ULL, 0x8000000000008002ULL, 0x8000000000000080ULL,
+    0x000000000000800aULL, 0x800000008000000aULL, 0x8000000080008081ULL,
+    0x8000000000008080ULL, 0x0000000080000001ULL, 0x8000000080008008ULL};
 
-#include <stdint.h>
+/* MLK_thetaRhoPiChiIota: single round macro with in-place state update */
+#define MLK_thetaRhoPiChiIota(i, A)                                           \
+  Ca = MLK_XOR256(                                                            \
+      A##ba, MLK_XOR256(A##ga, MLK_XOR256(A##ka, MLK_XOR256(A##ma, A##sa)))); \
+  Ce = MLK_XOR256(                                                            \
+      A##be, MLK_XOR256(A##ge, MLK_XOR256(A##ke, MLK_XOR256(A##me, A##se)))); \
+  Ci = MLK_XOR256(                                                            \
+      A##bi, MLK_XOR256(A##gi, MLK_XOR256(A##ki, MLK_XOR256(A##mi, A##si)))); \
+  Co = MLK_XOR256(                                                            \
+      A##bo, MLK_XOR256(A##go, MLK_XOR256(A##ko, MLK_XOR256(A##mo, A##so)))); \
+  Cu = MLK_XOR256(                                                            \
+      A##bu, MLK_XOR256(A##gu, MLK_XOR256(A##ku, MLK_XOR256(A##mu, A##su)))); \
+                                                                              \
+  MLK_ROL64IN256(Ce1, Ce, 1);                                                 \
+  Da = MLK_XOR256(Cu, Ce1);                                                   \
+  MLK_ROL64IN256(Ci1, Ci, 1);                                                 \
+  De = MLK_XOR256(Ca, Ci1);                                                   \
+  MLK_ROL64IN256(Co1, Co, 1);                                                 \
+  Di = MLK_XOR256(Ce, Co1);                                                   \
+  MLK_ROL64IN256(Cu1, Cu, 1);                                                 \
+  Do = MLK_XOR256(Ci, Cu1);                                                   \
+  MLK_ROL64IN256(Ca1, Ca, 1);                                                 \
+  Du = MLK_XOR256(Co, Ca1);                                                   \
+                                                                              \
+  MLK_XOREQ256(A##ba, Da);                                                    \
+  Bba = A##ba;                                                                \
+  MLK_XOREQ256(A##ge, De);                                                    \
+  MLK_ROL64IN256(Bbe, A##ge, 44);                                             \
+  MLK_XOREQ256(A##ki, Di);                                                    \
+  MLK_ROL64IN256(Bbi, A##ki, 43);                                             \
+  Tba = MLK_XOR256(Bba, MLK_ANDNU256(Bbe, Bbi));                              \
+  MLK_XOREQ256(Tba, MLK_CONST256_64(mlk_keccakf1600RoundConstants[i]));       \
+  Ca = Tba;                                                                   \
+  MLK_XOREQ256(A##mo, Do);                                                    \
+  MLK_ROL64IN256(Bbo, A##mo, 21);                                             \
+  Tbe = MLK_XOR256(Bbe, MLK_ANDNU256(Bbi, Bbo));                              \
+  Ce = Tbe;                                                                   \
+  MLK_XOREQ256(A##su, Du);                                                    \
+  MLK_ROL64IN256(Bbu, A##su, 14);                                             \
+  Tbi = MLK_XOR256(Bbi, MLK_ANDNU256(Bbo, Bbu));                              \
+  Ci = Tbi;                                                                   \
+  Tbo = MLK_XOR256(Bbo, MLK_ANDNU256(Bbu, Bba));                              \
+  Co = Tbo;                                                                   \
+  Tbu = MLK_XOR256(Bbu, MLK_ANDNU256(Bba, Bbe));                              \
+  Cu = Tbu;                                                                   \
+                                                                              \
+  MLK_XOREQ256(A##bo, Do);                                                    \
+  MLK_ROL64IN256(Bga, A##bo, 28);                                             \
+  MLK_XOREQ256(A##gu, Du);                                                    \
+  MLK_ROL64IN256(Bge, A##gu, 20);                                             \
+  MLK_XOREQ256(A##ka, Da);                                                    \
+  MLK_ROL64IN256(Bgi, A##ka, 3);                                              \
+  Tga = MLK_XOR256(Bga, MLK_ANDNU256(Bge, Bgi));                              \
+  MLK_XOREQ256(Ca, Tga);                                                      \
+  MLK_XOREQ256(A##me, De);                                                    \
+  MLK_ROL64IN256(Bgo, A##me, 45);                                             \
+  Tge = MLK_XOR256(Bge, MLK_ANDNU256(Bgi, Bgo));                              \
+  MLK_XOREQ256(Ce, Tge);                                                      \
+  MLK_XOREQ256(A##si, Di);                                                    \
+  MLK_ROL64IN256(Bgu, A##si, 61);                                             \
+  Tgi = MLK_XOR256(Bgi, MLK_ANDNU256(Bgo, Bgu));                              \
+  MLK_XOREQ256(Ci, Tgi);                                                      \
+  Tgo = MLK_XOR256(Bgo, MLK_ANDNU256(Bgu, Bga));                              \
+  MLK_XOREQ256(Co, Tgo);                                                      \
+  Tgu = MLK_XOR256(Bgu, MLK_ANDNU256(Bga, Bge));                              \
+  MLK_XOREQ256(Cu, Tgu);                                                      \
+                                                                              \
+  MLK_XOREQ256(A##be, De);                                                    \
+  MLK_ROL64IN256(Bka, A##be, 1);                                              \
+  MLK_XOREQ256(A##gi, Di);                                                    \
+  MLK_ROL64IN256(Bke, A##gi, 6);                                              \
+  MLK_XOREQ256(A##ko, Do);                                                    \
+  MLK_ROL64IN256(Bki, A##ko, 25);                                             \
+  Tka = MLK_XOR256(Bka, MLK_ANDNU256(Bke, Bki));                              \
+  MLK_XOREQ256(Ca, Tka);                                                      \
+  MLK_XOREQ256(A##mu, Du);                                                    \
+  MLK_ROL64IN256_8(Bko, A##mu);                                               \
+  Tke = MLK_XOR256(Bke, MLK_ANDNU256(Bki, Bko));                              \
+  MLK_XOREQ256(Ce, Tke);                                                      \
+  MLK_XOREQ256(A##sa, Da);                                                    \
+  MLK_ROL64IN256(Bku, A##sa, 18);                                             \
+  Tki = MLK_XOR256(Bki, MLK_ANDNU256(Bko, Bku));                              \
+  MLK_XOREQ256(Ci, Tki);                                                      \
+  Tko = MLK_XOR256(Bko, MLK_ANDNU256(Bku, Bka));                              \
+  MLK_XOREQ256(Co, Tko);                                                      \
+  Tku = MLK_XOR256(Bku, MLK_ANDNU256(Bka, Bke));                              \
+  MLK_XOREQ256(Cu, Tku);                                                      \
+                                                                              \
+  MLK_XOREQ256(A##bu, Du);                                                    \
+  MLK_ROL64IN256(Bma, A##bu, 27);                                             \
+  MLK_XOREQ256(A##ga, Da);                                                    \
+  MLK_ROL64IN256(Bme, A##ga, 36);                                             \
+  MLK_XOREQ256(A##ke, De);                                                    \
+  MLK_ROL64IN256(Bmi, A##ke, 10);                                             \
+  Tma = MLK_XOR256(Bma, MLK_ANDNU256(Bme, Bmi));                              \
+  MLK_XOREQ256(Ca, Tma);                                                      \
+  MLK_XOREQ256(A##mi, Di);                                                    \
+  MLK_ROL64IN256(Bmo, A##mi, 15);                                             \
+  Tme = MLK_XOR256(Bme, MLK_ANDNU256(Bmi, Bmo));                              \
+  MLK_XOREQ256(Ce, Tme);                                                      \
+  MLK_XOREQ256(A##so, Do);                                                    \
+  MLK_ROL64IN256_56(Bmu, A##so);                                              \
+  Tmi = MLK_XOR256(Bmi, MLK_ANDNU256(Bmo, Bmu));                              \
+  MLK_XOREQ256(Ci, Tmi);                                                      \
+  Tmo = MLK_XOR256(Bmo, MLK_ANDNU256(Bmu, Bma));                              \
+  MLK_XOREQ256(Co, Tmo);                                                      \
+  Tmu = MLK_XOR256(Bmu, MLK_ANDNU256(Bma, Bme));                              \
+  MLK_XOREQ256(Cu, Tmu);                                                      \
+                                                                              \
+  MLK_XOREQ256(A##bi, Di);                                                    \
+  MLK_ROL64IN256(Bsa, A##bi, 62);                                             \
+  MLK_XOREQ256(A##go, Do);                                                    \
+  MLK_ROL64IN256(Bse, A##go, 55);                                             \
+  MLK_XOREQ256(A##ku, Du);                                                    \
+  MLK_ROL64IN256(Bsi, A##ku, 39);                                             \
+  Tsa = MLK_XOR256(Bsa, MLK_ANDNU256(Bse, Bsi));                              \
+  MLK_XOREQ256(Ca, Tsa);                                                      \
+  MLK_XOREQ256(A##ma, Da);                                                    \
+  MLK_ROL64IN256(Bso, A##ma, 41);                                             \
+  Tse = MLK_XOR256(Bse, MLK_ANDNU256(Bsi, Bso));                              \
+  MLK_XOREQ256(Ce, Tse);                                                      \
+  MLK_XOREQ256(A##se, De);                                                    \
+  MLK_ROL64IN256(Bsu, A##se, 2);                                              \
+  Tsi = MLK_XOR256(Bsi, MLK_ANDNU256(Bso, Bsu));                              \
+  MLK_XOREQ256(Ci, Tsi);                                                      \
+  Tso = MLK_XOR256(Bso, MLK_ANDNU256(Bsu, Bsa));                              \
+  MLK_XOREQ256(Co, Tso);                                                      \
+  Tsu = MLK_XOR256(Bsu, MLK_ANDNU256(Bsa, Bse));                              \
+  MLK_XOREQ256(Cu, Tsu);                                                      \
+                                                                              \
+  A##ba = Tba;                                                                \
+  A##be = Tbe;                                                                \
+  A##bi = Tbi;                                                                \
+  A##bo = Tbo;                                                                \
+  A##bu = Tbu;                                                                \
+  A##ga = Tga;                                                                \
+  A##ge = Tge;                                                                \
+  A##gi = Tgi;                                                                \
+  A##go = Tgo;                                                                \
+  A##gu = Tgu;                                                                \
+  A##ka = Tka;                                                                \
+  A##ke = Tke;                                                                \
+  A##ki = Tki;                                                                \
+  A##ko = Tko;                                                                \
+  A##ku = Tku;                                                                \
+  A##ma = Tma;                                                                \
+  A##me = Tme;                                                                \
+  A##mi = Tmi;                                                                \
+  A##mo = Tmo;                                                                \
+  A##mu = Tmu;                                                                \
+  A##sa = Tsa;                                                                \
+  A##se = Tse;                                                                \
+  A##si = Tsi;                                                                \
+  A##so = Tso;                                                                \
+  A##su = Tsu;
 
-#define MLK_COPY_FROM_STATE(X, state)                                       \
-  do                                                                        \
-  {                                                                         \
-    const uint64_t *state64 = (const uint64_t *)(state);                    \
-    __m256i _idx =                                                          \
-        _mm256_set_epi64x((long long)&state64[75], (long long)&state64[50], \
-                          (long long)&state64[25], (long long)&state64[0]); \
-    X##ba = _mm256_i64gather_epi64((long long *)(0 * 8), _idx, 1);          \
-    X##be = _mm256_i64gather_epi64((long long *)(1 * 8), _idx, 1);          \
-    X##bi = _mm256_i64gather_epi64((long long *)(2 * 8), _idx, 1);          \
-    X##bo = _mm256_i64gather_epi64((long long *)(3 * 8), _idx, 1);          \
-    X##bu = _mm256_i64gather_epi64((long long *)(4 * 8), _idx, 1);          \
-    X##ga = _mm256_i64gather_epi64((long long *)(5 * 8), _idx, 1);          \
-    X##ge = _mm256_i64gather_epi64((long long *)(6 * 8), _idx, 1);          \
-    X##gi = _mm256_i64gather_epi64((long long *)(7 * 8), _idx, 1);          \
-    X##go = _mm256_i64gather_epi64((long long *)(8 * 8), _idx, 1);          \
-    X##gu = _mm256_i64gather_epi64((long long *)(9 * 8), _idx, 1);          \
-    X##ka = _mm256_i64gather_epi64((long long *)(10 * 8), _idx, 1);         \
-    X##ke = _mm256_i64gather_epi64((long long *)(11 * 8), _idx, 1);         \
-    X##ki = _mm256_i64gather_epi64((long long *)(12 * 8), _idx, 1);         \
-    X##ko = _mm256_i64gather_epi64((long long *)(13 * 8), _idx, 1);         \
-    X##ku = _mm256_i64gather_epi64((long long *)(14 * 8), _idx, 1);         \
-    X##ma = _mm256_i64gather_epi64((long long *)(15 * 8), _idx, 1);         \
-    X##me = _mm256_i64gather_epi64((long long *)(16 * 8), _idx, 1);         \
-    X##mi = _mm256_i64gather_epi64((long long *)(17 * 8), _idx, 1);         \
-    X##mo = _mm256_i64gather_epi64((long long *)(18 * 8), _idx, 1);         \
-    X##mu = _mm256_i64gather_epi64((long long *)(19 * 8), _idx, 1);         \
-    X##sa = _mm256_i64gather_epi64((long long *)(20 * 8), _idx, 1);         \
-    X##se = _mm256_i64gather_epi64((long long *)(21 * 8), _idx, 1);         \
-    X##si = _mm256_i64gather_epi64((long long *)(22 * 8), _idx, 1);         \
-    X##so = _mm256_i64gather_epi64((long long *)(23 * 8), _idx, 1);         \
-    X##su = _mm256_i64gather_epi64((long long *)(24 * 8), _idx, 1);         \
-  } while (0);
+#define MLK_LOAD_LANE(X, state, lane)                              \
+  do                                                               \
+  {                                                                \
+    const uint64_t *state64 = (const uint64_t *)(state);           \
+    __m256i t0, t1, t2, t3, t4, t6;                                \
+    t0 = _mm256_loadu_si256((const __m256i *)&state64[lane]);      \
+    t1 = _mm256_loadu_si256((const __m256i *)&state64[lane + 25]); \
+    t2 = _mm256_loadu_si256((const __m256i *)&state64[lane + 50]); \
+    t3 = _mm256_loadu_si256((const __m256i *)&state64[lane + 75]); \
+    t4 = _mm256_unpacklo_epi64(t0, t1);                            \
+    t6 = _mm256_unpacklo_epi64(t2, t3);                            \
+    X = _mm256_permute2x128_si256(t4, t6, 0x20);                   \
+  } while (0)
+
+/* Lane 24 requires scalar loads to avoid reading past the end of the state */
+#define MLK_LOAD_LANE_24(X, state)                                           \
+  do                                                                         \
+  {                                                                          \
+    const uint64_t *state64 = (const uint64_t *)(state);                     \
+    __m128i lo = _mm_set_epi64x((int64_t)state64[49], (int64_t)state64[24]); \
+    __m128i hi = _mm_set_epi64x((int64_t)state64[99], (int64_t)state64[74]); \
+    X = _mm256_inserti128_si256(_mm256_castsi128_si256(lo), hi, 1);          \
+  } while (0)
+
+#define MLK_COPY_FROM_STATE(X, state) \
+  do                                  \
+  {                                   \
+    MLK_LOAD_LANE(X##ba, state, 0);   \
+    MLK_LOAD_LANE(X##be, state, 1);   \
+    MLK_LOAD_LANE(X##bi, state, 2);   \
+    MLK_LOAD_LANE(X##bo, state, 3);   \
+    MLK_LOAD_LANE(X##bu, state, 4);   \
+    MLK_LOAD_LANE(X##ga, state, 5);   \
+    MLK_LOAD_LANE(X##ge, state, 6);   \
+    MLK_LOAD_LANE(X##gi, state, 7);   \
+    MLK_LOAD_LANE(X##go, state, 8);   \
+    MLK_LOAD_LANE(X##gu, state, 9);   \
+    MLK_LOAD_LANE(X##ka, state, 10);  \
+    MLK_LOAD_LANE(X##ke, state, 11);  \
+    MLK_LOAD_LANE(X##ki, state, 12);  \
+    MLK_LOAD_LANE(X##ko, state, 13);  \
+    MLK_LOAD_LANE(X##ku, state, 14);  \
+    MLK_LOAD_LANE(X##ma, state, 15);  \
+    MLK_LOAD_LANE(X##me, state, 16);  \
+    MLK_LOAD_LANE(X##mi, state, 17);  \
+    MLK_LOAD_LANE(X##mo, state, 18);  \
+    MLK_LOAD_LANE(X##mu, state, 19);  \
+    MLK_LOAD_LANE(X##sa, state, 20);  \
+    MLK_LOAD_LANE(X##se, state, 21);  \
+    MLK_LOAD_LANE(X##si, state, 22);  \
+    MLK_LOAD_LANE(X##so, state, 23);  \
+    MLK_LOAD_LANE_24(X##su, state);   \
+  } while (0)
 
 #define MLK_SCATTER_STORE256(state, idx, v)                    \
   do                                                           \
   {                                                            \
-    const uint64_t *state64 = (const uint64_t *)(state);       \
+    uint64_t *state64 = (uint64_t *)(state);                   \
     __m128d t = _mm_castsi128_pd(_mm256_castsi256_si128((v))); \
     _mm_storel_pd((double *)&state64[0 + (idx)], t);           \
     _mm_storeh_pd((double *)&state64[25 + (idx)], t);          \
@@ -397,67 +335,24 @@ static MLK_ALIGN const uint64_t mlk_keccakf1600RoundConstants[24] = {
   MLK_SCATTER_STORE256(state, 23, X##so); \
   MLK_SCATTER_STORE256(state, 24, X##su);
 
-#define MLK_COPY_STATE_VARIABLES(X, Y) \
-  X##ba = Y##ba;                       \
-  X##be = Y##be;                       \
-  X##bi = Y##bi;                       \
-  X##bo = Y##bo;                       \
-  X##bu = Y##bu;                       \
-  X##ga = Y##ga;                       \
-  X##ge = Y##ge;                       \
-  X##gi = Y##gi;                       \
-  X##go = Y##go;                       \
-  X##gu = Y##gu;                       \
-  X##ka = Y##ka;                       \
-  X##ke = Y##ke;                       \
-  X##ki = Y##ki;                       \
-  X##ko = Y##ko;                       \
-  X##ku = Y##ku;                       \
-  X##ma = Y##ma;                       \
-  X##me = Y##me;                       \
-  X##mi = Y##mi;                       \
-  X##mo = Y##mo;                       \
-  X##mu = Y##mu;                       \
-  X##sa = Y##sa;                       \
-  X##se = Y##se;                       \
-  X##si = Y##si;                       \
-  X##so = Y##so;                       \
-  X##su = Y##su;
-
 /* clang-format off */
-#define MLK_ROUNDS24 \
-    MLK_prepareTheta \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 0, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 1, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 2, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 3, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 4, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 5, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 6, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 7, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 8, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta( 9, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(10, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(11, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(12, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(13, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(14, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(15, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(16, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(17, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(18, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(19, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(20, A, E) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(21, E, A) \
-    MLK_thetaRhoPiChiIotaPrepareTheta(22, A, E) \
-    MLK_thetaRhoPiChiIota(23, E, A)
+#define MLK_ROUNDS24_LOOP              \
+  do {                                 \
+    int i;                             \
+    for (i = 0; i < 12; i++) {         \
+      MLK_thetaRhoPiChiIota(2*i, A)    \
+      MLK_thetaRhoPiChiIota(2*i+1, A)  \
+    }                                  \
+  } while(0)
 /* clang-format on */
 
 void mlk_keccakf1600x4_permute24(void *states)
 {
   __m256i *statesAsLanes = (__m256i *)states;
-  MLK_DECLARE_ABCDE MLK_COPY_FROM_STATE(A, statesAsLanes)
-      MLK_ROUNDS24 MLK_COPY_TO_STATE(statesAsLanes, A)
+  MLK_DECLARE_ABCDE
+  MLK_COPY_FROM_STATE(A, statesAsLanes);
+  MLK_ROUNDS24_LOOP;
+  MLK_COPY_TO_STATE(statesAsLanes, A);
 }
 
 #else /* MLK_FIPS202_X86_64_XKCP && !MLK_CONFIG_MULTILEVEL_NO_SHARED */
@@ -479,11 +374,10 @@ MLK_EMPTY_CU(fips202_avx2_keccakx4)
 #undef MLK_XOREQ256
 #undef MLK_SNP_LANELENGTHINBYTES
 #undef MLK_DECLARE_ABCDE
-#undef MLK_prepareTheta
-#undef MLK_thetaRhoPiChiIotaPrepareTheta
 #undef MLK_thetaRhoPiChiIota
+#undef MLK_LOAD_LANE
+#undef MLK_LOAD_LANE_24
 #undef MLK_COPY_FROM_STATE
 #undef MLK_SCATTER_STORE256
 #undef MLK_COPY_TO_STATE
-#undef MLK_COPY_STATE_VARIABLES
-#undef MLK_ROUNDS24
+#undef MLK_ROUNDS24_LOOP


### PR DESCRIPTION
* Ported from @manastasova's https://github.com/pq-code-package/mlkem-native/pull/1481


This commit improves the performance of the AVX2 Keccak-F1600x4 implementation by:

- Replacing gather-based state loads with explicit unpack/permute operations, avoiding slow _mm256_i64gather_epi64 instructions
- Merging the two round macros into a single in-place state update
- Using a loop instead of fully unrolled rounds


Suggested-by: manastasova <manastasova2017@fau.edu>