### PR TITLE
x86_64: Remove native poly_decompress_d4/d10 implementations

### DIFF
--- a/dev/x86_64/meta.h
+++ b/dev/x86_64/meta.h
@@ -24,9 +24,7 @@
 #define MLK_USE_NATIVE_POLY_COMPRESS_D5
 #define MLK_USE_NATIVE_POLY_COMPRESS_D10
 #define MLK_USE_NATIVE_POLY_COMPRESS_D11
-#define MLK_USE_NATIVE_POLY_DECOMPRESS_D4
 #define MLK_USE_NATIVE_POLY_DECOMPRESS_D5
-#define MLK_USE_NATIVE_POLY_DECOMPRESS_D10
 #define MLK_USE_NATIVE_POLY_DECOMPRESS_D11
 
 #if !defined(__ASSEMBLER__)
@@ -217,31 +215,6 @@ static MLK_INLINE int mlk_poly_compress_d10_native(
   return MLK_NATIVE_FUNC_SUCCESS;
 }
 
-MLK_MUST_CHECK_RETURN_VALUE
-static MLK_INLINE int mlk_poly_decompress_d4_native(
-    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
-{
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_AVX2))
-  {
-    return MLK_NATIVE_FUNC_FALLBACK;
-  }
-
-  mlk_poly_decompress_d4_avx2(r, a);
-  return MLK_NATIVE_FUNC_SUCCESS;
-}
-
-MLK_MUST_CHECK_RETURN_VALUE
-static MLK_INLINE int mlk_poly_decompress_d10_native(
-    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
-{
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_AVX2))
-  {
-    return MLK_NATIVE_FUNC_FALLBACK;
-  }
-
-  mlk_poly_decompress_d10_avx2(r, a);
-  return MLK_NATIVE_FUNC_SUCCESS;
-}
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 2 || MLKEM_K == 3 */
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 4

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -71,15 +71,9 @@ void mlk_tomont_avx2(int16_t *r);
 #define mlk_poly_compress_d4_avx2 MLK_NAMESPACE(poly_compress_d4_avx2)
 void mlk_poly_compress_d4_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
                                const int16_t *MLK_RESTRICT a);
-#define mlk_poly_decompress_d4_avx2 MLK_NAMESPACE(poly_decompress_d4_avx2)
-void mlk_poly_decompress_d4_avx2(int16_t *MLK_RESTRICT r,
-                                 const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4]);
 #define mlk_poly_compress_d10_avx2 MLK_NAMESPACE(poly_compress10_avx2)
 void mlk_poly_compress_d10_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
                                 const int16_t *MLK_RESTRICT a);
-#define mlk_poly_decompress_d10_avx2 MLK_NAMESPACE(poly_decompress10_avx2)
-void mlk_poly_decompress_d10_avx2(
-    int16_t *MLK_RESTRICT r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10]);
 #define mlk_poly_compress_d5_avx2 MLK_NAMESPACE(poly_compress_d5_avx2)
 void mlk_poly_compress_d5_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
                                const int16_t *MLK_RESTRICT a);

--- a/mlkem/mlkem_native.S
+++ b/mlkem/mlkem_native.S
@@ -548,9 +548,7 @@
 #undef MLK_USE_NATIVE_POLY_COMPRESS_D11
 #undef MLK_USE_NATIVE_POLY_COMPRESS_D4
 #undef MLK_USE_NATIVE_POLY_COMPRESS_D5
-#undef MLK_USE_NATIVE_POLY_DECOMPRESS_D10
 #undef MLK_USE_NATIVE_POLY_DECOMPRESS_D11
-#undef MLK_USE_NATIVE_POLY_DECOMPRESS_D4
 #undef MLK_USE_NATIVE_POLY_DECOMPRESS_D5
 #undef MLK_USE_NATIVE_POLY_FROMBYTES
 #undef MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE
@@ -570,9 +568,7 @@
 #undef mlk_poly_compress_d11_avx2
 #undef mlk_poly_compress_d4_avx2
 #undef mlk_poly_compress_d5_avx2
-#undef mlk_poly_decompress_d10_avx2
 #undef mlk_poly_decompress_d11_avx2
-#undef mlk_poly_decompress_d4_avx2
 #undef mlk_poly_decompress_d5_avx2
 #undef mlk_poly_mulcache_compute_avx2
 #undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k2

--- a/mlkem/mlkem_native.c
+++ b/mlkem/mlkem_native.c
@@ -537,9 +537,7 @@
 #undef MLK_USE_NATIVE_POLY_COMPRESS_D11
 #undef MLK_USE_NATIVE_POLY_COMPRESS_D4
 #undef MLK_USE_NATIVE_POLY_COMPRESS_D5
-#undef MLK_USE_NATIVE_POLY_DECOMPRESS_D10
 #undef MLK_USE_NATIVE_POLY_DECOMPRESS_D11
