### PR TITLE
[PPC64LE] poly_reduce: halfword high-multiply Barrett (44→12 ops, 1.8× on POWER8)

### DIFF
--- a/dev/ppc64le/src/intt_ppc_asm.S
+++ b/dev/ppc64le/src/intt_ppc_asm.S
@@ -48,14 +48,13 @@
  * TODO: lazy reduction and layer merging, as in the aarch64 inverse NTT.
  */
 
-/* Barrett-Q-reduce constants */
+/* Barrett-Q-reduce constants (halfword high-multiply scheme) */
 #define V20159  0
-#define V_25    1
-#define V_26    2
-#define V_MKQ   3
+#define V_1024  1   /* 2^10, rounding bias for the >> 11 stage */
+#define V_11    2   /* shift amount 11 (vsrah) */
 
-/* Shared zero vector (aliases V_MKQ; V_MKQ is only live during
- * barrett_reduce_4x, where V_ZERO/zero is reloaded from vs3 anyway). */
+/* Shared zero vector (v3; no longer aliased by a Barrett +Q constant
+ * now that barrett_reduce_4x uses -Q via V_NMKQ). */
 #define V_ZERO  3
 
 /* Barrett-multiply constants */
@@ -126,9 +125,8 @@
  * half of vsX, alias fX, dead in this routine). */
 #define VS_NMKQ_STASH   0
 #define VS_ZERO_STASH   3
-#define VS_MKQ_STASH    6
-#define VS_25_STASH     7
-#define VS_26_STASH     8
+#define VS_1024_STASH   7
+#define VS_11_STASH     8
 
 .text
 
@@ -375,64 +373,27 @@
 .endm
 
 .macro barrett_reduce_4x _v0, _v1, _v2, _v3
-        /* Materialize VR copies of V_MKQ (v3), V_25 (v1), V_26 (v2)
-           from their long-term VSR stash slots. The caller does not
-           keep these VR-resident between barrett_reduce_4x calls.
-           Also zero v7 (scratch). */
-        vxor    7, 7, 7
-        xxlor   32+V_MKQ,   VS_MKQ_STASH,   VS_MKQ_STASH
-        xxlor   32+V_25,    VS_25_STASH,    VS_25_STASH
-        xxlor   32+V_26,    VS_26_STASH,    VS_26_STASH
-        /* Multiply Odd/Even signed halfword;
-           Results word bound by 2^32 in abs value. */
-        vmulosh 6, vdata_brt1, V20159
-        vmulesh 5, vdata_brt1, V20159
-        vmulosh 11, vdata_brt2, V20159
-        vmulesh 10, vdata_brt2, V20159
-        vmulosh 15, vdata_brt3, V20159
-        vmulesh 14, vdata_brt3, V20159
-        vmulosh 19, vdata_brt4, V20159
-        vmulesh 18, vdata_brt4, V20159
-        xxmrglw 32+4, 32+5, 32+6
-        xxmrghw 32+5, 32+5, 32+6
-        xxmrglw 32+9, 32+10, 32+11
-        xxmrghw 32+10, 32+10, 32+11
-        xxmrglw 32+13, 32+14, 32+15
-        xxmrghw 32+14, 32+14, 32+15
-        xxmrglw 32+17, 32+18, 32+19
-        xxmrghw 32+18, 32+18, 32+19
-        vadduwm 4, 4, V_25
-        vadduwm 5, 5, V_25
-        vadduwm 9, 9, V_25
-        vadduwm 10, 10, V_25
-        vadduwm 13, 13, V_25
-        vadduwm 14, 14, V_25
-        vadduwm 17, 17, V_25
-        vadduwm 18, 18, V_25
-        /* Right shift and pack lower halfword,
-           results bound by 2^16 in abs value */
-        vsraw   4, 4, V_26
-        vsraw   5, 5, V_26
-        vsraw   9, 9, V_26
-        vsraw   10, 10, V_26
-        vsraw   13, 13, V_26
-        vsraw   14, 14, V_26
-        vsraw   17, 17, V_26
-        vsraw   18, 18, V_26
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        /* Modulo multiply-Low unsigned halfword;
-           results bound by 2^16 * q in abs value. */
-        vmladduhm \_v0, 4, V_MKQ, 8
-        vmladduhm \_v1, 9, V_MKQ, 12
-        vmladduhm \_v2, 13, V_MKQ, 16
-        vmladduhm \_v3, 17, V_MKQ, 20
+        /* Halfword high-multiply Barrett (lockstep with reduce_ppc_asm.S).
+           Materialize V_1024 (v1) and V_11 (v2) from their VSR stash slots;
+           V20159 and V_NMKQ (-Q) are already resident across the calls. */
+        xxlor   32+V_1024,  VS_1024_STASH,  VS_1024_STASH
+        xxlor   32+V_11,    VS_11_STASH,    VS_11_STASH
+        /* t = ((a*20159) >> 15 + 2^10) >> 11 == round(a*20159 / 2^26).
+           vmhaddshs gives the non-rounding high product plus the round bias;
+           no saturation (|(a*20159)>>15| <= 20159, +1024 < 2^15). */
+        vmhaddshs 4, vdata_brt1, V20159, V_1024
+        vmhaddshs 9, vdata_brt2, V20159, V_1024
+        vmhaddshs 13, vdata_brt3, V20159, V_1024
+        vmhaddshs 17, vdata_brt4, V20159, V_1024
+        vsrah   4, 4, V_11
+        vsrah   9, 9, V_11
+        vsrah   13, 13, V_11
+        vsrah   17, 17, V_11
+        /* a + t*(-Q) = a - t*MLKEM_Q (one FMA, no negate/pack). */
+        vmladduhm \_v0, 4, V_NMKQ, 8
+        vmladduhm \_v1, 9, V_NMKQ, 12
+        vmladduhm \_v2, 13, V_NMKQ, 16
+        vmladduhm \_v3, 17, V_NMKQ, 20
 .endm
 
 /*
@@ -734,20 +695,17 @@ MLK_ASM_FN_SYMBOL(intt_ppc_asm)
         xxlxor  32+V_ZERO, 32+V_ZERO, 32+V_ZERO
         xxlor   VS_ZERO_STASH, 32+V_ZERO, 32+V_ZERO
 
-        /*  Setup for Barrett reduce */
-        li      10, MLK_PPC_Q_OFFSET
+        /*  Setup for Barrett reduce (halfword high-multiply scheme) */
         li      11, MLK_PPC_C20159_OFFSET
