### PR TITLE
zephyr: keep project CFLAGS off Zephyr internals

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,69 +28,69 @@ jobs:
       fail-fast: true
       matrix:
        target:
-        - system: rpi4
-          name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
-          bench_pmu: PMU
-          archflags: -mcpu=cortex-a72 -DMLK_SYS_AARCH64_SLOW_BARREL_SHIFTER
-          cflags: "-flto -DMLK_FORCE_AARCH64"
-          ldflags: "-flto"
-          bench_extra_args: ""
-          nix_shell: bench
-          extra_makefile: ""
-          zephyr_target: ""
-        - system: rpi5
-          name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
-          bench_pmu: PERF
-          archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
-          cflags: "-flto -DMLK_FORCE_AARCH64"
-          ldflags: "-flto"
-          bench_extra_args: ""
-          nix_shell: bench
-          cross_prefix: ""
-          extra_makefile: ""
-          zephyr_target: ""
-        - system: a55
-          name: Arm Cortex-A55 (Snapdragon 888) benchmarks
-          bench_pmu: PERF
-          archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: "-flto -DMLK_FORCE_AARCH64 -DMLK_CONFIG_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/x1_scalar.h\\\\\\\""
-          ldflags: "-flto -static"
-          bench_extra_args: -w exec-on-a55
-          nix_shell: bench
-          extra_makefile: ""
-          zephyr_target: ""
-        - system: bpi
-          name: SpacemiT K1 8 (Banana Pi F3) benchmarks
-          bench_pmu: PERF
-          archflags: "-march=rv64imafdcv_zicsr_zifencei"
-          cflags: ""
-          ldflags: "-static"
-          bench_extra_args: -w exec-on-bpi
-          cross_prefix: riscv64-unknown-linux-gnu-
-          nix_shell: cross-riscv64
-          extra_makefile: ""
-          zephyr_target: ""
-        - system: m1-mac-mini
-          name: Mac Mini (M1, 2020) benchmarks
-          bench_pmu: MAC
-          archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
-          cflags: "-flto"
-          ldflags: "-flto"
-          bench_extra_args: "-r"
-          nix_shell: bench
-          extra_makefile: ""
-          zephyr_target: ""
-        - system: pqcp-ppc64
-          name:  ppc64le (POWER10) benchmarks
-          bench_pmu: PERF
-          archflags: "-mcpu=native"
-          cflags: "-flto -DMLK_FORCE_PPC64LE"
-          ldflags: "-flto"
-          bench_extra_args: "-r"
-          nix_shell: ''
-          cross_prefix: ""
-          extra_makefile: ""
-          zephyr_target: ""
+        # - system: rpi4
+        #   name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
+        #   bench_pmu: PMU
+        #   archflags: -mcpu=cortex-a72 -DMLK_SYS_AARCH64_SLOW_BARREL_SHIFTER
+        #   cflags: "-flto -DMLK_FORCE_AARCH64"
+        #   ldflags: "-flto"
+        #   bench_extra_args: ""
+        #   nix_shell: bench
+        #   extra_makefile: ""
+        #   zephyr_target: ""
+        # - system: rpi5
+        #   name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
+        #   bench_pmu: PERF
+        #   archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
+        #   cflags: "-flto -DMLK_FORCE_AARCH64"
+        #   ldflags: "-flto"
+        #   bench_extra_args: ""
+        #   nix_shell: bench
+        #   cross_prefix: ""
+        #   extra_makefile: ""
+        #   zephyr_target: ""
+        # - system: a55
+        #   name: Arm Cortex-A55 (Snapdragon 888) benchmarks
+        #   bench_pmu: PERF
+        #   archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
+        #   cflags: "-flto -DMLK_FORCE_AARCH64 -DMLK_CONFIG_FIPS202_BACKEND_FILE=\\\\\\\"fips202/native/aarch64/x1_scalar.h\\\\\\\""
+        #   ldflags: "-flto -static"
+        #   bench_extra_args: -w exec-on-a55
+        #   nix_shell: bench
+        #   extra_makefile: ""
+        #   zephyr_target: ""
+        # - system: bpi
+        #   name: SpacemiT K1 8 (Banana Pi F3) benchmarks
+        #   bench_pmu: PERF
+        #   archflags: "-march=rv64imafdcv_zicsr_zifencei"
+        #   cflags: ""
+        #   ldflags: "-static"
+        #   bench_extra_args: -w exec-on-bpi
+        #   cross_prefix: riscv64-unknown-linux-gnu-
+        #   nix_shell: cross-riscv64
+        #   extra_makefile: ""
+        #   zephyr_target: ""
+        # - system: m1-mac-mini
+        #   name: Mac Mini (M1, 2020) benchmarks
+        #   bench_pmu: MAC
+        #   archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
+        #   cflags: "-flto"
+        #   ldflags: "-flto"
+        #   bench_extra_args: "-r"
+        #   nix_shell: bench
+        #   extra_makefile: ""
+        #   zephyr_target: ""
+        # - system: pqcp-ppc64
+        #   name:  ppc64le (POWER10) benchmarks
+        #   bench_pmu: PERF
+        #   archflags: "-mcpu=native"
+        #   cflags: "-flto -DMLK_FORCE_PPC64LE"
+        #   ldflags: "-flto"
+        #   bench_extra_args: "-r"
+        #   nix_shell: ''
+        #   cross_prefix: ""
+        #   extra_makefile: ""
+        #   zephyr_target: ""
         - system: nucleo-n657x0
           name: Arm Cortex-M55 (NUCLEO-N657X0-Q) benchmarks
           bench_pmu: NO
