### PR TITLE
Add documentation for `randombytes` and `mlk_randombytes`

### DIFF
--- a/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
+++ b/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
@@ -406,15 +406,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/custom_backend/mlkem_native/mlkem_native_config.h
+++ b/examples/custom_backend/mlkem_native/mlkem_native_config.h
@@ -401,15 +401,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/monolithic_build/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build/mlkem_native/mlkem_native_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
@@ -406,15 +406,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
@@ -406,15 +406,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* Even though we use the default randombytes signature here, registering it

--- a/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/multilevel_build/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build/mlkem_native/mlkem_native_config.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
@@ -403,15 +403,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/mlkem/mlkem_native_config.h
+++ b/mlkem/mlkem_native_config.h
@@ -389,15 +389,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/mlkem/src/randombytes.h
+++ b/mlkem/src/randombytes.h
@@ -12,8 +12,45 @@
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
 #if !defined(MLK_CONFIG_CUSTOM_RANDOMBYTES)
+/*************************************************
+ * Name:        randombytes
+ *
+ * Description: Fill a buffer with cryptographically secure random bytes.
+ *
+ *              mlkem-native does not provide an implementation of this
+ *              function. It must be provided by the consumer.
+ *
+ *              To use a custom random byte source with a different name
+ *              or signature, set MLK_CONFIG_CUSTOM_RANDOMBYTES and define
+ *              mlk_randombytes directly.
+ *
+ * Arguments:   - uint8_t *out: pointer to output buffer
+ *              - size_t outlen: number of random bytes to write
+ *
+ * Returns:     0 on success, non-zero on failure.
+ *              On failure, top-level APIs return MLK_ERR_RNG_FAIL.
+ *
+ **************************************************/
 int randombytes(uint8_t *out, size_t outlen);
 
+/*************************************************
+ * Name:        mlk_randombytes
+ *
+ * Description: Internal wrapper around randombytes().
+ *
+ *              Fill a buffer with cryptographically secure random bytes.
+ *
+ *              This function can be replaced by setting
+ *              MLK_CONFIG_CUSTOM_RANDOMBYTES and defining mlk_randombytes
+ *              directly.
+ *
+ * Arguments:   - uint8_t *out: pointer to output buffer
+ *              - size_t outlen: number of random bytes to write
+ *
+ * Returns:     0 on success, non-zero on failure.
+ *              On failure, top-level APIs return MLK_ERR_RNG_FAIL.
+ *
+ **************************************************/
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_randombytes(uint8_t *out, size_t outlen)
 __contract__(

--- a/proofs/cbmc/mlkem_native_config_cbmc.h
+++ b/proofs/cbmc/mlkem_native_config_cbmc.h
@@ -406,15 +406,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -405,15 +405,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -405,15 +405,18 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -406,15 +406,18 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -404,15 +404,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -407,15 +407,18 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function
  *              int randombytes(uint8_t *out, size_t outlen).
+ *              It is expected to return zero on success, and non-zero on
+ *              failure. In case of failure, the top level APIs will return a
+ *              MLK_ERR_RNG_FAIL error code.
  *
- *              Set this option and define `mlk_randombytes` if you want to
- *              use a custom method to sample randombytes with a different name
- *              or signature.
+ *              Set this option and define `mlk_randombytes` (with the same
+ *              signature and behaviour) if you want to use a custom method to
+ *              sample randombytes with a different name or signature.
  *
  *****************************************************************************/
 /* #define MLK_CONFIG_CUSTOM_RANDOMBYTES


### PR DESCRIPTION
Previosuly, there was no documentation about the meaning of the randombytes return value.
This commit adds documentation to randombytes.h (which is referenced from the examples), and also the configuration file.