### PR TITLE
Native monobuild: Give single assembly unit a unique name

### DIFF
--- a/examples/monolithic_build_multilevel_native/Makefile
+++ b/examples/monolithic_build_multilevel_native/Makefile
@@ -55,7 +55,7 @@ endif
 #
 # Here, the monolithic C file for mlkem-native is directly included in main.c,
 # However, we still need to incldue the monolithic assembly file.
-MLK_SOURCE_ASM = mlkem_native/mlkem_native.S
+MLK_SOURCE_ASM = mlkem_native/mlkem_native_asm.S
 
 INC=-Imlkem_native/ -I./
 

--- a/examples/monolithic_build_multilevel_native/README.md
+++ b/examples/monolithic_build_multilevel_native/README.md
@@ -16,7 +16,7 @@ Use this approach when:
 
 1. Source tree [mlkem_native/*](mlkem_native), including top-level compilation unit
    [mlkem_native.c](mlkem_native/mlkem_native.c) (gathering all C sources),
-   [mlkem_native.S](mlkem_native/mlkem_native.S) (gathering all assembly sources),
+   [mlkem_native_asm.S](mlkem_native/mlkem_native_asm.S) (gathering all assembly sources),
    and the mlkem-native API [mlkem_native.h](mlkem_native/mlkem_native.h).
 2. Manually provided wrapper file [mlkem_native_all.c](mlkem_native_all.c),
    including `mlkem_native.c` three times (in this example, we don't use a
@@ -66,7 +66,7 @@ The application [main.c](main.c) embeds the wrapper and imports constants:
 
 ## Notes
 
-- Both `mlkem_native_all.c` and `mlkem_native.S` must be compiled and linked
+- Both `mlkem_native_all.c` and `mlkem_native_asm.S` must be compiled and linked
 - `MLK_CONFIG_MULTILEVEL_WITH_SHARED` must be set for exactly ONE level
 - `MLK_CONFIG_CONSTANTS_ONLY` imports size constants without function declarations
 - Native backends are auto-selected based on target architecture

--- a/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native.S
+++ b/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native.S
@@ -1,1 +1,0 @@
-../../../mlkem/mlkem_native.S

--- a/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_asm.S
+++ b/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_asm.S
@@ -1,0 +1,1 @@
+../../../mlkem/mlkem_native_asm.S

--- a/examples/monolithic_build_native/Makefile
+++ b/examples/monolithic_build_native/Makefile
@@ -57,7 +57,7 @@ Q ?= @
 #
 # Here, we use just a single C and assembly unit.
 
-MLK_SOURCE=mlkem_native/mlkem_native.c mlkem_native/mlkem_native.S
+MLK_SOURCE=mlkem_native/mlkem_native.c mlkem_native/mlkem_native_asm.S
 
 INC=-Imlkem_native/
 
@@ -98,7 +98,7 @@ $(LIB512_FULL): $(MLK_SOURCE)
 	$(Q)echo "$@"
 	$(Q)[ -d $(@) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=512 $(INC) mlkem_native/mlkem_native.c -o $(BUILD_DIR)/mlkem_native512.c.o
-	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=512 $(INC) mlkem_native/mlkem_native.S -o $(BUILD_DIR)/mlkem_native512.S.o
+	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=512 $(INC) mlkem_native/mlkem_native_asm.S -o $(BUILD_DIR)/mlkem_native512.S.o
 	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mlkem_native512.c.o $(BUILD_DIR)/mlkem_native512.S.o
 	$(Q)strip -S $@
 
@@ -106,7 +106,7 @@ $(LIB768_FULL): $(MLK_SOURCE)
 	$(Q)echo "$@"
 	$(Q)[ -d $(@) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=768 $(INC) mlkem_native/mlkem_native.c -o $(BUILD_DIR)/mlkem_native768.c.o
-	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=768 $(INC) mlkem_native/mlkem_native.S -o $(BUILD_DIR)/mlkem_native768.S.o
+	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=768 $(INC) mlkem_native/mlkem_native_asm.S -o $(BUILD_DIR)/mlkem_native768.S.o
 	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mlkem_native768.c.o $(BUILD_DIR)/mlkem_native768.S.o
 	$(Q)strip -S $@
 
@@ -114,7 +114,7 @@ $(LIB1024_FULL): $(MLK_SOURCE)
 	$(Q)echo "$@"
 	$(Q)[ -d $(@) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=1024 $(INC) mlkem_native/mlkem_native.c -o $(BUILD_DIR)/mlkem_native1024.c.o
-	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=1024 $(INC) mlkem_native/mlkem_native.S -o $(BUILD_DIR)/mlkem_native1024.S.o
+	$(Q)$(CC) -c $(CFLAGS) -DMLK_CONFIG_PARAMETER_SET=1024 $(INC) mlkem_native/mlkem_native_asm.S -o $(BUILD_DIR)/mlkem_native1024.S.o
 	$(Q)$(AR) rcs $@ $(BUILD_DIR)/mlkem_native1024.c.o $(BUILD_DIR)/mlkem_native1024.S.o
 	$(Q)strip -S $@
 

--- a/examples/monolithic_build_native/README.md
+++ b/examples/monolithic_build_native/README.md
@@ -3,7 +3,7 @@
 # Monolithic Build (Native Backend)
 
 This directory contains a minimal example for building mlkem-native as a single compilation unit
-with native assembly backends, using the auto-generated `mlkem_native.c` and `mlkem_native.S` files.
+with native assembly backends, using the auto-generated `mlkem_native.c` and `mlkem_native_asm.S` files.
 
 ## Use Case
 
@@ -15,7 +15,7 @@ Use this approach when:
 
 1. Source tree [mlkem_native/*](mlkem_native), including top-level compilation unit
    [mlkem_native.c](mlkem_native/mlkem_native.c) (gathering all C sources),
-   [mlkem_native.S](mlkem_native/mlkem_native.S) (gathering all assembly sources),
+   [mlkem_native_asm.S](mlkem_native/mlkem_native_asm.S) (gathering all assembly sources),
    and the mlkem-native API [mlkem_native.h](mlkem_native/mlkem_native.h).
 2. A secure random number generator implementing [`randombytes.h`](../../mlkem/src/randombytes.h)
 3. Your application source code
@@ -30,7 +30,7 @@ The configuration file [mlkem_native_config.h](mlkem_native/mlkem_native_config.
 
 ## Notes
 
-- Both `mlkem_native.c` and `mlkem_native.S` must be compiled and linked
+- Both `mlkem_native.c` and `mlkem_native_asm.S` must be compiled and linked
 - Native backends are auto-selected based on target architecture
 - On unsupported platforms, the C backend is used automatically
 

--- a/examples/monolithic_build_native/mlkem_native/mlkem_native.S
+++ b/examples/monolithic_build_native/mlkem_native/mlkem_native.S
@@ -1,1 +1,0 @@
-../../../mlkem/mlkem_native.S

--- a/examples/monolithic_build_native/mlkem_native/mlkem_native_asm.S
+++ b/examples/monolithic_build_native/mlkem_native/mlkem_native_asm.S
@@ -1,0 +1,1 @@
+../../../mlkem/mlkem_native_asm.S

--- a/mlkem/README.md
+++ b/mlkem/README.md
@@ -8,7 +8,7 @@ This is the main source tree of mlkem-native.
 
 To build a mlkem-native for a fixed parameter set (ML-KEM-512/768/1024), build the compilation in units in `src/*` separately, and link to an RNG and your application. See [examples/basic](../examples/basic) for a simple example.
 
-Alternatively, you can use the auto-geneated helper files [mlkem_native.c](mlkem_native.c) and [mlkem_native.S](mlkem_native.S), which bundle all *.c and *.S files together. See [examples/monolithic_build](../examples/monolithic_build) and [examples/monolithic_build_native](../examples/monolithic_build_native) for examples with and without native code.
+Alternatively, you can use the auto-geneated helper files [mlkem_native.c](mlkem_native.c) and [mlkem_native_asm.S](mlkem_native_asm.S), which bundle all *.c and *.S files together. See [examples/monolithic_build](../examples/monolithic_build) and [examples/monolithic_build_native](../examples/monolithic_build_native) for examples with and without native code.
 
 ## Configuration
 

--- a/mlkem/mlkem_native_asm.S
+++ b/mlkem/mlkem_native_asm.S
@@ -52,7 +52,7 @@
  *
  * Example:
  * ```bash
- * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native.S
+ * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_asm.S
  * ```
  */
 

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -1948,7 +1948,7 @@ def gen_monolithic_asm_file():
         yield " *"
         yield " * Example:"
         yield " * ```bash"
-        yield " * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native.S"
+        yield " * unifdef -UMLK_CONFIG_USE_NATIVE_BACKEND_ARITH mlkem_native_asm.S"
         yield " * ```"
         yield " */"
         yield ""
@@ -2001,7 +2001,7 @@ def gen_monolithic_asm_file():
         ]
         yield from gen_macro_undefs(extra_notes=extra)
 
-    update_file("mlkem/mlkem_native.S", "\n".join(gen()), force_format=True)
+    update_file("mlkem/mlkem_native_asm.S", "\n".join(gen()), force_format=True)
 
 
 def get_config_options():


### PR DESCRIPTION
Rename mlkem_native.S to mlkem_native_asm.S so C and assembly compilation units have unique base names, allowing simpler build rules for consumers.

- Ported from https://github.com/pq-code-package/mldsa-native/pull/954