### PR TITLE
Avoid mismatched comparison (suggested code improvement, not a bug!)

### DIFF
--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -333,7 +333,7 @@ __contract__(
   ensures((return_value == 0) == forall(i, 0, len, (a[i] == b[i]))))
 {
   uint8_t r = 0, s = 0;
-  unsigned i;
+  size_t i;
 
   for (i = 0; i < len; i++)
   __loop__(


### PR DESCRIPTION
I searched for all comparisons where the left and right hand sides have different types.

If we exclude cases where either side is a constant (e.g., `inlen > 0` corresponds to `size_t > int`), then there are only six results.

Five results occur in `fips202.c` and `fips202x4.c`, and all of them involve upcasting `r` from `unsigned int` to `size_t`. So this can never result in an issue, even when verification is turned off.

The sixth result occurs in `verify.h`, where the comparison `i < len` corresponds to `unsigned int < size_t`. I am suggesting to avoid this mismatched comparison by declaring `i` as `size_t` instead of `unsigned`.

This is not a bug, but a potential issue if `mlk_ct_memcmp` is used to replace `memcmp` in an unrelated project where verification is turned off (otherwise the precondition on `len` will detect any issues).

I am suggesting my proposed change not as a bug but as a code improvement, as it may benefit projects that reuse `mlk_ct_memcmp` without verification.