### PR TITLE
Add clang-tidy to lint

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# clang-tidy configuration for mlkem-native
+#
+# We enable whole C-relevant families and disable individual checks with
+# rationale provided inline below.
+Checks:
+  - bugprone-*
+  - cert-*
+  - clang-analyzer-*
+  - concurrency-*
+  - misc-*
+  - performance-*
+  - portability-*
+  - readability-*
+  # Spec/maths use 1-letter names (a, b, r, f, t, k).
+  - -readability-identifier-length
+  # Spec constants; already vetted by scripts/check-magic.
+  - -readability-magic-numbers
+  # Multi-var decls (e.g. `unsigned i, j;`) are deliberate; style only.
+  - -readability-isolate-declaration
+  # Repo uniformly uses lowercase suffixes (1u); this check wants uppercase (1U).
+  - -readability-uppercase-literal-suffix
+  # Repo uses `#if defined(X)` uniformly for composability.
+  - -readability-use-concise-preprocessor-directives
+  # Public symbols are namespaced by macro; the check can't see through it.
+  - -readability-identifier-naming
+  # Only index/bit-packing maths (r[11*j+0]); precedence is the intended reading.
+  - -readability-math-missing-parentheses
+  # 13 sites, all spec/API-fixed signatures (adjacent same-/convertible-type args).
+  - -bugprone-easily-swappable-parameters
+  # 37 sites, all spec-bounded const/index offsets; no real overflow.
+  - -bugprone-implicit-widening-of-multiplication-result
+  # Relies on transitive includes via common.h and single-CU builds.
+  - -misc-include-cleaner
+
+# Report diagnostics in our own headers (under mlkem/src), but never in
+# system or third-party headers.
+HeaderFilterRegex: 'mlkem/src/.*'
+
+# Be strict where we run at all: every enabled check that fires is an error.
+# The CI job is blocking, so this keeps local runs honest with CI.
+WarningsAsErrors: '*'
+
+FormatStyle: file

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -7,7 +7,7 @@ description: Lint
 inputs:
   nix-shell:
     description: Run in the specified Nix environment if exists
-    default: "linter"
+    default: "ci"
   nix-cache:
     description: Determine whether to enable nix cache
     default: "false"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/lint
         with:
-          nix-shell: linter
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           cross-prefix: "aarch64-unknown-linux-gnu-"
   quickcheck:

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -167,7 +167,6 @@ jobs:
         if: ${{ inputs.lint }}
         uses: ./.github/actions/lint
         with:
-          nix-shell: linter
           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
           nix-verbose: ${{ inputs.verbose }}
       - name: Functional Tests

--- a/flake.nix
+++ b/flake.nix
@@ -173,9 +173,6 @@
 
           devShells.cross-avr = util.mkShell (import ./nix/avr { inherit pkgs; });
 
-          devShells.linter = util.mkShellNoCC {
-            packages = builtins.attrValues { inherit (config.packages) linters; };
-          };
           devShells.clang19 = util.mkShellWithCC' pkgs.clang_19;
           devShells.clang20 = util.mkShellWithCC' pkgs.clang_20;
           devShells.clang21 = util.mkShellWithCC' pkgs.clang_21;

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -112,13 +112,13 @@
 /****************************** Error codes ***********************************/
 
 /* Generic failure condition */
-#define MLK_ERR_FAIL -1
+#define MLK_ERR_FAIL (-1)
 /* An allocation failed. This can only happen if MLK_CONFIG_CUSTOM_ALLOC_FREE
  * is defined and the provided MLK_CUSTOM_ALLOC can fail. */
-#define MLK_ERR_OUT_OF_MEMORY -2
+#define MLK_ERR_OUT_OF_MEMORY (-2)
 /* An rng failure occured. Might be due to insufficient entropy or
  * system misconfiguration. */
-#define MLK_ERR_RNG_FAIL -3
+#define MLK_ERR_RNG_FAIL (-3)
 
 /****************************** Function API **********************************/
 

--- a/mlkem/src/cbmc.h
+++ b/mlkem/src/cbmc.h
@@ -8,16 +8,27 @@
 /***************************************************
  * Basic replacements for __CPROVER_XXX contracts
  ***************************************************/
+/*
+ * The `__contract__` / `__loop__` annotation macros use a
+ * leading-double-underscore spelling in line with other CBMC macros.
+ * clang-tidy flags these as reserved identifiers; we suppress the diagnostic
+ * at each definition site (NOLINT) rather than disabling the check globally,
+ * so it stays active for the rest of the tree.
+ */
 #ifndef CBMC
 