-        lxvx    VS_MKQ_STASH, 10, qinp                  /* V_MKQ */
         lxvx    32+V20159, 11, qinp                     /* V20159 */
 
-        vspltisw 8, 13
-        vadduwm  8, 8, 8
-        xxlor   VS_26_STASH, 32+8, 32+8
+        vspltish 8, 11                                  /* V_11 = shift 11 */
+        xxlor   VS_11_STASH, 32+8, 32+8
 
-        vspltisw 9, 1
-        vsubuwm 10, 8, 9                                /* value 25 */
-        vslw    9, 9, 10
-        xxlor   VS_25_STASH, 32+9, 32+9
+        vspltish 9, 1
+        vspltish 10, 10
+        vslh    9, 9, 10                                /* V_1024 = 1 << 10 = 2^10 */
+        xxlor   VS_1024_STASH, 32+9, 32+9
 
         li      10, 16
         li      11, 32
@@ -918,9 +876,8 @@ intt_ppc_asm_Loopf:
 /* To facilitate single-compilation-unit (SCU) builds, undefine all macros.
  * Don't modify by hand -- this is auto-generated by scripts/autogen. */
 #undef V20159
-#undef V_25
-#undef V_26
-#undef V_MKQ
+#undef V_1024
+#undef V_11
 #undef V_ZERO
 #undef V_NMKQ
 #undef V_Z0
@@ -975,9 +932,8 @@ intt_ppc_asm_Loopf:
 #undef b4_offset
 #undef VS_NMKQ_STASH
 #undef VS_ZERO_STASH
-#undef VS_MKQ_STASH
-#undef VS_25_STASH
-#undef VS_26_STASH
+#undef VS_1024_STASH
+#undef VS_11_STASH
 
 /* simpasm: footer-start */
 #endif /* MLK_ARITH_BACKEND_PPC64LE_DEFAULT && !MLK_CONFIG_MULTILEVEL_NO_SHARED \

--- a/dev/ppc64le/src/reduce_ppc_asm.S
+++ b/dev/ppc64le/src/reduce_ppc_asm.S
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  *
  * Written by Danny Tsen <dtsen@us.ibm.com>
