### PR TITLE
Make --slice-formula default for all CBMC proofs

### DIFF
--- a/proofs/cbmc/Makefile.common
+++ b/proofs/cbmc/Makefile.common
@@ -281,10 +281,6 @@ PROVER_NAME=cvc5
 SMT_FORMAT := --cvc5
 endif
 
-# CBMC flags used for property checking and coverage checking
-
-CBMCFLAGS += $(CBMC_FLAG_FLUSH)
-
 # CBMC 6.0.0 enables all standard checks by default, which can make coverage analysis
 # very slow. See https://github.com/diffblue/cbmc/issues/8389
 # For now, we disable these checks when generating coverage info.
@@ -543,10 +539,14 @@ SPACE :=$() $()
 COMMA :=,
 
 ################################################################
-# Set C compiler defines
-
+# CBMC flags common to all proofs
+CBMCFLAGS += $(CBMC_FLAG_FLUSH)
 CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+CBMCFLAGS += --slice-formula
 
+
+################################################################
+# Set C compiler defines
 DEFINES += -DCBMC=1
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_MAX_OBJECT_SIZE="(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"

--- a/proofs/cbmc/enc_getnoise_eta1_eta2/Makefile
+++ b/proofs/cbmc/enc_getnoise_eta1_eta2/Makefile
@@ -37,7 +37,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = mlk_enc_getnoise_eta1_eta2
 

--- a/proofs/cbmc/indcpa_enc/Makefile
+++ b/proofs/cbmc/indcpa_enc/Makefile
@@ -43,7 +43,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_smt_only --z3
 
 FUNCTION_NAME = mlk_indcpa_enc
 

--- a/proofs/cbmc/indcpa_keypair_derand/Makefile
+++ b/proofs/cbmc/indcpa_keypair_derand/Makefile
@@ -36,7 +36,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = mlk_indcpa_keypair_derand
 

--- a/proofs/cbmc/keccak_squeeze_once/Makefile
+++ b/proofs/cbmc/keccak_squeeze_once/Makefile
@@ -38,7 +38,6 @@ CBMCFLAGS=--bitwuzla
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_keccak_squeeze_once
 

--- a/proofs/cbmc/keccak_squeezeblocks/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks/Makefile
@@ -38,7 +38,6 @@ CBMCFLAGS=--bitwuzla
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_keccak_squeezeblocks
 

--- a/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
+++ b/proofs/cbmc/keccak_squeezeblocks_x4/Makefile
@@ -38,7 +38,6 @@ CBMCFLAGS=--bitwuzla
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_keccak_squeezeblocks_x4
 

--- a/proofs/cbmc/keccakf1600_permute/Makefile
+++ b/proofs/cbmc/keccakf1600_permute/Makefile
@@ -37,7 +37,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_keccakf1600_permute
 

--- a/proofs/cbmc/keccakf1600_permute_c/Makefile
+++ b/proofs/cbmc/keccakf1600_permute_c/Makefile
@@ -37,7 +37,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_keccakf1600_permute_c
 

--- a/proofs/cbmc/keccakf1600x4_permute/Makefile
+++ b/proofs/cbmc/keccakf1600x4_permute/Makefile
@@ -37,7 +37,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_keccakf1600x4_permute
 

--- a/proofs/cbmc/keypair_getnoise_eta1/Makefile
+++ b/proofs/cbmc/keypair_getnoise_eta1/Makefile
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2 --slice-formula
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = mlk_keypair_getnoise_eta1
 

--- a/proofs/cbmc/matvec_mul/Makefile
+++ b/proofs/cbmc/matvec_mul/Makefile
@@ -36,7 +36,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_matvec_mul
 

--- a/proofs/cbmc/polymat_permute_bitrev_to_custom/Makefile
+++ b/proofs/cbmc/polymat_permute_bitrev_to_custom/Makefile
@@ -36,7 +36,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_polymat_permute_bitrev_to_custom
 

--- a/proofs/cbmc/polyvec_add/Makefile
+++ b/proofs/cbmc/polyvec_add/Makefile
@@ -36,7 +36,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_polyvec_add
 

--- a/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
+++ b/proofs/cbmc/polyvec_basemul_acc_montgomery_cached/Makefile
@@ -37,7 +37,6 @@ CBMCFLAGS=--smt2
 # For functions that use large and multi-dimensional arrays, this yields
 # a substantial improvement in proof performance.
 CBMCFLAGS += --no-array-field-sensitivity
-CBMCFLAGS += --slice-formula
 
 FUNCTION_NAME = mlk_polyvec_basemul_acc_montgomery_cached
 

--- a/proofs/cbmc/polyvec_compress_du/Makefile
+++ b/proofs/cbmc/polyvec_compress_du/Makefile
@@ -27,7 +27,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 
 FUNCTION_NAME = mlk_polyvec_compress_du

--- a/proofs/cbmc/polyvec_tobytes/Makefile
+++ b/proofs/cbmc/polyvec_tobytes/Makefile
@@ -26,7 +26,6 @@ USE_DYNAMIC_FRAMES=1
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
 CBMCFLAGS=--smt2
-CBMCFLAGS += --slice-formula
 CBMCFLAGS += --no-array-field-sensitivity
 
 FUNCTION_NAME = mlk_polyvec_tobytes


### PR DESCRIPTION
CBMC team have recommended that, with CBMC 6.9.0 and above, the `--slice-formula` option for CBMC
should always be used, and that --no-array-field-sensitivity should never be used.

This PR implements the first of those changes.

1. Add --slice-formula to Makefile.common
2. Remove --slice-formula from per-function Makefiles
3. SMT only Z3 tactic for indcpa_enc() stabilizes proof time for this function for all values of K and on macOS/Linux. 

Proof times on r8g instance, all proofs, total CPU "user time" for MLKEM_K=2,3,4
```
main branch: 33m35s, 33m21s, 33m13s (note much improved stability for values of K)
this branch: 33m47s, 33m3s, 32m57s
```
so no significant change.

Running all proofs on r8g with -j64 completes all proofs in 3 minutes real time.
