### PR TITLE
HOL-Light: Prefix imports to separate mlkem-native from s2n-bignum

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -71,7 +71,7 @@ jobs:
           nix-shell: 'hol_light'
           script: |
             make -C proofs/hol_light/aarch64 mlkem/poly_tobytes_aarch64_asm.o
-            echo 'needs "aarch64/proofs/poly_tobytes_aarch64_asm.ml";;' | hol.sh
+            echo 'needs "mlkem_native/aarch64/proofs/poly_tobytes_aarch64_asm.ml";;' | hol.sh
   hol_light_proofs:
     needs: [ hol_light_bytecode ]
     strategy:
@@ -179,7 +179,7 @@ jobs:
           nix-shell: 'hol_light'
           script: |
             make -C proofs/hol_light/x86_64 mlkem/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.o
-            echo 'needs "x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.ml";;' | hol.sh
+            echo 'needs "mlkem_native/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.ml";;' | hol.sh
   hol_light_proofs_x86_64:
     needs: [ hol_light_bytecode_x86_64 ]
     strategy:

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,12 @@
           holLightShellHook = ''
             export PATH=$PWD/scripts:$PATH
             export PROOF_DIR="$PWD/proofs/hol_light"
+            # Namespaced imports root for HOL-Light proofs.
+            # See scripts/check-hol-light-imports for the enforced rule.
+            export IMPORTS_DIR="$PROOF_DIR/.imports"
+            mkdir -p "$IMPORTS_DIR"
+            ln -sfn "$S2N_BIGNUM_DIR" "$IMPORTS_DIR/s2n_bignum"
+            ln -sfn "$PROOF_DIR"      "$IMPORTS_DIR/mlkem_native"
           '';
         in
         {
@@ -87,7 +93,7 @@
           packages.toolchain_aarch64_be = util.toolchain_aarch64_be;
           packages.gcc-arm-embedded = pkgs.gcc-arm-embedded;
 
-          devShells.default = util.mkShell {
+          devShells.default = (util.mkShell {
             packages = builtins.attrValues
               {
                 inherit (config.packages) linters cbmc hol_light s2n_bignum slothy toolchains_native hol_server;
@@ -96,7 +102,7 @@
                   nix-direnv
                   zig_0_13;
               } ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ config.packages.valgrind_varlat ];
-          };
+          }).overrideAttrs (old: { shellHook = holLightShellHook; });
 
           packages.hol_server = util.hol_server.hol_server_start;
           devShells.hol_light = (util.mkShell {

--- a/nix/hol_light/0005-Configure-hol-sh-for-mlkem-native.patch
+++ b/nix/hol_light/0005-Configure-hol-sh-for-mlkem-native.patch
@@ -2,20 +2,19 @@
 diff --git a/hol_4.14.sh b/hol_4.14.sh
 --- a/hol_4.14.sh
 +++ b/hol_4.14.sh
-@@ -57,4 +57,13 @@ if [ "${HOL_ML_PATH}" == "" ]; then
+@@ -57,4 +57,12 @@ if [ "${HOL_ML_PATH}" == "" ]; then
    HOL_ML_PATH="${HOLLIGHT_DIR}/hol.ml"
  fi
 
 -${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR}
 +# Add site-lib directory for topfind
 +SITELIB=$(dirname $(ocamlfind query findlib 2>/dev/null) 2>/dev/null)
-+
-+# Set HOLLIGHT_LOAD_PATH to include S2N_BIGNUM_DIR and mlkem-native proofs
-+export HOLLIGHT_LOAD_PATH="${S2N_BIGNUM_DIR}:${PROOF_DIR}:${HOLLIGHT_LOAD_PATH}"
-+
-+# Change to mlkem-native proofs directory if set, so define_from_elf can find object files
++# Resolve namespace-prefixed imports via $IMPORTS_DIR (populated by the
++# nix shellHook). The $S2N_BIGNUM_DIR fallback is retained only so
++# s2n-bignum's own internal `needs "common/..."` directives still resolve
++# during transitive loads; mlkem-native code never produces a bare path.
++export HOLLIGHT_LOAD_PATH="${IMPORTS_DIR}:${S2N_BIGNUM_DIR}:${HOLLIGHT_LOAD_PATH}"
 +[ -n "${PROOF_DIR}" ] && cd "${PROOF_DIR}"
-+
 +${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOL_ML_PATH} -I ${HOLLIGHT_DIR} ${SITELIB:+-I "$SITELIB"}
 diff --git a/hol_4.sh b/hol_4.sh
 --- a/hol_4.sh

--- a/proofs/cbmc/run-cbmc-proofs.py
+++ b/proofs/cbmc/run-cbmc-proofs.py
@@ -58,8 +58,8 @@ additional jobs that you want to execute with `litani add-job`; and
 finally run `litani run-build`.
 
 The litani dashboard will be written under the `output` directory; the
-cbmc-viewer reports remain in the `$PROOF_DIR/report` directory. The
-HTML dashboard from the latest Litani run will always be symlinked to
+cbmc-viewer reports remain in the `report` directory. The HTML dashboard
+from the latest Litani run will always be symlinked to
 `output/latest/html/index.html`, so you can keep that page open in
 your browser and reload the page whenever you re-run this script.
 """

--- a/proofs/hol_light/.gitignore
+++ b/proofs/hol_light/.gitignore
@@ -2,3 +2,4 @@
 **/*.o
 **/*.native
 **/*.correct
+.imports/

--- a/proofs/hol_light/aarch64/proofs/build-proof.sh
+++ b/proofs/hol_light/aarch64/proofs/build-proof.sh
@@ -56,7 +56,10 @@ echo "Generating a template .ml that loads the file...: ${template_ml}"
 inlined_prefix="$(mktemp)"
 inlined_ml="${inlined_prefix}.ml"
 inlined_cmx="${inlined_prefix}.cmx"
-(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH=${ROOT} ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
+# The $S2N_BIGNUM_DIR fallback on HOLLIGHT_LOAD_PATH is kept solely so
+# s2n-bignum's own internal `needs "common/..."` directives still resolve
+# during transitive loads. mlkem-native code never produces a bare path.
+(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH="${IMPORTS_DIR}:${S2N_BIGNUM_DIR}" ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
 
 # Give a large stack size.
 OCAMLRUNPARAM=l=2000000000 \

--- a/proofs/hol_light/aarch64/proofs/dump_bytecode.ml
+++ b/proofs/hol_light/aarch64/proofs/dump_bytecode.ml
@@ -4,7 +4,7 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
 print_string "=== bytecode start: aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.o ===\n";;
 print_literal_from_elf "aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.o";;

--- a/proofs/hol_light/aarch64/proofs/intt_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/intt_aarch64_asm.ml
@@ -8,11 +8,11 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
-needs "aarch64/proofs/mlkem_zetas.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_zetas.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/intt_aarch64_asm.o";;
  ****)
@@ -751,8 +751,8 @@ let MLKEM_INTT_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_scalar_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_scalar_aarch64_asm.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mlkem_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/keccak_f1600_x1_scalar_aarch64_asm.o";;
  ****)
@@ -519,8 +519,8 @@ let KECCAK_F1600_X1_SCALAR_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_v84a_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x1_v84a_aarch64_asm.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mlkem_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.o";;
  ****)
@@ -304,8 +304,8 @@ let KECCAK_F1600_X1_V84A_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x2_v84a_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x2_v84a_aarch64_asm.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mlkem_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/keccak_f1600_x2_v84a_aarch64_asm.o";;
  ****)
@@ -385,8 +385,8 @@ let KECCAK_F1600_X2_V84A_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mlkem_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.o";;
  ****)
@@ -1492,8 +1492,8 @@ let KECCAK_F1600_X4_V8A_SCALAR_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.ml
@@ -9,9 +9,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "aarch64/proofs/keccak_utils.ml";;
+needs "mlkem_native/aarch64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.o";;
  ****)
@@ -1397,8 +1397,8 @@ let KECCAK_F1600_X4_V8A_V84A_SCALAR_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/keccak_utils.ml
+++ b/proofs/hol_light/aarch64/proofs/keccak_utils.ml
@@ -7,7 +7,7 @@
 (* Keccak utilities for AArch64 proofs.                                      *)
 (* ========================================================================= *)
 
-needs "common/keccak_spec.ml";;
+needs "mlkem_native/common/keccak_spec.ml";;
 
 (* ------------------------------------------------------------------------- *)
 (* Some custom normalization for logical equivalence and conjunction, which  *)

--- a/proofs/hol_light/aarch64/proofs/mlkem_utils.ml
+++ b/proofs/hol_light/aarch64/proofs/mlkem_utils.ml
@@ -89,4 +89,4 @@ let MAP_UNTIL_TARGET_PC f n = fun (asl, w) ->
   in
     core n (asl, w);;
 
-needs "arm/proofs/consttime.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;

--- a/proofs/hol_light/aarch64/proofs/ntt_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/ntt_aarch64_asm.ml
@@ -8,11 +8,11 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
-needs "aarch64/proofs/mlkem_zetas.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_zetas.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/ntt_aarch64_asm.o";;
  ****)
@@ -686,8 +686,8 @@ let MLKEM_NTT_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/poly_mulcache_compute_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_mulcache_compute_aarch64_asm.ml
@@ -4,11 +4,11 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
-needs "aarch64/proofs/mlkem_zetas.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_zetas.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/poly_mulcache_compute.o";;
 ****)
@@ -286,7 +286,7 @@ let MLKEM_MULCACHE_COMPUTE_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/poly_reduce_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_reduce_aarch64_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/poly_reduce_aarch64_asm.o";;
  ****)
@@ -276,8 +276,8 @@ let MLKEM_POLY_REDUCE_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/poly_tobytes_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_tobytes_aarch64_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/poly_tobytes_aarch64_asm.o";;
  ****)
@@ -275,7 +275,7 @@ let MLKEM_POLY_TOBYTES_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/poly_tomont_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/poly_tomont_aarch64_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/poly_tomont_aarch64_asm.o";;
  ****)
@@ -260,8 +260,8 @@ let MLKEM_TOMONT_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.o";;
  ****)
@@ -460,8 +460,8 @@ let MLKEM_BASEMUL_K2_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.o";;
  ****)
@@ -529,8 +529,8 @@ let basemul3_odd = define
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.o";;
  ****)
@@ -601,8 +601,8 @@ let basemul4_odd = define
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "arm/proofs/consttime.ml";;
-needs "aarch64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
+needs "mlkem_native/aarch64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:false

--- a/proofs/hol_light/aarch64/proofs/rej_uniform_aarch64_asm.ml
+++ b/proofs/hol_light/aarch64/proofs/rej_uniform_aarch64_asm.ml
@@ -8,11 +8,11 @@
 (* ========================================================================= *)
 
 (* Load base theories for AArch64 from s2n-bignum *)
-needs "arm/proofs/base.ml";;
+needs "s2n_bignum/arm/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "aarch64/proofs/mlkem_utils.ml";;
-needs "aarch64/proofs/mlkem_rej_uniform_table.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/aarch64/proofs/mlkem_rej_uniform_table.ml";;
 
 (**** print_literal_from_elf "aarch64/mlkem/rej_uniform_aarch64_asm.o";;
  ****)
@@ -1681,7 +1681,7 @@ let MLKEM_REJ_UNIFORM_SUBROUTINE_CORRECT = prove
 (* data (which buffer elements pass the < 3329 filter).                      *)
 (* ========================================================================= *)
 
-needs "arm/proofs/consttime.ml";;
+needs "s2n_bignum/arm/proofs/consttime.ml";;
 
 (* Helper: discharge the memsafe postcondition
      exists e2. read events s = APPEND e2 e /\ memaccess_inbounds e2 R W

--- a/proofs/hol_light/common/keccak_spec.ml
+++ b/proofs/hol_light/common/keccak_spec.ml
@@ -8,7 +8,7 @@
 (* ========================================================================= *)
 
 needs "Library/words.ml";;
-needs "common/keccak_constants.ml";;
+needs "mlkem_native/common/keccak_constants.ml";;
 
 (*** Some abbreviations on top of the word library ***)
 

--- a/proofs/hol_light/s2n_bignum_allowlist.txt
+++ b/proofs/hol_light/s2n_bignum_allowlist.txt
@@ -1,0 +1,19 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Allowlist of s2n-bignum files that mlkem-native HOL-Light proofs may import.
+#
+# Each entry is the path *inside* s2n-bignum; in proof files it appears as
+# `needs "s2n_bignum/<entry>"`. Adding a new cross-repository dependency
+# requires adding the file here (surfacing the decision in code review).
+#
+# Keep the list limited to generic verification infrastructure: ELF loading,
+# relational reasoning, ARM/x86 base semantics, and the constant-time
+# framework. Do NOT add mlkem-specific proofs or specs from s2n-bignum --
+# those must live in proofs/hol_light/common/ so that mlkem-native remains
+# standalone-reproducible.
+
+arm/proofs/base.ml
+arm/proofs/consttime.ml
+x86/proofs/base.ml
+x86/proofs/consttime.ml

--- a/proofs/hol_light/x86_64/proofs/build-proof.sh
+++ b/proofs/hol_light/x86_64/proofs/build-proof.sh
@@ -56,7 +56,10 @@ echo "Generating a template .ml that loads the file...: ${template_ml}"
 inlined_prefix="$(mktemp)"
 inlined_ml="${inlined_prefix}.ml"
 inlined_cmx="${inlined_prefix}.cmx"
-(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH=${ROOT} ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
+# The $S2N_BIGNUM_DIR fallback on HOLLIGHT_LOAD_PATH is kept solely so
+# s2n-bignum's own internal `needs "common/..."` directives still resolve
+# during transitive loads. mlkem-native code never produces a bare path.
+(cd "${S2N_BIGNUM_DIR}" && HOLLIGHT_LOAD_PATH="${IMPORTS_DIR}:${S2N_BIGNUM_DIR}" ocaml ${HOLLIGHT_DIR}/inline_load.ml "${template_ml}" "${inlined_ml}")
 
 # Give a large stack size.
 OCAMLRUNPARAM=l=2000000000 \

--- a/proofs/hol_light/x86_64/proofs/dump_bytecode.ml
+++ b/proofs/hol_light/x86_64/proofs/dump_bytecode.ml
@@ -4,7 +4,7 @@
  *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
 print_string "=== bytecode start: x86_64/mlkem/ntt_avx2_asm.o ===\n";;
 print_literal_from_elf "x86_64/mlkem/ntt_avx2_asm.o";;

--- a/proofs/hol_light/x86_64/proofs/intt_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/intt_avx2_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "x86_64/proofs/mlkem_zetas.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_zetas.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/intt_avx2_asm.o";; *)
 
@@ -1276,8 +1276,8 @@ let MLKEM_INTT_SUBROUTINE_CORRECT  = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true
     (assoc "mlkem_intt" subroutine_signatures)

--- a/proofs/hol_light/x86_64/proofs/keccak_f1600_x4_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/keccak_f1600_x4_avx2_asm.ml
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)
 
- needs "x86/proofs/base.ml";;
+ needs "s2n_bignum/x86/proofs/base.ml";;
 
- needs "x86_64/proofs/keccak_utils.ml";;
+ needs "mlkem_native/x86_64/proofs/keccak_utils.ml";;
 
 (**** print_literal_from_elf "x86/sha3/keccak_f1600_x4_avx2_asm.o";;
 ****)
@@ -1117,8 +1117,8 @@ let KECCAK_F1600_X4_AVX2_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 
 let full_spec,public_vars = mk_safety_spec

--- a/proofs/hol_light/x86_64/proofs/keccak_utils.ml
+++ b/proofs/hol_light/x86_64/proofs/keccak_utils.ml
@@ -7,8 +7,8 @@
 (* Keccak utilities for x86_64 proofs.                                       *)
 (* ========================================================================= *)
 
-needs "common/keccak_spec.ml";;
-needs "x86_64/proofs/keccak_f1600_x4_avx2_constants.ml";;
+needs "mlkem_native/common/keccak_spec.ml";;
+needs "mlkem_native/x86_64/proofs/keccak_f1600_x4_avx2_constants.ml";;
 
 (* ------------------------------------------------------------------------- *)
 (* Some custom normalization for logical equivalence and conjunction, which  *)

--- a/proofs/hol_light/x86_64/proofs/mlkem_compress_common.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_compress_common.ml
@@ -7,7 +7,7 @@
 (* Shared definitions and lemmas for compression/decompression proofs.       *)
 (* ========================================================================= *)
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 (* ------------------------------------------------------------------------- *)
 (* Bound lemmas for decompression (definitions in common/mlkem_specs.ml)     *)

--- a/proofs/hol_light/x86_64/proofs/mlkem_utils.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_utils.ml
@@ -7,4 +7,4 @@
 (* Utility definitions for ML-KEM x86_64 proofs.                            *)
 (* ========================================================================= *)
 
-needs "x86/proofs/consttime.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;

--- a/proofs/hol_light/x86_64/proofs/ntt_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/ntt_avx2_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "x86_64/proofs/mlkem_zetas.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_zetas.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/ntt_avx2_asm.o";; *)
 
@@ -1286,8 +1286,8 @@ let MLKEM_NTT_SUBROUTINE_CORRECT  = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/nttfrombytes_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/nttfrombytes_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/nttfrombytes_avx2_asm.o";; *)
 
@@ -496,8 +496,8 @@ let MLKEM_FROMBYTES_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/ntttobytes_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/ntttobytes_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/ntttobytes_avx2_asm.o";; *)
 
@@ -455,8 +455,8 @@ let MLKEM_TOBYTES_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/nttunpack_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/nttunpack_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/nttunpack_avx2_asm.o";; *)
 
@@ -431,8 +431,8 @@ let MLKEM_UNPACK_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_compress_d10_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_compress_d10_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_compress_d10_avx2_asm.o";; *)
 
@@ -952,8 +952,8 @@ let MLKEM_POLY_COMPRESS_D10_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_compress_d11_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_compress_d11_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_compress_d11_avx2_asm.o";; *)
 
@@ -1018,8 +1018,8 @@ let MLKEM_POLY_COMPRESS_D11_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_compress_d4_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_compress_d4_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_compress_d4_avx2_asm.o";; *)
 
@@ -485,8 +485,8 @@ let MLKEM_POLY_COMPRESS_D4_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_compress_d5_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_compress_d5_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_compress_d5_avx2_asm.o";; *)
 
@@ -758,8 +758,8 @@ let MLKEM_POLY_COMPRESS_D5_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_decompress_d10_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_decompress_d10_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_decompress_d10_avx2_asm.o";; *)
 
@@ -548,8 +548,8 @@ let MLKEM_POLY_DECOMPRESS_D10_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_decompress_d11_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_decompress_d11_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_decompress_d11_avx2_asm.o";; *)
 
@@ -633,8 +633,8 @@ let MLKEM_POLY_DECOMPRESS_D11_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_decompress_d4_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_decompress_d4_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_decompress_d4_avx2_asm.o";; *)
 
@@ -452,8 +452,8 @@ let MLKEM_POLY_DECOMPRESS_D4_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_decompress_d5_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_decompress_d5_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "x86_64/proofs/mlkem_compress_common.ml";;
-needs "x86_64/proofs/mlkem_compress_consts.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_common.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_compress_consts.ml";;
 
 (** print_literal_from_elf "x86_64/mlkem/poly_decompress_d5_avx2_asm.o";; *)
 
@@ -455,8 +455,8 @@ let MLKEM_POLY_DECOMPRESS_D5_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/poly_mulcache_compute_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/poly_mulcache_compute_avx2_asm.ml
@@ -4,10 +4,10 @@
  *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "x86_64/proofs/mlkem_zetas.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_zetas.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/poly_mulcache_compute_avx2_asm.o";; *)
 
@@ -329,8 +329,8 @@ let MLKEM_MULCACHE_COMPUTE_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 let mlkem_basemul_k2_mc =
   define_assert_from_elf "mlkem_basemul_k2_mc" "x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.o"
@@ -1195,8 +1195,8 @@ let MLKEM_BASEMUL_K2_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k3_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k3_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 let mlkem_basemul_k3_mc =
   define_assert_from_elf "mlkem_basemul_k3_mc" "x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_avx2_asm.o"
@@ -1690,8 +1690,8 @@ let MLKEM_BASEMUL_K3_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k4_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/polyvec_basemul_acc_montgomery_cached_k4_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 let mlkem_basemul_k4_mc =
   define_assert_from_elf "mlkem_basemul_k4_mc" "x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_avx2_asm.o"
@@ -2192,8 +2192,8 @@ let MLKEM_BASEMUL_K4_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/reduce_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/reduce_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/reduce_avx2_asm.o";; *)
 
@@ -472,8 +472,8 @@ let MLKEM_REDUCE_SUBROUTINE_CORRECT = prove
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/proofs/hol_light/x86_64/proofs/rej_uniform_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/rej_uniform_avx2_asm.ml
@@ -8,10 +8,10 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
-needs "x86_64/proofs/mlkem_rej_uniform_table.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_rej_uniform_table.ml";;
 
 (**** print_literal_from_elf "x86_64/mlkem/rej_uniform_avx2_asm.o";;
  ****)
@@ -868,7 +868,7 @@ let MLKEM_REJ_UNIFORM_SUBROUTINE_CORRECT = prove
 (* data (which buffer elements pass the < 3329 filter).                      *)
 (* ========================================================================= *)
 
-needs "x86_64/proofs/mlkem_utils.ml";;
+needs "mlkem_native/x86_64/proofs/mlkem_utils.ml";;
 
 (* Helper: discharge the memsafe postcondition
      exists e2. read events s = APPEND e2 e /\ memaccess_inbounds e2 R W

--- a/proofs/hol_light/x86_64/proofs/tomont_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/tomont_avx2_asm.ml
@@ -8,9 +8,9 @@
 (* ========================================================================= *)
 
 (* Load base theories for x86_64 from s2n-bignum *)
-needs "x86/proofs/base.ml";;
+needs "s2n_bignum/x86/proofs/base.ml";;
 
-needs "common/mlkem_specs.ml";;
+needs "mlkem_native/common/mlkem_specs.ml";;
 
 (* print_literal_from_elf "x86_64/mlkem/tomont_avx2_asm.o";; *)
 
@@ -362,8 +362,8 @@ let MLKEM_TOMONT_SUBROUTINE_CORRECT = prove(
 (* Constant-time and memory safety proof.                                    *)
 (* ------------------------------------------------------------------------- *)
 
-needs "x86/proofs/consttime.ml";;
-needs "x86_64/proofs/subroutine_signatures.ml";;
+needs "s2n_bignum/x86/proofs/consttime.ml";;
+needs "mlkem_native/x86_64/proofs/subroutine_signatures.ml";;
 
 let full_spec,public_vars = mk_safety_spec
     ~keep_maychanges:true

--- a/scripts/check-hol-light-imports
+++ b/scripts/check-hol-light-imports
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+
+"""Lint HOL-Light import directives.
+
+Every `needs`, `loadt`, or `loads` directive in proofs/hol_light/**/*.ml
+must have a namespace-prefixed target:
+
+  - `mlkem_native/...`   for local files
+  - `s2n_bignum/...`     for s2n-bignum files (must also be on the allowlist)
+  - `Library/...`        for HOL-Light standard library
+
+This guarantees that every cross-repository import is declared explicitly
+at the call site and that no s2n-bignum file can silently shadow a local
+file through load-path ordering (the namespace prefixes are disjoint).
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PROOF_ROOT = ROOT / "proofs" / "hol_light"
+ALLOWLIST = PROOF_ROOT / "s2n_bignum_allowlist.txt"
+
+DIRECTIVE = re.compile(r'^\s*(needs|loadt|loads)\s+"([^"]+)"')
+
+
+def load_allowlist():
+    if not ALLOWLIST.exists():
+        return set()
+    entries = set()
+    for raw in ALLOWLIST.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def main():
+    allowlist = load_allowlist()
+    violations = []
+
+    for path in sorted(PROOF_ROOT.rglob("*.ml")):
+        rel = path.relative_to(ROOT)
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            m = DIRECTIVE.match(line)
+            if not m:
+                continue
+            target = m.group(2)
+            if target.startswith("mlkem_native/") or target.startswith("Library/"):
+                continue
+            if target.startswith("s2n_bignum/"):
+                rest = target[len("s2n_bignum/") :]
+                if rest not in allowlist:
+                    violations.append(
+                        (
+                            rel,
+                            lineno,
+                            f"s2n-bignum import '{target}' is not on the allowlist "
+                            f"({ALLOWLIST.relative_to(ROOT)})",
+                        )
+                    )
+                continue
+            violations.append(
+                (
+                    rel,
+                    lineno,
+                    f"unqualified import '{target}' -- expected prefix "
+                    "'mlkem_native/', 's2n_bignum/', or 'Library/'",
+                )
+            )
+
+    for rel, lineno, msg in violations:
+        print(f"{rel}:{lineno}: {msg}", file=sys.stderr)
+
+    if violations:
+        print(f"\n{len(violations)} violation(s)", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lint
+++ b/scripts/lint
@@ -309,6 +309,22 @@ gh_group_start "Check contracts"
 check-contracts
 gh_group_end
 
+check-hol-light-imports()
+{
+  if python3 "$ROOT"/scripts/check-hol-light-imports; then
+    info "Check HOL-Light imports"
+    gh_summary_success "Check HOL-Light imports"
+  else
+    error "Check HOL-Light imports"
+    gh_summary_failure "Check HOL-Light imports"
+    SUCCESS=false
+  fi
+}
+
+gh_group_start "Check HOL-Light imports"
+check-hol-light-imports
+gh_group_end
+
 check-doxygen()
 {
   if ! command -v doxygen >/dev/null; then


### PR DESCRIPTION
Ports: https://github.com/pq-code-package/mldsa-native/pull/1088/

Issue: every `needs` directive in mlkem-native proof files resolved ambiguously against both $PROOF_DIR and $S2N_BIGNUM_DIR, so a file with the same relative path in either tree could silently shadow the other.

Proposed resolution: Every import now declares its source at the call site with a namespace prefix.

  needs "mlkem_native/common/mlkem_specs.ml";;   (* local *)
  needs "s2n_bignum/arm/proofs/base.ml";;        (* external *)
  needs "Library/words.ml";;                     (* HOL-Light stdlib *)

The nix shellHook creates a temporary .imports directory with symlinks `mlkem_native` and `s2n_bignum` pointing to the local resp. s2n-bignum directories, and HOLLIGHT_LOAD_PATH points at that import directory. The `mlkem_native/` and `s2n_bignum/` namespaces are disjoint by prefix, so path collisions become structurally impossible.

A new scripts/check-hol-light-imports enforces the rule across proofs/hol_light/**/*.ml and is wired into scripts/lint and both build-proof.sh scripts. s2n-bignum imports must additionally appear on proofs/hol_light/s2n_bignum_allowlist.txt, so new cross-repo dependencies surface in review.

A side-benefit of exposing proofs/hol_light/.imports is that it is easier to navigate to the nix-imported s2n-bignum sources for inspection.