### PR TITLE
Avoid mismatched comparison and fix error in forall/exists macros

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
           pkgs-2405 = inputs.nixpkgs-2405.legacyPackages.${system};
           util = pkgs.callPackage ./nix/util.nix {
-            inherit (pkgs) bitwuzla z3;
+            inherit (pkgs) bitwuzla cvc5 z3;
             inherit (pkgs-unstable) cbmc;
             # TODO: switch back to stable python3 for slothy once ortools is fixed in 25.11
             python3-for-slothy = pkgs-unstable.python3;
@@ -237,7 +237,7 @@
             pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.x86_64-linux;
             util = pkgs.callPackage ./nix/util.nix {
               inherit pkgs;
-              inherit (pkgs) bitwuzla z3;
+              inherit (pkgs) bitwuzla cvc5 z3;
               inherit (pkgs-unstable) cbmc;
               # TODO: switch back to stable python3 for slothy once ortools is fixed in 25.11
               python3-for-slothy = pkgs-unstable.python3;

--- a/mlkem/src/cbmc.h
+++ b/mlkem/src/cbmc.h
@@ -96,7 +96,7 @@
 #define exists(qvar, qvar_lb, qvar_ub, predicate)               \
   __CPROVER_exists                                              \
   {                                                             \
-    size_t qvar;                                                  \
+    size_t qvar;                                                \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) && (predicate)  \
   }
 /* clang-format on */

--- a/mlkem/src/cbmc.h
+++ b/mlkem/src/cbmc.h
@@ -89,14 +89,14 @@
 #define forall(qvar, qvar_lb, qvar_ub, predicate)                 \
   __CPROVER_forall                                                \
   {                                                               \
-    unsigned qvar;                                                \
+    size_t qvar;                                                  \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) ==> (predicate)   \
   }
 
 #define exists(qvar, qvar_lb, qvar_ub, predicate)               \
   __CPROVER_exists                                              \
   {                                                             \
-    unsigned qvar;                                              \
+    size_t qvar;                                                  \
     ((qvar_lb) <= (qvar) && (qvar) < (qvar_ub)) && (predicate)  \
   }
 /* clang-format on */

--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -317,8 +317,7 @@ __contract__(ensures(return_value == (cond ? a : b)))
  *
  * @param[in] a   First byte array.
  * @param[in] b   Second byte array.
- * @param     len Length of the byte arrays, upper-bounded to UINT16_MAX to
- *                control proof complexity only.
+ * @param     len Length of the byte arrays.
  *
  * @retval 0    The byte arrays are equal.
  * @retval 0xFF The byte arrays are not equal.
