### PR TITLE
Add infrastructure and scripts to run the Wycheproof test suite.

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -44,6 +44,9 @@ inputs:
   acvp:
     description: Determine whether to run acvp test or not
     default: "true"
+  wycheproof:
+    description: Determine whether to run wycheproof test or not
+    default: "true"
   examples:
     description: Determine whether to run examples or not
     default: "true"
@@ -80,6 +83,7 @@ runs:
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
           echo UNIT="${{ inputs.unit == 'true' && 'unit' || 'no-unit' }}" >> $GITHUB_ENV
           echo ACVP="${{ inputs.acvp == 'true' && 'acvp' || 'no-acvp' }}" >> $GITHUB_ENV
+          echo WYCHEPROOF="${{ inputs.wycheproof == 'true' && 'wycheproof' || 'no-wycheproof' }}" >> $GITHUB_ENV
           echo EXAMPLES="${{ inputs.examples == 'true' && 'examples' || 'no-examples' }}" >> $GITHUB_ENV
           echo STACK="${{ inputs.stack == 'true' && 'stack' || 'no-stack' }}" >> $GITHUB_ENV
           echo ALLOC="${{ inputs.alloc == 'true' && 'alloc' || 'no-alloc' }}" >> $GITHUB_ENV
@@ -118,7 +122,7 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           make clean
-          ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.RNGFAIL }} -v ${{ inputs.extra_args }}
+          ${{ inputs.extra_env }} ./scripts/tests all ${{ inputs.check_namespace == 'true' && '--check-namespace' || ''}} --exec-wrapper="${{ inputs.exec_wrapper }}" --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --ldflags="${{ inputs.ldflags }}" --opt=${{ inputs.opt }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.ACVP }} --${{ env.WYCHEPROOF }} --${{ env.EXAMPLES }} --${{ env.STACK }} --${{ env.UNIT }} --${{ env.ALLOC }} --${{ env.RNGFAIL }} -v ${{ inputs.extra_args }}
       - name: Post ${{ env.MODE }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -41,6 +41,9 @@ inputs:
   acvp:
     description: Determine whether to run acvp test or not
     default: "true"
+  wycheproof:
+    description: Determine whether to run wycheproof test or not
+    default: "true"
   examples:
     description: Determine whether to run examples or not
     default: "true"
@@ -84,6 +87,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -109,6 +113,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -134,6 +139,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -159,6 +165,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -184,6 +191,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -209,6 +217,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -233,6 +242,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -257,6 +267,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -281,6 +292,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}
@@ -306,6 +318,7 @@ runs:
           kat: ${{ inputs.kat }}
           unit: ${{ inputs.unit }}
           acvp: ${{ inputs.acvp }}
+          wycheproof: ${{ inputs.wycheproof }}
           examples: ${{ inputs.examples }}
           check_namespace: ${{ inputs.check_namespace }}
           stack: ${{ inputs.stack }}

--- a/.github/workflows/baremetal.yml
+++ b/.github/workflows/baremetal.yml
@@ -23,6 +23,7 @@ jobs:
            func: true
            kat: true
            acvp: true
+           wycheproof: false
            alloc: true
            bench: true
            opt: all
@@ -33,6 +34,7 @@ jobs:
            func: true
            kat: true
            acvp: true
+           wycheproof: false
            alloc: false
            bench: false
            opt: no_opt
@@ -50,6 +52,7 @@ jobs:
           func: ${{ matrix.target.func }}
           kat: ${{ matrix.target.kat }}
           acvp: ${{ matrix.target.acvp }}