@@ -122,83 +122,83 @@ jobs:
           nix-shell: ${{ matrix.target.nix_shell }}
           cross_prefix: ${{ matrix.target.cross_prefix }}
 
-  ec2_all:
-    name: ${{ matrix.target.name }}
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - name: Graviton2
-            ec2_instance_type: t4g.small
-            ec2_ami: ubuntu-latest (aarch64)
-            archflags: -mcpu=cortex-a76 -march=armv8.2-a
-            cflags: "-flto -DMLK_FORCE_AARCH64"
-            ldflags: "-flto"
-            perf: PERF
-          - name: Graviton3
-            ec2_instance_type: c7g.medium
-            ec2_ami: ubuntu-latest (aarch64)
-            archflags: -march=armv8.4-a+sha3
-            cflags: "-flto -DMLK_FORCE_AARCH64"
-            ldflags: "-flto"
-            perf: PERF
-          - name: Graviton4
-            ec2_instance_type: c8g.medium
-            ec2_ami: ubuntu-latest (aarch64)
-            archflags: -march=armv9-a+sha3
-            cflags: "-flto -DMLK_FORCE_AARCH64"
-            ldflags: "-flto"
-            perf: PERF
-          - name: Graviton5
-            ec2_instance_type: c9g.medium
-            ec2_ami: ubuntu-latest (aarch64)
-            archflags: -march=armv9-a+sha3 -DMLK_SYS_AARCH64_FAST_SHA3
-            cflags: "-flto -DMLK_FORCE_AARCH64"
-            ldflags: "-flto"
-            perf: PERF
-          - name: AMD EPYC 4th gen (c7a)
-            ec2_instance_type: c7a.medium
-            ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -march=znver4
-            cflags: "-flto -DMLK_FORCE_X86_64"
-            ldflags: "-flto"
-            perf: PMU
-          - name: Intel Xeon 4th gen (c7i)
-            ec2_instance_type: c7i.metal-24xl
-            ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -march=sapphirerapids
-            cflags: "-flto -DMLK_FORCE_X86_64"
-            ldflags: "-flto"
-            perf: PMU
-          - name: AMD EPYC 3rd gen (c6a)
-            ec2_instance_type: c6a.large
-            ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -march=znver3
-            cflags: "-flto -DMLK_FORCE_X86_64"
-            ldflags: "-flto"
-            perf: PMU
-          - name: Intel Xeon 3rd gen (c6i)
-            ec2_instance_type: c6i.large
-            ec2_ami: ubuntu-latest (x86_64)
-            archflags: -mavx2 -mbmi2 -mpopcnt -march=icelake-server
-            cflags: "-flto -DMLK_FORCE_X86_64"
-            ldflags: "-flto"
-            perf: PMU
-    uses: ./.github/workflows/bench_ec2_reusable.yml
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
-    with:
-      ec2_instance_type: ${{ matrix.target.ec2_instance_type }}
-      ec2_ami: ${{ matrix.target.ec2_ami }}
-      archflags: ${{ matrix.target.archflags }}
-      cflags: ${{ matrix.target.cflags }}
-      ldflags: ${{ matrix.target.ldflags }}
-      opt: "all"
-      store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
-      name: ${{ matrix.target.name }}
-      perf: ${{ matrix.target.perf }}
-    secrets:
-      AWS_GITHUB_TOKEN: ${{ secrets.AWS_GITHUB_TOKEN }}
+  # ec2_all:
+  #   name: ${{ matrix.target.name }}
+  #   permissions:
+  #     contents: write
+  #     pull-requests: write
+  #     id-token: write
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       target:
+  #         - name: Graviton2
+  #           ec2_instance_type: t4g.small
+  #           ec2_ami: ubuntu-latest (aarch64)
+  #           archflags: -mcpu=cortex-a76 -march=armv8.2-a
+  #           cflags: "-flto -DMLK_FORCE_AARCH64"
+  #           ldflags: "-flto"
+  #           perf: PERF
+  #         - name: Graviton3
+  #           ec2_instance_type: c7g.medium
+  #           ec2_ami: ubuntu-latest (aarch64)
+  #           archflags: -march=armv8.4-a+sha3
+  #           cflags: "-flto -DMLK_FORCE_AARCH64"
+  #           ldflags: "-flto"
+  #           perf: PERF
+  #         - name: Graviton4
+  #           ec2_instance_type: c8g.medium
+  #           ec2_ami: ubuntu-latest (aarch64)
+  #           archflags: -march=armv9-a+sha3
+  #           cflags: "-flto -DMLK_FORCE_AARCH64"
+  #           ldflags: "-flto"
+  #           perf: PERF
+  #         - name: Graviton5
+  #           ec2_instance_type: c9g.medium
+  #           ec2_ami: ubuntu-latest (aarch64)
+  #           archflags: -march=armv9-a+sha3 -DMLK_SYS_AARCH64_FAST_SHA3
+  #           cflags: "-flto -DMLK_FORCE_AARCH64"
+  #           ldflags: "-flto"
+  #           perf: PERF
+  #         - name: AMD EPYC 4th gen (c7a)
+  #           ec2_instance_type: c7a.medium
+  #           ec2_ami: ubuntu-latest (x86_64)
+  #           archflags: -mavx2 -mbmi2 -mpopcnt -march=znver4
+  #           cflags: "-flto -DMLK_FORCE_X86_64"
+  #           ldflags: "-flto"
+  #           perf: PMU
+  #         - name: Intel Xeon 4th gen (c7i)
+  #           ec2_instance_type: c7i.metal-24xl
+  #           ec2_ami: ubuntu-latest (x86_64)
+  #           archflags: -mavx2 -mbmi2 -mpopcnt -march=sapphirerapids
+  #           cflags: "-flto -DMLK_FORCE_X86_64"
+  #           ldflags: "-flto"
+  #           perf: PMU
+  #         - name: AMD EPYC 3rd gen (c6a)
+  #           ec2_instance_type: c6a.large
+  #           ec2_ami: ubuntu-latest (x86_64)
+  #           archflags: -mavx2 -mbmi2 -mpopcnt -march=znver3
+  #           cflags: "-flto -DMLK_FORCE_X86_64"
+  #           ldflags: "-flto"
+  #           perf: PMU
+  #         - name: Intel Xeon 3rd gen (c6i)
+  #           ec2_instance_type: c6i.large
+  #           ec2_ami: ubuntu-latest (x86_64)
+  #           archflags: -mavx2 -mbmi2 -mpopcnt -march=icelake-server
+  #           cflags: "-flto -DMLK_FORCE_X86_64"
+  #           ldflags: "-flto"
+  #           perf: PMU
+  #   uses: ./.github/workflows/bench_ec2_reusable.yml
+  #   if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
+  #   with:
+  #     ec2_instance_type: ${{ matrix.target.ec2_instance_type }}
+  #     ec2_ami: ${{ matrix.target.ec2_ami }}
+  #     archflags: ${{ matrix.target.archflags }}
+  #     cflags: ${{ matrix.target.cflags }}
+  #     ldflags: ${{ matrix.target.ldflags }}
+  #     opt: "all"
+  #     store_results: ${{ github.repository_owner == 'pq-code-package' && github.ref == 'refs/heads/main' }} # Only store optimized results
+  #     name: ${{ matrix.target.name }}
+  #     perf: ${{ matrix.target.perf }}
+  #   secrets:
+  #     AWS_GITHUB_TOKEN: ${{ secrets.AWS_GITHUB_TOKEN }}