-#define __contract__(x)
-#define __loop__(x)
+/* clang-format off */
+#define __contract__(x) /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+#define __loop__(x) /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+/* clang-format on */
 
 #else /* !CBMC */
 
 
-#define __contract__(x) x
-#define __loop__(x) x
+/* clang-format off */
+#define __contract__(x) x /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+#define __loop__(x) x /* NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+/* clang-format on */
 
 /* https://diffblue.github.io/cbmc/contracts-assigns.html */
 #define assigns(...) __CPROVER_assigns(__VA_ARGS__)

--- a/mlkem/src/common.h
+++ b/mlkem/src/common.h
@@ -222,14 +222,18 @@
 #if !defined(MLK_CONFIG_CUSTOM_ALLOC_FREE)
 /* Default: stack allocation */
 
+/* This is a declaration macro, not an expression macro: T is a type and v is
+ * a declarator, neither of which can be wrapped in parentheses. The
+ * bugprone-macro-parentheses diagnostic is therefore a false positive here. */
 #define MLK_ALLOC(v, T, N, context) \
   MLK_ALIGN T mlk_alloc_##v[N];     \
-  T *v = mlk_alloc_##v
+  T *v = mlk_alloc_##v /* NOLINT(bugprone-macro-parentheses) */
 
-/* TODO: This leads to a circular dependency between common and verify.h
- * It just works out before we're at the end of the file, but it's still
- * prone to issues in the future. */
-#include "verify.h"
+/* The MLK_FREE macro body references mlk_zeroize(), which is declared in
+ * verify.h. We deliberately do NOT include verify.h here: doing so would
+ * create a circular dependency (verify.h includes common.h), and common.h
+ * itself never calls mlk_zeroize() -- only the macro expansion does. Each
+ * translation unit that uses MLK_FREE therefore includes verify.h directly. */
 #define MLK_FREE(v, T, N, context)                     \
   do                                                   \
   {                                                    \
@@ -265,13 +269,13 @@
 /****************************** Error codes ***********************************/
 
 /* Generic failure condition */
-#define MLK_ERR_FAIL -1
+#define MLK_ERR_FAIL (-1)
 /* An allocation failed. This can only happen if MLK_CONFIG_CUSTOM_ALLOC_FREE
  * is defined and the provided MLK_CUSTOM_ALLOC can fail. */
-#define MLK_ERR_OUT_OF_MEMORY -2
+#define MLK_ERR_OUT_OF_MEMORY (-2)
 /* An rng failure occured. Might be due to insufficient entropy or
  * system misconfiguration. */
-#define MLK_ERR_RNG_FAIL -3
+#define MLK_ERR_RNG_FAIL (-3)
 
 #endif /* !__ASSEMBLER__ */
 

--- a/mlkem/src/compress.c
+++ b/mlkem/src/compress.c
@@ -714,10 +714,10 @@ void mlk_poly_frommsg(mlk_poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES])
  *              in the range [-(MLKEM_Q-1), MLKEM_Q-1].
  */
 MLK_INTERNAL_API
-void mlk_poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const mlk_poly *a)
+void mlk_poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const mlk_poly *r)
 {
   unsigned i;
-  mlk_assert_bound(a, MLKEM_N, 0, MLKEM_Q);
+  mlk_assert_bound(r, MLKEM_N, 0, MLKEM_Q);
 
   for (i = 0; i < MLKEM_N / 8; i++)
   __loop__(invariant(i <= MLKEM_N / 8)
@@ -730,7 +730,7 @@ void mlk_poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const mlk_poly *a)
       invariant(i <= MLKEM_N / 8 && j <= 8)
       decreases(8 - j))
     {
-      uint32_t t = mlk_scalar_compress_d1(a->coeffs[8 * i + j]);
+      uint32_t t = mlk_scalar_compress_d1(r->coeffs[8 * i + j]);
       msg[i] |= (uint8_t)(t << j);
     }
   }

--- a/mlkem/src/indcpa.c
+++ b/mlkem/src/indcpa.c
@@ -23,6 +23,7 @@
 #include "randombytes.h"
 #include "sampling.h"
 #include "symmetric.h"