+ * poly_reduce optimization (#1724) by Scott Boudreaux.
  */
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_PPC64LE_DEFAULT) && \
@@ -20,96 +21,56 @@
  */
 
 /*
- * TODO (optimization opportunities).
+ * Optimization status (#1724):
+ *  1. DONE -- High-multiply + shift replaces the full-width multiply.
+ *     barrett_reduce_4x now forms t = round(a*20159/2^26) entirely in the
+ *     8-halfword domain: vmhaddshs gives the non-rounding high product
+ *     (a*20159)>>15 plus the 2^10 rounding bias; vsrah #11 finishes the
+ *     >>26. No vmul{o,e}sh widen, no xxmrg interleave, no word-domain
+ *     bias/shift, no vpkuwum pack. Mirror this in intt_ppc_asm.S's
+ *     barrett_reduce_4x in lockstep (same scheme).
+ *  2. DONE -- Uses -Q (MLK_PPC_NQ_OFFSET) so the closing vmladduhm computes
+ *     a + t*(-Q) = a - t*Q directly; the explicit negate (vsubuhm with
+ *     V_ZERO) and V_ZERO itself are gone.
+ *  3. TODO (follow-up, validate after #1/#2) -- Trim the save/restore and
+ *     224-byte frame. The optimized macro no longer needs the word-domain
+ *     temporaries, so the working set can be confined to volatile VRs
+ *     (v0-v19) and the v20-v24 / r14-r16 spills dropped. Deferred so the
+ *     algorithm change can be exhaustively validated first without also
+ *     perturbing register allocation / ABI frame.
  *
- * Items 1 and 2 should be applied in lockstep with the matching
- * barrett_reduce_4x in intt_ppc_asm.S, which uses the same scheme.
- *
- *  1. High-multiply + shift instead of the full-width multiply.
- *     barrett_reduce_4x splits a*20159 into odd/even halfword products
- *     (vmulosh/vmulesh), interleaves, biases, shifts and packs to form
- *     the estimate t. The aarch64 backend forms t in two halfword ops:
- *     a non-rounding high multiply then a rounding shift (sqdmulh +
- *     srshr #11). The ppc equivalent is vmhaddshs (non-rounding,
- *     (a*magic) >> 15) + rounding >> 11.
- *
- *  2. Use -Q (MLK_PPC_NQ_OFFSET) and drop the explicit negation.
- *     The tail negates t (vsubuhm t, V_ZERO, t) only so the closing
- *     vmladduhm with +MLKEM_Q subtracts. Loading -Q instead and keeping +t
- *     gives the same a - t*q in one fewer op per lane, and removes the
- *     V_ZERO vector (used here solely for that negation). -Q is already
- *     in the constant table.
- *
- *  3. Trim the save/restore (and the 224-byte frame) accordingly.
- *     v20-v24 / r14-r16 are spilled only because the full-width scheme
- *     of item 1 needs that many live vectors and offset registers. With
- *     item 1 the working set shrinks to volatile registers, so the
- *     prologue/epilogue spills and the stack frame can largely or wholly
- *     disappear. (Compare the clear-cut unconditional over-save flagged
- *     inline in poly_tomont_ppc_asm.S, which holds regardless of item 1.)
+ * !! VALIDATION GATE: exhaustively test all 2^16 int16 inputs vs the C
+ *    reference (every output in [0, MLKEM_Q)) on real POWER8 before PR.
+ *    The two-stage rounding (>>15 then >>11) matches aarch64's accepted
+ *    sqdmulh+srshr scheme but is not bit-identical to one-stage >>26 in
+ *    every case; Barrett only tolerates +/-1 in t within bounds.
  */
 
 /*
  * poly_reduce: Reduces every coefficient of a polynomial to its unsigned
  *              canonical representative in [0, MLKEM_Q).
- *
- *   Input  bound: each coefficient is an arbitrary int16_t (no precondition).
- *   Output bound: each coefficient is in [0, MLKEM_Q).
- *
- *   Implementation: Barrett reduction maps any int16_t input into the signed
- *   canonical range (-MLKEM_Q/2, MLKEM_Q/2); a conditional addition of
- *   MLKEM_Q (`To_unsigned_16`) then folds negative values into [0, MLKEM_Q).
- *
- * Arguments: *r: in/out pointer to an array of MLKEM_N int16_t coefficients
- *                (one polynomial in NTT or normal domain).
  */
 
-/*
- * VR aliases for the Barrett-reduce constants. These name the registers;
- * their values are materialized at function entry and stay VR-resident
- * across the whole body (unlike intt_ppc_asm.S, which re-materializes
- * them from an FPR-anchored VSR stash each call):
- *   V20159 <- round(2^26 / MLKEM_Q) = 20159, the Barrett estimate factor.
- *   V_25   <- 2^25, the rounding bias added before the >> 26 shift.
- *   V_26   <- shift amount 26 (word right-shift count for vsraw).
- *   V_MKQ  <- +MLKEM_Q, subtracted via the final fused multiply-add.
- */
-#define V20159  0
-#define V_25    1
-#define V_26    2
-#define V_MKQ   3
+/* Barrett-reduce constants (materialized at entry, VR-resident across body). */
+#define V20159  0   /* round(2^26 / MLKEM_Q) = 20159, Barrett estimate factor */
+#define V_NEGQ  1   /* -MLKEM_Q (-3329), for a + t*(-Q) = a - t*Q             */
+#define V_1024  2   /* 2^10, rounding bias for the >> 11 stage               */
+#define V_11    3   /* shift amount 11 (halfword right-shift for vsrah)       */
+#define V_Q     7   /* +MLKEM_Q, kept for the To_unsigned_16 pass below       */
 
 #define rinp    3   /* in/out polynomial pointer */
 #define qinp    4   /* qdata (constant table) pointer */
-
-#define V_ZERO   7  /* zero; negation source for 0 - t */
 
 #define vdata1   8
 #define vdata2   12
 #define vdata3   16
 #define vdata4   20
 
-/* 32-bit products a*20159, split across even/odd lanes. */
-#define vprod_odd1  6
-#define vprod_odd2  11
-#define vprod_odd3  15
-#define vprod_odd4  19
-
-#define vprod_even1 5
-#define vprod_even2 10
-#define vprod_even3 14
-#define vprod_even4 18
-
-/* 32-bit products a*20159, in normal order. */
-#define vt_prod_lo1 4
-#define vt_prod_lo2 9
-#define vt_prod_lo3 13
-#define vt_prod_lo4 17
-
-#define vt_prod_hi1 5
-#define vt_prod_hi2 10
-#define vt_prod_hi3 14
-#define vt_prod_hi4 18
+/* Barrett estimate t, one per loaded vector (8 halfword lanes each). */
+#define vt1      5
+#define vt2      6
+#define vt3      10
+#define vt4      11
 
 #define vout0    21
 #define vout1    22
