### PR TITLE
Stabilize proof of polyvec_add()

### DIFF
--- a/mlkem/src/poly_k.c
+++ b/mlkem/src/poly_k.c
@@ -259,6 +259,18 @@ void mlk_polyvec_add(mlk_polyvec *r, const mlk_polyvec *b)
 {
   unsigned i;
   for (i = 0; i < MLKEM_K; i++)
+  __loop__(
+    assigns(i, memory_slice(r, sizeof(mlk_polyvec)))
+    invariant(i <= MLKEM_K)
+    invariant(forall(j0, i, MLKEM_K,
+                forall(k0, 0, MLKEM_N,
+                       ((int32_t)r->vec[j0].coeffs[k0] + b->vec[j0].coeffs[k0] <= INT16_MAX) &&
+                       ((int32_t)r->vec[j0].coeffs[k0] + b->vec[j0].coeffs[k0] >= INT16_MIN))))
+    invariant(forall(j2, 0, i,
+                forall(k2, 0, MLKEM_N,
+                       (r->vec[j2].coeffs[k2] <= INT16_MAX) &&
+                       (r->vec[j2].coeffs[k2] >= INT16_MIN))))
+  )
   {
     mlk_poly_add(&r->vec[i], &b->vec[i]);
   }

--- a/proofs/cbmc/polyvec_add/Makefile
+++ b/proofs/cbmc/polyvec_add/Makefile
@@ -14,7 +14,6 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += mlk_polyvec_add.0:4 # Largest value of MLKEM_K
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/poly_k.c
@@ -26,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_bv_sort --z3
+CBMCFLAGS=--smt2
 
 # For this proof we tell CBMC to
 #  - not decompose arrays into their individual cells


### PR DESCRIPTION
The proof of polyvec_add() uses loop unrolling, and so scales poorly for increasing values of MLKEM_K, especially on macOS. There is also instability in this proof between macOS and Linux.

This PR proposes:

1. Switch back to z3 with no command-line options, which is faster.
2. Add simple loop invariant and disable loop unrolling.

Proof time data to follow.