+#include "verify.h"
 
 /* Parameter set namespacing
  * This is to facilitate building multiple instances

--- a/mlkem/src/poly.c
+++ b/mlkem/src/poly.c
@@ -453,20 +453,20 @@ __contract__(
 }
 
 MLK_INTERNAL_API
-void mlk_poly_ntt(mlk_poly *p)
+void mlk_poly_ntt(mlk_poly *r)
 {
 #if defined(MLK_USE_NATIVE_NTT)
   int ret;
-  mlk_assert_abs_bound(p, MLKEM_N, MLKEM_Q);
-  ret = mlk_ntt_native(p->coeffs);
+  mlk_assert_abs_bound(r, MLKEM_N, MLKEM_Q);
+  ret = mlk_ntt_native(r->coeffs);
   if (ret == MLK_NATIVE_FUNC_SUCCESS)
   {
-    mlk_assert_abs_bound(p, MLKEM_N, MLK_NTT_BOUND);
+    mlk_assert_abs_bound(r, MLKEM_N, MLK_NTT_BOUND);
     return;
   }
 #endif /* MLK_USE_NATIVE_NTT */
 
-  mlk_poly_ntt_c(p);
+  mlk_poly_ntt_c(r);
 }
 
 
@@ -554,19 +554,19 @@ __contract__(
 }
 
 MLK_INTERNAL_API
-void mlk_poly_invntt_tomont(mlk_poly *p)
+void mlk_poly_invntt_tomont(mlk_poly *r)
 {
 #if defined(MLK_USE_NATIVE_INTT)
   int ret;
-  ret = mlk_intt_native(p->coeffs);
+  ret = mlk_intt_native(r->coeffs);
   if (ret == MLK_NATIVE_FUNC_SUCCESS)
   {
-    mlk_assert_abs_bound(p, MLKEM_N, MLK_INVNTT_BOUND);
+    mlk_assert_abs_bound(r, MLKEM_N, MLK_INVNTT_BOUND);
     return;
   }
 #endif /* MLK_USE_NATIVE_INTT */
 
-  mlk_poly_invntt_tomont_c(p);
+  mlk_poly_invntt_tomont_c(r);
 }
 
 #else /* !MLK_CONFIG_MULTILEVEL_NO_SHARED */

--- a/mlkem/src/poly_k.c
+++ b/mlkem/src/poly_k.c
@@ -27,6 +27,7 @@
 #include "debug.h"
 #include "sampling.h"
 #include "symmetric.h"
+#include "verify.h"
 
 /* Parameter set namespacing
  * This is to facilitate building multiple instances

--- a/mlkem/src/sampling.c
+++ b/mlkem/src/sampling.c
@@ -23,6 +23,7 @@
 #include "debug.h"
 #include "sampling.h"
 #include "symmetric.h"
+#include "verify.h"
 
 /* Reference: `rej_uniform()` in the reference implementation @[REF].
  *            - Our signature differs from the reference implementation
@@ -62,8 +63,9 @@ __contract__(
      * - The conversion to int16_t is safe due to the explicit 0xFFF
      *   truncation.
      */
-    val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
-    val1 = ((buf[pos + 1] >> 4) | (buf[pos + 2] << 4)) & 0xFFF;
+    val0 = (int16_t)(((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) &
+                     0xFFF);
+    val1 = (int16_t)(((buf[pos + 1] >> 4) | (buf[pos + 2] << 4)) & 0xFFF);
     pos += 3;
 
     if (val0 < MLKEM_Q)
@@ -290,8 +292,10 @@ void mlk_poly_cbd2(mlk_poly *r, const uint8_t buf[2 * MLKEM_N / 4])
       invariant(array_abs_bound(r->coeffs, 0, 8 * i + j, 3))
       decreases(8 - j))
     {
-      const int16_t a = (d >> (4 * j + 0)) & 0x3;
-      const int16_t b = (d >> (4 * j + 2)) & 0x3;
+      /* Safety: The & 0x3 masks each value to 2 bits (range [0, 3]), so the
+       * truncation and subsequent subtraction in int16_t is lossless. */
+      const int16_t a = (int16_t)((d >> (4 * j + 0)) & 0x3);
+      const int16_t b = (int16_t)((d >> (4 * j + 2)) & 0x3);
       r->coeffs[8 * i + j] = (int16_t)(a - b);
     }
   }
