### PR TITLE
HOL-Light: Add CT proofs for x86_64 basemul, (i)NTT functions

### DIFF
--- a/proofs/hol_light/x86_64/proofs/mlkem_frombytes.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_frombytes.ml
@@ -293,6 +293,22 @@ let mlkem_frombytes_mc =
 let mlkem_frombytes_tmc = define_trimmed "mlkem_frombytes_tmc" mlkem_frombytes_mc;;
 let mlkem_frombytes_TMC_EXEC = X86_MK_CORE_EXEC_RULE mlkem_frombytes_tmc;;
 
+let LENGTH_MLKEM_FROMBYTES_TMC =
+  REWRITE_CONV[mlkem_frombytes_tmc] `LENGTH mlkem_frombytes_tmc`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let MLKEM_FROMBYTES_POSTAMBLE_LENGTH = new_definition
+  `MLKEM_FROMBYTES_POSTAMBLE_LENGTH = 1`;;
+
+let MLKEM_FROMBYTES_CORE_END = new_definition
+  `MLKEM_FROMBYTES_CORE_END = LENGTH mlkem_frombytes_tmc - MLKEM_FROMBYTES_POSTAMBLE_LENGTH`;;
+
+let LENGTH_SIMPLIFY_CONV =
+  REWRITE_CONV[LENGTH_MLKEM_FROMBYTES_TMC;
+              MLKEM_FROMBYTES_CORE_END;
+              MLKEM_FROMBYTES_POSTAMBLE_LENGTH] THENC
+  NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
+
 let avx_order = new_definition
   `avx_order i = 
     let half = i DIV 128 in
@@ -324,15 +340,15 @@ let MLKEM_FROMBYTES_CORRECT = prove(
     `!r a (l:(12 word) list) pc.
         aligned 32 a /\
         aligned 32 r /\
-        nonoverlapping (word pc, 818) (a, 384) /\
-        nonoverlapping (word pc, 818) (r, 512) /\
+        nonoverlapping (word pc, LENGTH mlkem_frombytes_tmc) (a, 384) /\
+        nonoverlapping (word pc, LENGTH mlkem_frombytes_tmc) (r, 512) /\
         nonoverlapping (a, 384) (r, 512)
         ==> ensures x86
              (\s. bytes_loaded s (word pc) (BUTLAST mlkem_frombytes_tmc) /\
                   read RIP s = word pc /\
                   C_ARGUMENTS [r; a] s /\
                   read (memory :> bytes(a, 384)) s = num_of_wordlist l)
