### PR TITLE
Consolidate imports of stdint.h and add footnote to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-mlkem-native is a secure, fast, and portable C90 implementation of ML-KEM[^FIPS203].
+mlkem-native is a secure, fast, and portable C90[^C90] implementation of ML-KEM[^FIPS203].
 It is a fork of the ML-KEM reference implementation[^REF].
 
 All C code in [mlkem/src/*](mlkem) and [mlkem/src/fips202/*](mlkem/src/fips202) is proved memory-safe (no memory overflow) and type-safe (no integer overflow)
@@ -185,6 +185,8 @@ If you have any other question / non-security related issue / feature request, p
 
 If you want to help us build mlkem-native, please reach out. You can contact the mlkem-native team
 through the [PQCA Discord](https://discord.com/invite/xyVnwzfg5R). See also [CONTRIBUTING.md](CONTRIBUTING.md).
+
+[^C90]: Strictly speaking, we rely on C90 + `stdint.h` + 64-bit `unsigned long long`.
 
 <!--- bibliography --->
 [^ACVP]: National Institute of Standards and Technology: Automated Cryptographic Validation Protocol (ACVP) Server, [https://github.com/usnistgov/ACVP-Server](https://github.com/usnistgov/ACVP-Server)

--- a/dev/aarch64_clean/src/aarch64_zetas.c
+++ b/dev/aarch64_clean/src/aarch64_zetas.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_aarch64.h"
 
 /*

--- a/dev/aarch64_clean/src/arith_native_aarch64.h
+++ b/dev/aarch64_clean/src/arith_native_aarch64.h
@@ -5,8 +5,6 @@
 #ifndef MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H
 #define MLK_DEV_AARCH64_CLEAN_SRC_ARITH_NATIVE_AARCH64_H
 
-#include <stdint.h>
-
 #include "../../../cbmc.h"
 #include "../../../common.h"
 

--- a/dev/aarch64_clean/src/rej_uniform_table.c
+++ b/dev/aarch64_clean/src/rej_uniform_table.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_aarch64.h"
 
 /*

--- a/dev/aarch64_opt/src/aarch64_zetas.c
+++ b/dev/aarch64_opt/src/aarch64_zetas.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_aarch64.h"
 
 /*

--- a/dev/aarch64_opt/src/arith_native_aarch64.h
+++ b/dev/aarch64_opt/src/arith_native_aarch64.h
@@ -5,7 +5,6 @@
 #ifndef MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H
 #define MLK_DEV_AARCH64_OPT_SRC_ARITH_NATIVE_AARCH64_H
 
-#include <stdint.h>
 #include "../../../cbmc.h"
 #include "../../../common.h"
 

--- a/dev/aarch64_opt/src/rej_uniform_table.c
+++ b/dev/aarch64_opt/src/rej_uniform_table.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_aarch64.h"
 
 /*

--- a/dev/fips202/aarch64/src/fips202_native_aarch64.h
+++ b/dev/fips202/aarch64/src/fips202_native_aarch64.h
@@ -5,11 +5,8 @@
 #ifndef MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 #define MLK_DEV_FIPS202_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 
-#include <stdint.h>
-
 #include "../../../../cbmc.h"
 #include "../../../../common.h"
-
 
 #define mlk_keccakf1600_round_constants \
   MLK_NAMESPACE(keccakf1600_round_constants)

--- a/dev/fips202/aarch64/src/keccakf1600_round_constants.c
+++ b/dev/fips202/aarch64/src/keccakf1600_round_constants.c
@@ -12,8 +12,6 @@
      defined(MLK_FIPS202_AARCH64_NEED_X4_V8A_V84A_SCALAR_HYBRID)) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
-
 #include "fips202_native_aarch64.h"
 
 MLK_ALIGN const uint64_t mlk_keccakf1600_round_constants[] = {

--- a/dev/fips202/armv81m/mve.h
+++ b/dev/fips202/armv81m/mve.h
@@ -14,7 +14,6 @@
 #define MLK_FIPS202_ARMV81M_NEED_X4
 
 #if !defined(__ASSEMBLER__)
-#include <stdint.h>
 #include "../api.h"
 
 #define mlk_keccak_f1600_x4_native_impl \

--- a/dev/fips202/armv81m/src/fips202_native_armv81m.h
+++ b/dev/fips202/armv81m/src/fips202_native_armv81m.h
@@ -5,7 +5,6 @@
 #ifndef MLK_DEV_FIPS202_ARMV81M_SRC_FIPS202_NATIVE_ARMV81M_H
 #define MLK_DEV_FIPS202_ARMV81M_SRC_FIPS202_NATIVE_ARMV81M_H
 
-#include <stdint.h>
 #include "../../../../common.h"
 
 /* Keccak round constants in bit-interleaved form */

--- a/dev/fips202/armv81m/src/keccak_f1600_x4_mve.c
+++ b/dev/fips202/armv81m/src/keccak_f1600_x4_mve.c
@@ -9,7 +9,6 @@
 #if defined(MLK_FIPS202_ARMV81M_NEED_X4) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "fips202_native_armv81m.h"
 
 /*

--- a/dev/fips202/armv81m/src/keccakf1600_round_constants.c
+++ b/dev/fips202/armv81m/src/keccakf1600_round_constants.c
@@ -8,8 +8,6 @@
 #if defined(MLK_FIPS202_ARMV81M_NEED_X4) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
-
 #include "fips202_native_armv81m.h"
 
 /*

--- a/dev/x86_64/src/arith_native_x86_64.h
+++ b/dev/x86_64/src/arith_native_x86_64.h
@@ -7,7 +7,6 @@
 
 #include "../../../common.h"
 
-#include <stdint.h>
 #include "consts.h"
 
 #define MLK_AVX2_REJ_UNIFORM_BUFLEN \

--- a/dev/x86_64/src/compress_avx2.c
+++ b/dev/x86_64/src/compress_avx2.c
@@ -23,7 +23,6 @@
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
 #include <immintrin.h>
-#include <stdint.h>
 #include "arith_native_x86_64.h"
 #include "consts.h"
 

--- a/dev/x86_64/src/rej_uniform_table.c
+++ b/dev/x86_64/src/rej_uniform_table.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_X86_64_DEFAULT) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_x86_64.h"
 
 /*

--- a/mlkem/src/cbmc.h
+++ b/mlkem/src/cbmc.h
@@ -15,7 +15,6 @@
 
 #else /* !CBMC */
 
-#include <stdint.h>
 
 #define __contract__(x) x
 #define __loop__(x) x

--- a/mlkem/src/common.h
+++ b/mlkem/src/common.h
@@ -5,6 +5,10 @@
 #ifndef MLK_COMMON_H
 #define MLK_COMMON_H
 
+#ifndef __ASSEMBLER__
+#include <stdint.h>
+#endif
+
 #define MLK_BUILD_INTERNAL
 
 #if defined(MLK_CONFIG_FILE)

--- a/mlkem/src/compress.c
+++ b/mlkem/src/compress.c
@@ -20,7 +20,6 @@
 #include "common.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "compress.h"

--- a/mlkem/src/compress.h
+++ b/mlkem/src/compress.h
@@ -20,7 +20,6 @@
 #ifndef MLK_COMPRESS_H
 #define MLK_COMPRESS_H
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "common.h"

--- a/mlkem/src/debug.h
+++ b/mlkem/src/debug.h
@@ -7,7 +7,6 @@
 #include "common.h"
 
 #if defined(MLKEM_DEBUG)
-#include <stdint.h>
 
 /*************************************************
  * Name:        mlk_assert

--- a/mlkem/src/fips202/fips202.c
+++ b/mlkem/src/fips202/fips202.c
@@ -34,7 +34,6 @@
 #include "../common.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 
 #include "../verify.h"
 #include "fips202.h"

--- a/mlkem/src/fips202/fips202.h
+++ b/mlkem/src/fips202/fips202.h
@@ -4,7 +4,6 @@
  */
 #ifndef MLK_FIPS202_FIPS202_H
 #define MLK_FIPS202_FIPS202_H
-#include <stdint.h>
 
 #include "../cbmc.h"
 #include "../common.h"

--- a/mlkem/src/fips202/fips202x4.h
+++ b/mlkem/src/fips202/fips202x4.h
@@ -5,7 +5,6 @@
 #ifndef MLK_FIPS202_FIPS202X4_H
 #define MLK_FIPS202_FIPS202X4_H
 
-#include <stdint.h>
 
 #include "../cbmc.h"
 #include "../common.h"

--- a/mlkem/src/fips202/keccakf1600.c
+++ b/mlkem/src/fips202/keccakf1600.c
@@ -26,7 +26,6 @@
  * implementation @[supercop, crypto_hash/keccakc512/simple/]
  * by Ronny Van Keer, and the public domain @[tweetfips] implementation. */
 
-#include <stdint.h>
 
 #include "keccakf1600.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)

--- a/mlkem/src/fips202/keccakf1600.h
+++ b/mlkem/src/fips202/keccakf1600.h
@@ -4,7 +4,6 @@
  */
 #ifndef MLK_FIPS202_KECCAKF1600_H
 #define MLK_FIPS202_KECCAKF1600_H
-#include <stdint.h>
 #include "../cbmc.h"
 #include "../common.h"
 

--- a/mlkem/src/fips202/native/aarch64/src/fips202_native_aarch64.h
+++ b/mlkem/src/fips202/native/aarch64/src/fips202_native_aarch64.h
@@ -5,11 +5,8 @@
 #ifndef MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 #define MLK_FIPS202_NATIVE_AARCH64_SRC_FIPS202_NATIVE_AARCH64_H
 
-#include <stdint.h>
-
 #include "../../../../cbmc.h"
 #include "../../../../common.h"
-
 
 #define mlk_keccakf1600_round_constants \
   MLK_NAMESPACE(keccakf1600_round_constants)

--- a/mlkem/src/fips202/native/aarch64/src/keccakf1600_round_constants.c
+++ b/mlkem/src/fips202/native/aarch64/src/keccakf1600_round_constants.c
@@ -12,8 +12,6 @@
      defined(MLK_FIPS202_AARCH64_NEED_X4_V8A_V84A_SCALAR_HYBRID)) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