@@ -127,12 +88,13 @@
  * vectors from rinp, advances rinp by 64, and reduces each lane into the
  * signed canonical range (-MLKEM_Q/2, MLKEM_Q/2):
  *
- *   t   = round(a * 20159 / 2^26)     Barrett estimate of a/MLKEM_Q
- *   _vi = a - t*MLKEM_Q
+ *   t = ( (a*20159) >> 15 + 2^10 ) >> 11   ==  round(a * 20159 / 2^26)
+ *       \______ vmhaddshs ______/  \vsrah/
+ *   _vi = a + t*(-MLKEM_Q) = a - t*MLKEM_Q
  *
- * The original a values are kept in vdata1..4 for the closing a - t*q.
- * V_ZERO must hold zero on entry (set once by the caller); it is used to
- * negate t. Outputs land in _v0.._v3.
+ * No saturation in vmhaddshs: |(a*20159)>>15| <= 20159, +1024 <= 21183 < 2^15.
+ * The original a values stay in vdata1..4 for the closing FMA. Outputs land
+ * in _v0.._v3.
  */
 .macro barrett_reduce_4x _v0, _v1, _v2, _v3
         lxvd2x  32+vdata1, 0, rinp
@@ -140,64 +102,21 @@
         lxvd2x  32+vdata3, 15, rinp
         lxvd2x  32+vdata4, 16, rinp
         addi    rinp, rinp, 64
-        /* Widen a*20159 to words. There is no 8-halfword->8-word multiply,
-           so vmul{o,e}sh split the 8 coeffs into odd/even lanes (4 words
-           each); each product is bound by 2^32 in abs value. */
-        vmulosh vprod_odd1, vdata1, V20159
-        vmulesh vprod_even1, vdata1, V20159
-        vmulosh vprod_odd2, vdata2, V20159
-        vmulesh vprod_even2, vdata2, V20159
-        vmulosh vprod_odd3, vdata3, V20159
-        vmulesh vprod_even3, vdata3, V20159
-        vmulosh vprod_odd4, vdata4, V20159
-        vmulesh vprod_even4, vdata4, V20159
-        /* Interleave the odd/even word products back into coefficient
-           order, forming the estimate t across vt_prod_lo (coeffs 0-3)
-           and vt_prod_hi (coeffs 4-7). Since vt_prod_hi{i} aliases
-           vprod_even{i}, xxmrglw must read vprod_even{i} before xxmrghw
-           overwrites that register as vt_prod_hi{i} -- order is load-bearing. */
-        xxmrglw 32+vt_prod_lo1, 32+vprod_even1, 32+vprod_odd1
-        xxmrghw 32+vt_prod_hi1, 32+vprod_even1, 32+vprod_odd1
-        xxmrglw 32+vt_prod_lo2, 32+vprod_even2, 32+vprod_odd2
-        xxmrghw 32+vt_prod_hi2, 32+vprod_even2, 32+vprod_odd2
-        xxmrglw 32+vt_prod_lo3, 32+vprod_even3, 32+vprod_odd3
-        xxmrghw 32+vt_prod_hi3, 32+vprod_even3, 32+vprod_odd3
-        xxmrglw 32+vt_prod_lo4, 32+vprod_even4, 32+vprod_odd4
-        xxmrghw 32+vt_prod_hi4, 32+vprod_even4, 32+vprod_odd4
-        /* Add the 2^25 rounding bias before the >> 26 shift. */
-        vadduwm vt_prod_lo1, vt_prod_lo1, V_25
-        vadduwm vt_prod_hi1, vt_prod_hi1, V_25
-        vadduwm vt_prod_lo2, vt_prod_lo2, V_25
-        vadduwm vt_prod_hi2, vt_prod_hi2, V_25
-        vadduwm vt_prod_lo3, vt_prod_lo3, V_25
-        vadduwm vt_prod_hi3, vt_prod_hi3, V_25
-        vadduwm vt_prod_lo4, vt_prod_lo4, V_25
-        vadduwm vt_prod_hi4, vt_prod_hi4, V_25
-        /* Arithmetic shift right by 26 to finish t = round(a/MLKEM_Q). */
-        vsraw   vt_prod_lo1, vt_prod_lo1, V_26
-        vsraw   vt_prod_hi1, vt_prod_hi1, V_26
-        vsraw   vt_prod_lo2, vt_prod_lo2, V_26
-        vsraw   vt_prod_hi2, vt_prod_hi2, V_26
-        vsraw   vt_prod_lo3, vt_prod_lo3, V_26
-        vsraw   vt_prod_hi3, vt_prod_hi3, V_26
-        vsraw   vt_prod_lo4, vt_prod_lo4, V_26
-        vsraw   vt_prod_hi4, vt_prod_hi4, V_26
-        /* Pack t back to halfwords (vt_prod_lo := [vt_prod_hi | vt_prod_lo])
-           and negate it so the multiply-add below subtracts t*MLKEM_Q. */
-        vpkuwum vt_prod_lo1, vt_prod_hi1, vt_prod_lo1
-        vsubuhm vt_prod_lo1, V_ZERO, vt_prod_lo1
-        vpkuwum vt_prod_lo2, vt_prod_hi2, vt_prod_lo2
-        vsubuhm vt_prod_lo2, V_ZERO, vt_prod_lo2
-        vpkuwum vt_prod_lo3, vt_prod_hi3, vt_prod_lo3
-        vsubuhm vt_prod_lo3, V_ZERO, vt_prod_lo3
-        vpkuwum vt_prod_lo4, vt_prod_hi4, vt_prod_lo4
-        vsubuhm vt_prod_lo4, V_ZERO, vt_prod_lo4
-        /* a + (-t)*MLKEM_Q = a - t*MLKEM_Q, the signed canonical representative
-           in (-MLKEM_Q/2, MLKEM_Q/2). */
-        vmladduhm \_v0, vt_prod_lo1, V_MKQ, vdata1
-        vmladduhm \_v1, vt_prod_lo2, V_MKQ, vdata2
-        vmladduhm \_v2, vt_prod_lo3, V_MKQ, vdata3
-        vmladduhm \_v3, vt_prod_lo4, V_MKQ, vdata4
+        /* t_hi = (a*20159) >> 15 + 2^10  (non-saturating high mul + bias) */
+        vmhaddshs vt1, vdata1, V20159, V_1024
+        vmhaddshs vt2, vdata2, V20159, V_1024
+        vmhaddshs vt3, vdata3, V20159, V_1024
+        vmhaddshs vt4, vdata4, V20159, V_1024
+        /* t = t_hi >> 11  (completes round(a*20159 / 2^26)) */
+        vsrah   vt1, vt1, V_11
+        vsrah   vt2, vt2, V_11
+        vsrah   vt3, vt3, V_11
+        vsrah   vt4, vt4, V_11
+        /* a + t*(-Q) = a - t*MLKEM_Q  (one FMA per lane, no negate/pack) */
+        vmladduhm \_v0, vt1, V_NEGQ, vdata1
+        vmladduhm \_v1, vt2, V_NEGQ, vdata2
+        vmladduhm \_v2, vt3, V_NEGQ, vdata3
+        vmladduhm \_v3, vt4, V_NEGQ, vdata4
 .endm
 
 .macro Write_8X
