### PR TITLE
Fix minor inconsistencies

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   quickcheck:
     name: Quickcheck (riscv)
+    if: ${{ github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork }}
     # via https://riseproject-dev.github.io/riscv-runner/
     runs-on: ubuntu-24.04-riscv
     steps:

--- a/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
+++ b/examples/bring_your_own_fips202/custom_fips202/fips202x4.h
@@ -76,8 +76,9 @@ static MLK_INLINE void mlk_shake128x4_release(mlk_shake128x4ctx *state)
 #define mlk_shake256x4 MLK_NAMESPACE(shake256x4)
 static MLK_INLINE void mlk_shake256x4(uint8_t *out0, uint8_t *out1,
                                       uint8_t *out2, uint8_t *out3,
-                                      size_t outlen, uint8_t *in0, uint8_t *in1,
-                                      uint8_t *in2, uint8_t *in3, size_t inlen)
+                                      size_t outlen, const uint8_t *in0,
+                                      const uint8_t *in1, const uint8_t *in2,
+                                      const uint8_t *in3, size_t inlen)
 {
   mlk_shake256(out0, outlen, in0, inlen);
   mlk_shake256(out1, outlen, in1, inlen);

--- a/mlkem/src/fips202/fips202x4.c
+++ b/mlkem/src/fips202/fips202x4.c
@@ -162,8 +162,8 @@ static void mlk_shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1,
 }
 
 void mlk_shake256x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
-                    size_t outlen, uint8_t *in0, uint8_t *in1, uint8_t *in2,
-                    uint8_t *in3, size_t inlen)
+                    size_t outlen, const uint8_t *in0, const uint8_t *in1,
+                    const uint8_t *in2, const uint8_t *in3, size_t inlen)
 {
   mlk_shake256x4_ctx statex;
   size_t nblocks = outlen / SHAKE256_RATE;

--- a/mlkem/src/fips202/fips202x4.h
+++ b/mlkem/src/fips202/fips202x4.h
@@ -59,8 +59,8 @@ void mlk_shake128x4_release(mlk_shake128x4ctx *state);
 
 #define mlk_shake256x4 MLK_NAMESPACE(shake256x4)
 void mlk_shake256x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
-                    size_t outlen, uint8_t *in0, uint8_t *in1, uint8_t *in2,
-                    uint8_t *in3, size_t inlen)
+                    size_t outlen, const uint8_t *in0, const uint8_t *in1,
+                    const uint8_t *in2, const uint8_t *in3, size_t inlen)
 __contract__(
   requires(inlen <= MLK_MAX_BUFFER_SIZE)
   requires(outlen <= MLK_MAX_BUFFER_SIZE)

--- a/mlkem/src/fips202/keccakf1600.c
+++ b/mlkem/src/fips202/keccakf1600.c
@@ -31,7 +31,7 @@
 #if !defined(MLK_CONFIG_MULTILEVEL_NO_SHARED)
 
 #define MLK_KECCAK_NROUNDS 24
-#define MLK_KECCAK_ROL(a, offset) ((a << offset) ^ (a >> (64 - offset)))
+#define MLK_KECCAK_ROL(a, offset) (((a) << (offset)) ^ ((a) >> (64 - (offset))))
 
 void mlk_keccakf1600_extract_bytes(uint64_t *state, unsigned char *data,
                                    unsigned offset, unsigned length)

--- a/mlkem/src/indcpa.c
+++ b/mlkem/src/indcpa.c
@@ -412,8 +412,8 @@ __contract__(
   mlk_poly_getnoise_eta2(epp, coins, 4);
 #elif MLKEM_K == 3
   /*
-   * In this call, only the first three output buffers are needed.
-   * The last parameter is a dummy that's overwritten later.
+   * In this call, only the first three output buffers are needed,
+   * so we pass NULL as the fourth parameter, and 0xFF as its dummy nonce.
    */
   mlk_poly_getnoise_eta1_4x(&sp->vec[0], &sp->vec[1], &sp->vec[2], NULL, coins,
                             0, 1, 2, 0xFF /* irrelevant */);

--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -205,6 +205,12 @@ static MLK_INLINE uint16_t mlk_ct_cmask_neg_i16(int16_t x)
 __contract__(ensures(return_value == ((x < 0) ? 0xFFFF : 0)))
 {
   int32_t tmp = mlk_value_barrier_i32((int32_t)x);
+  /*
+   * PORTABILITY: Right-shift on a signed integer is
+   * implementation-defined for negative left argument.
+   * Here, we assume it's sign-preserving "arithmetic" shift right.
+   * See (C99 6.5.7 (5))
+   */
   tmp >>= 16;
   return mlk_cast_int32_to_uint16(tmp);
 }
@@ -224,6 +230,12 @@ static MLK_INLINE uint16_t mlk_ct_cmask_nonzero_u16(uint16_t x)
 __contract__(ensures(return_value == ((x == 0) ? 0 : 0xFFFF)))
 {
   int32_t tmp = mlk_value_barrier_i32(-((int32_t)x));
+  /*
+   * PORTABILITY: Right-shift on a signed integer is
+   * implementation-defined for negative left argument.
+   * Here, we assume it's sign-preserving "arithmetic" shift right.
+   * See (C99 6.5.7 (5))
+   */
   tmp >>= 16;
   return mlk_cast_int32_to_uint16(tmp);
 }

--- a/test/notrandombytes/notrandombytes.h
+++ b/test/notrandombytes/notrandombytes.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The mlkem-native project authors
- * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MI
+ * SPDX-License-Identifier: LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT
  */
 
 /* References


### PR DESCRIPTION
Spotted by Claude Opus 4.8:

- indcpa.c: Fix comment on the unused noise buffer in mlk_indcpa_enc (K=3): it is NULL and skipped, not "overwritten later".
- verify.h: Document the arithmetic right-shift assumption in the mask helpers, matching the existing note in poly.c.
- keccakf1600.c: Parenthesize the arguments of MLK_KECCAK_ROL.
- fips202x4: const-qualify the input pointers of mlk_shake256x4.
- notrandombytes.h: Fix truncated SPDX identifier (MI -> MIT).
- riscv.yml: Gate the RISE RISC-V runner jobs on non-fork PRs,
  consistent with the other jobs not running on Github runners.