### PR TITLE
HOL-Light: Switch to `mlk_` namespace

### DIFF
--- a/proofs/hol_light/aarch64/mlkem/intt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/intt_aarch64_asm.S
@@ -56,11 +56,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_intt_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_intt_aarch64_asm:
+.global _mlk_intt_aarch64_asm
+_mlk_intt_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_intt_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_intt_aarch64_asm:
+.global mlk_intt_aarch64_asm
+mlk_intt_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x1_scalar_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x1_scalar_aarch64_asm.S
@@ -39,11 +39,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_scalar_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_scalar_aarch64_asm:
+.global _mlk_keccak_f1600_x1_scalar_aarch64_asm
+_mlk_keccak_f1600_x1_scalar_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_scalar_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_scalar_aarch64_asm:
+.global mlk_keccak_f1600_x1_scalar_aarch64_asm
+mlk_keccak_f1600_x1_scalar_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -55,11 +55,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_aarch64_asm:
+.global _mlk_keccak_f1600_x1_v84a_aarch64_asm
+_mlk_keccak_f1600_x1_v84a_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x1_v84a_aarch64_asm:
+.global mlk_keccak_f1600_x1_v84a_aarch64_asm
+mlk_keccak_f1600_x1_v84a_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -55,11 +55,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x2_v84a_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x2_v84a_aarch64_asm:
+.global _mlk_keccak_f1600_x2_v84a_aarch64_asm
+_mlk_keccak_f1600_x2_v84a_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x2_v84a_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x2_v84a_aarch64_asm:
+.global mlk_keccak_f1600_x2_v84a_aarch64_asm
+mlk_keccak_f1600_x2_v84a_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -39,11 +39,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm:
+.global _mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm
+_mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm:
+.global mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm
+mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -40,11 +40,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm:
+.global _mlk_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm
+_mlk_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm:
+.global mlk_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm
+mlk_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/ntt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/ntt_aarch64_asm.S
@@ -56,11 +56,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_ntt_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_ntt_aarch64_asm:
+.global _mlk_ntt_aarch64_asm
+_mlk_ntt_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_ntt_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_ntt_aarch64_asm:
+.global mlk_ntt_aarch64_asm
+mlk_ntt_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/poly_mulcache_compute_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_mulcache_compute_aarch64_asm.S
@@ -45,11 +45,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_aarch64_asm:
+.global _mlk_poly_mulcache_compute_aarch64_asm
+_mlk_poly_mulcache_compute_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_aarch64_asm:
+.global mlk_poly_mulcache_compute_aarch64_asm
+mlk_poly_mulcache_compute_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/poly_reduce_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_reduce_aarch64_asm.S
@@ -27,11 +27,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_reduce_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_reduce_aarch64_asm:
+.global _mlk_poly_reduce_aarch64_asm
+_mlk_poly_reduce_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_reduce_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_reduce_aarch64_asm:
+.global mlk_poly_reduce_aarch64_asm
+mlk_poly_reduce_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/poly_tobytes_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_tobytes_aarch64_asm.S
@@ -33,11 +33,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_tobytes_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_tobytes_aarch64_asm:
+.global _mlk_poly_tobytes_aarch64_asm
+_mlk_poly_tobytes_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_tobytes_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_tobytes_aarch64_asm:
+.global mlk_poly_tobytes_aarch64_asm
+mlk_poly_tobytes_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/poly_tomont_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_tomont_aarch64_asm.S
@@ -27,11 +27,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_tomont_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_tomont_aarch64_asm:
+.global _mlk_poly_tomont_aarch64_asm
+_mlk_poly_tomont_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_tomont_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_tomont_aarch64_asm:
+.global mlk_poly_tomont_aarch64_asm
+mlk_poly_tomont_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
@@ -57,11 +57,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm:
+.global _mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm
+_mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm:
+.global mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm
+mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
@@ -57,11 +57,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm:
+.global _mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm
+_mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm:
+.global mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm
+mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
@@ -57,11 +57,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm:
+.global _mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm
+_mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm:
+.global mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm
+mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/aarch64/mlkem/rej_uniform_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/rej_uniform_aarch64_asm.S
@@ -45,11 +45,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_aarch64_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_aarch64_asm:
+.global _mlk_rej_uniform_aarch64_asm
+_mlk_rej_uniform_aarch64_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_aarch64_asm
-PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_aarch64_asm:
+.global mlk_rej_uniform_aarch64_asm
+mlk_rej_uniform_aarch64_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/intt_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/intt_avx2_asm.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2_asm:
+.global _mlk_invntt_avx2_asm
+_mlk_invntt_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_invntt_avx2_asm:
+.global mlk_invntt_avx2_asm
+mlk_invntt_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/keccak_f1600_x4_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/keccak_f1600_x4_avx2_asm.S
@@ -12,11 +12,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_avx2_asm:
+.global _mlk_keccak_f1600_x4_avx2_asm
+_mlk_keccak_f1600_x4_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_keccak_f1600_x4_avx2_asm:
+.global mlk_keccak_f1600_x4_avx2_asm
+mlk_keccak_f1600_x4_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/ntt_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/ntt_avx2_asm.S
@@ -33,11 +33,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_ntt_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_ntt_avx2_asm:
+.global _mlk_ntt_avx2_asm
+_mlk_ntt_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_ntt_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_ntt_avx2_asm:
+.global mlk_ntt_avx2_asm
+mlk_ntt_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/nttfrombytes_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/nttfrombytes_avx2_asm.S
@@ -27,11 +27,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_nttfrombytes_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_nttfrombytes_avx2_asm:
+.global _mlk_nttfrombytes_avx2_asm
+_mlk_nttfrombytes_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_nttfrombytes_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_nttfrombytes_avx2_asm:
+.global mlk_nttfrombytes_avx2_asm
+mlk_nttfrombytes_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/ntttobytes_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/ntttobytes_avx2_asm.S
@@ -27,11 +27,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_ntttobytes_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_ntttobytes_avx2_asm:
+.global _mlk_ntttobytes_avx2_asm
+_mlk_ntttobytes_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_ntttobytes_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_ntttobytes_avx2_asm:
+.global mlk_ntttobytes_avx2_asm
+mlk_ntttobytes_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/nttunpack_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/nttunpack_avx2_asm.S
@@ -27,11 +27,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_nttunpack_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_nttunpack_avx2_asm:
+.global _mlk_nttunpack_avx2_asm
+_mlk_nttunpack_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_nttunpack_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_nttunpack_avx2_asm:
+.global mlk_nttunpack_avx2_asm
+mlk_nttunpack_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_compress_d10_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_compress_d10_avx2_asm.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d10_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d10_avx2_asm:
+.global _mlk_poly_compress_d10_avx2_asm
+_mlk_poly_compress_d10_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d10_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d10_avx2_asm:
+.global mlk_poly_compress_d10_avx2_asm
+mlk_poly_compress_d10_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_compress_d11_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_compress_d11_avx2_asm.S
@@ -39,11 +39,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d11_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d11_avx2_asm:
+.global _mlk_poly_compress_d11_avx2_asm
+_mlk_poly_compress_d11_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d11_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d11_avx2_asm:
+.global mlk_poly_compress_d11_avx2_asm
+mlk_poly_compress_d11_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_compress_d4_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_compress_d4_avx2_asm.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d4_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d4_avx2_asm:
+.global _mlk_poly_compress_d4_avx2_asm
+_mlk_poly_compress_d4_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d4_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d4_avx2_asm:
+.global mlk_poly_compress_d4_avx2_asm
+mlk_poly_compress_d4_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_compress_d5_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_compress_d5_avx2_asm.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d5_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d5_avx2_asm:
+.global _mlk_poly_compress_d5_avx2_asm
+_mlk_poly_compress_d5_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d5_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_compress_d5_avx2_asm:
+.global mlk_poly_compress_d5_avx2_asm
+mlk_poly_compress_d5_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_decompress_d10_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_decompress_d10_avx2_asm.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d10_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d10_avx2_asm:
+.global _mlk_poly_decompress_d10_avx2_asm
+_mlk_poly_decompress_d10_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d10_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d10_avx2_asm:
+.global mlk_poly_decompress_d10_avx2_asm
+mlk_poly_decompress_d10_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_decompress_d11_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_decompress_d11_avx2_asm.S
@@ -39,11 +39,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d11_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d11_avx2_asm:
+.global _mlk_poly_decompress_d11_avx2_asm
+_mlk_poly_decompress_d11_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d11_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d11_avx2_asm:
+.global mlk_poly_decompress_d11_avx2_asm
+mlk_poly_decompress_d11_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_decompress_d4_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_decompress_d4_avx2_asm.S
@@ -37,11 +37,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d4_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d4_avx2_asm:
+.global _mlk_poly_decompress_d4_avx2_asm
+_mlk_poly_decompress_d4_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d4_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d4_avx2_asm:
+.global mlk_poly_decompress_d4_avx2_asm
+mlk_poly_decompress_d4_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_decompress_d5_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_decompress_d5_avx2_asm.S
@@ -38,11 +38,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d5_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d5_avx2_asm:
+.global _mlk_poly_decompress_d5_avx2_asm
+_mlk_poly_decompress_d5_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d5_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_decompress_d5_avx2_asm:
+.global mlk_poly_decompress_d5_avx2_asm
+mlk_poly_decompress_d5_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/poly_mulcache_compute_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/poly_mulcache_compute_avx2_asm.S
@@ -12,11 +12,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_avx2_asm:
+.global _mlk_poly_mulcache_compute_avx2_asm
+_mlk_poly_mulcache_compute_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_poly_mulcache_compute_avx2_asm:
+.global mlk_poly_mulcache_compute_avx2_asm
+mlk_poly_mulcache_compute_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.S
@@ -12,11 +12,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm:
+.global _mlk_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm
+_mlk_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm:
+.global mlk_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm
+mlk_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_avx2_asm.S
@@ -12,11 +12,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm:
+.global _mlk_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm
+_mlk_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm:
+.global mlk_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm
+mlk_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_avx2_asm.S
@@ -12,11 +12,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm:
+.global _mlk_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm
+_mlk_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm:
+.global mlk_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm
+mlk_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/reduce_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/reduce_avx2_asm.S
@@ -33,11 +33,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_reduce_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_reduce_avx2_asm:
+.global _mlk_reduce_avx2_asm
+_mlk_reduce_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_reduce_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_reduce_avx2_asm:
+.global mlk_reduce_avx2_asm
+mlk_reduce_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/rej_uniform_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/rej_uniform_avx2_asm.S
@@ -28,11 +28,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_avx2_asm:
+.global _mlk_rej_uniform_avx2_asm
+_mlk_rej_uniform_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_rej_uniform_avx2_asm:
+.global mlk_rej_uniform_avx2_asm
+mlk_rej_uniform_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/proofs/hol_light/x86_64/mlkem/tomont_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/tomont_avx2_asm.S
@@ -31,11 +31,11 @@
 .text
 .balign 4
 #ifdef __APPLE__