@@ -342,8 +346,10 @@ void mlk_poly_cbd3(mlk_poly *r, const uint8_t buf[3 * MLKEM_N / 4])
       invariant(array_abs_bound(r->coeffs, 0, 4 * i + j, 4))
       decreases(4 - j))
     {
-      const int16_t a = (d >> (6 * j + 0)) & 0x7;
-      const int16_t b = (d >> (6 * j + 3)) & 0x7;
+      /* Safety: The & 0x7 masks each value to 3 bits (range [0, 7]), so the
+       * truncation and subsequent subtraction in int16_t is lossless. */
+      const int16_t a = (int16_t)((d >> (6 * j + 0)) & 0x7);
+      const int16_t b = (int16_t)((d >> (6 * j + 3)) & 0x7);
       r->coeffs[4 * i + j] = (int16_t)(a - b);
     }
   }

--- a/mlkem/src/verify.h
+++ b/mlkem/src/verify.h
@@ -183,7 +183,7 @@ static MLK_ALWAYS_INLINE uint16_t mlk_cast_int32_to_uint16(int32_t x)
  */
 static MLK_ALWAYS_INLINE uint16_t mlk_cast_int16_to_uint16(int32_t x)
 {
-  return mlk_cast_int32_to_uint16((int32_t)x);
+  return mlk_cast_int32_to_uint16(x);
 }
 
 /**

--- a/scripts/lint
+++ b/scripts/lint
@@ -194,6 +194,64 @@ lint-c-files()
 checkerr "Lint C" "$(lint-c-files)"
 gh_group_end
 
+lint-clang-tidy()
+{
+  if ! command -v clang-tidy >/dev/null; then
+    gh_error_simple "clang-tidy missing" "clang-tidy is not installed"
+    error "Lint clang-tidy"
+    SUCCESS=false
+    gh_summary_failure "Lint clang-tidy"
+    return 0
+  fi
+
+  # Files to analyse, by language. Add directories here to widen coverage;
+  # native backends are deliberately excluded (they need per-arch flags).
+  # Pathspecs use :(glob) so '*' does not cross '/' (top-level of each dir).
+  local c_files=(":(glob)mlkem/src/*.c" ":(glob)mlkem/src/fips202/*.c")
+  local h_files=(":(glob)mlkem/src/*.h" ":(glob)mlkem/src/fips202/*.h")
+
+  local nproc success=true
+  nproc=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+
+  # Run clang-tidy over a set of files. $1 is a label for diagnostics, $2 is a
+  # space-separated list of git pathspecs, and the rest are passed verbatim to
+  # clang-tidy's compiler invocation (after `--`). Note: not invoked via a pipe
+  # so that `success=false` propagates to the enclosing function.
+  run-clang-tidy()
+  {
+    local label="$1" pathspecs="$2" out
+    shift 2
+    if ! out=$(git ls-files -- $pathspecs |
+      xargs -P "$nproc" -I {} \
+        clang-tidy --quiet {} -- -I"$ROOT"/mlkem -std=c90 "$@" 2>&1); then
+      echo "$out"
+      gh_error_simple "clang-tidy error" "clang-tidy reported findings ($label)"
+      success=false
+    fi
+  }
+
+  for params in 512 768 1024; do
+    # Headers are passed with `-x c` so clang-tidy treats them as C, not C++.
+    run-clang-tidy "ML-KEM-$params .c" "${c_files[*]}" \
+      -DMLK_CONFIG_PARAMETER_SET="$params"
+    run-clang-tidy "ML-KEM-$params .h" "${h_files[*]}" \
+      -x c -DMLK_CONFIG_PARAMETER_SET="$params"
+  done
+
+  if $success; then
+    info "Lint clang-tidy"
+    gh_summary_success "Lint clang-tidy"
+  else
+    error "Lint clang-tidy"
+    SUCCESS=false
+    gh_summary_failure "Lint clang-tidy"
+  fi
+}
+
+gh_group_start "Static analysis with clang-tidy"
+lint-clang-tidy
+gh_group_end
+
 check-eol-dry-run()
 {
   for file in $(git ls-files -- ":/" ":/!:*.png"); do


### PR DESCRIPTION
Add clang-tidy to lint with pedantic config

Run clang-tidy as part of scripts/lint. clang-tidy needs a C compiler to resolve system headers, so the lint CI job moves from the compiler-less 'linter' shell to 'ci' (linters + native toolchain); the now-unused 'linter' devShell is removed.

Pre-suppress style checks hostile to this codebase; fix or suppress the substantive findings, including breaking the common.h <-> verify.h include cycle and renaming the definition parameters of poly_ntt, poly_invntt_tomont and poly_tomsg to match their header declarations.