-             (\s. read RIP s = word (pc + 818) /\
+             (\s. read RIP s = word (pc + MLKEM_FROMBYTES_CORE_END) /\
                   (LENGTH l = 256
                    ==> read(memory :> bytes(r, 512)) s =
                        num_of_wordlist (MAP word_zx (unpermute_list l):int16 list)))
@@ -342,6 +358,7 @@ let MLKEM_FROMBYTES_CORRECT = prove(
               MAYCHANGE [ZMM0; ZMM1; ZMM3; ZMM4; ZMM5; ZMM6; ZMM7;
                          ZMM8; ZMM9; ZMM10; ZMM11; ZMM12; ZMM13; ZMM14; ZMM15])`,
 
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   MAP_EVERY X_GEN_TAC [`r:int64`; `a:int64`; `l:(12 word) list`; `pc:num`] THEN
   REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
               NONOVERLAPPING_CLAUSES] THEN
@@ -444,7 +461,9 @@ let MLKEM_FROMBYTES_NOIBT_SUBROUTINE_CORRECT = prove(
                        num_of_wordlist (MAP word_zx (unpermute_list l):int16 list)))
              (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
               MAYCHANGE [RSP] ,, MAYCHANGE [memory :> bytes(r, 512)])`,
-  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_frombytes_tmc MLKEM_FROMBYTES_CORRECT);;
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_frombytes_tmc
+    (CONV_RULE LENGTH_SIMPLIFY_CONV MLKEM_FROMBYTES_CORRECT));;
 
 (* NOTE: This must be kept in sync with the CBMC specification
  * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
@@ -491,8 +510,8 @@ let MLKEM_FROMBYTES_SAFE = time prove
        forall e r a pc.
            aligned 32 a /\
            aligned 32 r /\
-           nonoverlapping (word pc,818) (a,384) /\
-           nonoverlapping (word pc,818) (r,512) /\
+           nonoverlapping (word pc,LENGTH mlkem_frombytes_tmc) (a,384) /\
+           nonoverlapping (word pc,LENGTH mlkem_frombytes_tmc) (r,512) /\
            nonoverlapping (a,384) (r,512)
            ==> ensures x86
                (\s.
@@ -501,11 +520,12 @@ let MLKEM_FROMBYTES_SAFE = time prove
                     C_ARGUMENTS [r; a] s /\
                     read events s = e)
                (\s.
-                    read RIP s = word (pc + 818) /\
+                    read RIP s = word (pc + MLKEM_FROMBYTES_CORE_END) /\
                     (exists e2.
                          read events s = APPEND e2 e /\
                          e2 = f_events a r pc /\
                          memaccess_inbounds e2 [a,384; r,512] [r,512]))
                (\s s'. T)`,
-  ASSERT_CONCL_TAC full_spec THEN
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  ASSERT_CONCL_TAC (rhs(concl(LENGTH_SIMPLIFY_CONV full_spec))) THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars mlkem_frombytes_TMC_EXEC);;

--- a/proofs/hol_light/x86_64/proofs/mlkem_mulcache_compute.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_mulcache_compute.ml
@@ -122,21 +122,42 @@ let avx2_mulcache = define
    let t = 64 * r + 2 * (q DIV 32) + 4 * (q MOD 16) in
    (f s * (&17 pow (2 * bitreverse7 t + 1))) rem &3329`;;
 
+let LENGTH_MLKEM_MULCACHE_COMPUTE_TMC =
+  REWRITE_CONV[mlkem_mulcache_compute_tmc] `LENGTH mlkem_mulcache_compute_tmc`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let LENGTH_QDATA_FULL =
+  REWRITE_CONV[qdata_full] `LENGTH qdata_full`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let MLKEM_MULCACHE_COMPUTE_POSTAMBLE_LENGTH = new_definition
+  `MLKEM_MULCACHE_COMPUTE_POSTAMBLE_LENGTH = 1`;;
+
+let MLKEM_MULCACHE_COMPUTE_CORE_END = new_definition
+  `MLKEM_MULCACHE_COMPUTE_CORE_END = LENGTH mlkem_mulcache_compute_tmc - MLKEM_MULCACHE_COMPUTE_POSTAMBLE_LENGTH`;;
+
+let LENGTH_SIMPLIFY_CONV =
+  REWRITE_CONV[LENGTH_MLKEM_MULCACHE_COMPUTE_TMC;
+              LENGTH_QDATA_FULL;
+              MLKEM_MULCACHE_COMPUTE_CORE_END;
+              MLKEM_MULCACHE_COMPUTE_POSTAMBLE_LENGTH] THENC
+  NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
+
 let MLKEM_MULCACHE_COMPUTE_CORRECT = prove(
  `!r a zetas (zetas_list:int16 list) x pc.
     aligned 32 r /\
     aligned 32 a /\
     aligned 32 zetas /\
-    nonoverlapping (r, 256) (word pc, 323) /\
+    nonoverlapping (r, 256) (word pc, LENGTH mlkem_mulcache_compute_tmc) /\
     nonoverlapping (r, 256) (a, 512) /\
-    nonoverlapping (r, 256) (zetas, 1248)
+    nonoverlapping (r, 256) (zetas, LENGTH qdata_full * 2)
     ==> ensures x86
           (\s. bytes_loaded s (word pc) (BUTLAST mlkem_mulcache_compute_tmc) /\
               read RIP s = word pc /\
               C_ARGUMENTS [r; a; zetas] s /\
               wordlist_from_memory(zetas, 624) s = MAP (iword: int -> 16 word) qdata_full /\
               (!i. i < 256 ==> read(memory :> bytes16(word_add a (word(2 * i)))) s = x i))
-          (\s. read RIP s = word(pc + 323) /\
+          (\s. read RIP s = word(pc + MLKEM_MULCACHE_COMPUTE_CORE_END) /\
                !i. i < 128
                    ==> let zi =
                       read(memory :> bytes16(word_add r (word(2 * i)))) s in
@@ -147,8 +168,9 @@ let MLKEM_MULCACHE_COMPUTE_CORRECT = prove(
            MAYCHANGE [RIP] ,, MAYCHANGE [RAX] ,,
            MAYCHANGE [memory :> bytes(r, 256)])`,
 
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   MAP_EVERY X_GEN_TAC
-   [`r:int64`; `a:int64`; `zetas:int64`; `zetas_list:int16 list`; `x:num->int16`; `pc:num`] THEN
+   [`r:int64`; `a:int64`; `zetas:int64`; `x:num->int16`; `pc:num`] THEN
   REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
               NONOVERLAPPING_CLAUSES; ALL] THEN
 
@@ -244,7 +266,7 @@ let MLKEM_MULCACHE_COMPUTE_NOIBT_SUBROUTINE_CORRECT  = prove(
     aligned 32 zetas /\
     nonoverlapping (r, 256) (word pc, LENGTH mlkem_mulcache_compute_tmc) /\
     nonoverlapping (r, 256) (a, 512) /\
-    nonoverlapping (r, 256) (zetas, 1248) /\
+    nonoverlapping (r, 256) (zetas, LENGTH qdata_full * 2) /\
     nonoverlapping (r, 256) (stackpointer, 8)
     ==> ensures x86
           (\s. bytes_loaded s (word pc) mlkem_mulcache_compute_tmc /\
@@ -263,9 +285,11 @@ let MLKEM_MULCACHE_COMPUTE_NOIBT_SUBROUTINE_CORRECT  = prove(
                       (abs(ival zi) <= &3328))
           (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
            MAYCHANGE [memory :> bytes(r, 256)])`,
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
   CONV_TAC TWEAK_CONV THEN
-  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_mulcache_compute_tmc (CONV_RULE TWEAK_CONV MLKEM_MULCACHE_COMPUTE_CORRECT));;
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_mulcache_compute_tmc
+    (CONV_RULE TWEAK_CONV (CONV_RULE LENGTH_SIMPLIFY_CONV MLKEM_MULCACHE_COMPUTE_CORRECT)));;
 
 (* NOTE: This must be kept in sync with the CBMC specification
  * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
@@ -277,7 +301,7 @@ let MLKEM_MULCACHE_COMPUTE_SUBROUTINE_CORRECT = prove(
     aligned 32 zetas /\
     nonoverlapping (r, 256) (word pc, LENGTH mlkem_mulcache_compute_mc) /\
     nonoverlapping (r, 256) (a, 512) /\
-    nonoverlapping (r, 256) (zetas, 1248) /\
+    nonoverlapping (r, 256) (zetas, LENGTH qdata_full * 2) /\
     nonoverlapping (r, 256) (stackpointer, 8)
     ==> ensures x86
           (\s. bytes_loaded s (word pc) mlkem_mulcache_compute_mc /\
@@ -320,9 +344,9 @@ let MLKEM_MULCACHE_COMPUTE_SAFE = time prove
            aligned 32 r /\
            aligned 32 a /\
            aligned 32 zetas /\
-           nonoverlapping (r,256) (word pc,323) /\
+           nonoverlapping (r,256) (word pc,LENGTH mlkem_mulcache_compute_tmc) /\
            nonoverlapping (r,256) (a,512) /\
-           nonoverlapping (r,256) (zetas,1248)
+           nonoverlapping (r,256) (zetas,LENGTH qdata_full * 2)
            ==> ensures x86
                (\s.
                     bytes_loaded s (word pc)
@@ -331,13 +355,14 @@ let MLKEM_MULCACHE_COMPUTE_SAFE = time prove
                     C_ARGUMENTS [r; a; zetas] s /\
                     read events s = e)
                (\s.
-                    read RIP s = word (pc + 323) /\
+                    read RIP s = word (pc + MLKEM_MULCACHE_COMPUTE_CORE_END) /\
                     (exists e2.
                          read events s = APPEND e2 e /\
                          e2 = f_events a zetas r pc /\
                          memaccess_inbounds e2
-                           [a,512; zetas,1248; r,256] [r,256]))
+                           [a,512; zetas,LENGTH qdata_full * 2; r,256] [r,256]))
                (\s s'. T)`,
-  ASSERT_CONCL_TAC full_spec THEN
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  ASSERT_CONCL_TAC (rhs(concl(LENGTH_SIMPLIFY_CONV full_spec))) THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars
     MLKEM_MULCACHE_COMPUTE_TMC_EXEC);;

--- a/proofs/hol_light/x86_64/proofs/mlkem_ntt.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_ntt.ml
@@ -1045,13 +1045,34 @@ let mlkem_ntt_mc = define_assert_from_elf "mlkem_ntt_mc" "x86_64/mlkem/mlkem_ntt
 let mlkem_ntt_tmc = define_trimmed "mlkem_ntt_tmc" mlkem_ntt_mc;;
 let MLKEM_NTT_TMC_EXEC = X86_MK_CORE_EXEC_RULE mlkem_ntt_tmc;;
 
+let LENGTH_MLKEM_NTT_TMC =
+  REWRITE_CONV[mlkem_ntt_tmc] `LENGTH mlkem_ntt_tmc`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let LENGTH_QDATA_FULL =
+  REWRITE_CONV[qdata_full] `LENGTH qdata_full`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let MLKEM_NTT_POSTAMBLE_LENGTH = new_definition
+  `MLKEM_NTT_POSTAMBLE_LENGTH = 1`;;
+
+let MLKEM_NTT_CORE_END = new_definition
+  `MLKEM_NTT_CORE_END = LENGTH mlkem_ntt_tmc - MLKEM_NTT_POSTAMBLE_LENGTH`;;
+
+let LENGTH_SIMPLIFY_CONV =
+  REWRITE_CONV[LENGTH_MLKEM_NTT_TMC;
+              LENGTH_QDATA_FULL;
+              MLKEM_NTT_CORE_END;
+              MLKEM_NTT_POSTAMBLE_LENGTH] THENC
+  NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
+
 let MLKEM_NTT_CORRECT = prove
   (`!a zetas (zetas_list:int16 list) x pc.
     aligned 32 a /\
     aligned 32 zetas /\
-    nonoverlapping (word pc, 3069) (a, 512) /\
-    nonoverlapping (word pc, 3069) (zetas, 1248) /\
-    nonoverlapping (a, 512) (zetas, 1248)
+    nonoverlapping (word pc, LENGTH mlkem_ntt_tmc) (a, 512) /\
+    nonoverlapping (word pc, LENGTH mlkem_ntt_tmc) (zetas, LENGTH qdata_full * 2) /\
+    nonoverlapping (a, 512) (zetas, LENGTH qdata_full * 2)
     ==> ensures x86
           (\s. bytes_loaded s (word pc) (BUTLAST mlkem_ntt_tmc) /\
               read RIP s = word pc /\
@@ -1059,7 +1080,7 @@ let MLKEM_NTT_CORRECT = prove
               wordlist_from_memory(zetas, 624) s = MAP (iword: int -> 16 word) qdata_full /\
               (!i. i < 256 ==> abs(ival(x i)) <= &8191) /\
               (!i. i < 256 ==> read(memory :> bytes16(word_add a (word(2 * i)))) s = x i))
-          (\s. read RIP s = word(pc + 3069) /\
+          (\s. read RIP s = word(pc + MLKEM_NTT_CORE_END) /\
               (!i. i < 256
                         ==> let zi =
                       read(memory :> bytes16(word_add a (word(2 * i)))) s in
@@ -1071,8 +1092,9 @@ let MLKEM_NTT_CORRECT = prove
            MAYCHANGE [RAX] ,, MAYCHANGE SOME_FLAGS ,,
            MAYCHANGE [memory :> bytes(a, 512)])`,
 
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   MAP_EVERY X_GEN_TAC
-   [`a:int64`; `zetas:int64`; `zetas_list:int16 list`; `x:num->int16`; `pc:num`] THEN
+   [`a:int64`; `zetas:int64`; `x:num->int16`; `pc:num`] THEN
   REWRITE_TAC[MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI; C_ARGUMENTS;
               NONOVERLAPPING_CLAUSES; ALL] THEN
 
@@ -1196,10 +1218,10 @@ let MLKEM_NTT_NOIBT_SUBROUTINE_CORRECT  = prove
     aligned 32 a /\
     aligned 32 zetas /\
     nonoverlapping (word pc, LENGTH mlkem_ntt_tmc) (a, 512) /\
-    nonoverlapping (word pc, LENGTH mlkem_ntt_tmc) (zetas, 1248) /\
-    nonoverlapping (a, 512) (zetas, 1248) /\
+    nonoverlapping (word pc, LENGTH mlkem_ntt_tmc) (zetas, LENGTH qdata_full * 2) /\
+    nonoverlapping (a, 512) (zetas, LENGTH qdata_full * 2) /\
     nonoverlapping (a, 512) (stackpointer, 8) /\
-    nonoverlapping (zetas, 1248) (stackpointer, 8)
+    nonoverlapping (zetas, LENGTH qdata_full * 2) (stackpointer, 8)
     ==> ensures x86
           (\s. bytes_loaded s (word pc) mlkem_ntt_tmc /\
               read RIP s = word pc /\
@@ -1218,9 +1240,11 @@ let MLKEM_NTT_NOIBT_SUBROUTINE_CORRECT  = prove
                       abs(ival zi) <= &23594))
           (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
            MAYCHANGE [memory :> bytes(a, 512)])`,
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   let TWEAK_CONV = ONCE_DEPTH_CONV WORDLIST_FROM_MEMORY_CONV in
   CONV_TAC TWEAK_CONV THEN
-  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_ntt_tmc (CONV_RULE TWEAK_CONV MLKEM_NTT_CORRECT));;
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_ntt_tmc
+    (CONV_RULE TWEAK_CONV (CONV_RULE LENGTH_SIMPLIFY_CONV MLKEM_NTT_CORRECT)));;
 
 (* NOTE: This must be kept in sync with the CBMC specification
  * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
@@ -1230,10 +1254,10 @@ let MLKEM_NTT_SUBROUTINE_CORRECT  = prove
     aligned 32 a /\
     aligned 32 zetas /\
     nonoverlapping (word pc, LENGTH mlkem_ntt_mc) (a, 512) /\
-    nonoverlapping (word pc, LENGTH mlkem_ntt_mc) (zetas, 1248) /\
-    nonoverlapping (a, 512) (zetas, 1248) /\
+    nonoverlapping (word pc, LENGTH mlkem_ntt_mc) (zetas, LENGTH qdata_full * 2) /\
+    nonoverlapping (a, 512) (zetas, LENGTH qdata_full * 2) /\
     nonoverlapping (a, 512) (stackpointer, 8) /\
-    nonoverlapping (zetas, 1248) (stackpointer, 8)
+    nonoverlapping (zetas, LENGTH qdata_full * 2) (stackpointer, 8)
     ==> ensures x86
           (\s. bytes_loaded s (word pc) mlkem_ntt_mc /\
               read RIP s = word pc /\
@@ -1278,9 +1302,9 @@ let MLKEM_NTT_SAFE = time prove
        forall e a zetas pc.
            aligned 32 a /\
            aligned 32 zetas /\
-           nonoverlapping (word pc,3069) (a,512) /\
-           nonoverlapping (word pc,3069) (zetas,1248) /\
-           nonoverlapping (a,512) (zetas,1248)
+           nonoverlapping (word pc,LENGTH mlkem_ntt_tmc) (a,512) /\
+           nonoverlapping (word pc,LENGTH mlkem_ntt_tmc) (zetas,LENGTH qdata_full * 2) /\
+           nonoverlapping (a,512) (zetas,LENGTH qdata_full * 2)
            ==> ensures x86
                (\s.
                     bytes_loaded s (word pc) (BUTLAST mlkem_ntt_tmc) /\
@@ -1288,12 +1312,13 @@ let MLKEM_NTT_SAFE = time prove
                     C_ARGUMENTS [a; zetas] s /\
                     read events s = e)
                (\s.
-                    read RIP s = word (pc + 3069) /\
+                    read RIP s = word (pc + MLKEM_NTT_CORE_END) /\
                     (exists e2.
                          read events s = APPEND e2 e /\
                          e2 = f_events zetas a pc /\
                          memaccess_inbounds e2
-                           [a,512; zetas,1248] [a,512]))
+                           [a,512; zetas,LENGTH qdata_full * 2] [a,512]))
                (\s s'. T)`,
-  ASSERT_CONCL_TAC full_spec THEN
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  ASSERT_CONCL_TAC (rhs(concl(LENGTH_SIMPLIFY_CONV full_spec))) THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars MLKEM_NTT_TMC_EXEC);;

--- a/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k3.ml
@@ -1218,6 +1218,22 @@ let mlkem_basemul_k3_mc =
 let mlkem_basemul_k3_tmc = define_trimmed "mlkem_basemul_k3_tmc" mlkem_basemul_k3_mc;;
 let mlkem_basemul_k3_tmc_EXEC = X86_MK_CORE_EXEC_RULE mlkem_basemul_k3_tmc;;
 
+let LENGTH_MLKEM_BASEMUL_K3_TMC =
+  REWRITE_CONV[mlkem_basemul_k3_tmc] `LENGTH mlkem_basemul_k3_tmc`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let MLKEM_BASEMUL_K3_POSTAMBLE_LENGTH = new_definition
+  `MLKEM_BASEMUL_K3_POSTAMBLE_LENGTH = 1`;;
+
+let MLKEM_BASEMUL_K3_CORE_END = new_definition
+  `MLKEM_BASEMUL_K3_CORE_END = LENGTH mlkem_basemul_k3_tmc - MLKEM_BASEMUL_K3_POSTAMBLE_LENGTH`;;
+
+let LENGTH_SIMPLIFY_CONV =
+  REWRITE_CONV[LENGTH_MLKEM_BASEMUL_K3_TMC;
+              MLKEM_BASEMUL_K3_CORE_END;
+              MLKEM_BASEMUL_K3_POSTAMBLE_LENGTH] THENC
+  NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
+
 (* Enable simplification of word_subwords by default.
    Nedded to prevent the symbolic simulation to explode
    as we add more instructions. *)
@@ -1279,7 +1295,7 @@ let MLKEM_BASEMUL_K3_CORRECT = prove(
         aligned 32 src2t /\
         aligned 32 dst /\
         ALL (nonoverlapping (dst, 512)) [(src1, 1536); (src2, 1536); (src2t, 768)] /\
-        nonoverlapping (dst, 512) (word pc, 3852)
+        nonoverlapping (dst, 512) (word pc, LENGTH mlkem_basemul_k3_tmc)
         ==> ensures x86
               (\s. bytes_loaded s (word pc) (BUTLAST mlkem_basemul_k3_tmc) /\
                    read RIP s = word pc /\
@@ -1331,7 +1347,7 @@ let MLKEM_BASEMUL_K3_CORRECT = prove(
                    (!i. i < 16 ==> !j. j < 8
                         ==> read(memory :> bytes16
                              (word_add src2t (word (512 + 32*j + 2*i)))) s = dz2 i j))
-              (\s. read RIP s = word (pc + 3852) /\
+              (\s. read RIP s = word (pc + MLKEM_BASEMUL_K3_CORE_END) /\
                    (!i. i < 16 ==> !j. j < 4
                         ==> (let j' = 2*j in
                               (abs(ival(a0 i j')) <= &2 pow 12  /\
@@ -1383,6 +1399,7 @@ let MLKEM_BASEMUL_K3_CORRECT = prove(
                           ZMM8; ZMM9; ZMM10; ZMM11; ZMM12; ZMM13; ZMM14] ,,
                MAYCHANGE [memory :> bytes(dst, 512)])`,
 
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI;
     NONOVERLAPPING_CLAUSES; ALL; C_ARGUMENTS; fst mlkem_basemul_k3_tmc_EXEC] THEN
   REPEAT STRIP_TAC THEN
@@ -1549,7 +1566,9 @@ let MLKEM_BASEMUL_K3_NOIBT_SUBROUTINE_CORRECT = prove(
                             ) (mod &3329)))
               (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
                MAYCHANGE [memory :> bytes(dst, 512)])`,
-  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k3_tmc MLKEM_BASEMUL_K3_CORRECT);;
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k3_tmc
+    (CONV_RULE LENGTH_SIMPLIFY_CONV MLKEM_BASEMUL_K3_CORRECT));;
 
 (* NOTE: This must be kept in sync with the CBMC specification
  * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
@@ -1689,7 +1708,7 @@ let MLKEM_BASEMUL_K3_SAFE = time prove
            aligned 32 src2t /\
            aligned 32 dst /\
            ALL (nonoverlapping (dst,512)) [src1,1536; src2,1536; src2t,768] /\
-           nonoverlapping (dst,512) (word pc,3852)
+           nonoverlapping (dst,512) (word pc,LENGTH mlkem_basemul_k3_tmc)
            ==> ensures x86
                (\s.
                     bytes_loaded s (word pc)
@@ -1698,7 +1717,7 @@ let MLKEM_BASEMUL_K3_SAFE = time prove
                     C_ARGUMENTS [dst; src1; src2; src2t] s /\
                     read events s = e)
                (\s.
-                    read RIP s = word (pc + 3852) /\
+                    read RIP s = word (pc + MLKEM_BASEMUL_K3_CORE_END) /\
                     (exists e2.
                          read events s = APPEND e2 e /\
                          e2 = f_events src1 src2 src2t dst pc /\
@@ -1706,5 +1725,6 @@ let MLKEM_BASEMUL_K3_SAFE = time prove
                            [src1,1536; src2,1536; src2t,768; dst,512]
                            [dst,512]))
                (\s s'. T)`,
-  ASSERT_CONCL_TAC full_spec THEN
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  ASSERT_CONCL_TAC (rhs(concl(LENGTH_SIMPLIFY_CONV full_spec))) THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars mlkem_basemul_k3_tmc_EXEC);;

--- a/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_poly_basemul_acc_montgomery_cached_k4.ml
@@ -1633,6 +1633,22 @@ let mlkem_basemul_k4_mc =
 let mlkem_basemul_k4_tmc = define_trimmed "mlkem_basemul_k4_tmc" mlkem_basemul_k4_mc;;
 let mlkem_basemul_k4_tmc_EXEC = X86_MK_CORE_EXEC_RULE mlkem_basemul_k4_tmc;;
 
+let LENGTH_MLKEM_BASEMUL_K4_TMC =
+  REWRITE_CONV[mlkem_basemul_k4_tmc] `LENGTH mlkem_basemul_k4_tmc`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let MLKEM_BASEMUL_K4_POSTAMBLE_LENGTH = new_definition
+  `MLKEM_BASEMUL_K4_POSTAMBLE_LENGTH = 1`;;
+
+let MLKEM_BASEMUL_K4_CORE_END = new_definition
+  `MLKEM_BASEMUL_K4_CORE_END = LENGTH mlkem_basemul_k4_tmc - MLKEM_BASEMUL_K4_POSTAMBLE_LENGTH`;;
+
+let LENGTH_SIMPLIFY_CONV =
+  REWRITE_CONV[LENGTH_MLKEM_BASEMUL_K4_TMC;
+              MLKEM_BASEMUL_K4_CORE_END;
+              MLKEM_BASEMUL_K4_POSTAMBLE_LENGTH] THENC
+  NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
+
 (* Enable simplification of word_subwords by default.
    Nedded to prevent the symbolic simulation to explode
    as we add more instructions. *)
@@ -1706,7 +1722,7 @@ let MLKEM_BASEMUL_K4_CORRECT = prove(
         aligned 32 src2t /\
         aligned 32 dst /\
         ALL (nonoverlapping (dst, 512)) [(src1, 2048); (src2, 2048); (src2t, 1024)] /\
-        nonoverlapping (dst, 512) (word pc, 5202)
+        nonoverlapping (dst, 512) (word pc, LENGTH mlkem_basemul_k4_tmc)
         ==> ensures x86
               (\s. bytes_loaded s (word pc) (BUTLAST mlkem_basemul_k4_tmc) /\
                    read RIP s = word pc /\
@@ -1774,7 +1790,7 @@ let MLKEM_BASEMUL_K4_CORRECT = prove(
                    (!i. i < 16 ==> !j. j < 8
                         ==> read(memory :> bytes16
                              (word_add src2t (word (768 + 32*j + 2*i)))) s = dz3 i j))
-              (\s. read RIP s = word (pc + 5202) /\
+              (\s. read RIP s = word (pc + MLKEM_BASEMUL_K4_CORE_END) /\
                    (!i. i < 16 ==> !j. j < 4
                         ==> (let j' = 2*j in
                               (abs(ival(a0 i j')) <= &2 pow 12  /\
@@ -1835,6 +1851,7 @@ let MLKEM_BASEMUL_K4_CORRECT = prove(
                           ZMM8; ZMM9; ZMM10; ZMM11; ZMM12; ZMM13; ZMM14] ,,
                MAYCHANGE [memory :> bytes(dst, 512)])`,
 
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI;
     NONOVERLAPPING_CLAUSES; ALL; C_ARGUMENTS; fst mlkem_basemul_k4_tmc_EXEC] THEN
   REPEAT STRIP_TAC THEN
@@ -2026,7 +2043,9 @@ let MLKEM_BASEMUL_K4_NOIBT_SUBROUTINE_CORRECT = prove(
                             ) (mod &3329)))
               (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
                MAYCHANGE [memory :> bytes(dst, 512)])`,
-  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k4_tmc MLKEM_BASEMUL_K4_CORRECT);;
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_basemul_k4_tmc
+    (CONV_RULE LENGTH_SIMPLIFY_CONV MLKEM_BASEMUL_K4_CORRECT));;
 
 (* NOTE: This must be kept in sync with the CBMC specification
  * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
@@ -2191,7 +2210,7 @@ let MLKEM_BASEMUL_K4_SAFE = time prove
            aligned 32 src2t /\
            aligned 32 dst /\
            ALL (nonoverlapping (dst,512)) [src1,2048; src2,2048; src2t,1024] /\
-           nonoverlapping (dst,512) (word pc,5202)
+           nonoverlapping (dst,512) (word pc,LENGTH mlkem_basemul_k4_tmc)
            ==> ensures x86
                (\s.
                     bytes_loaded s (word pc)
@@ -2200,7 +2219,7 @@ let MLKEM_BASEMUL_K4_SAFE = time prove
                     C_ARGUMENTS [dst; src1; src2; src2t] s /\
                     read events s = e)
                (\s.
-                    read RIP s = word (pc + 5202) /\
+                    read RIP s = word (pc + MLKEM_BASEMUL_K4_CORE_END) /\
                     (exists e2.
                          read events s = APPEND e2 e /\
                          e2 = f_events src1 src2 src2t dst pc /\
@@ -2208,6 +2227,7 @@ let MLKEM_BASEMUL_K4_SAFE = time prove
                            [src1,2048; src2,2048; src2t,1024; dst,512]
                            [dst,512]))
                (\s s'. T)`,
-  ASSERT_CONCL_TAC full_spec THEN
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  ASSERT_CONCL_TAC (rhs(concl(LENGTH_SIMPLIFY_CONV full_spec))) THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars mlkem_basemul_k4_tmc_EXEC);;
 

--- a/proofs/hol_light/x86_64/proofs/mlkem_tomont.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_tomont.ml
@@ -184,10 +184,26 @@ let mlkem_tomont_mc =
 let mlkem_tomont_tmc = define_trimmed "mlkem_tomont_tmc" mlkem_tomont_mc;;
 let mlkem_tomont_TMC_EXEC = X86_MK_CORE_EXEC_RULE mlkem_tomont_tmc;;
 
+let LENGTH_MLKEM_TOMONT_TMC =
+  REWRITE_CONV[mlkem_tomont_tmc] `LENGTH mlkem_tomont_tmc`
+  |> CONV_RULE(RAND_CONV LENGTH_CONV);;
+
+let MLKEM_TOMONT_POSTAMBLE_LENGTH = new_definition
+  `MLKEM_TOMONT_POSTAMBLE_LENGTH = 1`;;
+
+let MLKEM_TOMONT_CORE_END = new_definition
+  `MLKEM_TOMONT_CORE_END = LENGTH mlkem_tomont_tmc - MLKEM_TOMONT_POSTAMBLE_LENGTH`;;
+
+let LENGTH_SIMPLIFY_CONV =
+  REWRITE_CONV[LENGTH_MLKEM_TOMONT_TMC;
+              MLKEM_TOMONT_CORE_END;
+              MLKEM_TOMONT_POSTAMBLE_LENGTH] THENC
+  NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
+
 let MLKEM_TOMONT_CORRECT = prove(
   `!a x pc.
         aligned 32 a /\
-        nonoverlapping (word pc, 544) (a, 512)
+        nonoverlapping (word pc, LENGTH mlkem_tomont_tmc) (a, 512)
         ==> ensures x86
              (\s. bytes_loaded s (word pc) (BUTLAST mlkem_tomont_tmc) /\
                   read RIP s = word pc /\
@@ -195,7 +211,7 @@ let MLKEM_TOMONT_CORRECT = prove(
                   !i. i < 256
                       ==> read(memory :> bytes16(word_add a (word(2 * i)))) s =
                           x i)
-             (\s. read RIP s = word (pc + 544) /\
+             (\s. read RIP s = word (pc + MLKEM_TOMONT_CORE_END) /\
                   !i. i < 256
                     ==> let z_i = read(memory :> bytes16
                                      (word_add a (word (2 * i)))) s in
@@ -206,6 +222,7 @@ let MLKEM_TOMONT_CORRECT = prove(
               MAYCHANGE [RIP] ,, MAYCHANGE [RAX] ,,
               MAYCHANGE [ZMM0; ZMM1; ZMM2; ZMM3; ZMM4; ZMM5; ZMM6; ZMM7; ZMM8;
                          ZMM9; ZMM10; ZMM11; ZMM12; ZMM13; ZMM14; ZMM15])`,
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   REWRITE_TAC[fst mlkem_tomont_TMC_EXEC] THEN
   REPEAT STRIP_TAC THEN
   REWRITE_TAC[C_ARGUMENTS] THEN
@@ -310,7 +327,9 @@ let MLKEM_TOMONT_NOIBT_SUBROUTINE_CORRECT = prove(
                         abs(ival z_i) <= &3328)
              (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
               MAYCHANGE [memory :> bytes(a,512)])`,
-  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_tomont_tmc MLKEM_TOMONT_CORRECT);;
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  X86_PROMOTE_RETURN_NOSTACK_TAC mlkem_tomont_tmc
+    (CONV_RULE LENGTH_SIMPLIFY_CONV MLKEM_TOMONT_CORRECT));;
 
 (* NOTE: This must be kept in sync with the CBMC specification
  * in mlkem/src/native/x86_64/src/arith_native_x86_64.h *)
@@ -360,7 +379,7 @@ let full_spec = ONCE_DEPTH_CONV MEMACCESS_INBOUNDS_DEDUP_CONV full_spec |> concl
 let MLKEM_TOMONT_SAFE = time prove
  (`exists f_events.
        forall e a pc.
-           aligned 32 a /\ nonoverlapping (word pc,544) (a,512)
+           aligned 32 a /\ nonoverlapping (word pc,LENGTH mlkem_tomont_tmc) (a,512)
            ==> ensures x86
                (\s.
                     bytes_loaded s (word pc) (BUTLAST mlkem_tomont_tmc) /\
@@ -368,11 +387,12 @@ let MLKEM_TOMONT_SAFE = time prove
                     C_ARGUMENTS [a] s /\
                     read events s = e)
                (\s.
-                    read RIP s = word (pc + 544) /\
+                    read RIP s = word (pc + MLKEM_TOMONT_CORE_END) /\
                     (exists e2.
                          read events s = APPEND e2 e /\
                          e2 = f_events a pc /\
                          memaccess_inbounds e2 [a,512] [a,512]))
                (\s s'. T)`,
-  ASSERT_CONCL_TAC full_spec THEN
+  CONV_TAC LENGTH_SIMPLIFY_CONV THEN
+  ASSERT_CONCL_TAC (rhs(concl(LENGTH_SIMPLIFY_CONV full_spec))) THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars mlkem_tomont_TMC_EXEC);;


### PR DESCRIPTION
- Towards #1261 
- Depends on #1570 