### PR TITLE
AVR: Propagate test exit codes through simavr

### DIFF
--- a/nix/avr/default.nix
+++ b/nix/avr/default.nix
@@ -10,6 +10,11 @@ let
       ./simavr-32kb-ram.patch
       ./simavr-uart-output-fix.patch
       ./simavr-16k-eeprom.patch
+      # Exit-code commands (SIMAVR_CMD_EXIT_CODE_*), not yet in a release
+      (pkgs.fetchpatch {
+        url = "https://github.com/buserror/simavr/commit/c9354b32e057e409c2fbc9454e26db3b3103c26a.patch";
+        hash = "sha256-JKIjBmvlIrUe/0lJ2ngVgN3sCB0UJYWtv2dNp0wcPEY=";
+      })
     ];
   });
 in

--- a/test/baremetal/platform/avr/avr_wrapper.c
+++ b/test/baremetal/platform/avr/avr_wrapper.c
@@ -9,6 +9,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <simavr/avr/avr_mcu_section.h>
+
+/* Register for sending commands (e.g. exit codes) to simavr */
+AVR_MCU_SIMAVR_COMMAND(&GPIOR0);
+
 #define RAM_BASE 0x2000
 
 static int uart_putchar(char c, FILE *stream)
@@ -38,12 +43,16 @@ void setup_stdout(void) __attribute__((naked, section(".init7"), used));
  * "ERROR (file,line)" lines would never reach simavr. */
 void setup_stdout(void) { stdout = stderr = &mystdout; }
 
-/* The above sequence makes simavr stop. */
-void program_exit(void) __attribute__((section(".fini1"), used));
-void program_exit(void)
+/* Override avr-libc exit(): pass the exit code to simavr. Called with the
+ * return value of main() after main() returns. */
+void exit(int code)
 {
   cli();
+  GPIOR0 = (code == 0) ? SIMAVR_CMD_EXIT_CODE_0 : SIMAVR_CMD_EXIT_CODE_1;
+  /* Fallback in case the exit-code command is not supported */
   sleep_cpu();
+  for (;;)
+    ;
 }
 
 /* Called on UBSan traps (-fsanitize-trap). The avr-libc default would
@@ -51,8 +60,5 @@ void program_exit(void)
 void abort(void)
 {
   printf("ERROR: abort() called (e.g. UBSan trap)\n");
-  cli();
-  sleep_cpu();
-  for (;;)
-    ;
+  exit(1);
 }

--- a/test/baremetal/platform/avr/platform.mk
+++ b/test/baremetal/platform/avr/platform.mk
@@ -41,11 +41,13 @@ LDFLAGS += \
 	-Wl,--gc-sections \
 	-Wl,--relax \
 	-Wl,--defsym=__stack=0x81FF \
+	-Wl,--undefined=_simavr_command_register \
+	-Wl,--section-start=.mmcu=0x910000 \
 	-lprintf_min
 
 # Add minimal AVR runtime
 EXTRA_SOURCES = $(PLATFORM_PATH)/avr_wrapper.c $(PLATFORM_PATH)/init7.S
-EXTRA_SOURCES_CFLAGS =
+EXTRA_SOURCES_CFLAGS = -I$(realpath $(dir $(shell which simavr))../include)
 
 # Use simavr for execution
 EXEC_WRAPPER := $(realpath $(PLATFORM_PATH)/exec_wrapper.py)


### PR DESCRIPTION
simavr always exited with code 0 regardless of the firmware behaviour, so the AVR functional test could not fail in CI. simavr recently gained exit-code commands (buserror/simavr@c9354b3, not yet in a release): the firmware declares a command register via AVR_MCU_SIMAVR_COMMAND, and writing SIMAVR_CMD_EXIT_CODE_0/1 to it makes simavr exit 0/1. Backport this as a patch to our simavr build. Override exit() in the test wrapper to forward the return value of main(), and make abort() exit nonzero so that UBSan traps fail the test.

The .mmcu section holding the command register declaration must be placed outside the flash address range (following the linker flags used by simavr's own examples): the linker otherwise places it between the .text and .data load segments, and simavr then loads .data at the wrong address, breaking the firmware.

- Resolves #1728