-
 #include "fips202_native_aarch64.h"
 
 MLK_ALIGN const uint64_t mlk_keccakf1600_round_constants[] = {

--- a/mlkem/src/fips202/native/api.h
+++ b/mlkem/src/fips202/native/api.h
@@ -12,7 +12,6 @@
  * It should not be included by backend implementations.
  */
 
-#include <stdint.h>
 #include "../../cbmc.h"
 
 /* Backends must return MLK_NATIVE_FUNC_SUCCESS upon success. */

--- a/mlkem/src/fips202/native/armv81m/mve.h
+++ b/mlkem/src/fips202/native/armv81m/mve.h
@@ -14,7 +14,6 @@
 #define MLK_FIPS202_ARMV81M_NEED_X4
 
 #if !defined(__ASSEMBLER__)
-#include <stdint.h>
 #include "../api.h"
 
 #define mlk_keccak_f1600_x4_native_impl \

--- a/mlkem/src/fips202/native/armv81m/src/fips202_native_armv81m.h
+++ b/mlkem/src/fips202/native/armv81m/src/fips202_native_armv81m.h
@@ -5,7 +5,6 @@
 #ifndef MLK_FIPS202_NATIVE_ARMV81M_SRC_FIPS202_NATIVE_ARMV81M_H
 #define MLK_FIPS202_NATIVE_ARMV81M_SRC_FIPS202_NATIVE_ARMV81M_H
 
-#include <stdint.h>
 #include "../../../../common.h"
 
 /* Keccak round constants in bit-interleaved form */

--- a/mlkem/src/fips202/native/armv81m/src/keccak_f1600_x4_mve.c
+++ b/mlkem/src/fips202/native/armv81m/src/keccak_f1600_x4_mve.c
@@ -9,7 +9,6 @@
 #if defined(MLK_FIPS202_ARMV81M_NEED_X4) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "fips202_native_armv81m.h"
 
 /*

--- a/mlkem/src/fips202/native/armv81m/src/keccakf1600_round_constants.c
+++ b/mlkem/src/fips202/native/armv81m/src/keccakf1600_round_constants.c
@@ -8,8 +8,6 @@
 #if defined(MLK_FIPS202_ARMV81M_NEED_X4) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
-
 #include "fips202_native_armv81m.h"
 
 /*

--- a/mlkem/src/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
+++ b/mlkem/src/fips202/native/x86_64/src/KeccakP_1600_times4_SIMD256.c
@@ -29,7 +29,6 @@ http://creativecommons.org/publicdomain/zero/1.0/
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
 #include <immintrin.h>
-#include <stdint.h>
 
 #include "KeccakP_1600_times4_SIMD256.h"
 
@@ -322,7 +321,6 @@ static MLK_ALIGN const uint64_t mlk_keccakf1600RoundConstants[24] = {
     (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008080ULL,
     (uint64_t)0x0000000080000001ULL, (uint64_t)0x8000000080008008ULL};
 
-#include <stdint.h>
 
 #define MLK_COPY_FROM_STATE(X, state)                                       \
   do                                                                        \

--- a/mlkem/src/fips202/native/x86_64/xkcp.h
+++ b/mlkem/src/fips202/native/x86_64/xkcp.h
@@ -11,7 +11,6 @@
 #define MLK_FIPS202_X86_64_XKCP
 
 #if !defined(__ASSEMBLER__)
-#include <stdint.h>
 #include "../api.h"
 #include "src/KeccakP_1600_times4_SIMD256.h"
 

--- a/mlkem/src/indcpa.c
+++ b/mlkem/src/indcpa.c
@@ -17,13 +17,9 @@
  *   https://github.com/pq-crystals/kyber/tree/main/ref
  */
 
-#include <stdint.h>
-
-#include "cbmc.h"
-#include "debug.h"
 #include "indcpa.h"
-#include "poly.h"
-#include "poly_k.h"
+
+#include "debug.h"
 #include "randombytes.h"
 #include "sampling.h"
 #include "symmetric.h"

--- a/mlkem/src/indcpa.h
+++ b/mlkem/src/indcpa.h
@@ -15,7 +15,6 @@
 #ifndef MLK_INDCPA_H
 #define MLK_INDCPA_H
 
-#include <stdint.h>
 #include "cbmc.h"
 #include "common.h"
 #include "poly_k.h"

--- a/mlkem/src/kem.c
+++ b/mlkem/src/kem.c
@@ -23,10 +23,9 @@
  *   https://github.com/pq-crystals/kyber/tree/main/ref
  */
 
-#include <stdint.h>
+#include "kem.h"
 
 #include "indcpa.h"
-#include "kem.h"
 #include "randombytes.h"
 #include "symmetric.h"
 #include "verify.h"

--- a/mlkem/src/kem.h
+++ b/mlkem/src/kem.h
@@ -20,7 +20,6 @@
 #ifndef MLK_KEM_H
 #define MLK_KEM_H
 
-#include <stdint.h>
 #include "cbmc.h"
 #include "common.h"
 #include "sys.h"

--- a/mlkem/src/native/aarch64/src/aarch64_zetas.c
+++ b/mlkem/src/native/aarch64/src/aarch64_zetas.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_aarch64.h"
 
 /*

--- a/mlkem/src/native/aarch64/src/arith_native_aarch64.h
+++ b/mlkem/src/native/aarch64/src/arith_native_aarch64.h
@@ -5,7 +5,6 @@
 #ifndef MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H
 #define MLK_NATIVE_AARCH64_SRC_ARITH_NATIVE_AARCH64_H
 
-#include <stdint.h>
 #include "../../../cbmc.h"
 #include "../../../common.h"
 

--- a/mlkem/src/native/aarch64/src/rej_uniform_table.c
+++ b/mlkem/src/native/aarch64/src/rej_uniform_table.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_AARCH64) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_aarch64.h"
 
 /*

--- a/mlkem/src/native/api.h
+++ b/mlkem/src/native/api.h
@@ -17,7 +17,6 @@
  * and run sanity checks.
  */
 
-#include <stdint.h>
 #include "../cbmc.h"
 #include "../common.h"
 

--- a/mlkem/src/native/riscv64/src/arith_native_riscv64.h
+++ b/mlkem/src/native/riscv64/src/arith_native_riscv64.h
@@ -5,7 +5,6 @@
 #ifndef MLK_NATIVE_RISCV64_SRC_ARITH_NATIVE_RISCV64_H
 #define MLK_NATIVE_RISCV64_SRC_ARITH_NATIVE_RISCV64_H
 
-#include <stdint.h>
 #include "../../../common.h"
 
 #define mlk_rv64v_poly_ntt MLK_NAMESPACE(ntt_riscv64)

--- a/mlkem/src/native/riscv64/src/rv64v_izetas.inc
+++ b/mlkem/src/native/riscv64/src/rv64v_izetas.inc
@@ -9,7 +9,6 @@
  *          Do not modify it directly.
  */
 
-#include <stdint.h>
 #include "arith_native_riscv64.h"
 
 const int16_t izeta[] = {

--- a/mlkem/src/native/riscv64/src/rv64v_zetas.inc
+++ b/mlkem/src/native/riscv64/src/rv64v_zetas.inc
@@ -9,7 +9,6 @@
  *          Do not modify it directly.
  */
 
-#include <stdint.h>
 #include "arith_native_riscv64.h"
 
 const int16_t zeta[] = {

--- a/mlkem/src/native/riscv64/src/rv64v_zetas_basemul.inc
+++ b/mlkem/src/native/riscv64/src/rv64v_zetas_basemul.inc
@@ -9,7 +9,6 @@
  *          Do not modify it directly.
  */
 
-#include <stdint.h>
 #include "arith_native_riscv64.h"
 
 const int16_t roots[] = {

--- a/mlkem/src/native/x86_64/src/arith_native_x86_64.h
+++ b/mlkem/src/native/x86_64/src/arith_native_x86_64.h
@@ -7,7 +7,6 @@
 
 #include "../../../common.h"
 
-#include <stdint.h>
 #include "consts.h"
 
 #define MLK_AVX2_REJ_UNIFORM_BUFLEN \

--- a/mlkem/src/native/x86_64/src/compress_avx2.c
+++ b/mlkem/src/native/x86_64/src/compress_avx2.c
@@ -23,7 +23,6 @@
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
 #include <immintrin.h>
-#include <stdint.h>
 #include "arith_native_x86_64.h"
 #include "consts.h"
 

--- a/mlkem/src/native/x86_64/src/rej_uniform_table.c
+++ b/mlkem/src/native/x86_64/src/rej_uniform_table.c
@@ -14,7 +14,6 @@
 #if defined(MLK_ARITH_BACKEND_X86_64_DEFAULT) && \
     !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 #include "arith_native_x86_64.h"
 
 /*

--- a/mlkem/src/poly.c
+++ b/mlkem/src/poly.c
@@ -20,7 +20,6 @@
 #include "common.h"
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "debug.h"

--- a/mlkem/src/poly.h
+++ b/mlkem/src/poly.h
@@ -15,7 +15,6 @@
 #ifndef MLK_POLY_H
 #define MLK_POLY_H
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "common.h"

--- a/mlkem/src/poly_k.c
+++ b/mlkem/src/poly_k.c
@@ -22,11 +22,9 @@
  *   https://github.com/pq-crystals/kyber/tree/main/ref
  */
 
-#include <stdint.h>
-
-#include "compress.h"
-#include "debug.h"
 #include "poly_k.h"
+
+#include "debug.h"
 #include "sampling.h"
 #include "symmetric.h"
 

--- a/mlkem/src/poly_k.h
+++ b/mlkem/src/poly_k.h
@@ -15,7 +15,6 @@
 #ifndef MLK_POLY_K_H
 #define MLK_POLY_K_H
 
-#include <stdint.h>
 #include "common.h"
 #include "compress.h"
 #include "poly.h"

--- a/mlkem/src/randombytes.h
+++ b/mlkem/src/randombytes.h
@@ -5,7 +5,6 @@
 #ifndef MLK_RANDOMBYTES_H
 #define MLK_RANDOMBYTES_H
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "common.h"

--- a/mlkem/src/sampling.h
+++ b/mlkem/src/sampling.h
@@ -15,7 +15,6 @@
 #ifndef MLK_SAMPLING_H
 #define MLK_SAMPLING_H
 
-#include <stdint.h>
 #include "cbmc.h"
 #include "common.h"
 #include "poly.h"

--- a/mlkem/src/symmetric.h
+++ b/mlkem/src/symmetric.h
@@ -15,7 +15,6 @@
 #ifndef MLK_SYMMETRIC_H
 #define MLK_SYMMETRIC_H
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "common.h"

--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -30,7 +30,6 @@
 #ifndef MLK_VERIFY_H
 #define MLK_VERIFY_H
 
-#include <stdint.h>
 
 #include "cbmc.h"
 #include "common.h"

--- a/mlkem/src/zetas.inc
+++ b/mlkem/src/zetas.inc
@@ -9,7 +9,6 @@
  *          Do not modify it directly.
  */
 
-#include <stdint.h>
 
 /*
  * Table of zeta values used in the reference NTT and inverse NTT.

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -730,7 +730,6 @@ def gen_c_zetas():
 def gen_c_zeta_file():
     def gen():
         yield from gen_header()
-        yield "#include <stdint.h>"
         yield ""
         yield "/*"
         yield " * Table of zeta values used in the reference NTT and inverse NTT."
@@ -999,7 +998,6 @@ def gen_aarch64_zeta_file():
         yield "#if defined(MLK_ARITH_BACKEND_AARCH64) && \\"
         yield "    !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)"
         yield ""
-        yield "#include <stdint.h>"
         yield '#include "arith_native_aarch64.h"'
         yield ""
         yield "/*"
@@ -1089,7 +1087,6 @@ def gen_aarch64_rej_uniform_table():
         yield "#if defined(MLK_ARITH_BACKEND_AARCH64) && \\"
         yield "    !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)"
         yield ""
-        yield "#include <stdint.h>"
         yield '#include "arith_native_aarch64.h"'
         yield ""
         yield "/*"
@@ -1141,7 +1138,6 @@ def gen_avx2_rej_uniform_table():
         yield "#if defined(MLK_ARITH_BACKEND_X86_64_DEFAULT) && \\"
         yield "    !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)"
         yield ""
-        yield "#include <stdint.h>"
         yield '#include "arith_native_x86_64.h"'
         yield ""
         yield "/*"
@@ -1439,7 +1435,6 @@ def gen_riscv64_zeta_files():
     # Generate rv64v_zetas.inc
     def gen_zetas():
         yield from gen_header()
-        yield "#include <stdint.h>"
         yield '#include "arith_native_riscv64.h"'
         yield ""
         yield "const int16_t zeta[] = {"
@@ -1456,7 +1451,6 @@ def gen_riscv64_zeta_files():
     # Generate rv64v_izetas.inc
     def gen_izetas():
         yield from gen_header()
-        yield "#include <stdint.h>"
         yield '#include "arith_native_riscv64.h"'
         yield ""
         yield "const int16_t izeta[] = {"
@@ -1473,7 +1467,6 @@ def gen_riscv64_zeta_files():
     # Generate rv64v_zetas_basemul.inc
     def gen_basemul():
         yield from gen_header()
-        yield "#include <stdint.h>"
         yield '#include "arith_native_riscv64.h"'
         yield "  "
         yield "const int16_t roots[] = {"
@@ -3031,11 +3024,19 @@ def gen_markdown_citations_for(filename, bibliography):
     except ValueError:
         pass
 
-    # Add footnotes for all citations found
-    if len(citations) > 0:
-        content.append(footnote_footer_start)
-    cite_ids = list(citations.keys())
+    # Find explicit footnote definitions outside the bibliography block
+    # These are lines matching `[^ID]: ...` and should be excluded from autogeneration
+    explicit_footnotes = set()
+    for l in content:
+        m = re.match(r"^\[\^(\w+)\]:", l)
+        if m:
+            explicit_footnotes.add(m.group(1))
+
+    # Add footnotes for all citations found (excluding explicit ones)
+    cite_ids = [c for c in citations.keys() if c not in explicit_footnotes]
     cite_ids.sort()
+    if len(cite_ids) > 0:
+        content.append(footnote_footer_start)
     for cite_id in cite_ids:
         uses = citations[cite_id]
         entry = bibliography.get(cite_id, None)
@@ -3050,7 +3051,7 @@ def gen_markdown_citations_for(filename, bibliography):
         # Remember this usage of the bibliography entry
         entry.register_usages(uses)
 
-    if len(citations) > 0:
+    if len(cite_ids) > 0:
         content.append("")
 
     update_file(filename, "\n".join(content))


### PR DESCRIPTION
* Resolves #1479 

mlkem-native depends on stdint.h which is a popular extension to C90, but not part of it -- contrary to our documentation stating C90 compliance.

As a step towards clarifying the reliance on non-standard headers, this commit consolidates all imports of stdint.h into common.h and mlkem_native.h.

We also add a footnote to README indicating the need for `stdint.h`.