### PR TITLE
README: Replace stale sub-workflow badges with all.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # mlkem-native
 
-![Base tests](https://github.com/pq-code-package/mlkem-native/actions/workflows/base.yml/badge.svg)
-![Extended tests](https://github.com/pq-code-package/mlkem-native/actions/workflows/ci.yml/badge.svg)
-![Proof: CBMC](https://github.com/pq-code-package/mlkem-native/actions/workflows/cbmc.yml/badge.svg)
+![CI](https://github.com/pq-code-package/mlkem-native/actions/workflows/all.yml/badge.svg)
 ![Proof: HOL-Light](https://github.com/pq-code-package/mlkem-native/actions/workflows/hol_light.yml/badge.svg)
 ![Benchmarks](https://github.com/pq-code-package/mlkem-native/actions/workflows/bench.yml/badge.svg)
 ![C90](https://img.shields.io/badge/language-C90-blue.svg)


### PR DESCRIPTION
base.yml, ci.yml and cbmc.yml no longer have their own push/PR triggers; they run only as reusable workflows via all.yml, so their badges reflected stale workflow_dispatch runs. Point a single CI badge at all.yml instead.