### PR TITLE
Unit tests: Add native Keccak x1 and x4 tests

### DIFF
--- a/mlkem/src/fips202/keccakf1600.c
+++ b/mlkem/src/fips202/keccakf1600.c
@@ -136,7 +136,8 @@ static const uint64_t mlk_KeccakF_RoundConstants[MLK_KECCAK_NROUNDS] = {
     (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008080ULL,
     (uint64_t)0x0000000080000001ULL, (uint64_t)0x8000000080008008ULL};
 
-static void mlk_keccakf1600_permute_c(uint64_t *state)
+MLK_STATIC_TESTABLE
+void mlk_keccakf1600_permute_c(uint64_t *state)
 {
   unsigned round;
 


### PR DESCRIPTION
Add unit tests for keccakf1600 x1 and x4 permutation functions that compare native implementations against the C reference implementation.

- test_keccakf1600_permute: tests x1 permutation when MLK_USE_FIPS202_X1_NATIVE
- test_keccakf1600x4_permute: tests x4 permutation when MLK_USE_FIPS202_X4_NATIVE
- Expose mlk_keccakf1600_permute_c via MLK_STATIC_TESTABLE for testing
- Reduce NUM_RANDOM_TESTS from 10000 to 8000 to maintain similar runtime

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1503
- Resolves https://github.com/pq-code-package/mlkem-native/issues/1504