### PR TITLE
CI: Run apt update before installing other software via apt

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -62,8 +62,10 @@ runs:
       shell: bash
       run: |
         if [[ -f /.dockerenv ]]; then
+          apt update
           apt install nix -y
         else
+          sudo apt update
           sudo apt install nix -y
         fi
         mkdir -p ~/.config/nix


### PR DESCRIPTION
We are seeing errors in CI when trying to install nix via apt. This commit adds an apt update before to fix the issue.

In https://github.com/pq-code-package/mldsa-native/pull/945 we can see that this resolves the issue.