@@ -326,7 +325,7 @@ __contract__(ensures(return_value == (cond ? a : b)))
 static MLK_INLINE uint8_t mlk_ct_memcmp(const uint8_t *a, const uint8_t *b,
                                         const size_t len)
 __contract__(
-  requires(len <= UINT16_MAX)
+  requires(len <= MLK_MAX_BUFFER_SIZE)
   requires(memory_no_alias(a, len))
   requires(memory_no_alias(b, len))
   ensures((return_value == 0) || (return_value == 0xFF))

--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -333,7 +333,7 @@ __contract__(
   ensures((return_value == 0) == forall(i, 0, len, (a[i] == b[i]))))
 {
   uint8_t r = 0, s = 0;
-  unsigned i;
+  size_t i;
 
   for (i = 0; i < len; i++)
   __loop__(

--- a/nix/cbmc/default.nix
+++ b/nix/cbmc/default.nix
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 { buildEnv
 , cbmc
+, cvc5
 , fetchFromGitHub
 , callPackage
 , bitwuzla
@@ -37,6 +38,7 @@ buildEnv {
 
       inherit
         bitwuzla# 0.8.2
+        cvc5# 1.3.2
         ninja; # 1.13.2
     };
 }

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -2,7 +2,7 @@
 # Copyright (c) The mldsa-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 
-{ pkgs, cbmc, bitwuzla, z3, python3-for-slothy }:
+{ pkgs, cbmc, bitwuzla, cvc5, z3, python3-for-slothy }:
 rec {
   glibc-join = p: p.buildPackages.symlinkJoin {
     name = "glibc-join";
@@ -96,7 +96,7 @@ rec {
     };
   };
 
-  cbmc_pkgs = pkgs.callPackage ./cbmc { inherit cbmc bitwuzla z3; };
+  cbmc_pkgs = pkgs.callPackage ./cbmc { inherit cbmc bitwuzla cvc5 z3; };
 
   valgrind_varlat = pkgs.callPackage ./valgrind { };
   hol_light' = pkgs.callPackage ./hol_light { };

--- a/proofs/cbmc/ct_memcmp/Makefile
+++ b/proofs/cbmc/ct_memcmp/Makefile
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--cvc5
 
 FUNCTION_NAME = mlk_ct_memcmp
 

--- a/proofs/cbmc/indcpa_dec/Makefile
+++ b/proofs/cbmc/indcpa_dec/Makefile
@@ -37,7 +37,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--cvc5 --refine-arrays
 
 FUNCTION_NAME = mlk_indcpa_dec
 

--- a/proofs/cbmc/indcpa_enc/Makefile
+++ b/proofs/cbmc/indcpa_enc/Makefile
@@ -43,7 +43,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--external-smt2-solver $(PROOF_ROOT)/lib/z3_smt_only --z3
+CBMCFLAGS=--cvc5 --refine-arrays
 
 FUNCTION_NAME = mlk_indcpa_enc
 

--- a/proofs/cbmc/indcpa_keypair_derand/Makefile
+++ b/proofs/cbmc/indcpa_keypair_derand/Makefile
@@ -36,7 +36,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--cvc5 --refine-arrays
 
 FUNCTION_NAME = mlk_indcpa_keypair_derand
 

--- a/proofs/cbmc/keccak_squeeze_once/Makefile
+++ b/proofs/cbmc/keccak_squeeze_once/Makefile
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--z3
 
 FUNCTION_NAME = mlk_keccak_squeeze_once
 

--- a/proofs/cbmc/nttunpack_native_x86_64/Makefile
+++ b/proofs/cbmc/nttunpack_native_x86_64/Makefile
@@ -28,7 +28,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--smt2
+CBMCFLAGS=--cvc5 --refine-arrays
 
 FUNCTION_NAME = nttunpack_native_x86_64
 

--- a/proofs/cbmc/poly_ntt_native/Makefile
+++ b/proofs/cbmc/poly_ntt_native/Makefile
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--cvc5 --refine-arrays
 
 FUNCTION_NAME = mlk_poly_ntt
 

--- a/proofs/cbmc/poly_reduce_native/Makefile
+++ b/proofs/cbmc/poly_reduce_native/Makefile
@@ -27,7 +27,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--cvc5 --refine-arrays
 
 FUNCTION_NAME = mlk_poly_reduce_native
 


### PR DESCRIPTION
I searched for all comparisons where the left and right hand sides have different types.

If we exclude cases where either side is a constant (e.g., `inlen > 0` corresponds to `size_t > int`), then there are only six results.

Five results occur in `fips202.c` and `fips202x4.c`, and all of them involve upcasting `r` from `unsigned int` to `size_t`. So this can never result in an issue, even when verification is turned off.

The sixth result occurs in `verify.h`, where the comparison `i < len` corresponds to `unsigned int < size_t`. I am suggesting to avoid this mismatched comparison by declaring `i` as `size_t` instead of `unsigned`.

This is not a bug, but a potential issue if `mlk_ct_memcmp` is used to replace `memcmp` in an unrelated project where verification is turned off (otherwise the precondition on `len` will detect any issues).

I am suggesting my proposed change not as a bug but as a code improvement, as it may benefit projects that reuse `mlk_ct_memcmp` without verification.