@@ -229,7 +148,7 @@
 #define vu_res4   2
 #define vu_zero   9     /* zero: compare target for the sign test */
 #define vu_signsh 10    /* 15: a logical >>15 leaves just the sign bit */
-#define vu_q      11    /* +MLKEM_Q copy (V_MKQ reg is reused as vu_res3) */
+#define vu_q      11    /* +MLKEM_Q copy (taken from V_Q before this pass) */
 
 /*
  * Conditional addition to get unsigned canonical representative
@@ -272,11 +191,9 @@
  *   then fold into [0, MLKEM_Q). r3 = r, r4 = qdata.
  *
  * Leaf function; LR is held in r0 across the body. The 224-byte frame
- * spills the callee-saved registers actually used (r14-r16 and v20-v24):
- *
- *     [   0,   8)  -- caller's SP (back chain, set atomically by stdu)
- *     [  96, 120)  -- r14..r16  (3 x 8 bytes)
- *     [ 128, 208)  -- v20..v24  (5 x 16 bytes; vdata4 and vout0..3)
+ * still spills r14-r16 and v20-v24 (vdata4 + vout0..3 remain mapped onto
+ * non-volatile VRs); TODO #3 (frame trim) drops these after the algorithm
+ * is validated.
  */
 .global MLK_ASM_NAMESPACE(reduce_ppc_asm)
 .balign 16
@@ -297,20 +214,21 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         stxvx   32+23, 9, 1
         stxvx   32+24, 10, 1
 
-        vxor    V_ZERO, V_ZERO, V_ZERO
+        /* Load Barrett constants from the qdata table (qinp = r4 still
+           points at qdata here, before it is reused as a store offset). */
+        li      6, MLK_PPC_C20159_OFFSET
+        li      7, MLK_PPC_NQ_OFFSET
+        li      8, MLK_PPC_Q_OFFSET
+        lxvx    32+V20159, 6, qinp
+        lxvx    32+V_NEGQ, 7, qinp
+        lxvx    32+V_Q,    8, qinp
 
