### PR TITLE
CI: Bump ACVP, liboqs, expo, and AWS-LC versions

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -75,7 +75,7 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/integration-awslc.yml
     with:
-      commit: a75e930cecced7221631220475f2589335d4d67f # main (2026-04-03)
+      commit: v1.72.0
     secrets: inherit
   ct-test:
     name: Constant-time

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -76,7 +76,7 @@ jobs:
          # via https://riseproject-dev.github.io/riscv-runner/
          # - runner: ubuntu-24.04-riscv
          #   name: 'riscv'
-        acvp-version: [v1.1.0.39, v1.1.0.40, v1.1.0.41]
+        acvp-version: [v1.1.0.40, v1.1.0.41, v1.1.0.42]
         exclude:
           - {external: true,
              target: {

--- a/.github/workflows/integration-liboqs.yml
+++ b/.github/workflows/integration-liboqs.yml
@@ -40,7 +40,7 @@ jobs:
           packages: 'cmake python3-jinja2 python3-tabulate python3-git python3-pytest valgrind'
       - uses: ./.github/actions/setup-oqs
         with:
-          commit: '97f6b86b1b6d109cfd43cf276ae39c2e776aed80' # v0.15.0
+          commit: 'd8509387febc9e32466c86aab544d225d60c8e3c' # main (2026-04-21)
           gh_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply patch
         run: |

--- a/.github/workflows/integration-opentitan.yml
+++ b/.github/workflows/integration-opentitan.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: ./.github/actions/setup-opentitan
         with:
           expo-repository: https://github.com/zerorisc/expo
-          expo-commit: 375803409deee1f5f7965f0757e316670b13f544
+          expo-commit: 53619a73e64cb96ee6e61a4b4b992f7250ab7477
 
       - name: Patch mlkem-native dependency
         run: |

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -139,15 +139,12 @@ def run_encapDecap_test(tg, tc):
             results[k] = v
     elif tg["function"] == "decapsulation":
         acvp_bin = get_acvp_binary(tg)
-        # TODO: Remove this fallback workaround. v.1.1.0.40 moved the dk from the
-        # tg to the tc. This can be removed when v1.1.0.39 is removed.
-        dk_value = tc.get("dk", tg.get("dk"))
         acvp_call = exec_prefix + [
             acvp_bin,
             "encapDecap",
             "VAL",
             "decapsulation",
-            f"dk={dk_value}",
+            f"dk={tc['dk']}",
             f"c={tc['c']}",
         ]
         result = subprocess.run(acvp_call, encoding="utf-8", capture_output=True)


### PR DESCRIPTION
- ACVP: slide window to [v1.1.0.40, v1.1.0.41, v1.1.0.42]
- liboqs: bump to main (2026-04-21, d8509387)
- expo: bump to master (2026-04-21, 53619a73)
- AWS-LC: bump to v1.72.0

Drop the v1.1.0.39 `dk`-in-tg fallback in test/acvp/acvp_client.py now that v1.1.0.39 is no longer in the test matrix.