### PR TITLE
AArch64: Synchronize clean and optimized assembly

### DIFF
--- a/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
@@ -285,16 +285,16 @@ rej_uniform_loop48:
         tbl     val2.16b, {val2.16b}, table2.16b
         tbl     val3.16b, {val3.16b}, table3.16b
 
-        str     val0q, [output_tmp]
+        st1     {val0.8h}, [output_tmp]
         add     output_tmp, output_tmp, ctr0, lsl #1
 
-        str     val1q, [output_tmp]
+        st1     {val1.8h}, [output_tmp]
         add     output_tmp, output_tmp, ctr1, lsl #1
 
-        str     val2q, [output_tmp]
+        st1     {val2.8h}, [output_tmp]
         add     output_tmp, output_tmp, ctr2, lsl #1
 
-        str     val3q, [output_tmp]
+        st1     {val3.8h}, [output_tmp]
         add     output_tmp, output_tmp, ctr3, lsl #1
 
         add     ctr01, ctr0, ctr1
@@ -313,7 +313,6 @@ rej_uniform_loop48_end:
     cmp buflen, #24
     b.lo rej_uniform_memory_copy
 
-        sub     buflen, buflen, #24
         ld3     {buf0.8b, buf1.8b, buf2.8b}, [buf], #24
 
         zip1    tmp0.16b, buf0.16b, buf1.16b
@@ -352,11 +351,10 @@ rej_uniform_loop48_end:
         tbl     val0.16b, {val0.16b}, table0.16b
         tbl     val1.16b, {val1.16b}, table1.16b
 
-        str     val0q, [output_tmp]
+        st1     {val0.8h}, [output_tmp]
         add     output_tmp, output_tmp, ctr0, lsl #1
 
-        str     val1q, [output_tmp]
-        add     output_tmp, output_tmp, ctr1, lsl #1
+        st1     {val1.8h}, [output_tmp]
 
         add     count, count, ctr0
         add     count, count, ctr1
@@ -385,7 +383,6 @@ rej_uniform_final_copy:
         b.lt rej_uniform_final_copy
 
     mov x0, count
-    b rej_uniform_return
 
 rej_uniform_return:
     pop_stack


### PR DESCRIPTION
The commits

- "AArch64: Use alignment-safe Neon stores in rej_uniform" (6dc035bea)
- "AArch64 rej_uniform: Remove three dead instructions"    (9c442c429)

introduced changes to the optimized versions of the AArch64 backend that were not backported to the clean versions. This commit conducts such backports.