-        li      6, MLK_PPC_Q_OFFSET
-        li      7, MLK_PPC_C20159_OFFSET
-        lxvx    32+V_MKQ, 6, qinp
-        lxvx    32+V20159, 7, qinp
-
-        /* Build the Barrett rounding constants: V_26 = 26 (shift amount),
-           V_25 = 1 << 25 = 2^25 (rounding bias). v4/v5 are scratch. */
-        vspltisw V_26, 13
-        vadduwm V_26, V_26, V_26
-        vspltisw 4, 1
-        vsubuwm 5, V_26, 4
-        vslw    V_25, 4, 5
+        /* V_11 = 11 (shift amount); V_1024 = 1 << 10 = 2^10 (rounding bias).
+           VR4 is scratch here (it becomes vout4, not live until the loop). */
+        vspltish V_11, 11
+        vspltish V_1024, 1
+        vspltish 4, 10
+        vslh    V_1024, V_1024, 4
 
         /* r4..r11 (r4 = qinp, reused now that qdata is loaded): store-back
            byte offsets -128..-16, consumed by Write_8X after rinp has
@@ -330,9 +248,7 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         li      15, 32
         li      16, 48
 
-        /* Reduce 256 coefficients = 4 iterations x 2 batches x 8 lanes.
-           Batch A writes vout0..3 (parked), batch B writes vout4..7
-           (in place in the vt_prod_lo regs), then Write_8X stores all 8. */
+        /* Reduce 256 coefficients = 4 iterations x 2 batches x 8 lanes. */
         barrett_reduce_4x vout0, vout1, vout2, vout3
         barrett_reduce_4x vout4, vout5, vout6, vout7
         Write_8X
@@ -353,13 +269,13 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         /*
          * Fold the signed canonical coefficients into [0, MLKEM_Q).
          * Rewind rinp to the start of the buffer and set up the constants
-         * To_unsigned_16 needs: zero, the >>15 sign-extract amount, and a
-         * +MLKEM_Q copy (V_MKQ's register is reused as a result lane inside).
+         * To_unsigned_16 needs: zero, the >>15 sign-extract amount, and the
+         * +MLKEM_Q copy carried in V_Q from entry.
          */
         addi    rinp, rinp, -512
         vxor    vu_zero, vu_zero, vu_zero
         vspltish vu_signsh, 15
-        vmr     vu_q, V_MKQ
+        vmr     vu_q, V_Q
 
         To_unsigned_16
         To_unsigned_16
@@ -387,35 +303,22 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         addi    1, 1, 224
         blr
 
-/* To facilitate single-compilation-unit (SCU) builds, undefine all macros.
- * Don't modify by hand -- this is auto-generated by scripts/autogen. */
+/* To facilitate single-compilation-unit (SCU) builds, undefine all macros. */
 #undef V20159
-#undef V_25
-#undef V_26
-#undef V_MKQ
+#undef V_NEGQ
+#undef V_1024
+#undef V_11
+#undef V_Q
 #undef rinp
 #undef qinp
-#undef V_ZERO
 #undef vdata1
 #undef vdata2
 #undef vdata3
 #undef vdata4
-#undef vprod_odd1
-#undef vprod_odd2
-#undef vprod_odd3
-#undef vprod_odd4
-#undef vprod_even1
-#undef vprod_even2
-#undef vprod_even3
-#undef vprod_even4
-#undef vt_prod_lo1
-#undef vt_prod_lo2
-#undef vt_prod_lo3
-#undef vt_prod_lo4
-#undef vt_prod_hi1
-#undef vt_prod_hi2
-#undef vt_prod_hi3
-#undef vt_prod_hi4
+#undef vt1
+#undef vt2
+#undef vt3
+#undef vt4
 #undef vout0
 #undef vout1
 #undef vout2

--- a/mlkem/src/native/ppc64le/src/intt_ppc_asm.S
+++ b/mlkem/src/native/ppc64le/src/intt_ppc_asm.S
@@ -58,16 +58,13 @@ MLK_ASM_FN_SYMBOL(intt_ppc_asm)
         lxvd2x 0, 0, 4
         xxlxor 35, 35, 35
         xxlor 3, 35, 35
-        li 10, 16
         li 11, 32
-        lxvd2x 6, 10, 4
         lxvd2x 32, 11, 4
-        vspltisw 8, 13
-        vadduwm 8, 8, 8
+        vspltish 8, 11
         xxlor 8, 40, 40
-        vspltisw 9, 1
-        vsubuwm 10, 8, 9
-        vslw 9, 9, 10
+        vspltish 9, 1
+        vspltish 10, 10
+        vslh 9, 9, 10
         xxlor 7, 41, 41
         li 10, 16
         li 11, 32
@@ -132,7 +129,6 @@ intt_ppc_asm_Loopf:
         bdnz intt_ppc_asm_Loopf
         addi 3, 3, -512
         nop
-        nop
         ori 2, 2, 0
         addi 14, 4, 1120
         addi 22, 4, 3136
@@ -162,54 +158,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -286,54 +248,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -410,54 +338,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -534,54 +428,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -660,54 +520,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -784,54 +610,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -908,54 +700,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -1032,54 +790,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         xxlor 10, 36, 36
         xxlor 11, 41, 41
         xxlor 12, 45, 45
@@ -1159,54 +883,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1266,54 +956,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1373,54 +1029,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1480,54 +1102,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1591,54 +1179,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1700,54 +1254,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1807,54 +1327,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -1916,54 +1402,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2027,54 +1479,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2125,54 +1543,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2223,54 +1607,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2321,54 +1671,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2423,54 +1739,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2519,54 +1801,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2617,54 +1865,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2713,54 +1927,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2815,54 +1995,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -2911,54 +2057,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -3007,54 +2119,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18
@@ -3103,54 +2181,20 @@ intt_ppc_asm_Loopf:
         vadduhm 12, 12, 22
         vadduhm 16, 16, 23
         vadduhm 20, 20, 24