--- a/scripts/check-namespace
+++ b/scripts/check-namespace
@@ -13,18 +13,21 @@
 # PQCP_MLKEM_NATIVE_MLKEM768_ for MLKEM768 code
 # PQCP_MLKEM_NATIVE_MLKEM1024_ for MLKEM1024 code
 
-import subprocess
 import os
+import subprocess
 
 
-def check_file(file_path, namespaces):
+def check_file(file_path, namespaces, nm="nm"):
     print("checking namespacing: {}".format(file_path))
-    command = ["nm", "-g", file_path]
+    command = [nm, "-g", file_path]
 
     result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output = result.stdout.decode("utf-8")
+    if result.returncode != 0:
+        print(output)
+        raise RuntimeError("{} failed for {}".format(nm, file_path))
 
-    result = result.stdout.decode("utf-8")
-    lines = result.strip().split("\n")
+    lines = output.strip().split("\n")
     symbols = []
     for line in lines:
         if line.startswith("00"):
@@ -50,13 +53,34 @@ def check_file(file_path, namespaces):
     assert not non_namespaced, "Literals with missing namespaces"
 
 
-def check_folder(folder, namespace):
+def check_folder(folder, namespace, nm="nm"):
     checked = 0
     # recursively go through folder and check all object files
     for root, dirnames, filenames in os.walk(folder):
         for filename in filenames:
             if filename.endswith(".o"):
