### PR TITLE
Lint: Document context parameter in public API for Doxygen

### DIFF
--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -196,12 +196,15 @@ extern "C"
  *
  * @spec{Implements @[FIPS203, Algorithm 16, ML-KEM.KeyGen_Internal].}
  *
- * @param[out] pk    Output public key, an array of
- *                   MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- * @param[out] sk    Output private key, an array of
- *                   MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
- * @param[in]  coins Input randomness, an array of 2*MLKEM_SYMBYTES uniformly
- *                   random bytes.
+ * @param[out] pk      Output public key, an array of
+ *                     MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param[out] sk      Output private key, an array of
+ *                     MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param[in]  coins   Input randomness, an array of 2*MLKEM_SYMBYTES uniformly
+ *                     random bytes.
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          MLK_CONFIG_KEYGEN_PCT enabled and PCT failed.
@@ -227,10 +230,13 @@ int MLK_API_NAMESPACE(keypair_derand)(
  *
  * @spec{Implements @[FIPS203, Algorithm 19, ML-KEM.KeyGen].}
  *
- * @param[out] pk Output public key, an array of
- *                MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- * @param[out] sk Output private key, an array of
- *                MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param[out] pk      Output public key, an array of
+ *                     MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param[out] sk      Output private key, an array of
+ *                     MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          MLK_CONFIG_KEYGEN_PCT enabled and PCT failed.
@@ -255,12 +261,15 @@ int MLK_API_NAMESPACE(keypair)(
  *
  * @spec{Implements @[FIPS203, Algorithm 17, ML-KEM.Encaps_Internal].}
  *
- * @param[out] ct    Output ciphertext, an array of
- *                   MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
- * @param[out] ss    Output shared secret, an array of MLKEM_BYTES bytes.
- * @param[in]  pk    Input public key, an array of
- *                   MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
- * @param[in]  coins Input randomness, an array of MLKEM_SYMBYTES bytes.
+ * @param[out] ct      Output ciphertext, an array of
+ *                     MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
+ * @param[out] ss      Output shared secret, an array of MLKEM_BYTES bytes.
+ * @param[in]  pk      Input public key, an array of
+ *                     MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param[in]  coins   Input randomness, an array of MLKEM_SYMBYTES bytes.
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          The 'modulus check' @[FIPS203, Section 7.2]
@@ -287,11 +296,14 @@ int MLK_API_NAMESPACE(enc_derand)(
  *
  * @spec{Implements @[FIPS203, Algorithm 20, ML-KEM.Encaps].}
  *
- * @param[out] ct Output ciphertext, an array of
- *                MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
- * @param[out] ss Output shared secret, an array of MLKEM_BYTES bytes.
- * @param[in]  pk Input public key, an array of
- *                MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param[out] ct      Output ciphertext, an array of
+ *                     MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
+ * @param[out] ss      Output shared secret, an array of MLKEM_BYTES bytes.
+ * @param[in]  pk      Input public key, an array of
+ *                     MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          The 'modulus check' @[FIPS203, Section 7.2]
@@ -318,11 +330,14 @@ int MLK_API_NAMESPACE(enc)(
  *
  * @spec{Implements @[FIPS203, Algorithm 21, ML-KEM.Decaps].}
  *
- * @param[out] ss Output shared secret, an array of MLKEM_BYTES bytes.
- * @param[in]  ct Input ciphertext, an array of
- *                MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
- * @param[in]  sk Input private key, an array of
- *                MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param[out] ss      Output shared secret, an array of MLKEM_BYTES bytes.
+ * @param[in]  ct      Input ciphertext, an array of
+ *                     MLKEM{512,768,1024}_CIPHERTEXTBYTES bytes.
+ * @param[in]  sk      Input private key, an array of
+ *                     MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          The 'hash check' @[FIPS203, Section 7.3]
@@ -349,8 +364,11 @@ int MLK_API_NAMESPACE(dec)(
  *
  * @spec{Implements @[FIPS203, Section 7.2, 'modulus check'].}
  *
- * @param[in] pk Input public key, an array of
- *               MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param[in] pk      Input public key, an array of
+ *                    MLKEM{512,768,1024}_PUBLICKEYBYTES bytes.
+ * @param     context Application context. Only present when
+ *                    MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                    MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          Modulus check failed.
@@ -373,8 +391,11 @@ int MLK_API_NAMESPACE(check_pk)(
  *
  * @spec{Implements @[FIPS203, Section 7.3, 'hash check'].}
  *
- * @param[in] sk Input private key, an array of
- *               MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param[in] sk      Input private key, an array of
+ *                    MLKEM{512,768,1024}_SECRETKEYBYTES bytes.
+ * @param     context Application context. Only present when
+ *                    MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                    MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          Public key hash check failed.

--- a/mlkem/src/indcpa.h
+++ b/mlkem/src/indcpa.h
@@ -58,8 +58,9 @@ __contract__(
  * @param[out] sk      Output private key
  *                     (length MLKEM_INDCPA_SECRETKEYBYTES bytes).
  * @param[in]  coins   Input randomness (length MLKEM_SYMBYTES bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          MLK_CONFIG_KEYGEN_PCT enabled and PCT failed.
@@ -97,8 +98,9 @@ __contract__(
  *                     (length MLKEM_INDCPA_PUBLICKEYBYTES bytes).
  * @param[in]  coins   Input random coins used as seed (length MLKEM_SYMBYTES
  *                     bytes) to deterministically generate all randomness.
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          Operation failed.
@@ -134,8 +136,9 @@ __contract__(
  * @param[in]  c       Input ciphertext (length MLKEM_INDCPA_BYTES bytes).
  * @param[in]  sk      Input secret key
  *                     (length MLKEM_INDCPA_SECRETKEYBYTES bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          Operation failed.

--- a/mlkem/src/kem.h
+++ b/mlkem/src/kem.h
@@ -65,8 +65,9 @@
  *
  * @param[in] pk      Input public key (an already allocated array of
  *                    MLKEM_INDCCA_PUBLICKEYBYTES bytes).
- * @param     context Application context (build-configurable; see
- *                    MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param     context Application context. Only present when
+ *                    MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                    MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          Modulus check failed.
@@ -94,8 +95,9 @@ __contract__(
  *
  * @param[in] sk      Input private key (an already allocated array of
  *                    MLKEM_INDCCA_SECRETKEYBYTES bytes).
- * @param     context Application context (build-configurable; see
- *                    MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param     context Application context. Only present when
+ *                    MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                    MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          Public key hash check failed.
@@ -123,8 +125,9 @@ __contract__(
  *                     MLKEM_INDCCA_SECRETKEYBYTES bytes).
  * @param[in]  coins   Input randomness (an already allocated array filled
  *                     with 2*MLKEM_SYMBYTES random bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          MLK_CONFIG_KEYGEN_PCT enabled and PCT failed.
@@ -157,8 +160,9 @@ __contract__(
  *                     MLKEM_INDCCA_PUBLICKEYBYTES bytes).
  * @param[out] sk      Output private key (an already allocated array of
  *                     MLKEM_INDCCA_SECRETKEYBYTES bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_OUT_OF_MEMORY MLK_CONFIG_CUSTOM_ALLOC_FREE was used and
@@ -194,8 +198,9 @@ __contract__(
  *                     MLKEM_INDCCA_PUBLICKEYBYTES bytes).
  * @param[in]  coins   Input randomness (an already allocated array filled
  *                     with MLKEM_SYMBYTES random bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          The 'modulus check' @[FIPS203, Section 7.2]
@@ -232,8 +237,9 @@ __contract__(
  *                     MLKEM_SSBYTES bytes).
  * @param[in]  pk      Input public key (an already allocated array of
  *                     MLKEM_INDCCA_PUBLICKEYBYTES bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_OUT_OF_MEMORY MLK_CONFIG_CUSTOM_ALLOC_FREE was used and
@@ -270,8 +276,9 @@ __contract__(
  *                     MLKEM_INDCCA_CIPHERTEXTBYTES bytes).
  * @param[in]  sk      Input private key (an already allocated array of
  *                     MLKEM_INDCCA_SECRETKEYBYTES bytes).
- * @param      context Application context (build-configurable; see
- *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE).
+ * @param      context Application context. Only present when
+ *                     MLK_CONFIG_CONTEXT_PARAMETER is defined; type set by
+ *                     MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
  *
  * @retval 0                     Success.
  * @retval MLK_ERR_FAIL          The 'hash check' @[FIPS203, Section 7.3]

--- a/scripts/Doxyfile.lint
+++ b/scripts/Doxyfile.lint
@@ -31,4 +31,6 @@ WARN_AS_ERROR          = FAIL_ON_WARNINGS
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             = MLK_ALIGN= \
-                         __contract__(x)=
+                         __contract__(x)= \
+                         MLK_CONFIG_CONTEXT_PARAMETER \
+                         MLK_CONFIG_CONTEXT_PARAMETER_TYPE=void*


### PR DESCRIPTION
Add MLK_CONFIG_CONTEXT_PARAMETER and MLK_CONFIG_CONTEXT_PARAMETER_TYPE to the Doxygen PREDEFINED list so the lint pass sees the context-parameter codepath, then add @param context entries to the public API functions in mlkem/mlkem_native.h and align the wording with the existing docs in mlkem/src/{kem,indcpa}.h.