### PR TITLE
nix: Anchor HOL-Light shellHook to repo root, not $PWD

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,13 @@
             ];
           };
           holLightShellHook = ''
-            export PATH=$PWD/scripts:$PATH
-            export PROOF_DIR="$PWD/proofs/hol_light"
+            # Resolve the repo root independently of the directory from which
+            # `nix develop` was invoked, so that PROOF_DIR / IMPORTS_DIR always
+            # point at the real proofs/hol_light tree (and .imports is not
+            # created in a spurious subdirectory-nested path).
+            REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+            export PATH="$REPO_ROOT/scripts:$PATH"
+            export PROOF_DIR="$REPO_ROOT/proofs/hol_light"
             # Namespaced imports root for HOL-Light proofs.
             # See scripts/check-hol-light-imports for the enforced rule.
             export IMPORTS_DIR="$PROOF_DIR/.imports"


### PR DESCRIPTION
The holLightShellHook set PROOF_DIR (and thus IMPORTS_DIR) from $PWD, which is whatever directory the user ran `nix develop` from. Entering the shell from a subdirectory (e.g. proofs/cbmc/) caused PROOF_DIR to resolve to a non-existent nested path, and the .imports/ directory plus its `mlkem_native` / `s2n_bignum` symlinks were created under that wrong location -- with `mlkem_native` pointing at a path that does not exist.

Resolve the repo root via `git rev-parse --show-toplevel` (matching the pattern already used in nix/hol_light/hol-server.sh), with a $PWD fallback for non-git invocations, so PATH / PROOF_DIR / IMPORTS_DIR are stable regardless of the invocation cwd.

Ported from pq-code-package/mldsa-native#1105.