### PR TITLE
Lint: Replace `black` with `ruff`

### DIFF
--- a/nix/util.nix
+++ b/nix/util.nix
@@ -87,10 +87,11 @@ rec {
         nixpkgs-fmt
         shfmt
         shellcheck
-        actionlint;
+        actionlint
+        ruff;
 
       inherit (pkgs.python3Packages)
-        mpmath sympy black pyparsing pyyaml rich;
+        mpmath sympy pyparsing pyyaml rich;
     };
   };
 

--- a/proofs/cbmc/lib/summarize.py
+++ b/proofs/cbmc/lib/summarize.py
@@ -137,7 +137,6 @@ def export_result_json(output_path, run_file):
 
     failures, runtimes = [], []
     for name, status, duration_str in proof_table[1:]:  # skip header
-        is_timeout = duration_str == "TIMEOUT"
         is_success = status == "Success"
 
         if not is_success:

--- a/proofs/cbmc/run-cbmc-proofs.py
+++ b/proofs/cbmc/run-cbmc-proofs.py
@@ -107,8 +107,7 @@ def get_args():
         {
             "flags": ["--fail-on-proof-failure"],
             "action": "store_true",
-            "help": "exit with return code `10' if any proof failed"
-            " (default: exit 0)",
+            "help": "exit with return code `10' if any proof failed (default: exit 0)",
         },
         {
             "flags": ["--no-standalone"],
@@ -131,9 +130,7 @@ def get_args():
             "flags": ["--marker-file"],
             "metavar": "FILE",
             "default": "Makefile",
-            "help": (
-                "name of file that marks proof directories. Default: " "%(default)s"
-            ),
+            "help": ("name of file that marks proof directories. Default: %(default)s"),
         },
         {
             "flags": ["--no-memory-profile"],
@@ -217,8 +214,9 @@ def task_pool_size():
 def print_counter(counter):
     # pylint: disable=consider-using-f-string
     print(
-        "\rConfiguring CBMC proofs: "
-        "{complete:{width}} / {total:{width}}".format(**counter),
+        "\rConfiguring CBMC proofs: {complete:{width}} / {total:{width}}".format(
+            **counter
+        ),
         end="",
         file=sys.stderr,
     )

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,25 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+# In addition to ruff's default (*.py, *.pyi), format and lint the
+# extension-less python scripts under scripts/.
+extend-include = [
+    "scripts/autogen",
+    "scripts/cfify",
+    "scripts/check-namespace",
+    "scripts/simpasm",
+    "scripts/tests",
+]
+
+[lint]
+select = ["E", "F", "W"]
+ignore = [
+    "E501", # line too long
+    "E713", # `not in` rather than `not X in Y`
+    "E722", # bare except
+    "E731", # lambda assignment
+    "E741", # ambiguous variable name
+    "F541", # f-string without any placeholders
+    "F821", # undefined name
+    "F841", # unused variable
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,4 @@ extend-include = [
 select = ["E", "F", "W"]
 ignore = [
     "E501", # line too long
-    "E713", # `not in` rather than `not X in Y`
-    "E731", # lambda assignment
-    "E741", # ambiguous variable name
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,6 +20,5 @@ ignore = [
     "E731", # lambda assignment
     "E741", # ambiguous variable name
     "F541", # f-string without any placeholders
-    "F821", # undefined name
     "F841", # unused variable
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,7 +16,6 @@ select = ["E", "F", "W"]
 ignore = [
     "E501", # line too long
     "E713", # `not in` rather than `not X in Y`
-    "E722", # bare except
     "E731", # lambda assignment
     "E741", # ambiguous variable name
     "F541", # f-string without any placeholders

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,8 +6,11 @@
 extend-include = [
     "scripts/autogen",
     "scripts/cfify",
+    "scripts/check-contracts",
+    "scripts/check-magic",
     "scripts/check-namespace",
     "scripts/simpasm",
+    "scripts/stack",
     "scripts/tests",
 ]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,6 +18,4 @@ ignore = [
     "E713", # `not in` rather than `not X in Y`
     "E731", # lambda assignment
     "E741", # ambiguous variable name
-    "F541", # f-string without any placeholders
-    "F841", # unused variable
 ]

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -932,7 +932,6 @@ def gen_aarch64_mulcache_twiddles_twisted():
 
 
 def print_hol_light_array(g, as_int=True, entries_per_line=8, pad=0):
-
     # Format of integer list entries, including `;` separator:
     # - Positive numbers: &42;
     # - Negative numbers: -- &42;
@@ -1189,7 +1188,6 @@ def gen_avx2_root_of_unity_for_block(layer, block, inv=False):
 
 
 def gen_avx2_fwd_ntt_zetas():
-
     def gen_twiddles(layer, block, repeat):
         """Generates twisted twiddle, then twiddle, for given layer and block.
         Repeat both the given number of times."""
@@ -2144,7 +2142,6 @@ def get_checked_defines():
 
 
 def gen_monolithic_undef_all_core(filt=None, desc=""):
-
     if filt is None:
         filt = lambda c: True
 
@@ -2351,7 +2348,6 @@ def gen_macro_undefs(extra_notes=None):
 
 
 def gen_monolithic_source_file():
-
     def gen():
         c_sources = get_c_source_files(main_only=True, strip_mlkem=True)
         yield from gen_header()
@@ -2450,7 +2446,6 @@ def gen_monolithic_source_file():
 
 
 def gen_monolithic_asm_file():
-
     def gen():
         asm_sources = get_asm_source_files(main_only=True, strip_mlkem=True)
         yield from gen_header()
@@ -2825,7 +2820,6 @@ def update_via_simpasm(
     force_cross=False,
     x86_64_syntax="att",
 ):
-
     _, infile = os.path.split(infile_full)
     if outfile is None:
         outfile = infile
@@ -2930,7 +2924,6 @@ def gen_hol_light_asm_file(job):
 
 
 def gen_hol_light_asm():
-
     joblist_aarch64 = [
         (
             "ntt.S",
@@ -3195,7 +3188,6 @@ def gen_hol_light_asm():
 
 
 def update_via_copy(infile_full, outfile_full, transform=None):
-
     content = read_file(infile_full)
 
     if transform is not None:
@@ -3213,7 +3205,6 @@ SYNCHRONIZED_EXTENSIONS = (".c", ".h", ".i", ".inc", ".S")
 
 
 def synchronize_file(f, in_dir, out_dir, delete=False, no_simplify=False, **kwargs):
-
     if not f.endswith(SYNCHRONIZED_EXTENSIONS):
         return None
 
@@ -3390,7 +3381,6 @@ def synchronize_backends(
 
 
 def adjust_header_guard_for_filename(content, header_file):
-
     content = content.split("\n")
     exceptions = {
         "mlkem/mlkem_native.h": "MLK_H",
@@ -3467,7 +3457,6 @@ def gen_header_guards():
 
 
 def gen_source_undefs(source_file):
-
     # Get list of #define's clauses in this source file (ignore filename)
     undef_list = list(map(lambda c: c[1], get_defines_from_file(source_file)))
     if not undef_list:
@@ -3547,7 +3536,6 @@ def gen_slothy(funcs):
     targets = list(map(lambda s: s + ".S", funcs))
 
     for t in targets:
-
         if t.startswith("keccak"):
             base = "dev/fips202/aarch64/src"
         else:
@@ -3625,7 +3613,6 @@ class BibliographyEntry:
 
 
 def gen_markdown_citations_for(filename, bibliography):
-
     # Skip BIBLIOGRAPHY.md
     if filename == "BIBLIOGRAPHY.md":
         return
@@ -3687,7 +3674,6 @@ def gen_markdown_citations_for(filename, bibliography):
 
 
 def gen_c_citations_for(filename, bibliography):
-
     content = read_file(filename)
 
     if not _RE_C_CITE.search(content):
@@ -3793,7 +3779,6 @@ def gen_citations_for(filename, bibliography):
 
 
 def gen_bib_file(bibliography):
-
     content = [
         "[//]: # (SPDX-License-Identifier: CC-BY-4.0)",
         "[//]: # (This file is auto-generated from BIBLIOGRAPHY.yml)",

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2592,7 +2592,6 @@ def get_syscaps():
 
 def check_macro_typos():
     files = get_all_files()
-    configs = get_config_options()
     syscaps = get_syscaps()
 
     macros = set(map(lambda t: t[1], get_defines(all=True)))
@@ -2713,7 +2712,6 @@ def check_asm_loop_labels_for_file(filename):
     content = read_file(filename)
 
     # Find function symbol name
-    func_pattern = r"MLK_ASM_FN_SYMBOL\((.*)\)"
     res = _RE_FUNC_SYMBOL.search(content)
     if res is None:
         raise Exception(f"Could not find function symbol in assembly file {filename}")
@@ -2894,7 +2892,7 @@ def update_via_simpasm(
             # Add syntax option for x86_64
             if arch == "x86_64" and x86_64_syntax != "att":
                 cmd += ["--syntax", x86_64_syntax]
-            r = subprocess.run(
+            subprocess.run(
                 cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
@@ -3290,7 +3288,7 @@ def synchronize_backends(
         )
 
         update_via_copy(
-            f"dev/x86_64/meta.h",
+            "dev/x86_64/meta.h",
             "mlkem/src/native/x86_64/meta.h",
             transform=lambda c: adjust_header_guard_for_filename(
                 c, "mlkem/src/native/x86_64/meta.h"
@@ -3404,7 +3402,7 @@ def adjust_header_guard_for_filename(content, header_file):
         yield f"#define {guard_name}"
 
     def gen_footer():
-        yield f"#endif"
+        yield "#endif"
         yield ""
 
     guard = list(gen_guard())
@@ -3714,7 +3712,7 @@ def gen_c_citations_for(filename, bibliography):
             raise Exception(
                 f"Could not find bibliography entry {cite_id} referenced in {filename}"
             )
-        references.append(f" *")
+        references.append(" *")
         references.append(f" * - [{cite_id}]")
         prefix = " *   "
         # Wrap long lines at 80 chars
@@ -3799,11 +3797,11 @@ def gen_bib_file(bibliography):
         content.append(f"### `{cite_id}`")
         content.append("")
         content.append(f"* {entry.name}")
-        content.append(f"* Author(s):")
+        content.append("* Author(s):")
         for author in entry.authors:
             content.append(f"  - {author}")
         content.append(f"* URL: {entry.url}")
-        content.append(f"* Referenced from:")
+        content.append("* Referenced from:")
         # Usages are pairs of (filename, line_count)
         # Ignore line_count for now, as it would require `autogen` after
         # a change to source files.

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -556,23 +556,23 @@ def adjust_preprocessor_comments_for_filename(
     # - `force_print` indicates if a comment should be omitted
     if_stack = []
 
-    def merge_escaped_lines(l, i):
-        while l.endswith("\\"):
-            l = l.removesuffix("\\").rstrip() + content[i + 1].lstrip()
+    def merge_escaped_lines(line, i):
+        while line.endswith("\\"):
+            line = line.removesuffix("\\").rstrip() + content[i + 1].lstrip()
             i = i + 1
-        return (l, i)
+        return (line, i)
 
-    def merge_commented_lines(l, i):
+    def merge_commented_lines(line, i):
         # Not very robust, but good enough
-        if not "/*" in l or "*/" in l:
-            return (l, i)
+        if "/*" not in line or "*/" in line:
+            return (line, i)
         i += 1
         while "*/" not in content[i]:
-            l += content[i]
+            line += content[i]
             i += 1
 
-        l += content[i]
-        return (l, i)
+        line += content[i]
+        return (line, i)
 
     def should_print(cur_line_no, conds, line_no, force_print):
         line_threshold = 5
@@ -631,26 +631,26 @@ def adjust_preprocessor_comments_for_filename(
 
     i = 0
     while i < len(content):
-        l = content[i].strip()
+        line = content[i].strip()
         # Replace #ifdef by #if defined(...)
-        if l.startswith("#ifdef "):
-            l = "#if defined(" + l.removeprefix("#ifdef").strip() + ")"
-        if l.startswith("#ifndef "):
-            l = "#if !defined(" + l.removeprefix("#ifndef").strip() + ")"
-        if l.startswith("#if"):
-            l, _ = merge_escaped_lines(l, i)
-            cond = l.removeprefix("#if")
+        if line.startswith("#ifdef "):
+            line = "#if defined(" + line.removeprefix("#ifdef").strip() + ")"
+        if line.startswith("#ifndef "):
+            line = "#if !defined(" + line.removeprefix("#ifndef").strip() + ")"
+        if line.startswith("#if"):
+            line, _ = merge_escaped_lines(line, i)
+            cond = line.removeprefix("#if")
             if_stack.append(([cond], i, True, False))
             new_content.append(content[i])
-        elif l.startswith("#elif"):
+        elif line.startswith("#elif"):
             conds, _, _, force_print = if_stack.pop()
-            l, _ = merge_escaped_lines(l, i)
-            conds.append(l.removeprefix("#elif"))
+            line, _ = merge_escaped_lines(line, i)
+            conds.append(line.removeprefix("#elif"))
             if_stack.append((conds, i, True, force_print))
             new_content.append(content[i])
-        elif l.startswith("#else"):
-            l, i = merge_escaped_lines(l, i)
-            _, i = merge_commented_lines(l, i)
+        elif line.startswith("#else"):
+            line, i = merge_escaped_lines(line, i)
+            _, i = merge_commented_lines(line, i)
             conds, j, branch, force_print = if_stack.pop()
             assert branch is True
             print_else = should_print(i, cond, j, force_print)
@@ -660,9 +660,9 @@ def adjust_preprocessor_comments_for_filename(
                 new_content.append(adhoc_format("#else", cond))
             else:
                 new_content.append("#else")
-        elif l.startswith("#endif"):
-            l, i = merge_escaped_lines(l, i)
-            _, i = merge_commented_lines(l, i)
+        elif line.startswith("#endif"):
+            line, i = merge_escaped_lines(line, i)
+            _, i = merge_commented_lines(line, i)
             conds, j, branch, force_print = if_stack.pop()
             print_endif = should_print(i, conds, j, force_print)
             if print_endif is False:
@@ -675,7 +675,7 @@ def adjust_preprocessor_comments_for_filename(
             # handle `#if ...` inside documentation as this would
             # lead to nested `/* ... */`.
             i_old = i
-            _, i = merge_commented_lines(l, i_old)
+            _, i = merge_commented_lines(line, i_old)
             new_content += content[i_old : i + 1]
         i += 1
 
@@ -944,12 +944,12 @@ def print_hol_light_array(g, as_int=True, entries_per_line=8, pad=0):
         c = "&" if as_int is True else ""
         return f"{prefix}{c}{n:>{pad}};"
 
-    l = list(map(format_hol_light_int, g))
+    items = list(map(format_hol_light_int, g))
     # Remove `;` from end of last entry
-    l[-1] = l[-1][:-1]
+    items[-1] = items[-1][:-1]
 
-    for i in range(0, len(l), entries_per_line):
-        yield "  " + " ".join(l[i : i + entries_per_line])
+    for i in range(0, len(items), entries_per_line):
+        yield "  " + " ".join(items[i : i + entries_per_line])
 
 
 def gen_aarch64_hol_light_zeta_file():
@@ -1200,8 +1200,8 @@ def gen_avx2_fwd_ntt_zetas():
         root_pairs = list(
             map(lambda x: gen_twiddles(layer, block_base + x, repeat), block_offsets)
         )
-        yield from (r for l in root_pairs for r in l[1])
-        yield from (r for l in root_pairs for r in l[0])
+        yield from (r for pair in root_pairs for r in pair[1])
+        yield from (r for pair in root_pairs for r in pair[0])
 
     # Layers 1 twiddle
     yield from gen_twiddles_many(0, 0, range(1), 4)
@@ -1710,11 +1710,11 @@ def print_hol_light_word64_list(g, entries_per_line=4):
     Analogous to print_hol_light_array but for int64 word lists.
     Yields lines with leading indent, semicolon-separated.
     """
-    l = [f"word 0x{v:016X}" for v in g]
+    items = [f"word 0x{v:016X}" for v in g]
 
-    for i in range(0, len(l), entries_per_line):
-        row = l[i : i + entries_per_line]
-        is_last = i + entries_per_line >= len(l)
+    for i in range(0, len(items), entries_per_line):
+        row = items[i : i + entries_per_line]
+        is_last = i + entries_per_line >= len(items)
         line = "; ".join(row)
         if not is_last:
             line += ";"
@@ -2105,8 +2105,8 @@ def get_all_files():
 
 
 def get_defines_from_file(c):
-    for l in read_file(c).split("\n"):
-        m = _RE_DEFINE.match(l)
+    for line in read_file(c).split("\n"):
+        m = _RE_DEFINE.match(line)
         if m:
             yield (c, m.group(1))
 
@@ -2143,7 +2143,9 @@ def get_checked_defines():
 
 def gen_monolithic_undef_all_core(filt=None, desc=""):
     if filt is None:
-        filt = lambda c: True
+
+        def filt(c):
+            return True
 
     if desc != "":
         yield "/*"
@@ -2655,22 +2657,22 @@ def check_macro_typos():
 def check_asm_register_aliases_for_file(filename):
     """Checks that `filename` has no mismatching or dangling register aliases"""
 
-    def get_alias_def(l):
-        s = list(filter(lambda s: s != "", l.strip().split(" ")))
+    def get_alias_def(line):
+        s = list(filter(lambda s: s != "", line.strip().split(" ")))
         if len(s) < 3 or s[1] != ".req":
             return None
         return s[0]
 
-    def get_alias_undef(l):
-        if l.strip().startswith(".unreq") is False:
+    def get_alias_undef(line):
+        if line.strip().startswith(".unreq") is False:
             return None
-        return list(filter(lambda s: s != "", l.strip().split(" ")))[1]
+        return list(filter(lambda s: s != "", line.strip().split(" ")))[1]
 
     content = read_file(filename)
     aliases = {}
-    for i, l in enumerate(content.split("\n")):
-        alias_def = get_alias_def(l)
-        alias_undef = get_alias_undef(l)
+    for i, line in enumerate(content.split("\n")):
+        alias_def = get_alias_def(line)
+        alias_undef = get_alias_undef(line)
         if alias_def is not None:
             if alias_def in aliases.keys():
                 raise Exception(
@@ -3225,7 +3227,9 @@ def synchronize_file(f, in_dir, out_dir, delete=False, no_simplify=False, **kwar
         # don't do it here, the dry-run would fail because of a
         # mismatching intermediate file
         if f.endswith(".h"):
-            transform = lambda c: adjust_header_guard_for_filename(c, outfile_full)
+
+            def transform(c):
+                return adjust_header_guard_for_filename(c, outfile_full)
         else:
             transform = None
         update_via_copy(f, outfile_full, transform=transform)
@@ -3410,8 +3414,8 @@ def adjust_header_guard_for_filename(content, header_file):
 
     # Skip over initial commentary
     insert_at = None
-    for i, l in enumerate(content):
-        if l.strip() == "" or l.startswith(("/*", " *")):
+    for i, line in enumerate(content):
+        if line.strip() == "" or line.startswith(("/*", " *")):
             continue
         insert_at = i
         break
@@ -3623,8 +3627,8 @@ def gen_markdown_citations_for(filename, bibliography):
 
     # Lookup all citations in style `[^ID]`
     citations = {}
-    for i, l in enumerate(content):
-        for m in _RE_MARKDOWN_CITE.finditer(l):
+    for i, line in enumerate(content):
+        for m in _RE_MARKDOWN_CITE.finditer(line):
             cite_id = m.group("id")
             uses = citations.get(cite_id, [])
             uses.append((filename, i))
@@ -3641,8 +3645,8 @@ def gen_markdown_citations_for(filename, bibliography):
     # Find explicit footnote definitions outside the bibliography block
     # These are lines matching `[^ID]: ...` and should be excluded from autogeneration
     explicit_footnotes = set()
-    for l in content:
-        m = re.match(r"^\[\^(\w+)\]:", l)
+    for line in content:
+        m = re.match(r"^\[\^(\w+)\]:", line)
         if m:
             explicit_footnotes.add(m.group(1))
 
@@ -3691,8 +3695,8 @@ def gen_c_citations_for(filename, bibliography):
 
     # Lookup all citations in style `@[ID]`
     citations = {}
-    for i, l in enumerate(content):
-        for m in _RE_C_CITE.finditer(l):
+    for i, line in enumerate(content):
+        for m in _RE_C_CITE.finditer(line):
             cite_id = m.group("id")
             uses = citations.get(cite_id, [])
             # Remember usage. +1 because line counting starts at 1
@@ -3742,8 +3746,8 @@ def gen_c_citations_for(filename, bibliography):
         # Add references to file after initial header section
         # Skip over copyright
         insert_at = None
-        for i, l in enumerate(content):
-            if l.startswith(("/*", " *")):
+        for i, line in enumerate(content):
+            if line.startswith(("/*", " *")):
                 continue
             insert_at = i
             break

--- a/scripts/cfify
+++ b/scripts/cfify
@@ -192,7 +192,7 @@ def add_cfi_directives(text, arch):
                             result.append(
                                 f"{indent}.cfi_rel_offset d{reg_pair[1]}, 0x{offset_val + 8:x}"
                             )
-                        except:
+                        except ValueError:
                             result.append(
                                 f"{indent}.cfi_rel_offset d{reg_pair[0]}, {offsets[j]}"
                             )
@@ -232,7 +232,7 @@ def add_cfi_directives(text, arch):
                             result.append(
                                 f"{indent}.cfi_rel_offset x{reg_pair[1]}, 0x{offset_val + 8:x}"
                             )
-                        except:
+                        except ValueError:
                             result.append(
                                 f"{indent}.cfi_rel_offset x{reg_pair[0]}, {offsets[j]}"
                             )

--- a/scripts/cfify
+++ b/scripts/cfify
@@ -190,7 +190,7 @@ def add_cfi_directives(text, arch):
                                 f"{indent}.cfi_rel_offset d{reg_pair[0]}, 0x{offset_val:x}"
                             )
                             result.append(
-                                f"{indent}.cfi_rel_offset d{reg_pair[1]}, 0x{offset_val+8:x}"
+                                f"{indent}.cfi_rel_offset d{reg_pair[1]}, 0x{offset_val + 8:x}"
                             )
                         except:
                             result.append(
@@ -230,7 +230,7 @@ def add_cfi_directives(text, arch):
                                 f"{indent}.cfi_rel_offset x{reg_pair[0]}, 0x{offset_val:x}"
                             )
                             result.append(
-                                f"{indent}.cfi_rel_offset x{reg_pair[1]}, 0x{offset_val+8:x}"
+                                f"{indent}.cfi_rel_offset x{reg_pair[1]}, 0x{offset_val + 8:x}"
                             )
                         except:
                             result.append(
@@ -450,7 +450,6 @@ def add_cfi_directives(text, arch):
 
 
 def main():
-
     parser = argparse.ArgumentParser(
         description="Add CFI directives to AArch64 assembly"
     )

--- a/scripts/check-magic
+++ b/scripts/check-magic
@@ -10,89 +10,116 @@ import re
 import math
 import pathlib
 
-from sympy import simplify, sympify, Function, Rational
+from sympy import sympify, Rational
+
 
 def get_c_source_files():
     return get_files("mlkem/**/*.c")
 
+
 def get_header_files():
     return get_files("mlkem/**/*.h")
+
 
 def get_files(pattern):
     return list(map(str, pathlib.Path().glob(pattern)))
 
+
 # Standard color definitions
-GREEN="\033[32m"
-RED="\033[31m"
-BLUE="\033[94m"
-BOLD="\033[1m"
-NORMAL="\033[0m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+BLUE = "\033[94m"
+BOLD = "\033[1m"
+NORMAL = "\033[0m"
 
 CHECKED = f"{GREEN}✓{NORMAL}"
 FAIL = f"{RED}✗{NORMAL}"
 REMEMBERED = f"{BLUE}⊢{NORMAL}"
 
+
 def check_magic_numbers():
     mlkem_q = 3329
-    exceptions = [mlkem_q,
-                  1665, # q/2
-                  1600, # For Keccak-F1600
-                  1023, 1024, 2047, 2048, 4095, 4096, 8192, 32767, 32768, 65535, 65536,
-                  2025, # years
-                  ]
+    exceptions = [
+        mlkem_q,
+        1665,  # q/2
+        1600,  # For Keccak-F1600
+        1023,
+        1024,
+        2047,
+        2048,
+        4095,
+        4096,
+        8192,
+        32767,
+        32768,
+        65535,
+        65536,
+        2025,  # years
+    ]
     enable_marker = "check-magic: on"
     disable_marker = "check-magic: off"
     autogen_marker = "This file is auto-generated from scripts/autogen"
 
     files = get_c_source_files() + get_header_files()
 
-    def is_exception(filename, l, magic):
+    def is_exception(filename, line, magic):
         return magic in exceptions
 
-    def get_magic(l):
-        regexp = r'/\* check-magic:\s+([-]?\d{4,})\s*==\s*(.*?) \*/'
-        m = re.search(regexp, l)
+    def get_magic(line):
+        regexp = r"/\* check-magic:\s+([-]?\d{4,})\s*==\s*(.*?) \*/"
+        m = re.search(regexp, line)
         if m is not None:
             # Remove magic annotation to avoid it being treated
             # as magic value itself
-            l = re.sub(regexp,'',l)
-            return l, (int(m.group(1)), m.group(2))
-        return l, None
+            line = re.sub(regexp, "", line)
+            return line, (int(m.group(1)), m.group(2))
+        return line, None
 
-    def get_define(l):
-        m = re.search(r'#define\s+(\w+)', l)
+    def get_define(line):
+        m = re.search(r"#define\s+(\w+)", line)
         if m is not None:
             return m.group(1)
         return None
 
     def evaluate_magic(m, known_magics):
-        def unsigned_mod(x,y):
+        def unsigned_mod(x, y):
             return x % y
-        def signed_mod(x,y):
-            r = unsigned_mod(x,y)
+
+        def signed_mod(x, y):
+            r = unsigned_mod(x, y)
             if r >= y // 2:
                 r -= y
             return r
-        def pow_mod(x,y,m):
+
+        def pow_mod(x, y, m):
             x = int(x)
             y = int(y)
             m = int(m)
-            return signed_mod(pow(x,y,m),m)
+            return signed_mod(pow(x, y, m), m)
+
         def safe_round(x):
             if x - math.floor(x) == Rational(1, 2):
-                raise ValueError(f"Ambiguous rounding: {x} is an odd multiple of 0.5 and it is unclear if round-up or round-down is desired")
+                raise ValueError(
+                    f"Ambiguous rounding: {x} is an odd multiple of 0.5 and it is unclear if round-up or round-down is desired"
+                )
             return round(x)
+
         def safe_floordiv(x, y):
             x = int(x)
             y = int(y)
             if x % y != 0:
-                raise ValueError(f"Non-integral division: {x} // {y} has remainder {x % y}")
+                raise ValueError(
+                    f"Non-integral division: {x} // {y} has remainder {x % y}"
+                )
             return x // y
-        locals_dict = {'signed_mod': signed_mod,
-                       'unsigned_mod': unsigned_mod,
-                       'pow': pow_mod,
-                       'round': safe_round,
-                       'intdiv': safe_floordiv }
+
+        locals_dict = {
+            "signed_mod": signed_mod,
+            "unsigned_mod": unsigned_mod,
+            "pow": pow_mod,
+            "round": safe_round,
+            "intdiv": safe_floordiv,
+        }
         locals_dict.update(known_magics)
         return sympify(m, locals=locals_dict)
 
@@ -104,36 +131,40 @@ def check_magic_numbers():
         content = content.split("\n")
         # Use negative lookbefore and lookahead to exclude numbers
         # that occur as part of identifiers (e.g. layer12345 or 199901L)
-        pattern = r'(?<![0-9a-zA-Z/_-])([-]?\d{4,})(?![0-9a-zA-Z_-])'
+        pattern = r"(?<![0-9a-zA-Z/_-])([-]?\d{4,})(?![0-9a-zA-Z_-])"
         enabled = True
-        magic_dict = {'MLKEM_Q': mlkem_q}
+        magic_dict = {"MLKEM_Q": mlkem_q}
         magic_expr = None
         verified_magics = {}
-        for i, l in enumerate(content):
-            if enabled is True and disable_marker in l:
+        for i, line in enumerate(content):
+            if enabled is True and disable_marker in line:
                 enabled = False
                 continue
-            if enabled is False and enable_marker in l:
+            if enabled is False and enable_marker in line:
                 enabled = True
                 continue
             if enabled is False:
                 continue
-            l, g = get_magic(l)
+            line, g = get_magic(line)
             if g is not None:
                 magic_val, magic_expr = g
                 magic_val_check = evaluate_magic(magic_expr, magic_dict)
                 if magic_val != magic_val_check:
-                    print(f"{FAIL}:{filename}:{i}: Mismatching magic annotation: {magic_val} != {magic_expr} (= {magic_val_check})")
+                    print(
+                        f"{FAIL}:{filename}:{i}: Mismatching magic annotation: {magic_val} != {magic_expr} (= {magic_val_check})"
+                    )
                     exit(1)
-                print(f"{REMEMBERED}:{filename}:{i}: Verified explanation {magic_val} == {magic_expr}")
+                print(
+                    f"{REMEMBERED}:{filename}:{i}: Verified explanation {magic_val} == {magic_expr}"
+                )
                 verified_magics[magic_val] = magic_expr
 
-            found = next(re.finditer(pattern, l), None)
+            found = next(re.finditer(pattern, line), None)
             if found is None:
                 continue
 
             magic = int(found.group())
-            if is_exception(filename, l, magic):
+            if is_exception(filename, line, magic):
                 continue
 
             explanation = verified_magics.get(magic, None)
@@ -141,15 +172,19 @@ def check_magic_numbers():
                 print(f"{FAIL}:{filename}:{i}: No explanation for magic value {magic}")
                 exit(1)
 
-            print(f"{CHECKED}:{filename}:{i}: {magic} previously explained as {explanation}")
+            print(
+                f"{CHECKED}:{filename}:{i}: {magic} previously explained as {explanation}"
+            )
 
             # If this is a #define's clause, remember it
-            define = get_define(l)
+            define = get_define(line)
             if define is not None:
                 magic_dict[define] = magic
 
+
 def _main():
     check_magic_numbers()
+
 
 if __name__ == "__main__":
     _main()

--- a/scripts/format
+++ b/scripts/format
@@ -44,12 +44,12 @@ fi
 SHELL_SCRIPTS=$(git grep -l '' :/ | xargs printf "'%s' " | xargs -L 1 shfmt -f)
 echo $SHELL_SCRIPTS | xargs -L 1 shfmt -s -w -l -i 2 -ci -fn
 
-info "Formatting python scripts"
-if ! command -v black >/dev/null 2>&1; then
-  error "black not found. Are you running in a nix shell? See CONTRIBUTING.md."
+info "Formatting python scripts with ruff"
+if ! command -v ruff >/dev/null 2>&1; then
+  error "ruff not found. Are you running in a nix shell? See CONTRIBUTING.md."
   exit 1
 fi
-black --include "(scripts/tests|scripts/simpasm|scripts/cfify|scripts/autogen|scripts/check-namespace|\.py$)" "$ROOT"
+ruff format "$ROOT"
 
 info "Formatting c files"
 if ! command -v clang-format >/dev/null 2>&1; then

--- a/scripts/lint
+++ b/scripts/lint
@@ -155,15 +155,29 @@ else
 fi
 gh_group_end
 
-gh_group_start "Linting python scripts with black"
-if ! diff=$(black --check --diff -q --include "(scripts/tests|scripts/simpasm|scripts/cfify|scripts/autogen|scripts/check-namespace|\.py$)" "$ROOT"); then
+gh_group_start "Linting python scripts with ruff (format)"
+if ! diff=$(ruff format --check --diff "$ROOT" 2>&1); then
+  echo "$diff"
   gh_error_simple "Format error" "$diff"
-  error "Lint python"
+  error "Lint Python (ruff format)"
   SUCCESS=false
-  gh_summary_failure "Lint python"
+  gh_summary_failure "Lint Python (ruff format)"
 else
-  info "Lint Python"
-  gh_summary_success "Lint Python"
+  info "Lint Python (ruff format)"
+  gh_summary_success "Lint Python (ruff format)"
+fi
+gh_group_end
+
+gh_group_start "Linting python scripts with ruff (check)"
+if ! out=$(ruff check "$ROOT" 2>&1); then
+  echo "$out"
+  gh_error_simple "Lint error" "$out"
+  error "Lint Python (ruff check)"
+  SUCCESS=false
+  gh_summary_failure "Lint Python (ruff check)"
+else
+  info "Lint Python (ruff check)"
+  gh_summary_success "Lint Python (ruff check)"
 fi
 gh_group_end
 

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -29,41 +29,46 @@ def patchup_disasm(asm, cfify=False):
         return lbl + ":"
 
     # Find first label
-    for i, l in enumerate(asm):
-        if decode_label(l) is not None:
+    for i, line in enumerate(asm):
+        if decode_label(line) is not None:
             break
 
     asm = asm[i + 1 :]
 
     def gen(asm):
-        for l in asm:
-            if l.strip() == "":
+        for line in asm:
+            if line.strip() == "":
                 yield ""
                 continue
-            lbl = decode_label(l)
+            lbl = decode_label(line)
             # Re-format labels as assembly labels
             if lbl is not None:
                 yield make_label(lbl)
                 continue
             # Drop comments
-            l = l.split(";")[0]
+            line = line.split(";")[0]
             # Re-format references to labels
             # Those are assumed to have the form `0xDEADBEEF <label>`
             if cfify:
-                l = re.sub(
-                    r"(0x)?[0-9a-fA-F]+\s+<(?P<label>[a-zA-Z0-9_]+)>", r"L\g<label>", l
+                line = re.sub(
+                    r"(0x)?[0-9a-fA-F]+\s+<(?P<label>[a-zA-Z0-9_]+)>",
+                    r"L\g<label>",
+                    line,
                 )
             else:
-                l = re.sub(
-                    r"(0x)?[0-9a-fA-F]+\s+<(?P<label>[a-zA-Z0-9_]+)>", r"\g<label>", l
+                line = re.sub(
+                    r"(0x)?[0-9a-fA-F]+\s+<(?P<label>[a-zA-Z0-9_]+)>",
+                    r"\g<label>",
+                    line,
                 )
             # Drop address and byte code from line
             d = re.search(
-                r"^\s*[0-9a-fA-F]+:\s+([0-9a-fA-F][0-9a-fA-F][ ]*)+\s+(?P<inst>.*)$", l
+                r"^\s*[0-9a-fA-F]+:\s+([0-9a-fA-F][0-9a-fA-F][ ]*)+\s+(?P<inst>.*)$",
+                line,
             )
             if d is None:
                 raise Exception(
-                    f'The following does not seem to be an assembly line of the expected format `ADDRESS: BYTECODE INSTRUCTION`:\n"{l}"'
+                    f'The following does not seem to be an assembly line of the expected format `ADDRESS: BYTECODE INSTRUCTION`:\n"{line}"'
                 )
             yield " " * indentation + d.group("inst").expandtabs(1)
 
@@ -76,8 +81,8 @@ def find_header_footer(asm, filename):
 
     # Extract header
     header_end = None
-    for i, l in enumerate(asm):
-        if header_end_marker in l:
+    for i, line in enumerate(asm):
+        if header_end_marker in line:
             header_end = i
             break
     if header_end is None:
@@ -88,8 +93,8 @@ def find_header_footer(asm, filename):
 
     # Extract footer
     footer_start = None
-    for i, l in enumerate(asm):
-        if footer_start_marker in l:
+    for i, line in enumerate(asm):
+        if footer_start_marker in line:
             footer_start = i
             break
     if footer_start is None:
@@ -105,8 +110,8 @@ def find_header_footer(asm, filename):
 
 def find_globals(asm):
     global_symbols = []
-    for l in asm:
-        r = re.search(r"^\s*\.global\s+(.*)$", l)
+    for line in asm:
+        r = re.search(r"^\s*\.global\s+(.*)$", line)
         if r is None:
             continue
         global_symbols.append(r.group(1))
@@ -121,9 +126,9 @@ def drop_if_from_header(header):
     header_new = []
     i = 0
     while i < len(header):
-        l = header[i]
-        if not l.strip().startswith("#if"):
-            header_new.append(l)
+        line = header[i]
+        if not line.strip().startswith("#if"):
+            header_new.append(line)
             i += 1
             continue
         header_new.append("#if 1")
@@ -138,9 +143,9 @@ def drop_preprocessor_directives(header):
     header_new = []
     i = 0
     while i < len(header):
-        l = header[i]
-        if not l.strip().startswith("#"):
-            header_new.append(l)
+        line = header[i]
+        if not line.strip().startswith("#"):
+            header_new.append(line)
             i += 1
             continue
         while i < len(header) and header[i].endswith("\\"):

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -274,7 +274,7 @@ def simplify(logger, args, asm_input, asm_output=None):
         autogen_header = [
             "",
             "/*",
-            f" * WARNING: This file is auto-derived from the mlkem-native source file",
+            " * WARNING: This file is auto-derived from the mlkem-native source file",
             f" *   {asm_input} using scripts/simpasm. Do not modify it directly.",
             " */",
             "",
@@ -352,7 +352,7 @@ def simplify(logger, args, asm_input, asm_output=None):
             + elf_stack_section
         )
 
-        logger.debug(f"Assembling simplified assembly ...")
+        logger.debug("Assembling simplified assembly ...")
         logger.debug(new_asm)
         logger.debug(f"Command: {' '.join(cmd)}")
         run_cmd(cmd, input=new_asm)

--- a/scripts/simpasm
+++ b/scripts/simpasm
@@ -151,7 +151,6 @@ def drop_preprocessor_directives(header):
 
 
 def simplify(logger, args, asm_input, asm_output=None):
-
     def run_cmd(cmd, input=None):
         logger.debug(f"Running command: {' '.join(cmd)}")
         try:
@@ -189,10 +188,10 @@ def simplify(logger, args, asm_input, asm_output=None):
         cflags = []
 
     # Create temporary object files for byte code before/after simplification
-    with tempfile.NamedTemporaryFile(
-        suffix=".o", delete=False
-    ) as tmp0, tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp1:
-
+    with (
+        tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp0,
+        tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp1,
+    ):
         tmp_objfile0 = tmp0.name
         tmp_objfile1 = tmp1.name
 

--- a/scripts/stack
+++ b/scripts/stack
@@ -138,7 +138,7 @@ def run_valgrind_massif_per_api(stack_test_binary, dump_massif=False):
 
         return (
             True,
-            f"API-specific stack usage (measured with valgrind massif):\n"
+            "API-specific stack usage (measured with valgrind massif):\n"
             + "\n".join(result_lines),
         )
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -68,11 +68,11 @@ def github_summary(title, test_label, results):
             )
         ]
 
-    def find_last_consecutive_match(l, s):
-        for i, v in enumerate(l[s + 1 :]):
+    def find_last_consecutive_match(lines, s):
+        for i, v in enumerate(lines[s + 1 :]):
             if not v.startswith("|") or not v.endswith("|"):
                 return i + 1
-        return len(l)
+        return len(lines)
 
     def add_summaries(fn, title, summaries):
         summary_title = "| Tests |"
@@ -469,7 +469,7 @@ class Tests:
         # Add FIPS202 backend selection if specified and this is an OPT build
         if self.args.fips202_aarch64_backend != "auto" and opt is True:
             # Make sure we're forcing AArch64 architecture
-            if not " -DMLK_FORCE_AARCH64" in cflags:
+            if " -DMLK_FORCE_AARCH64" not in cflags:
                 cflags += " -DMLK_FORCE_AARCH64"
 
             # Enable native backend for FIPS202
@@ -718,16 +718,16 @@ class Tests:
 
     def examples(self):
         if self.args.l is None:
-            l = TEST_TYPES.examples()
+            items = TEST_TYPES.examples()
         else:
-            l = list(map(TEST_TYPES.from_string, self.args.l))
+            items = list(map(TEST_TYPES.from_string, self.args.l))
 
         # Filter out excluded examples
         if hasattr(self.args, "exclude_example") and self.args.exclude_example:
             excluded = [TEST_TYPES.from_string(ex) for ex in self.args.exclude_example]
-            l = [e for e in l if e not in excluded]
+            items = [e for e in items if e not in excluded]
 
-        for e in l:
+        for e in items:
             self._compile_schemes(e, None)
             self._run_scheme(e, None, None)
 
@@ -777,7 +777,7 @@ class Tests:
 
                 lines = [line for line in r.splitlines() if "=" in line]
 
-                d = {k.strip(): int(v) for k, v in (l.split("=") for l in lines)}
+                d = {k.strip(): int(v) for k, v in (ln.split("=") for ln in lines)}
                 for primitive in ["keypair", "encaps", "decaps"]:
                     v.append(
                         {

--- a/scripts/tests
+++ b/scripts/tests
@@ -1317,7 +1317,7 @@ def cli():
     )
 
     # wycheproof arguments
-    wycheproof_parser = cmd_subparsers.add_parser(
+    cmd_subparsers.add_parser(
         "wycheproof", help="Run Wycheproof client", parents=[common_parser]
     )
 
@@ -1377,7 +1377,7 @@ def cli():
         action="store_true",
         default=False,
     )
-    size_parser = cmd_subparsers.add_parser(
+    cmd_subparsers.add_parser(
         "size",
         help="Run the code size measurement for all object file",
         parents=[common_parser],
@@ -1493,12 +1493,12 @@ def cli():
     )
 
     # kat arguments
-    kat_parser = cmd_subparsers.add_parser(
+    cmd_subparsers.add_parser(
         "kat", help="Run the kat tests for all parameter sets", parents=[common_parser]
     )
 
     # unit arguments
-    unit_parser = cmd_subparsers.add_parser(
+    cmd_subparsers.add_parser(
         "unit",
         help="Run the unit tests for all parameter sets",
         parents=[common_parser],
@@ -1524,14 +1524,14 @@ def cli():
     )
 
     # alloc arguments
-    alloc_parser = cmd_subparsers.add_parser(
+    cmd_subparsers.add_parser(
         "alloc",
         help="Run the alloc tests for all parameter sets",
         parents=[common_parser],
     )
 
     # rng_fail arguments
-    rng_fail_parser = cmd_subparsers.add_parser(
+    cmd_subparsers.add_parser(
         "rng_fail",
         help="Run the RNG failure tests for all parameter sets",
         parents=[common_parser],

--- a/scripts/tests
+++ b/scripts/tests
@@ -808,7 +808,6 @@ class Tests:
         self.check_fail()
 
     def size(self):
-
         test_type = TEST_TYPES.SIZE
 
         resultss = None
@@ -899,7 +898,6 @@ class Tests:
         self.check_fail()
 
     def cbmc(self):
-
         def list_proofs():
             cmd_str = ["./proofs/cbmc/list_proofs.sh"]
             p = subprocess.run(cmd_str, capture_output=True, universal_newlines=False)
@@ -916,7 +914,7 @@ class Tests:
             scheme = SCHEME.from_k(mlkem_k)
             num_proofs = len(proofs)
             for i, func in enumerate(proofs):
-                log = logger(f"CBMC ({i+1}/{num_proofs})", scheme, None, None)
+                log = logger(f"CBMC ({i + 1}/{num_proofs})", scheme, None, None)
                 log.info(f"Starting CBMC proof for {func}")
                 start = time.time()
                 try:
@@ -1016,7 +1014,6 @@ class Tests:
         self.check_fail()
 
     def hol_light(self):
-
         if platform.machine().lower() in ["arm64", "aarch64"]:
             arch = "aarch64"
         elif platform.machine().lower() in ["x86_64"]:
@@ -1038,7 +1035,7 @@ class Tests:
         def run_hol_light_single_step(proofs, arch):
             num_proofs = len(proofs)
             for i, func in enumerate(proofs):
-                log = logger(f"HOL_LIGHT ({i+1}/{num_proofs})", None, None, None)
+                log = logger(f"HOL_LIGHT ({i + 1}/{num_proofs})", None, None, None)
                 log.info(f"Starting HOL-Light proof for {func}")
                 start = time.time()
                 proof_bin = f"mlkem/{func}.native"

--- a/scripts/tests
+++ b/scripts/tests
@@ -957,6 +957,7 @@ class Tests:
                     log.info(f"   SUCCESS (after {dur}s)")
 
         def run_cbmc(mlkem_k):
+            log = logger("CBMC", SCHEME.from_k(mlkem_k), None, None)
             all_proofs = list_proofs()
             proofs = all_proofs
             if self.args.start_with is not None:
@@ -965,7 +966,7 @@ class Tests:
                     proofs = proofs[idx:]
                 except ValueError:
                     log.error(
-                        "Could not find function {self.args.start_with}. Running all proofs"
+                        f"Could not find function {self.args.start_with}. Running all proofs"
                     )
             if self.args.proof is not None:
                 proofs = []

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -75,7 +75,6 @@ def loadAcvpData(prompt, expectedResults):
 
 
 def loadDefaultAcvpData(version):
-
     data_dir = f"test/acvp/.acvp-data/{version}/files"
     acvp_jsons_for_version = [
         (
@@ -308,13 +307,13 @@ def runTest(data, output):
 
 
 def test(prompt, expected, output, version):
-    assert (
-        prompt is not None or output is None
-    ), "cannot produce output if there is no input"
+    assert prompt is not None or output is None, (
+        "cannot produce output if there is no input"
+    )
 
-    assert prompt is None or (
-        output is not None or expected is not None
-    ), "if there is a prompt, either output or expectedResult required"
+    assert prompt is None or (output is not None or expected is not None), (
+        "if there is a prompt, either output or expectedResult required"
+    )
 
     # if prompt is passed, use it
     if prompt is not None:

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -134,8 +134,8 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for l in result.stdout.splitlines():
-            (k, v) = l.split("=")
+        for line in result.stdout.splitlines():
+            (k, v) = line.split("=")
             results[k] = v
     elif tg["function"] == "decapsulation":
         acvp_bin = get_acvp_binary(tg)
@@ -157,8 +157,8 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for l in result.stdout.splitlines():
-            (k, v) = l.split("=")
+        for line in result.stdout.splitlines():
+            (k, v) = line.split("=")
             results[k] = v
     elif tg["function"] == "encapsulationKeyCheck":
         acvp_bin = get_acvp_binary(tg)
@@ -176,8 +176,8 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for l in result.stdout.splitlines():
-            (k, v) = l.split("=")
+        for line in result.stdout.splitlines():
+            (k, v) = line.split("=")
             results[k] = v == "1"
 
     elif tg["function"] == "decapsulationKeyCheck":
@@ -196,8 +196,8 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for l in result.stdout.splitlines():
-            (k, v) = l.split("=")
+        for line in result.stdout.splitlines():
+            (k, v) = line.split("=")
             results[k] = v == "1"
     info("done")
     return results
@@ -222,8 +222,8 @@ def run_keyGen_test(tg, tc):
         err(result.stderr)
         exit(1)
     # Extract results
-    for l in result.stdout.splitlines():
-        (k, v) = l.split("=")
+    for line in result.stdout.splitlines():
+        (k, v) = line.split("=")
         results[k] = v
     info("done")
     return results

--- a/test/baremetal/platform/m55-an547/exec_wrapper.py
+++ b/test/baremetal/platform/m55-an547/exec_wrapper.py
@@ -23,7 +23,7 @@ arg0_offset = cmdline_offset + 4 + len(args) * 4
 arg_offsets = [sum(map(len, args[:i])) + i + arg0_offset for i in range(len(args))]
 
 binargs = st.pack(
-    f"<{1+len(args)}I" + "".join(f"{len(a)+1}s" for a in args),
+    f"<{1 + len(args)}I" + "".join(f"{len(a) + 1}s" for a in args),
     len(args),
     *arg_offsets,
     *map(lambda x: x.encode("utf-8"), args),

--- a/test/test_bounds.py
+++ b/test/test_bounds.py
@@ -85,7 +85,7 @@ def test_random(f, num_tests=10000000, bound=2 * R):
     print(f"Randomly checking Barrett<->Montgomery relation ({num_tests} tests)...")
     for i in range(num_tests):
         if i % 100000 == 0:
-            print(f"... run {i} tests ({((i * 1000) // num_tests)/10}%)")
+            print(f"... run {i} tests ({((i * 1000) // num_tests) / 10}%)")
         a = random.randrange(-bound, bound)
         b = random.randrange(-bound, bound)
         f(a, b)
@@ -107,7 +107,7 @@ def barmul_test(a, b):
     r0 = barmul(a, b)
     r1 = montmul_neg(a, bp)
     if r0 != r1:
-        print(f"barmul test failure for {a,b}!")
+        print(f"barmul test failure for {a, b}!")
         print(f"Barrett multiplication: {r0}")
         print(f"Montgomery multiplication: {r1} (factor {bp})")
         assert False
@@ -140,9 +140,9 @@ def bar_bound_test(a, b, max_scale=[]):
     scale = (Cp - 1 / 2) / C
     if len(max_scale) == 0 or scale > max_scale[-1]:
         max_scale.append(scale)
-        print(f"New scale bound for {(a,b)}: {scale}")
+        print(f"New scale bound for {(a, b)}: {scale}")
     if Cp >= scale_bound * C + 1 / 2:
-        print(f"bar bound test failure for (a,b)={(a,b)}")
+        print(f"bar bound test failure for (a,b)={(a, b)}")
         print(f"barmul(a,b): {ab}")
         print(f"C  (=a/q): {C}")
         print(f"Cp (=barmul(a,b)/q): {Cp}")

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -104,16 +104,16 @@ def run_keygen_seed_test(data_file):
             info(f"  tcId={tc['tcId']} ... ", end="")
             out = run_binary([binary, "keygen_seed", f"seed={tc['seed']}"])
             if tc["result"] == "valid":
-                assert (
-                    out["ek"].upper() == tc["ek"].upper()
-                ), f"ek mismatch tcId={tc['tcId']}"
-                assert (
-                    out["dk"].upper() == tc["dk"].upper()
-                ), f"dk mismatch tcId={tc['tcId']}"
+                assert out["ek"].upper() == tc["ek"].upper(), (
+                    f"ek mismatch tcId={tc['tcId']}"
+                )
+                assert out["dk"].upper() == tc["dk"].upper(), (
+                    f"dk mismatch tcId={tc['tcId']}"
+                )
             else:
-                assert (
-                    False
-                ), f"Unexpected result '{tc['result']}' for tcId={tc['tcId']}"
+                assert False, (
+                    f"Unexpected result '{tc['result']}' for tcId={tc['tcId']}"
+                )
             info("ok")
             count += 1
     info(f"  {count} keygen_seed tests passed")
@@ -134,20 +134,20 @@ def run_encaps_test(data_file):
             out = run_binary([binary, "encaps", f"ek={tc['ek']}", f"m={tc['m']}"])
             if tc["result"] == "invalid":
                 # _error: non-zero exit code; decode_error: explicit validation failure
-                assert (
-                    "_error" in out or "decode_error" in out
-                ), f"binary success on invalid tcId={tc['tcId']}"
+                assert "_error" in out or "decode_error" in out, (
+                    f"binary success on invalid tcId={tc['tcId']}"
+                )
             elif tc["result"] == "valid":
-                assert (
-                    out["c"].upper() == tc["c"].upper()
-                ), f"c mismatch tcId={tc['tcId']}"
-                assert (
-                    out["K"].upper() == tc["K"].upper()
-                ), f"K mismatch tcId={tc['tcId']}"
+                assert out["c"].upper() == tc["c"].upper(), (
+                    f"c mismatch tcId={tc['tcId']}"
+                )
+                assert out["K"].upper() == tc["K"].upper(), (
+                    f"K mismatch tcId={tc['tcId']}"
+                )
             else:
-                assert (
-                    False
-                ), f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                assert False, (
+                    f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                )
             info("ok")
             count += 1
     info(f"  {count} encaps tests passed")
@@ -168,15 +168,15 @@ def run_semi_expanded_decaps_test(data_file):
             out = run_binary([binary, "decaps", f"dk={tc['dk']}", f"c={tc['c']}"])
             if tc["result"] == "invalid":
                 # _error: non-zero exit code; decode_error: explicit validation failure
-                assert (
-                    "_error" in out or "decode_error" in out
-                ), f"binary success on invalid tcId={tc['tcId']}"
+                assert "_error" in out or "decode_error" in out, (
+                    f"binary success on invalid tcId={tc['tcId']}"
+                )
             elif tc["result"] == "valid":
                 assert "K" in out, f"missing K in output tcId={tc['tcId']}"
             else:
-                assert (
-                    False
-                ), f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                assert False, (
+                    f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                )
             info("ok")
             count += 1
     info(f"  {count} semi_expanded_decaps tests passed")
@@ -197,33 +197,33 @@ def run_combined_test(data_file):
             # Generate keypair from seed
             keygen_out = run_binary([binary, "keygen_seed", f"seed={tc['seed']}"])
             if "decode_error" in keygen_out:
-                assert (
-                    tc["result"] == "invalid"
-                ), f"keygen decode error on valid tcId={tc['tcId']}"
+                assert tc["result"] == "invalid", (
+                    f"keygen decode error on valid tcId={tc['tcId']}"
+                )
                 info("ok")
                 count += 1
                 continue
             # Keygen succeeded — check ek
             assert "ek" in tc, f"missing ek in test vector tcId={tc['tcId']}"
-            assert (
-                keygen_out["ek"].upper() == tc["ek"].upper()
-            ), f"ek mismatch tcId={tc['tcId']}"
+            assert keygen_out["ek"].upper() == tc["ek"].upper(), (
+                f"ek mismatch tcId={tc['tcId']}"
+            )
             # Decapsulate
             dk = keygen_out["dk"]
             decaps_out = run_binary([binary, "decaps", f"dk={dk}", f"c={tc['c']}"])
             if tc["result"] == "invalid":
                 # _error: non-zero exit code; decode_error: explicit validation failure
-                assert (
-                    "_error" in decaps_out or "decode_error" in decaps_out
-                ), f"binary success on invalid tcId={tc['tcId']}"
+                assert "_error" in decaps_out or "decode_error" in decaps_out, (
+                    f"binary success on invalid tcId={tc['tcId']}"
+                )
             elif tc["result"] == "valid":
-                assert (
-                    decaps_out["K"].upper() == tc["K"].upper()
-                ), f"K mismatch tcId={tc['tcId']}"
+                assert decaps_out["K"].upper() == tc["K"].upper(), (
+                    f"K mismatch tcId={tc['tcId']}"
+                )
             else:
-                assert (
-                    False
-                ), f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                assert False, (
+                    f"Unsupported test result '{tc['result']}' for tcId={tc['tcId']}"
+                )
             info("ok")
             count += 1
     info(f"  {count} combined tests passed")


### PR DESCRIPTION
This PR replaced `black` with `ruff` which is much faster and also offers linting.

A few real issues ruff flagged:         
  - run_cbmc() in scripts/tests references `log` before it is defined, and the message is a plain string where `{self.args.start_with}`                      
  - Two bare `except:` clauses in scripts/cfify which would swallow a CTRL+C
  - A handful of unused variables, unused argparse subparsers, and stray `f""` prefixes.

Being able to catch those issues in the future appears worthwhile to me.

I also fixed the other stylistic warnings (that I do not feel strongly about).
For now I have ignored `E501` complaining about too long lines - that would require a lot of changes.