-                check_file(os.path.join(root, filename), namespace)
+                check_file(os.path.join(root, filename), namespace, nm)
+                checked += 1
+    print("Checked {} files".format(checked))
+    assert checked > 0
+
+
+def check_zephyr_folder(folder, lvl):
+    checked = 0
+    namespace = make_mlkem_namespace(lvl)
+    nm = os.environ.get("NM", "arm-none-eabi-nm")
+    for root, dirnames, filenames in os.walk(folder):
+        rel = os.path.relpath(root, folder)
+        if rel.split(os.sep, 1)[0].endswith(str(lvl)) is False:
+            continue
+
+        parts = root.split(os.sep)
+        if "app.dir" not in parts or "mlkem" not in parts:
+            continue
+
+        for filename in filenames:
+            if filename.endswith(".obj"):
+                check_file(os.path.join(root, filename), namespace, nm)
                 checked += 1
     print("Checked {} files".format(checked))
     assert checked > 0
@@ -67,9 +91,18 @@ def make_mlkem_namespace(lvl):
 
 
 def run():
-    check_folder("test/build/mlkem512/mlkem", make_mlkem_namespace(512))
-    check_folder("test/build/mlkem768/mlkem", make_mlkem_namespace(768))
-    check_folder("test/build/mlkem1024/mlkem", make_mlkem_namespace(1024))
+    build_dir = os.environ.get("BUILD_DIR", "test/build")
+    zephyr_target = os.environ.get("ZEPHYR_TARGET")
+    if zephyr_target:
+        zephyr_build = os.path.join(build_dir, "zephyr", zephyr_target)
+        check_zephyr_folder(zephyr_build, 512)
+        check_zephyr_folder(zephyr_build, 768)
+        check_zephyr_folder(zephyr_build, 1024)
+        return
+
+    check_folder(os.path.join(build_dir, "mlkem512", "mlkem"), make_mlkem_namespace(512))
+    check_folder(os.path.join(build_dir, "mlkem768", "mlkem"), make_mlkem_namespace(768))
+    check_folder(os.path.join(build_dir, "mlkem1024", "mlkem"), make_mlkem_namespace(1024))
 
 
 if __name__ == "__main__":

