### PR TITLE
CI: Use availability-zones-config for EC2 runner workflows

### DIFF
--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -115,10 +115,14 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-07b2729e5e065962f
-          security-group-id: sg-0ab2e297196c8c381
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-07b2729e5e065962f","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c7739cbd02c2c1d2","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d69987f97f50fc1d","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d077bf47a0eef46e","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0019f164593f6df43","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0f0d1e7667a264a0e","securityGroupId":"sg-0ab2e297196c8c381"}]
   bench_nix:
     name: Bench (nix)
     permissions:

--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -104,10 +104,14 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-07b2729e5e065962f
-          security-group-id: sg-0ab2e297196c8c381
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-07b2729e5e065962f","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c7739cbd02c2c1d2","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d69987f97f50fc1d","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d077bf47a0eef46e","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0019f164593f6df43","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0f0d1e7667a264a0e","securityGroupId":"sg-0ab2e297196c8c381"}]
       - name: Start EC2 runner (wait before retry)
         if: steps.start-ec2-runner-first.outcome == 'failure'
         shell: bash
@@ -121,10 +125,14 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-07b2729e5e065962f
-          security-group-id: sg-0ab2e297196c8c381
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-07b2729e5e065962f","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c7739cbd02c2c1d2","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d69987f97f50fc1d","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d077bf47a0eef46e","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0019f164593f6df43","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0f0d1e7667a264a0e","securityGroupId":"sg-0ab2e297196c8c381"}]
       - name: Remember runner
         id: remember-runner
         shell: bash

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -114,11 +114,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
-          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-07b2729e5e065962f
-          security-group-id: sg-0ab2e297196c8c381
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-07b2729e5e065962f","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c7739cbd02c2c1d2","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d69987f97f50fc1d","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d077bf47a0eef46e","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0019f164593f6df43","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0f0d1e7667a264a0e","securityGroupId":"sg-0ab2e297196c8c381"}]
       - name: Start EC2c runner (wait before retry)
         if: steps.start-ec2-runner-first.outcome == 'failure'
         shell: bash
@@ -132,11 +136,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ steps.det_ami_id.outputs.AMI_ID }}
-          ec2-volume-size: ${{ inputs.ec2_volume_size }}
           ec2-instance-type: ${{ inputs.ec2_instance_type }}
-          subnet-id: subnet-07b2729e5e065962f
-          security-group-id: sg-0ab2e297196c8c381
+          ec2-volume-size: ${{ inputs.ec2_volume_size }}
+          availability-zones-config: >-
+            [{"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-07b2729e5e065962f","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0c7739cbd02c2c1d2","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d69987f97f50fc1d","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0d077bf47a0eef46e","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0019f164593f6df43","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ steps.det_ami_id.outputs.AMI_ID }}","subnetId":"subnet-0f0d1e7667a264a0e","securityGroupId":"sg-0ab2e297196c8c381"}]
       - name: Remember runner
         id: remember-runner
         shell: bash

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -39,11 +39,15 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.AWS_GITHUB_TOKEN }}
-          ec2-image-id: ${{ env.AMI_UBUNTU_22_04_X86_64 }}
           ec2-instance-type: c7i.2xlarge
           ec2-volume-size: 32
-          subnet-id: subnet-07b2729e5e065962f
-          security-group-id: sg-0ab2e297196c8c381
+          availability-zones-config: >-
+            [{"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-07b2729e5e065962f","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0c7739cbd02c2c1d2","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0d69987f97f50fc1d","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0d077bf47a0eef46e","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0019f164593f6df43","securityGroupId":"sg-0ab2e297196c8c381"},
+             {"imageId":"${{ env.AMI_UBUNTU_22_04_X86_64 }}","subnetId":"subnet-0f0d1e7667a264a0e","securityGroupId":"sg-0ab2e297196c8c381"}]
 
   opentitan_test:
     name: OpenTitan ML-KEM Test (verilator)


### PR DESCRIPTION
The hardcoded subnet-id pinned all EC2 instances to a single availability zone, causing failures when that AZ lacked capacity for the requested instance type. Replace subnet-id and security-group-id with availability-zones-config listing all subnets in the VPC, so the runner action automatically tries other AZs when one lacks capacity.

 - Fixes #1580