-#undef MLK_USE_NATIVE_POLY_DECOMPRESS_D4
 #undef MLK_USE_NATIVE_POLY_DECOMPRESS_D5
 #undef MLK_USE_NATIVE_POLY_FROMBYTES
 #undef MLK_USE_NATIVE_POLY_MULCACHE_COMPUTE
@@ -559,9 +557,7 @@
 #undef mlk_poly_compress_d11_avx2
 #undef mlk_poly_compress_d4_avx2
 #undef mlk_poly_compress_d5_avx2
-#undef mlk_poly_decompress_d10_avx2
 #undef mlk_poly_decompress_d11_avx2
-#undef mlk_poly_decompress_d4_avx2
 #undef mlk_poly_decompress_d5_avx2
 #undef mlk_poly_mulcache_compute_avx2
 #undef mlk_polyvec_basemul_acc_montgomery_cached_asm_k2

--- a/mlkem/src/native/x86_64/meta.h
+++ b/mlkem/src/native/x86_64/meta.h
@@ -24,9 +24,7 @@
 #define MLK_USE_NATIVE_POLY_COMPRESS_D5
 #define MLK_USE_NATIVE_POLY_COMPRESS_D10
 #define MLK_USE_NATIVE_POLY_COMPRESS_D11
-#define MLK_USE_NATIVE_POLY_DECOMPRESS_D4
 #define MLK_USE_NATIVE_POLY_DECOMPRESS_D5
-#define MLK_USE_NATIVE_POLY_DECOMPRESS_D10
 #define MLK_USE_NATIVE_POLY_DECOMPRESS_D11
 
 #if !defined(__ASSEMBLER__)
@@ -217,31 +215,6 @@ static MLK_INLINE int mlk_poly_compress_d10_native(
   return MLK_NATIVE_FUNC_SUCCESS;
 }
 
-MLK_MUST_CHECK_RETURN_VALUE
-static MLK_INLINE int mlk_poly_decompress_d4_native(
-    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4])
-{
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_AVX2))
-  {
-    return MLK_NATIVE_FUNC_FALLBACK;
-  }
-
-  mlk_poly_decompress_d4_avx2(r, a);
-  return MLK_NATIVE_FUNC_SUCCESS;
-}
-
-MLK_MUST_CHECK_RETURN_VALUE
-static MLK_INLINE int mlk_poly_decompress_d10_native(
-    int16_t r[MLKEM_N], const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10])
-{
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_AVX2))
-  {
-    return MLK_NATIVE_FUNC_FALLBACK;
-  }
-
-  mlk_poly_decompress_d10_avx2(r, a);
-  return MLK_NATIVE_FUNC_SUCCESS;
-}
 #endif /* MLK_CONFIG_MULTILEVEL_WITH_SHARED || MLKEM_K == 2 || MLKEM_K == 3 */
 
 #if defined(MLK_CONFIG_MULTILEVEL_WITH_SHARED) || MLKEM_K == 4

--- a/mlkem/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/src/native/x86_64/src/arith_native_x86_64.h
@@ -71,15 +71,9 @@ void mlk_tomont_avx2(int16_t *r);
 #define mlk_poly_compress_d4_avx2 MLK_NAMESPACE(poly_compress_d4_avx2)
 void mlk_poly_compress_d4_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D4],
                                const int16_t *MLK_RESTRICT a);
-#define mlk_poly_decompress_d4_avx2 MLK_NAMESPACE(poly_decompress_d4_avx2)
-void mlk_poly_decompress_d4_avx2(int16_t *MLK_RESTRICT r,
-                                 const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D4]);
 #define mlk_poly_compress_d10_avx2 MLK_NAMESPACE(poly_compress10_avx2)
 void mlk_poly_compress_d10_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D10],
                                 const int16_t *MLK_RESTRICT a);
-#define mlk_poly_decompress_d10_avx2 MLK_NAMESPACE(poly_decompress10_avx2)
-void mlk_poly_decompress_d10_avx2(
-    int16_t *MLK_RESTRICT r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES_D10]);
 #define mlk_poly_compress_d5_avx2 MLK_NAMESPACE(poly_compress_d5_avx2)
 void mlk_poly_compress_d5_avx2(uint8_t r[MLKEM_POLYCOMPRESSEDBYTES_D5],
                                const int16_t *MLK_RESTRICT a);

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2088,6 +2088,13 @@ def check_macro_typos():
             if m == "MLK_CONTEXT_PARAMETERS_n":
                 return True
 
+        # Macros for native implementations that don't currently exist
+        if m in [
+            "MLK_USE_NATIVE_POLY_DECOMPRESS_D4",
+            "MLK_USE_NATIVE_POLY_DECOMPRESS_D10",
+        ]:
+            return True
+
         return False
 
     run_parallel(


### PR DESCRIPTION
Benchmarking on my laptop shows these AVX2 intrinsics implementations are actually slower than the C fallback code that gcc generates.

This commit removes the two functions.