--- a/test/zephyr/platform.mk
+++ b/test/zephyr/platform.mk
@@ -110,10 +110,13 @@ CFLAGS += -DNTESTS_FUNC=3 -DNTESTS_KAT=100 \
 # Requires AUTO=0 (see .github/workflows/zephyr.yml): the host-arch flags AUTO=1
 # adds must not reach the Zephyr toolchain, which selects the target arch itself.
 ZEPHYR_TEST_CFLAGS = $(subst \",\\\",$(patsubst -Imlkem,-I$(abspath mlkem),$(CFLAGS)))
+# Keep make-exported project flags out of Zephyr's own CMake build; the app
+# sources get those flags explicitly via ZEPHYR_TEST_CFLAGS.
+ZEPHYR_CMAKE_ENV := env -u CFLAGS -u CXXFLAGS -u CPPFLAGS -u LDFLAGS
 
 CUSTOM_BUILD = \
 	echo "  ZEPHYR  $(ZEPHYR_TARGET): $(notdir $@)" && \
-	cmake -GNinja -S $(ZEPHYR_APP) -B $(ZEPHYR_OUT) \
+	$(ZEPHYR_CMAKE_ENV) cmake -GNinja -S $(ZEPHYR_APP) -B $(ZEPHYR_OUT) \
 		-DBOARD=$(ZEPHYR_BOARD) \
 		-DZEPHYR_NATIVE_ROOT=$(CURDIR) \
 		-DZEPHYR_TEST_SRCS="$(strip $(TEST_SRCS))" \
@@ -123,7 +126,7 @@ CUSTOM_BUILD = \
 		$(ZEPHYR_TARGET_CMAKE_ARGS) \
 		-DUSER_CACHE_DIR=$(abspath $(ZEPHYR_OUT)/.cache) \
 		>/dev/null && \
-	cmake --build $(ZEPHYR_OUT) >/dev/null && \
+	$(ZEPHYR_CMAKE_ENV) cmake --build $(ZEPHYR_OUT) >/dev/null && \
 	cp $(ZEPHYR_OUT)/zephyr/zephyr.elf $@
 
 # A custom build links the test sources directly rather than from objects, so


### PR DESCRIPTION
Forwarding mlkem-native CFLAGS into the Zephyr app build is intentional: it keeps the Zephyr test and benchmark sources on the same warning policy as the normal make build, including `-Werror`, `-Wpedantic`, `-Wconversion` and `-Wsign-conversion`. Keep that behavior. The mlkem-native app sources still receive the expanded flags explicitly through `ZEPHYR_TEST_CFLAGS`.

The failure was that the same flags also reached Zephyr's own CMake build through the process environment. In the NUCLEO-N657X0-Q benchmark action, the composed `--cflags="${inputs.cflags} ${inputs.archflags}"` becomes a single space when both inputs are empty. scripts/tests treats that as a non-empty value and exports `CFLAGS`. GNU make then appends mlkem-native's default warning policy to `CFLAGS` and, because `CFLAGS` originated in the environment, exports it to recipe children. CMake imports that environment `CFLAGS` value into the global Zephyr build, so Zephyr internals such as lib/heap/heap_constants.c are compiled under mlkem-native's pedantic warning policy and fail with `-Werror`.

This change does not weaken mlkem-native's flags, and does not stop forwarding them to the Zephyr app. Instead, it runs the Zephyr CMake configure and build steps with `CFLAGS`, `CXXFLAGS`, `CPPFLAGS` and `LDFLAGS` unset. This keeps the deliberate strict policy on the mlkem/test sources via `ZEPHYR_TEST_CFLAGS` while leaving Zephyr-controlled sources under Zephyr's own warning policy.

This did not fire in the Zephyr functional tests because that path passes an empty `--cflags=""` value, together with `--no-auto`, so scripts/tests does not export `CFLAGS`. The hardware benchmark path was different: its action always joins cflags and archflags with a space, producing the non-empty " " case that triggered the environment leak.