### PR TITLE
Optimized AVX2 batched Keccak_x4

### DIFF
--- a/mlkem/src/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
+++ b/mlkem/src/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
@@ -31,7 +31,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
  * - Eliminated separate E state variables by using temporaries (Tba, etc.)
  *   and copying back to A at end of each round, removing A/E alternation.
  * - Changed ROUNDS24 from 24 unrolled macro calls to a loop-based
- *   MLK_ROUNDS_x2 processing 2 rounds per iteration.
+ *   MLK_ROUNDS_X2 processing 2 rounds per iteration.
  */
 
 #include "../../../../common.h"
@@ -347,7 +347,7 @@ static MLK_ALIGN const uint64_t mlk_keccakf1600RoundConstants[24] = {
   } while (0)
 
 /* clang-format off */
-#define MLK_ROUNDS_x2                                               \
+#define MLK_ROUNDS_X2                                               \
       do {                                                          \
         int i;                                                      \
         for (i = 0; i < 12; i++) {                                  \
@@ -362,7 +362,7 @@ void mlk_keccakf1600x4_permute24(void *states)
   __m256i *statesAsLanes = (__m256i *)states;
   MLK_DECLARE_ABCDE;
   MLK_COPY_FROM_STATE(A, statesAsLanes);
-  MLK_ROUNDS_x2;
+  MLK_ROUNDS_X2;
   MLK_COPY_TO_STATE(statesAsLanes, A);
 }
 
@@ -391,4 +391,4 @@ MLK_EMPTY_CU(fips202_avx2_keccakx4)
 #undef MLK_SCATTER_STORE256_4X
 #undef MLK_SCATTER_STORE256_1X
 #undef MLK_COPY_TO_STATE
-#undef MLK_ROUNDS_x2
+#undef MLK_ROUNDS_X2


### PR DESCRIPTION
This commit improves the performance of the AVX2 Keccak-F1600x4 implementation by:
 * Replace gather-based loading (vpgatherqq) with explicit loads and transpose operations using unpack and permute instructions.
 * Replace individual scatter stores with batched 4-lane transpose and store operations (MLK_SCATTER_STORE256_4X).
 * Merged prepareTheta into thetaRhoPiChiIota at the start of each round.
 * Eliminated separate E state variables by using temporaries (Tba, etc.) and copying back to A at end of each round, removing A/E alternation.
 * Changed ROUNDS24 from 24 unrolled macro calls to a loop-based MLK_ROUNDS_x2 processing 2 rounds per iteration.