### PR TITLE
 Fix signed-shift UB on 16-bit-int targets in `mlk_rej_uniform_c` and `mlk_poly_frombytes_c`

### DIFF
--- a/mlkem/src/compress.c
+++ b/mlkem/src/compress.c
@@ -641,7 +641,12 @@ __contract__(
     const uint8_t t0 = a[3 * i + 0];
     const uint8_t t1 = a[3 * i + 1];
     const uint8_t t2 = a[3 * i + 2];
-    r->coeffs[2 * i + 0] = (int16_t)(t0 | ((t1 << 8) & 0xFFF));
+    /* Safety:
+     * - The explicit cast to uint16_t ensures that << 8 does
+     *   not signed-overflow even on a 16-bit system.
+     * - The cast to int16_t is safe due to the explicit 0xFFF truncation.
+     */
+    r->coeffs[2 * i + 0] = (int16_t)(t0 | (((uint16_t)t1 << 8) & 0xFFF));
     r->coeffs[2 * i + 1] = (int16_t)((t1 >> 4) | (t2 << 4));
   }
 

--- a/mlkem/src/sampling.c
+++ b/mlkem/src/sampling.c
@@ -56,7 +56,13 @@ __contract__(
     invariant(array_bound(r, 0, ctr, 0, MLKEM_Q))
     decreases(buflen - pos))
   {
-    val0 = ((buf[pos + 0] >> 0) | (buf[pos + 1] << 8)) & 0xFFF;
+    /* Safety:
+     * - The explicit cast to uint16_t ensures that << 8 does
+     *   not signed-overflow even on a 16-bit system.
+     * - The conversion to int16_t is safe due to the explicit 0xFFF
+     *   truncation.
+     */
+    val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
     val1 = ((buf[pos + 1] >> 4) | (buf[pos + 2] << 4)) & 0xFFF;
     pos += 3;
 

--- a/test/baremetal/platform/avr/avr_wrapper.c
+++ b/test/baremetal/platform/avr/avr_wrapper.c
@@ -33,7 +33,10 @@ void setup_args(void)
  * but before calling `main`. We mark it as naked but don't provide a return
  * instruction, so it is effectively inlined into the startup code. */
 void setup_stdout(void) __attribute__((naked, section(".init7"), used));
-void setup_stdout(void) { stdout = &mystdout; }
+/* Wire both stdout and stderr to the UART. The tests' CHECK(...) macros report
+ * failures via fprintf(stderr, ...); without this, stderr is NULL and those
+ * "ERROR (file,line)" lines would never reach simavr. */
+void setup_stdout(void) { stdout = stderr = &mystdout; }
 
 /* The above sequence makes simavr stop. */
 void program_exit(void) __attribute__((section(".fini1"), used));

--- a/test/baremetal/platform/avr/avr_wrapper.c
+++ b/test/baremetal/platform/avr/avr_wrapper.c
@@ -6,6 +6,7 @@
 #include <avr/io.h>
 #include <avr/sleep.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define RAM_BASE 0x2000
@@ -40,4 +41,15 @@ void program_exit(void)
 {
   cli();
   sleep_cpu();
+}
+
+/* Called on UBSan traps (-fsanitize-trap). The avr-libc default would
+ * stop simavr without any output, hiding the failure. */
+void abort(void)
+{
+  printf("ERROR: abort() called (e.g. UBSan trap)\n");
+  cli();
+  sleep_cpu();
+  for (;;)
+    ;
 }

--- a/test/baremetal/platform/avr/exec_wrapper.py
+++ b/test/baremetal/platform/avr/exec_wrapper.py
@@ -112,6 +112,7 @@ def main():
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
 
         # Somehow, the output ends up on stderr
+        output = ""
         if result.stderr:
             import re
 
@@ -123,8 +124,21 @@ def main():
                     # Remove ANSI color codes
                     clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
                     filtered_lines.append(clean_line)
-            print("\n".join(filtered_lines), end="")
+            output = "\n".join(filtered_lines)
 
+        # simavr does not propagate the guest exit code (returncode is always
+        # 0), so a guest-side failure would otherwise be reported as success.
+        # As a stopgap until simavr's exit-code mechanism is backported (#1728),
+        # scan the output for "ERROR" and fail instead. This catches both
+        # the UBSan-trap abort() in avr_wrapper.c and the CHECK(...) macros in
+        # the tests, which print "ERROR (file,line)" on failure.
+        #
+        # On failure, write to stderr, otherwise stdout.
+        if "ERROR" in output:
+            print(output, end="", file=sys.stderr)
+            sys.exit(1)
+
+        print(output, end="")
         sys.exit(result.returncode)
 
     except subprocess.TimeoutExpired:

--- a/test/baremetal/platform/avr/platform.mk
+++ b/test/baremetal/platform/avr/platform.mk
@@ -26,6 +26,13 @@ CFLAGS += \
 	-fno-fat-lto-objects \
 	-DNTESTS_FUNC=10
 
+# Trap on signed-shift UB; needs -fno-wrapv as avr-gcc defaults to -fwrapv.
+# On UB, abort() in avr_wrapper.c is called.
+CFLAGS += \
+	-fno-wrapv \
+	-fsanitize=shift \
+	-fsanitize-trap=shift
+
 CFLAGS += $(CFLAGS_EXTRA)
 
 # Non-standard stack end: 0x81FF = 0x200 + 8K instead of default 0x41FF


### PR DESCRIPTION
Fixes signed-shift UB and adds UBSan for AVR to catch similiar UB.
See individual commit messages.

- Resolves #1726 