-.global _PQCP_MLKEM_NATIVE_MLKEM768_tomont_avx2_asm
-_PQCP_MLKEM_NATIVE_MLKEM768_tomont_avx2_asm:
+.global _mlk_tomont_avx2_asm
+_mlk_tomont_avx2_asm:
 #else
-.global PQCP_MLKEM_NATIVE_MLKEM768_tomont_avx2_asm
-PQCP_MLKEM_NATIVE_MLKEM768_tomont_avx2_asm:
+.global mlk_tomont_avx2_asm
+mlk_tomont_avx2_asm:
 #endif
 
         .cfi_startproc

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -3271,10 +3271,14 @@ def update_via_simpasm(
 
 def gen_hol_light_asm_file(job):
     infile, indir, cflags, arch = job
+    # Override the default namespace (PQCP_MLKEM_NATIVE_MLKEM768) with a short
+    # `mlk_` prefix in the proofs/hol_light/ assembly drops. The exported symbol
+    # is determined by MLK_ASM_NAMESPACE() at preprocessing time, which expands
+    # via MLK_CONFIG_NAMESPACE_PREFIX with a trailing underscore appended.
     update_via_simpasm(
         f"{indir}/{infile}",
         "proofs/hol_light/" + arch + "/mlkem",
-        cflags=cflags + " -Imlkem",
+        cflags=cflags + " -Imlkem -DMLK_CONFIG_NAMESPACE_PREFIX=mlk",
         preserve_header=False,
     )
 


### PR DESCRIPTION
Previously, the HOL-Light assembly kernels used the default PQCP namespace. This namespace is both overly verbose and prefixed with the ML-KEM parameter set, which in the context of parameter-set independent assembly is confusing.

This commit switches the namespace used in the HOL-Light assembly to `mlk_`.