+          wycheproof: ${{ matrix.target.wycheproof }}
           examples: false
           stack: false
           alloc: ${{ matrix.target.alloc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -364,6 +365,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -377,6 +379,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -390,6 +393,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -404,6 +408,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -418,6 +423,7 @@ jobs:
           func: true
           kat: false
           acvp: false
+          wycheproof: false
           examples: ${{ matrix.compiler.examples }}
           opt: ${{ matrix.compiler.opt }}
           nix-shell: ${{ matrix.compiler.shell }}
@@ -452,6 +458,7 @@ jobs:
           func: false
           kat: false
           acvp: false
+          wycheproof: false
           examples: false
           stack: true
           check_namespace: false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test/build
 __pycache__/
 # Downloaded ACVP test data
 test/acvp/.acvp-data/
+# Downloaded Wycheproof test data
+test/wycheproof/.wycheproof-data/

--- a/BIBLIOGRAPHY.md
+++ b/BIBLIOGRAPHY.md
@@ -485,3 +485,13 @@ source code and documentation.
 * Referenced from:
   - [mlkem/src/fips202/fips202.c](mlkem/src/fips202/fips202.c)
   - [mlkem/src/fips202/keccakf1600.c](mlkem/src/fips202/keccakf1600.c)
+
+### `wycheproof`
+
+* Project Wycheproof
+* Author(s):
+  - Community Cryptography Specification Project
+* URL: https://github.com/C2SP/wycheproof
+* Referenced from:
+  - [README.md](README.md)
+  - [SOUNDNESS.md](SOUNDNESS.md)

--- a/BIBLIOGRAPHY.yml
+++ b/BIBLIOGRAPHY.yml
@@ -1,6 +1,11 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
+- id: wycheproof
+  name: Project Wycheproof
+  author: Community Cryptography Specification Project
+  url: https://github.com/C2SP/wycheproof
+
 - id: Candle
   name: "Candle: Formally Verified clone of HOL-Light"
   author:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-.PHONY: func kat acvp stack alloc rng_fail \
-	func_512 kat_512 acvp_512 stack_512 alloc_512 rng_fail_512 \
-	func_768 kat_768 acvp_768 stack_768 alloc_768 rng_fail_768 \
-	func_1024 kat_1024 acvp_1024 stack_1024 alloc_1024 rng_fail_1024 \
-	run_func run_kat run_acvp run_stack run_alloc run_rng_fail \
+.PHONY: func kat acvp wycheproof stack alloc rng_fail \
+	func_512 kat_512 acvp_512 wycheproof_512 stack_512 alloc_512 rng_fail_512 \
+	func_768 kat_768 acvp_768 wycheproof_768 stack_768 alloc_768 rng_fail_768 \
+	func_1024 kat_1024 acvp_1024 wycheproof_1024 stack_1024 alloc_1024 rng_fail_1024 \
+	run_func run_kat run_acvp run_wycheproof run_stack run_alloc run_rng_fail \
 	run_func_512 run_kat_512 run_stack_512 run_alloc_512 run_rng_fail_512 \
 	run_func_768 run_kat_768 run_stack_768 run_alloc_768 run_rng_fail_768 \
 	run_func_1024 run_kat_1024 run_stack_1024 run_alloc_1024 run_rng_fail_1024 \
@@ -43,10 +43,10 @@ endif
 
 quickcheck: test
 
-build: func kat acvp
+build: func kat acvp wycheproof
 	$(Q)echo "  Everything builds fine!"
 
-test: run_kat run_func run_acvp run_unit run_alloc run_rng_fail
+test: run_kat run_func run_acvp run_wycheproof run_unit run_alloc run_rng_fail
 	$(Q)echo "  Everything checks fine!"
 
 # Detect available SHA256 command
@@ -113,6 +113,17 @@ acvp_768:  $(MLKEM768_DIR)/bin/acvp_mlkem768
 acvp_1024: $(MLKEM1024_DIR)/bin/acvp_mlkem1024
 	$(Q)echo "  ACVP       ML-KEM-1024:  $^"
 acvp: acvp_512 acvp_768 acvp_1024
+
+wycheproof_512:  $(MLKEM512_DIR)/bin/wycheproof_mlkem512
+	$(Q)echo "  WYCHEPROOF ML-KEM-512:   $^"
+wycheproof_768:  $(MLKEM768_DIR)/bin/wycheproof_mlkem768
+	$(Q)echo "  WYCHEPROOF ML-KEM-768:   $^"
+wycheproof_1024: $(MLKEM1024_DIR)/bin/wycheproof_mlkem1024
+	$(Q)echo "  WYCHEPROOF ML-KEM-1024:  $^"
+wycheproof: wycheproof_512 wycheproof_768 wycheproof_1024
+
+run_wycheproof: wycheproof
+	EXEC_WRAPPER="$(EXEC_WRAPPER)" python3 ./test/wycheproof/wycheproof_client.py
 
 ifeq ($(HOST_PLATFORM),Linux-aarch64)
 # valgrind does not work with the AArch64 SHA3 extension

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See [dev/README.md](dev/README.md) for more details.
 ## Test Vectors
 
 mlkem-native is tested against all official ACVP ML-KEM test vectors[^ACVP] and the
-[Wycheproof](https://github.com/C2SP/wycheproof) ML-KEM test vectors.
+Wycheproof[^wycheproof] ML-KEM test vectors.
 
 ### ACVP
 
@@ -133,7 +133,7 @@ python3 ./test/acvp/acvp_client.py \
 
 ### Wycheproof
 
-You can run Wycheproof tests using the [`tests`](./scripts/tests) script or the [Wycheproof client](./test/wycheproof/wycheproof_client.py) directly:
+You can run Wycheproof[^wycheproof] tests using the [`tests`](./scripts/tests) script or the [Wycheproof client](./test/wycheproof/wycheproof_client.py) directly:
 
 ```bash
 # Using the tests script
@@ -220,3 +220,4 @@ through the [PQCA Discord](https://discord.com/invite/xyVnwzfg5R). See also [CON
 [^SLOTHY_Paper]: Abdulrahman, Becker, Kannwischer, Klein: Fast and Clean: Auditable high-performance assembly via constraint solving, [https://eprint.iacr.org/2022/1303](https://eprint.iacr.org/2022/1303)
 [^clangover]: Antoon Purnal: clangover, [https://github.com/antoonpurnal/clangover](https://github.com/antoonpurnal/clangover)
 [^tiny_sha3]: Markku-Juhani O. Saarinen: tiny_sha3, [https://github.com/mjosaarinen/tiny_sha3](https://github.com/mjosaarinen/tiny_sha3)
+[^wycheproof]: Community Cryptography Specification Project: Project Wycheproof, [https://github.com/C2SP/wycheproof](https://github.com/C2SP/wycheproof)

--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ Our AArch64 assembly is developed using the [SLOTHY](https://github.com/slothy-o
 We write 'clean' assembly by hand and automate micro-optimizations (e.g. see the [clean](dev/aarch64_clean/src/ntt.S) vs [optimized](dev/aarch64_opt/src/ntt.S) AArch64 NTT).
 See [dev/README.md](dev/README.md) for more details.
 
-## ACVP Testing
+## Test Vectors
 
-mlkem-native is tested against all official ACVP ML-KEM test vectors[^ACVP].
+mlkem-native is tested against all official ACVP ML-KEM test vectors[^ACVP] and the
+[Wycheproof](https://github.com/C2SP/wycheproof) ML-KEM test vectors.
+
+### ACVP
 
 You can run ACVP tests using the [`tests`](./scripts/tests) script or the [ACVP client](./test/acvp/acvp_client.py) directly:
 
@@ -126,6 +129,18 @@ python3 ./test/acvp/acvp_client.py --version v1.1.0.41
 python3 ./test/acvp/acvp_client.py \
   -p ./test/acvp/.acvp-data/v1.1.0.41/files/ML-KEM-keyGen-FIPS203/prompt.json \
   -e ./test/acvp/.acvp-data/v1.1.0.41/files/ML-KEM-keyGen-FIPS203/expectedResults.json
+```
+
+### Wycheproof
+
+You can run Wycheproof tests using the [`tests`](./scripts/tests) script or the [Wycheproof client](./test/wycheproof/wycheproof_client.py) directly:
+
+```bash
+# Using the tests script
+./scripts/tests wycheproof
+
+# Using the Wycheproof client directly
+python3 ./test/wycheproof/wycheproof_client.py
 ```
 
 ## Benchmarking

--- a/SOUNDNESS.md
+++ b/SOUNDNESS.md
@@ -131,7 +131,7 @@ a specification, or that an unspecified component is incorrect.
 - **Backends for platforms other than AArch64 and x86_64** (e.g. RISC-V RVV, Armv8.1-M MVE, PowerPC):
   Where present, these are not yet covered by specification.
 
-The full test suite (functional tests, KAT, ACVP, unit tests) validates functional
+The full test suite (functional tests, KAT, ACVP, Wycheproof, unit tests) validates functional
 correctness empirically across all platforms and configurations, but there is currently
 no automatic coverage check for CBMC or HOL Light. A function or configuration could slip
 through without being covered by specification.
@@ -172,7 +172,7 @@ The CBMC proofs do **not** currently cover:
   proved.
 
 These gaps are mitigated in complementary ways. The full test suite (functional tests, KAT,
-ACVP, unit tests) validates functional correctness empirically across all platforms and
+ACVP, Wycheproof, unit tests) validates functional correctness empirically across all platforms and
 configurations. For arithmetic correctness specifically, the most subtle bugs in ML-KEM
 implementations are rare overflows in the optimized polynomial arithmetic -- precisely the
 kind of bug that the type-safety and integer-overflow proofs are designed to catch: the CBMC
@@ -466,7 +466,7 @@ Also, the C language has many conformant implementations. For example, the width
 8/16/32/64-bit (or even larger on capability based architectures). CBMC models types and other implementation-defined
 behavior (such as struct padding) following the host system's C compiler. At present, mlkem-native's CBMC proofs are
 only run on 64-bit systems, and hence do not transfer to 16-bit or 32-bit systems. To mitigate this, the full functional
-test suite (KAT, ACVP, unit tests) is run on a large variety of platforms and C compilers, covering 16-bit, 32-bit, and
+test suite (functional tests, KAT, ACVP, Wycheproof, unit tests) is run on a large variety of platforms and C compilers, covering 16-bit, 32-bit, and
 64-bit C implementations. Moreover, mlkem-native uses fixed-width integer types (e.g. uint16_t) to reduce the risk of
 semantic differences across compilers, and targets the initial C90 revision of C, which is expected to have more mature
 compiler support and be less prone to modeling errors than newer language features.

--- a/SOUNDNESS.md
+++ b/SOUNDNESS.md
@@ -131,7 +131,7 @@ a specification, or that an unspecified component is incorrect.
 - **Backends for platforms other than AArch64 and x86_64** (e.g. RISC-V RVV, Armv8.1-M MVE, PowerPC):
   Where present, these are not yet covered by specification.
 
-The full test suite (functional tests, KAT, ACVP, Wycheproof, unit tests) validates functional
+The full test suite (functional tests, KAT, ACVP, Wycheproof[^wycheproof], unit tests) validates functional
 correctness empirically across all platforms and configurations, but there is currently
 no automatic coverage check for CBMC or HOL Light. A function or configuration could slip
 through without being covered by specification.
@@ -542,3 +542,4 @@ guarantee for the C proofs is therefore fundamentally weaker than for the assemb
 [^HOLTrace]: Daniel J. Bernstein: HOLTrace: A collection of tools for processing traces of a HOL Light session, [https://holtrace.cr.yp.to/](https://holtrace.cr.yp.to/)
 [^s2n-bignum]: Amazon Web Services: s2n-bignum: Library of formally assembly kernels verified in HOL-Light, [https://github.com/awslabs/s2n-bignum/](https://github.com/awslabs/s2n-bignum/)
 [^s2n-bignum-soundness]: Amazon Web Services: s2n-bignum soundness documentation, [https://github.com/awslabs/s2n-bignum/blob/main/doc/s2n_bignum_soundness.md](https://github.com/awslabs/s2n-bignum/blob/main/doc/s2n_bignum_soundness.md)
+[^wycheproof]: Community Cryptography Specification Project: Project Wycheproof, [https://github.com/C2SP/wycheproof](https://github.com/C2SP/wycheproof)

--- a/scripts/tests
+++ b/scripts/tests
@@ -213,6 +213,7 @@ class TEST_TYPES(Enum):
     UNIT = 19
     ALLOC = 20
     RNG_FAIL = 21
+    WYCHEPROOF = 22
 
     def is_benchmark(self):
         return self in [TEST_TYPES.BENCH, TEST_TYPES.BENCH_COMPONENTS]
@@ -259,6 +260,8 @@ class TEST_TYPES(Enum):
             return "Kat Test"
         if self == TEST_TYPES.ACVP:
             return "ACVP Test"
+        if self == TEST_TYPES.WYCHEPROOF:
+            return "Wycheproof Test"
         if self == TEST_TYPES.STACK:
             return "Stack Usage Test"
         if self == TEST_TYPES.BRING_YOUR_OWN_FIPS202:
@@ -328,6 +331,8 @@ class TEST_TYPES(Enum):
             return "kat"
         if self == TEST_TYPES.ACVP:
             return "acvp"
+        if self == TEST_TYPES.WYCHEPROOF:
+            return "wycheproof"
         if self == TEST_TYPES.STACK:
             return "stack"
         if self == TEST_TYPES.BRING_YOUR_OWN_FIPS202:
@@ -698,6 +703,19 @@ class Tests:
 
         self.check_fail()
 
+    def wycheproof(self):
+        def _wycheproof(opt):
+            self._compile_schemes(TEST_TYPES.WYCHEPROOF, opt)
+            if self.args.run:
+                self._run_scheme(TEST_TYPES.WYCHEPROOF, opt, None)
+
+        if self.do_no_opt():
+            _wycheproof(False)
+        if self.do_opt():
+            _wycheproof(True)
+
+        self.check_fail()
+
     def examples(self):
         if self.args.l is None:
             l = TEST_TYPES.examples()
@@ -816,6 +834,7 @@ class Tests:
         func = self.args.func
         kat = self.args.kat
         acvp = self.args.acvp
+        wycheproof = self.args.wycheproof
         examples = self.args.examples
         stack = self.args.stack
         unit = self.args.unit
@@ -829,6 +848,8 @@ class Tests:
                 self._compile_schemes(TEST_TYPES.KAT, opt)
             if acvp is True:
                 self._compile_schemes(TEST_TYPES.ACVP, opt)
+            if wycheproof is True:
+                self._compile_schemes(TEST_TYPES.WYCHEPROOF, opt)
             if stack is True:
                 self._compile_schemes(TEST_TYPES.STACK, opt)
             if unit is True:
@@ -856,6 +877,8 @@ class Tests:
                 self._run_schemes(TEST_TYPES.KAT, opt)
             if acvp is True:
                 self._run_scheme(TEST_TYPES.ACVP, opt, None)
+            if wycheproof is True:
+                self._run_scheme(TEST_TYPES.WYCHEPROOF, opt, None)
             if stack is True:
                 self._run_schemes(TEST_TYPES.STACK, opt, suppress_output=False)
             if unit is True:
@@ -1182,6 +1205,21 @@ def cli():
         "--no-acvp", action="store_false", dest="acvp", help="Do not run acvp test"
     )
 
+    wycheproof_group = all_parser.add_mutually_exclusive_group()
+    wycheproof_group.add_argument(
+        "--wycheproof",
+        action="store_true",
+        dest="wycheproof",
+        help="Run wycheproof test",
+        default=True,
+    )
+    wycheproof_group.add_argument(
+        "--no-wycheproof",
+        action="store_false",
+        dest="wycheproof",
+        help="Do not run wycheproof test",
+    )
+
     unit_group = all_parser.add_mutually_exclusive_group()
     unit_group.add_argument(
         "--unit", action="store_true", dest="unit", help="Run unit test", default=True
@@ -1278,6 +1316,11 @@ def cli():
         "--version",
         default="v1.1.0.41",
         help="ACVP test vector version (default: v1.1.0.41)",
+    )
+
+    # wycheproof arguments
+    wycheproof_parser = cmd_subparsers.add_parser(
+        "wycheproof", help="Run Wycheproof client", parents=[common_parser]
     )
 
     # examples arguments
@@ -1511,6 +1554,8 @@ def cli():
         Tests(args).examples()
     elif args.cmd == "acvp":
         Tests(args).acvp()
+    elif args.cmd == "wycheproof":
+        Tests(args).wycheproof()
     elif args.cmd == "bench":
         Tests(args).bench()
     elif args.cmd == "cbmc":

--- a/test/mk/components.mk
+++ b/test/mk/components.mk
@@ -14,11 +14,12 @@ endif
 
 BASIC_TESTS = test_mlkem gen_KAT test_stack
 ACVP_TESTS = acvp_mlkem
+WYCHEPROOF_TESTS = wycheproof_mlkem
 BENCH_TESTS = bench_mlkem bench_components_mlkem
 UNIT_TESTS = test_unit
 ALLOC_TESTS = test_alloc
 RNG_FAIL_TESTS = test_rng_fail
-ALL_TESTS = $(BASIC_TESTS) $(ACVP_TESTS) $(BENCH_TESTS) $(UNIT_TESTS) $(ALLOC_TESTS) $(RNG_FAIL_TESTS)
+ALL_TESTS = $(BASIC_TESTS) $(ACVP_TESTS) $(WYCHEPROOF_TESTS) $(BENCH_TESTS) $(UNIT_TESTS) $(ALLOC_TESTS) $(RNG_FAIL_TESTS)
 
 MLKEM512_DIR = $(BUILD_DIR)/mlkem512
 MLKEM768_DIR = $(BUILD_DIR)/mlkem768
@@ -121,6 +122,9 @@ endef
 $(foreach scheme,mlkem512 mlkem768 mlkem1024, \
 	$(foreach test,$(ACVP_TESTS), \
 		$(eval $(call ADD_SOURCE,$(scheme),$(test),acvp)) \
+	) \
+	$(foreach test,$(WYCHEPROOF_TESTS), \
+		$(eval $(call ADD_SOURCE,$(scheme),$(test),wycheproof)) \
 	) \
 	$(foreach test,$(BENCH_TESTS), \
 		$(eval $(call ADD_SOURCE,$(scheme),$(test),bench)) \

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# Wycheproof test client for ML-KEM
+# See https://github.com/C2SP/wycheproof
+# Invokes `wycheproof_mlkem{lvl}` under the hood.
+
+import argparse
+import os
+import json
+import sys
+import subprocess
+import urllib.request
+from pathlib import Path
+
+exec_prefix = os.environ.get("EXEC_WRAPPER", "")
+exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
+
+WYCHEPROOF_BASE_URL = (
+    "https://raw.githubusercontent.com/C2SP/wycheproof/main/testvectors_v1"
+)
+
+WYCHEPROOF_FILES = [
+    "mlkem_512_keygen_seed_test.json",
+    "mlkem_512_encaps_test.json",
+    "mlkem_512_semi_expanded_decaps_test.json",
+    "mlkem_512_test.json",
+    "mlkem_768_keygen_seed_test.json",
+    "mlkem_768_encaps_test.json",
+    "mlkem_768_semi_expanded_decaps_test.json",
+    "mlkem_768_test.json",
+    "mlkem_1024_keygen_seed_test.json",
+    "mlkem_1024_encaps_test.json",
+    "mlkem_1024_semi_expanded_decaps_test.json",
+    "mlkem_1024_test.json",
+]
+
+PARAMETER_SET_TO_LEVEL = {
+    "ML-KEM-512": 512,
+    "ML-KEM-768": 768,
+    "ML-KEM-1024": 1024,
+}
+
+
+def err(msg, **kwargs):
+    print(msg, file=sys.stderr, **kwargs)
+
+
+def info(msg, **kwargs):
+    print(msg, **kwargs)
+
+
+def download_wycheproof_files(data_dir):
+    """Download Wycheproof test vector files if not present."""
+    data_dir = Path(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    for filename in WYCHEPROOF_FILES:
+        local_file = data_dir / filename
+        if not local_file.exists():
+            url = f"{WYCHEPROOF_BASE_URL}/{filename}"
+            print(f"Downloading {filename}...", file=sys.stderr)
+            try:
+                urllib.request.urlretrieve(url, local_file)
+                with open(local_file, "r", encoding="utf-8") as f:
+                    json.load(f)
+            except (json.JSONDecodeError, Exception) as e:
+                print(f"Error downloading {filename}: {e}", file=sys.stderr)
+                local_file.unlink(missing_ok=True)
+                return False
+    return True
+
+
+def get_binary(level):
+    basedir = f"./test/build/mlkem{level}/bin"
+    return f"{basedir}/wycheproof_mlkem{level}"
+
+
+def run_binary(args_list):
+    result = subprocess.run(
+        exec_prefix + args_list, encoding="utf-8", capture_output=True
+    )
+    if result.returncode != 0:
+        return {"_error": str(result.returncode)}
+    out = {}
+    for line in result.stdout.strip().splitlines():
+        k, v = line.split("=", 1)
+        out[k] = v
+    return out
+
+
+def run_keygen_seed_test(data_file):
+    """Run mlkem_*_keygen_seed_test.json tests."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running keygen_seed tests from {data_file}")
+    count = 0
+    for tg in data["testGroups"]:
+        level = PARAMETER_SET_TO_LEVEL[tg["parameterSet"]]
+        binary = get_binary(level)
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            out = run_binary([binary, "keygen_seed", f"seed={tc['seed']}"])
+            if "_error" in out or "decode_error" in out:
+                assert (
+                    tc["result"] == "invalid"
+                ), f"binary error on non-invalid tcId={tc['tcId']}"
+            elif tc["result"] in ("valid", "acceptable"):
+                assert (
+                    out["ek"].upper() == tc["ek"].upper()
+                ), f"ek mismatch tcId={tc['tcId']}"
+                assert (
+                    out["dk"].upper() == tc["dk"].upper()
+                ), f"dk mismatch tcId={tc['tcId']}"
+            info("ok")
+            count += 1
+    info(f"  {count} keygen_seed tests passed")
+
+
+def run_encaps_test(data_file):
+    """Run mlkem_*_encaps_test.json tests."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running encaps tests from {data_file}")
+    count = 0
+    for tg in data["testGroups"]:
+        level = PARAMETER_SET_TO_LEVEL[tg["parameterSet"]]
+        binary = get_binary(level)
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            out = run_binary([binary, "encaps", f"ek={tc['ek']}", f"m={tc['m']}"])
+            if "_error" in out or "decode_error" in out:
+                assert (
+                    tc["result"] == "invalid"
+                ), f"binary error on non-invalid tcId={tc['tcId']}"
+            elif tc["result"] in ("valid", "acceptable"):
+                assert (
+                    out["c"].upper() == tc["c"].upper()
+                ), f"c mismatch tcId={tc['tcId']}"
+                assert (
+                    out["K"].upper() == tc["K"].upper()
+                ), f"K mismatch tcId={tc['tcId']}"
+            elif tc["result"] == "invalid":
+                assert (
+                    out["K"].upper() != tc["K"].upper()
+                ), f"K should not match for invalid tcId={tc['tcId']}"
+            info("ok")
+            count += 1
+    info(f"  {count} encaps tests passed")
+
+
+def run_semi_expanded_decaps_test(data_file):
+    """Run mlkem_*_semi_expanded_decaps_test.json tests."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running semi_expanded_decaps tests from {data_file}")
+    count = 0
+    for tg in data["testGroups"]:
+        level = PARAMETER_SET_TO_LEVEL[tg["parameterSet"]]
+        binary = get_binary(level)
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            out = run_binary([binary, "decaps", f"dk={tc['dk']}", f"c={tc['c']}"])
+            # For errors (wrong length dk/c, or runtime failure), just check it didn't crash unexpectedly
+            if "_error" not in out and "decode_error" not in out:
+                assert "K" in out, f"missing K in output tcId={tc['tcId']}"
+            info("ok")
+            count += 1
+    info(f"  {count} semi_expanded_decaps tests passed")
+
+
+def run_combined_test(data_file):
+    """Run mlkem_*_test.json tests (keygen + decaps)."""
+    with open(data_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    info(f"Running combined (keygen+decaps) tests from {data_file}")
+    count = 0
+    for tg in data["testGroups"]:
+        level = PARAMETER_SET_TO_LEVEL[tg["parameterSet"]]
+        binary = get_binary(level)
+        for tc in tg["tests"]:
+            info(f"  tcId={tc['tcId']} ... ", end="")
+            # Generate keypair from seed
+            keygen_out = run_binary([binary, "keygen_seed", f"seed={tc['seed']}"])
+            if "_error" in keygen_out or "decode_error" in keygen_out:
+                assert (
+                    tc["result"] == "invalid"
+                ), f"keygen error on non-invalid tcId={tc['tcId']}"
+                info("ok")
+                count += 1
+                continue
+            # Check ek matches if present
+            if "ek" in tc and tc["result"] in ("valid", "acceptable"):
+                assert (
+                    keygen_out["ek"].upper() == tc["ek"].upper()
+                ), f"ek mismatch tcId={tc['tcId']}"
+            # Decapsulate
+            dk = keygen_out["dk"]
+            decaps_out = run_binary([binary, "decaps", f"dk={dk}", f"c={tc['c']}"])
+            if "_error" in decaps_out or "decode_error" in decaps_out:
+                assert (
+                    tc["result"] == "invalid"
+                ), f"decaps error on non-invalid tcId={tc['tcId']}"
+            elif tc["result"] in ("valid", "acceptable"):
+                assert (
+                    decaps_out["K"].upper() == tc["K"].upper()
+                ), f"K mismatch tcId={tc['tcId']}"
+            elif tc["result"] == "invalid":
+                assert (
+                    decaps_out["K"].upper() != tc["K"].upper()
+                ), f"K should not match for invalid tcId={tc['tcId']}"
+            info("ok")
+            count += 1
+    info(f"  {count} combined tests passed")
+
+
+def run_all(data_dir):
+    """Run all Wycheproof test vector files."""
+    data_dir = Path(data_dir)
+    for filename in WYCHEPROOF_FILES:
+        filepath = data_dir / filename
+        if "keygen_seed_test" in filename:
+            run_keygen_seed_test(filepath)
+        elif "encaps_test" in filename:
+            run_encaps_test(filepath)
+        elif "semi_expanded_decaps_test" in filename:
+            run_semi_expanded_decaps_test(filepath)
+        elif filename.endswith("_test.json"):
+            run_combined_test(filepath)
+    info("ALL GOOD!")
+
+
+parser = argparse.ArgumentParser(description="Wycheproof ML-KEM test client")
+parser.add_argument(
+    "-f",
+    "--file",
+    help="Path to a specific Wycheproof test vector JSON file",
+    required=False,
+)
+parser.add_argument(
+    "--data-dir",
+    default="test/wycheproof/.wycheproof-data",
+    help="Directory for downloaded test vectors (default: test/wycheproof/.wycheproof-data)",
+)
+args = parser.parse_args()
+
+if args.file:
+    # Run a single file
+    filename = os.path.basename(args.file)
+    if "keygen_seed_test" in filename:
+        run_keygen_seed_test(args.file)
+    elif "encaps_test" in filename:
+        run_encaps_test(args.file)
+    elif "semi_expanded_decaps_test" in filename:
+        run_semi_expanded_decaps_test(args.file)
+    elif filename.endswith("_test.json"):
+        run_combined_test(args.file)
+    else:
+        err(f"Unknown test file type: {filename}")
+        sys.exit(1)
+    info("ALL GOOD!")
+else:
+    # Download and run all
+    if not download_wycheproof_files(args.data_dir):
+        err("Failed to download Wycheproof test files")
+        sys.exit(1)
+    run_all(args.data_dir)

--- a/test/wycheproof/wycheproof_mlkem.c
+++ b/test/wycheproof/wycheproof_mlkem.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/*
+ * Wycheproof test driver for ML-KEM.
+ *
+ * Usage:
+ *   wycheproof_mlkem{lvl} keygen_seed seed=HEX
+ *   wycheproof_mlkem{lvl} encaps ek=HEX m=HEX
+ *   wycheproof_mlkem{lvl} decaps dk=HEX c=HEX
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../mlkem/src/common.h"
+
+#include "../../mlkem/mlkem_native.h"
+
+
+#define CHECK(x)                                              \
+  do                                                          \
+  {                                                           \
+    int rc;                                                   \
+    rc = (x);                                                 \
+    if (!rc)                                                  \
+    {                                                         \
+      fprintf(stderr, "ERROR (%s,%d)\n", __FILE__, __LINE__); \
+      exit(1);                                                \
+    }                                                         \
+  } while (0)
+
+static unsigned char decode_hex_char(char hex)
+{
+  if (hex >= '0' && hex <= '9')
+  {
+    return (unsigned char)(hex - '0');
+  }
+  else if (hex >= 'A' && hex <= 'F')
+  {
+    return (unsigned char)(10 + (unsigned char)(hex - 'A'));
+  }
+  else if (hex >= 'a' && hex <= 'f')
+  {
+    return (unsigned char)(10 + (unsigned char)(hex - 'a'));
+  }
+  else
+  {
+    return 0xFF;
+  }
+}
+
+static int decode_hex(const char *prefix, unsigned char *out, size_t out_len,
+                      const char *hex)
+{
+  size_t i;
+  size_t hex_len = strlen(hex);
+  size_t prefix_len = strlen(prefix);
+
+  if (hex_len < prefix_len + 1 || memcmp(prefix, hex, prefix_len) != 0 ||
+      hex[prefix_len] != '=')
+  {
+    return 1;
+  }
+
+  hex += prefix_len + 1;
+  hex_len -= prefix_len + 1;
+
+  if (hex_len != 2 * out_len)
+  {
+    return 1;
+  }
+
+  for (i = 0; i < out_len; i++, hex += 2, out++)
+  {
+    unsigned hex0 = decode_hex_char(hex[0]);
+    unsigned hex1 = decode_hex_char(hex[1]);
+    if (hex0 == 0xFF || hex1 == 0xFF)
+    {
+      return 1;
+    }
+    *out = (unsigned char)((hex0 << 4) | hex1);
+  }
+  return 0;
+}
+
+static void print_hex(const char *name, const unsigned char *raw, size_t len)
+{
+  if (name != NULL)
+  {
+    printf("%s=", name);
+  }
+  for (; len > 0; len--, raw++)
+  {
+    printf("%02X", *raw);
+  }
+  printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc < 2)
+  {
+    goto usage;
+  }
+
+  if (strcmp(argv[1], "keygen_seed") == 0)
+  {
+    /* keygen_seed seed=HEX (64 bytes = d || z) */
+    unsigned char seed[2 * MLKEM_SYMBYTES];
+    unsigned char ek[CRYPTO_PUBLICKEYBYTES];
+    unsigned char dk[CRYPTO_SECRETKEYBYTES];
+
+    if (argc != 3)
+    {
+      goto usage;
+    }
+
+    if (decode_hex("seed", seed, sizeof(seed), argv[2]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    CHECK(crypto_kem_keypair_derand(ek, dk, seed) == 0);
+    print_hex("ek", ek, sizeof(ek));
+    print_hex("dk", dk, sizeof(dk));
+  }
+  else if (strcmp(argv[1], "encaps") == 0)
+  {
+    /* encaps ek=HEX m=HEX */
+    unsigned char ek[CRYPTO_PUBLICKEYBYTES];
+    unsigned char m[MLKEM_SYMBYTES];
+    unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
+    unsigned char ss[CRYPTO_BYTES];
+
+    if (argc != 4)
+    {
+      goto usage;
+    }
+
+    if (decode_hex("ek", ek, sizeof(ek), argv[2]) != 0 ||
+        decode_hex("m", m, sizeof(m), argv[3]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    CHECK(crypto_kem_enc_derand(ct, ss, ek, m) == 0);
+    print_hex("c", ct, sizeof(ct));
+    print_hex("K", ss, sizeof(ss));
+  }
+  else if (strcmp(argv[1], "decaps") == 0)
+  {
+    /* decaps dk=HEX c=HEX */
+    unsigned char dk[CRYPTO_SECRETKEYBYTES];
+    unsigned char c[CRYPTO_CIPHERTEXTBYTES];
+    unsigned char ss[CRYPTO_BYTES];
+
+    if (argc != 4)
+    {
+      goto usage;
+    }
+
+    if (decode_hex("dk", dk, sizeof(dk), argv[2]) != 0)
+    {
+      /* Incorrect dk length - report decode failure */
+      printf("decode_error=1\n");
+      return 0;
+    }
+    if (decode_hex("c", c, sizeof(c), argv[3]) != 0)
+    {
+      printf("decode_error=1\n");
+      return 0;
+    }
+
+    CHECK(crypto_kem_dec(ss, c, dk) == 0);
+    print_hex("K", ss, sizeof(ss));
+  }
+  else
+  {
+    goto usage;
+  }
+
+  return 0;
+
+usage:
+  fprintf(stderr,
+          "Usage:\n"
+          "  wycheproof_mlkem{lvl} keygen_seed seed=HEX\n"
+          "  wycheproof_mlkem{lvl} encaps ek=HEX m=HEX\n"
+          "  wycheproof_mlkem{lvl} decaps dk=HEX c=HEX\n");
+  return 1;
+}


### PR DESCRIPTION
**Files created**

1. test/wycheproof/wycheproof_mlkem.c — C test driver that accepts three subcommands:
   - keygen_seed seed=HEX → calls crypto_kem_keypair_derand, prints ek= and dk=
   - encaps ek=HEX m=HEX → calls crypto_kem_enc_derand, prints c= and K=
   - decaps dk=HEX c=HEX → calls crypto_kem_dec, prints K=
   - All three report decode_error=1 for wrong-length hex inputs (graceful handling of invalid test vectors)

2. test/wycheproof/wycheproof_client.py — Python client that:
   - Downloads 12 JSON test vector files from C2SP/wycheproof main branch on demand into test/wycheproof/.wycheproof-data/
   - Handles all 4 test types: keygen_seed, encaps, semi_expanded_decaps, and combined (_test.json)
   - For valid/acceptable results: asserts outputs match expected values
   - For invalid results: asserts outputs do NOT match expected values (or accepts decode/runtime errors)
   - For semi_expanded_decaps: just verifies decaps doesn't crash

**Files modified**

3. test/mk/components.mk — Added WYCHEPROOF_TESTS = wycheproof_mlkem to the test lists and wired it into the ADD_SOURCE loop for all three parameter sets

4. Makefile — Added:
   - wycheproof to .PHONY targets
   - wycheproof_512, wycheproof_768, wycheproof_1024 build targets
   - run_wycheproof run target (invokes the Python client)
   - wycheproof to the build and test top-level targets

5. scripts/tests — Added:
   - WYCHEPROOF = 22 to TEST_TYPES enum with desc() and make_target() entries
   - wycheproof() method to Tests class (mirrors acvp() pattern)
   - Wycheproof integrated into all() method with --wycheproof/--no-wycheproof flags (default: enabled)
   - wycheproof subcommand in the CLI

6. .gitignore — Added test/wycheproof/.wycheproof-data/