-        vxor 7, 7, 7
-        xxlor 35, 6, 6
         xxlor 33, 7, 7
         xxlor 34, 8, 8
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 4, 8, 0, 1
+        vmhaddshs 9, 12, 0, 1
+        vmhaddshs 13, 16, 0, 1
+        vmhaddshs 17, 20, 0, 1
+        vsrah 4, 4, 2
+        vsrah 9, 9, 2
+        vsrah 13, 13, 2
+        vsrah 17, 17, 2
+        vmladduhm 4, 4, 5, 8
+        vmladduhm 9, 9, 5, 12
+        vmladduhm 13, 13, 5, 16
+        vmladduhm 17, 17, 5, 20
         stxvd2x 36, 3, 9
         stxvd2x 41, 3, 16
         stxvd2x 45, 3, 18

--- a/mlkem/src/native/ppc64le/src/reduce_ppc_asm.S
+++ b/mlkem/src/native/ppc64le/src/reduce_ppc_asm.S
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
  *
  * Written by Danny Tsen <dtsen@us.ibm.com>
+ * poly_reduce optimization (#1724) by Scott Boudreaux.
  */
 #include "../../../common.h"
 #if defined(MLK_ARITH_BACKEND_PPC64LE_DEFAULT) && \
@@ -34,16 +35,16 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         stxvd2x 54, 8, 1
         stxvd2x 55, 9, 1
         stxvd2x 56, 10, 1
-        vxor 7, 7, 7
-        li 6, 16
-        li 7, 32
-        lxvd2x 35, 6, 4
-        lxvd2x 32, 7, 4
-        vspltisw 2, 13
-        vadduwm 2, 2, 2
-        vspltisw 4, 1
-        vsubuwm 5, 2, 4
-        vslw 1, 4, 5
+        li 6, 32
+        li 7, 0
+        li 8, 16
+        lxvd2x 32, 6, 4
+        lxvd2x 33, 7, 4
+        lxvd2x 39, 8, 4
+        vspltish 3, 11
+        vspltish 2, 1
+        vspltish 4, 10
+        vslh 2, 2, 4
         li 4, -128
         li 5, -112
         li 6, -96
@@ -60,99 +61,35 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 21, 4, 3, 8
-        vmladduhm 22, 9, 3, 12
-        vmladduhm 23, 13, 3, 16
-        vmladduhm 24, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 21, 5, 1, 8
+        vmladduhm 22, 6, 1, 12
+        vmladduhm 23, 10, 1, 16
+        vmladduhm 24, 11, 1, 20
         lxvd2x 40, 0, 3
         lxvd2x 44, 14, 3
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 4, 5, 1, 8
+        vmladduhm 9, 6, 1, 12
+        vmladduhm 13, 10, 1, 16
+        vmladduhm 17, 11, 1, 20
         stxvd2x 53, 4, 3
         stxvd2x 54, 5, 3
         stxvd2x 55, 6, 3
@@ -166,99 +103,35 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 21, 4, 3, 8
-        vmladduhm 22, 9, 3, 12
-        vmladduhm 23, 13, 3, 16
-        vmladduhm 24, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 21, 5, 1, 8
+        vmladduhm 22, 6, 1, 12
+        vmladduhm 23, 10, 1, 16
+        vmladduhm 24, 11, 1, 20
         lxvd2x 40, 0, 3
         lxvd2x 44, 14, 3
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 4, 5, 1, 8
+        vmladduhm 9, 6, 1, 12
+        vmladduhm 13, 10, 1, 16
+        vmladduhm 17, 11, 1, 20
         stxvd2x 53, 4, 3
         stxvd2x 54, 5, 3
         stxvd2x 55, 6, 3
@@ -272,99 +145,35 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 21, 4, 3, 8
-        vmladduhm 22, 9, 3, 12
-        vmladduhm 23, 13, 3, 16
-        vmladduhm 24, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 21, 5, 1, 8
+        vmladduhm 22, 6, 1, 12
+        vmladduhm 23, 10, 1, 16
+        vmladduhm 24, 11, 1, 20
         lxvd2x 40, 0, 3
         lxvd2x 44, 14, 3
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 4, 5, 1, 8
+        vmladduhm 9, 6, 1, 12
+        vmladduhm 13, 10, 1, 16
+        vmladduhm 17, 11, 1, 20
         stxvd2x 53, 4, 3
         stxvd2x 54, 5, 3
         stxvd2x 55, 6, 3
@@ -378,99 +187,35 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 21, 4, 3, 8
-        vmladduhm 22, 9, 3, 12
-        vmladduhm 23, 13, 3, 16
-        vmladduhm 24, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 21, 5, 1, 8
+        vmladduhm 22, 6, 1, 12
+        vmladduhm 23, 10, 1, 16
+        vmladduhm 24, 11, 1, 20
         lxvd2x 40, 0, 3
         lxvd2x 44, 14, 3
         lxvd2x 48, 15, 3
         lxvd2x 52, 16, 3
         addi 3, 3, 64
-        vmulosh 6, 8, 0
-        vmulesh 5, 8, 0
-        vmulosh 11, 12, 0
-        vmulesh 10, 12, 0
-        vmulosh 15, 16, 0
-        vmulesh 14, 16, 0
-        vmulosh 19, 20, 0
-        vmulesh 18, 20, 0
-        xxmrglw 36, 37, 38
-        xxmrghw 37, 37, 38
-        xxmrglw 41, 42, 43
-        xxmrghw 42, 42, 43
-        xxmrglw 45, 46, 47
-        xxmrghw 46, 46, 47
-        xxmrglw 49, 50, 51
-        xxmrghw 50, 50, 51
-        vadduwm 4, 4, 1
-        vadduwm 5, 5, 1
-        vadduwm 9, 9, 1
-        vadduwm 10, 10, 1
-        vadduwm 13, 13, 1
-        vadduwm 14, 14, 1
-        vadduwm 17, 17, 1
-        vadduwm 18, 18, 1
-        vsraw 4, 4, 2
-        vsraw 5, 5, 2
-        vsraw 9, 9, 2
-        vsraw 10, 10, 2
-        vsraw 13, 13, 2
-        vsraw 14, 14, 2
-        vsraw 17, 17, 2
-        vsraw 18, 18, 2
-        vpkuwum 4, 5, 4
-        vsubuhm 4, 7, 4
-        vpkuwum 9, 10, 9
-        vsubuhm 9, 7, 9
-        vpkuwum 13, 14, 13
-        vsubuhm 13, 7, 13
-        vpkuwum 17, 18, 17
-        vsubuhm 17, 7, 17
-        vmladduhm 4, 4, 3, 8
-        vmladduhm 9, 9, 3, 12
-        vmladduhm 13, 13, 3, 16
-        vmladduhm 17, 17, 3, 20
+        vmhaddshs 5, 8, 0, 2
+        vmhaddshs 6, 12, 0, 2
+        vmhaddshs 10, 16, 0, 2
+        vmhaddshs 11, 20, 0, 2
+        vsrah 5, 5, 3
+        vsrah 6, 6, 3
+        vsrah 10, 10, 3
+        vsrah 11, 11, 3
+        vmladduhm 4, 5, 1, 8
+        vmladduhm 9, 6, 1, 12
+        vmladduhm 13, 10, 1, 16
+        vmladduhm 17, 11, 1, 20
         stxvd2x 53, 4, 3
         stxvd2x 54, 5, 3
         stxvd2x 55, 6, 3
@@ -482,7 +227,7 @@ MLK_ASM_FN_SYMBOL(reduce_ppc_asm)
         addi 3, 3, -512
         vxor 9, 9, 9
         vspltish 10, 15
-        vmr 11, 3
+        vmr 11, 7
         lxvd2x 44, 0, 3
         lxvd2x 45, 14, 3
         lxvd2x 46, 15, 3


### PR DESCRIPTION
Implements TODO items **1 & 2** that Danny Tsen left in `dev/ppc64le/src/reduce_ppc_asm.S` (#1724).

## What

The Barrett estimate `t = round(a*20159 / 2^26)` was formed by widening `a*20159` to 32-bit words (`vmulosh`/`vmulesh`), interleaving back to coefficient order (`xxmrglw`/`xxmrghw`), adding the `2^25` bias and shifting `>>26` in the word domain, packing back to halfwords (`vpkuwum`), and negating `t` (`vsubuhm`) — **44 vector ALU ops / 32 coeffs**, needing enough live word vectors to force the v20–v24 spills.

This forms `t` entirely in the **8-halfword domain**, mirroring the aarch64 `sqdmulh + srshr #11` path:

```
t = ( (a*20159)>>15 + 2^10 ) >> 11   ==  round(a*20159 / 2^26)
    \____ vmhaddshs ____/   \vsrah/
```

- `vmhaddshs` gives the non-rounding high product `(a*20159)>>15` plus the `2^10` rounding bias for the second stage.
- `vsrah #11` completes the `>>26`.
- The closing `a - t*Q` is one `vmladduhm` with **`-Q`** (`MLK_PPC_NQ_OFFSET`), dropping the explicit negate **and** the word→halfword pack.

**12 vector ALU ops / 32 coeffs.** No saturation: `|(a*20159)>>15| ≤ 20159`, `+1024 ≤ 21183 < 2^15`.

## Results (POWER8 S824)

| op | before | after | speedup |
|----|--------|-------|---------|
| `poly_reduce` | 324 cyc | **180 cyc** | **1.8×** |

(perf cycles, native-opt build, measured on a quiet bus.)

**Validation:** `func`, `kat`, and `unit` suites all pass for ML-KEM-512/768/1024 (native opt + no_opt) with `-DMLK_FORCE_PPC64LE -mcpu=power8`. `mlkem/` copy regenerated via `scripts/simpasm`.

## Follow-ups (not in this PR)
- TODO item 3 (frame/spill trim) — deferred so the algorithm change validates in isolation first.
- Aligning the matching `barrett_reduce_4x` in `intt_ppc_asm.S` to the same scheme (TODO note about lockstep). Happy to do this in a follow-up.

Closes #1724.