### PR TITLE
Add ACVP test Windows support (C backend)

### DIFF
--- a/Makefile.Microsoft_nmake
+++ b/Makefile.Microsoft_nmake
@@ -65,6 +65,21 @@ OPT = 0
     @if NOT EXIST $(MLKEM1024_BUILD_DIR)\test mkdir $(MLKEM1024_BUILD_DIR)\test
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=1024 /c /Fo$(MLKEM1024_BUILD_DIR)\test\ $<
 
+# compilation of acvp test for mlkem512
+{test\acvp}.c{$(MLKEM512_BUILD_DIR)\test\acvp}.obj::
+    @if NOT EXIST $(MLKEM512_BUILD_DIR)\test\acvp mkdir $(MLKEM512_BUILD_DIR)\test\acvp
+    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=512 /c /Fo$(MLKEM512_BUILD_DIR)\test\acvp\ $<
+
+# compilation of acvp test for mlkem768
+{test\acvp}.c{$(MLKEM768_BUILD_DIR)\test\acvp}.obj::
+    @if NOT EXIST $(MLKEM768_BUILD_DIR)\test\acvp mkdir $(MLKEM768_BUILD_DIR)\test\acvp
+    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=768 /c /Fo$(MLKEM768_BUILD_DIR)\test\acvp\ $<
+
+# compilation of acvp test for mlkem1024
+{test\acvp}.c{$(MLKEM1024_BUILD_DIR)\test\acvp}.obj::
+    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\test\acvp mkdir $(MLKEM1024_BUILD_DIR)\test\acvp
+    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=1024 /c /Fo$(MLKEM1024_BUILD_DIR)\test\acvp\ $<
+
 # compile functional test for mlkem512
 test_mlkem512: $(OBJ_FILES_512) $(MLKEM512_BUILD_DIR)\test\test_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
     @if NOT EXIST $(MLKEM512_BUILD_DIR)\bin mkdir $(MLKEM512_BUILD_DIR)\bin
@@ -80,7 +95,27 @@ test_mlkem1024: $(OBJ_FILES_1024) $(MLKEM1024_BUILD_DIR)\test\test_mlkem.obj $(B
     @if NOT EXIST $(MLKEM1024_BUILD_DIR)\bin mkdir $(MLKEM1024_BUILD_DIR)\bin
     $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=1024 /Fe$(MLKEM1024_BUILD_DIR)\bin\test_mlkem1024 $** /link
 
-quickcheck: test_mlkem512 test_mlkem768 test_mlkem1024
+# compile acvp test for mlkem512
+acvp_mlkem512: $(OBJ_FILES_512) $(MLKEM512_BUILD_DIR)\test\acvp\acvp_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLKEM512_BUILD_DIR)\bin mkdir $(MLKEM512_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=512 /Fe$(MLKEM512_BUILD_DIR)\bin\acvp_mlkem512 $** /link
+
+# compile acvp test for mlkem768
+acvp_mlkem768: $(OBJ_FILES_768) $(MLKEM768_BUILD_DIR)\test\acvp\acvp_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLKEM768_BUILD_DIR)\bin mkdir $(MLKEM768_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=768 /Fe$(MLKEM768_BUILD_DIR)\bin\acvp_mlkem768 $** /link
+
+# compile acvp test for mlkem1024
+acvp_mlkem1024: $(OBJ_FILES_1024) $(MLKEM1024_BUILD_DIR)\test\acvp\acvp_mlkem.obj $(BUILD_DIR)\randombytes\notrandombytes.obj
+    @if NOT EXIST $(MLKEM1024_BUILD_DIR)\bin mkdir $(MLKEM1024_BUILD_DIR)\bin
+    $(CC) $(CFLAGS) /D MLK_CONFIG_PARAMETER_SET=1024 /Fe$(MLKEM1024_BUILD_DIR)\bin\acvp_mlkem1024 $** /link
+
+acvp: acvp_mlkem512 acvp_mlkem768 acvp_mlkem1024
+
+run_acvp: acvp
+    python test/acvp/acvp_client.py
+
+quickcheck: test_mlkem512 test_mlkem768 test_mlkem1024 run_acvp
     $(MLKEM512_BUILD_DIR)\bin\test_mlkem512.exe
 	$(MLKEM768_BUILD_DIR)\bin\test_mlkem768.exe
 	$(MLKEM1024_BUILD_DIR)\bin\test_mlkem1024.exe


### PR DESCRIPTION
This PR adds ACVP test support for Windows using the C backend by adding the compilation and link rules in `Makefile.Microsoft_nmake`,  also integrate to CI testing flow.

- `mlkem-native` currently has no ACVP test coverage on Windows. This PR establishes the foundation for Windows support by enabling ACVP tests against the portable C backend, which is a start before solving the more complex work of enabling x86_64 and AArch64 assembly backends on Windows.
