### PR TITLE
CI: Install sqlite3 via apt instead of nix profile

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -98,7 +98,10 @@ runs:
           sudo chown -R $USER:nixbld /nix
         fi
 
-        nix profile install nixpkgs/nixos-24.11#sqlite
+        # sqlite3 is needed by cache-nix-action to merge the Nix store database.
+        if ! command -v sqlite3 >/dev/null 2>&1; then
+          sudo apt-get update && sudo apt-get install -y sqlite3
+        fi
         nix config show
         echo "::endgroup::"
     - uses: nix-community/cache-nix-action@dab0514428ae3988852b7787a6d86a6fc571cc9d #v6.0.0


### PR DESCRIPTION
cache-nix-action merges the Nix store database with sqlite3, which the setup-nix action provided via `nix profile install nixpkgs/nixos-24.11#sqlite`. Resolving the nixos-24.11 branch goes through api.github.com, which intermittently returns HTTP 429 when many EC2 runners start at once. When throttled, sqlite3 was never installed, the store-DB merge failed with "sqlite3: command not found", and the corrupted store then broke every subsequent `nix develop` in the job.

Install sqlite3 from apt instead, which never touches api.github.com. Guard on `command -v sqlite3` so it's a no-op where sqlite3 already exists (macOS and GitHub-hosted runners) and only installs on the bare EC2 AMIs.

 - Ports https://github.com/pq-code-package/mldsa-native/pull/1239