### PR TITLE
CI: Re-Enable Cortex-A76 benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,6 +36,15 @@ jobs:
           ldflags: "-flto"
           bench_extra_args: ""
           nix_shell: bench
+        - system: rpi5
+          name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
+          bench_pmu: PERF
+          archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
+          cflags: "-flto -DMLK_FORCE_AARCH64"
+          ldflags: "-flto"
+          bench_extra_args: ""
+          nix_shell: bench
+          cross_prefix: ""
         - system: a55
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
           bench_pmu: PERF


### PR DESCRIPTION
The Cortex-A76 runner (Raspberry Pi 5) was removed from the benchmarking CI in c0fb2320c due to a full disk. The disk space issue has been resolved by running `nix-collect-garbage -d` on the runner. 
This commit re-enables the Cortex-A76 benchmarks.