### PR TITLE
AArch64: Add runtime NEON capability gate to native backend

### DIFF
--- a/dev/aarch64_clean/meta.h
+++ b/dev/aarch64_clean/meta.h
@@ -28,6 +28,10 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_ntt_aarch64_asm(data, mlk_aarch64_ntt_zetas_layer12345,
                       mlk_aarch64_ntt_zetas_layer67);
   return MLK_NATIVE_FUNC_SUCCESS;
@@ -36,6 +40,10 @@ static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_intt_aarch64_asm(data, mlk_aarch64_invntt_zetas_layer12345,
                        mlk_aarch64_invntt_zetas_layer67);
   return MLK_NATIVE_FUNC_SUCCESS;
@@ -44,6 +52,10 @@ static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_reduce_aarch64_asm(data);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -51,6 +63,10 @@ static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_tomont_aarch64_asm(data);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -59,6 +75,10 @@ MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_mulcache_compute_native(int16_t x[MLKEM_N / 2],
                                                        const int16_t y[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_mulcache_compute_aarch64_asm(
       x, y, mlk_aarch64_zetas_mulcache_native,
       mlk_aarch64_zetas_mulcache_twisted_native);
@@ -71,6 +91,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -82,6 +106,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -93,6 +121,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -102,6 +134,10 @@ MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
                                               const int16_t a[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_tobytes_aarch64_asm(r, a);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -111,8 +147,8 @@ static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLKEM_N ||
-      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) || len != MLKEM_N ||
+      buflen % 24 != 0)
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/aarch64_clean/src/intt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/intt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_clean/src/ntt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/poly_mulcache_compute_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_mulcache_compute_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 256

--- a/dev/aarch64_clean/src/poly_reduce_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_reduce_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/poly_tobytes_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_tobytes_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 384

--- a/dev/aarch64_clean/src/poly_tomont_aarch64_asm.S
+++ b/dev/aarch64_clean/src/poly_tomont_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
+++ b/dev/aarch64_clean/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_clean/src/rej_uniform_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/meta.h
+++ b/dev/aarch64_opt/meta.h
@@ -28,6 +28,10 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_ntt_aarch64_asm(data, mlk_aarch64_ntt_zetas_layer12345,
                       mlk_aarch64_ntt_zetas_layer67);
   return MLK_NATIVE_FUNC_SUCCESS;
@@ -36,6 +40,10 @@ static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_intt_aarch64_asm(data, mlk_aarch64_invntt_zetas_layer12345,
                        mlk_aarch64_invntt_zetas_layer67);
   return MLK_NATIVE_FUNC_SUCCESS;
@@ -44,6 +52,10 @@ static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_reduce_aarch64_asm(data);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -51,6 +63,10 @@ static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_tomont_aarch64_asm(data);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -59,6 +75,10 @@ MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_mulcache_compute_native(int16_t x[MLKEM_N / 2],
                                                        const int16_t y[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_mulcache_compute_aarch64_asm(
       x, y, mlk_aarch64_zetas_mulcache_native,
       mlk_aarch64_zetas_mulcache_twisted_native);
@@ -71,6 +91,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -82,6 +106,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -93,6 +121,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -102,6 +134,10 @@ MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
                                               const int16_t a[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_tobytes_aarch64_asm(r, a);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -111,8 +147,8 @@ static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLKEM_N ||
-      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) || len != MLKEM_N ||
+      buflen % 24 != 0)
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/aarch64_opt/src/intt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/intt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/ntt_aarch64_asm.S
+++ b/dev/aarch64_opt/src/ntt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/poly_mulcache_compute_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_mulcache_compute_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 256

--- a/dev/aarch64_opt/src/poly_reduce_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_reduce_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/poly_tobytes_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_tobytes_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 384

--- a/dev/aarch64_opt/src/poly_tomont_aarch64_asm.S
+++ b/dev/aarch64_opt/src/poly_tomont_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
+++ b/dev/aarch64_opt/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
+++ b/dev/aarch64_opt/src/rej_uniform_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -21,7 +21,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 200

--- a/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -21,7 +21,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 400

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -15,6 +15,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 800

--- a/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/dev/fips202/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -15,7 +15,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 800

--- a/dev/fips202/aarch64/x1_v84a.h
+++ b/dev/fips202/aarch64/x1_v84a.h
@@ -21,7 +21,8 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x1_native(uint64_t *state)
 {
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) ||
+      !mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/aarch64/x2_v84a.h
+++ b/dev/fips202/aarch64/x2_v84a.h
@@ -21,7 +21,8 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) ||
+      !mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/dev/fips202/aarch64/x4_v8a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_scalar.h
@@ -17,6 +17,11 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x4_native(uint64_t *state)
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
+
   mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(
       state, mlk_keccakf1600_round_constants);
   return MLK_NATIVE_FUNC_SUCCESS;

--- a/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
+++ b/dev/fips202/aarch64/x4_v8a_v84a_scalar.h
@@ -21,7 +21,8 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) ||
+      !mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/integration/aws-lc/post_import.patch
+++ b/integration/aws-lc/post_import.patch
@@ -1,0 +1,25 @@
+# Copyright (c) The mlkem-native project authors
+# SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+#
+# Map mlkem-native's AArch64 NEON capability to AWS-LC's runtime CPU
+# capability detection.
+
+diff --git a/crypto/fipsmodule/ml_kem/mlkem_native_config.h b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
+--- a/crypto/fipsmodule/ml_kem/mlkem_native_config.h
++++ b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
+@@ -36,10 +36,15 @@
+ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
+ {
+ #if defined(MLK_SYS_X86_64)
+   if (cap == MLK_SYS_CAP_AVX2)
+   {
+     return CRYPTO_is_AVX2_capable();
+   }
++#elif defined(MLK_SYS_AARCH64)
++  if (cap == MLK_SYS_CAP_NEON)
++  {
++    return CRYPTO_is_NEON_capable();
++  }
+ #endif
+   return 0;
+ }

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -21,7 +21,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 200

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -21,7 +21,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 400

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -15,6 +15,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 800

--- a/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -15,7 +15,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 800

--- a/mlkem/src/fips202/native/aarch64/x1_v84a.h
+++ b/mlkem/src/fips202/native/aarch64/x1_v84a.h
@@ -21,7 +21,8 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x1_native(uint64_t *state)
 {
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) ||
+      !mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/mlkem/src/fips202/native/aarch64/x2_v84a.h
+++ b/mlkem/src/fips202/native/aarch64/x2_v84a.h
@@ -21,7 +21,8 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) ||
+      !mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/mlkem/src/fips202/native/aarch64/x4_v8a_scalar.h
+++ b/mlkem/src/fips202/native/aarch64/x4_v8a_scalar.h
@@ -17,6 +17,11 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x4_native(uint64_t *state)
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
+
   mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(
       state, mlk_keccakf1600_round_constants);
   return MLK_NATIVE_FUNC_SUCCESS;

--- a/mlkem/src/fips202/native/aarch64/x4_v8a_v84a_scalar.h
+++ b/mlkem/src/fips202/native/aarch64/x4_v8a_v84a_scalar.h
@@ -21,7 +21,8 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_keccak_f1600_x4_native(uint64_t *state)
 {
-  if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) ||
+      !mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/mlkem/src/native/aarch64/meta.h
+++ b/mlkem/src/native/aarch64/meta.h
@@ -28,6 +28,10 @@
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_ntt_aarch64_asm(data, mlk_aarch64_ntt_zetas_layer12345,
                       mlk_aarch64_ntt_zetas_layer67);
   return MLK_NATIVE_FUNC_SUCCESS;
@@ -36,6 +40,10 @@ static MLK_INLINE int mlk_ntt_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_intt_aarch64_asm(data, mlk_aarch64_invntt_zetas_layer12345,
                        mlk_aarch64_invntt_zetas_layer67);
   return MLK_NATIVE_FUNC_SUCCESS;
@@ -44,6 +52,10 @@ static MLK_INLINE int mlk_intt_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_reduce_aarch64_asm(data);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -51,6 +63,10 @@ static MLK_INLINE int mlk_poly_reduce_native(int16_t data[MLKEM_N])
 MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_tomont_native(int16_t data[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_tomont_aarch64_asm(data);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -59,6 +75,10 @@ MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_mulcache_compute_native(int16_t x[MLKEM_N / 2],
                                                        const int16_t y[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_mulcache_compute_aarch64_asm(
       x, y, mlk_aarch64_zetas_mulcache_native,
       mlk_aarch64_zetas_mulcache_twisted_native);
@@ -71,6 +91,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k2_native(
     int16_t r[MLKEM_N], const int16_t a[2 * MLKEM_N],
     const int16_t b[2 * MLKEM_N], const int16_t b_cache[2 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -82,6 +106,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k3_native(
     int16_t r[MLKEM_N], const int16_t a[3 * MLKEM_N],
     const int16_t b[3 * MLKEM_N], const int16_t b_cache[3 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -93,6 +121,10 @@ static MLK_INLINE int mlk_polyvec_basemul_acc_montgomery_cached_k4_native(
     int16_t r[MLKEM_N], const int16_t a[4 * MLKEM_N],
     const int16_t b[4 * MLKEM_N], const int16_t b_cache[4 * (MLKEM_N / 2)])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm(r, a, b, b_cache);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -102,6 +134,10 @@ MLK_MUST_CHECK_RETURN_VALUE
 static MLK_INLINE int mlk_poly_tobytes_native(uint8_t r[MLKEM_POLYBYTES],
                                               const int16_t a[MLKEM_N])
 {
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    return MLK_NATIVE_FUNC_FALLBACK;
+  }
   mlk_poly_tobytes_aarch64_asm(r, a);
   return MLK_NATIVE_FUNC_SUCCESS;
 }
@@ -111,8 +147,8 @@ static MLK_INLINE int mlk_rej_uniform_native(int16_t *r, unsigned len,
                                              const uint8_t *buf,
                                              unsigned buflen)
 {
-  if (len != MLKEM_N ||
-      buflen % 24 != 0) /* NEON support is mandatory for AArch64 */
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON) || len != MLKEM_N ||
+      buflen % 24 != 0)
   {
     return MLK_NATIVE_FUNC_FALLBACK;
   }

--- a/mlkem/src/native/aarch64/src/intt_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/intt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/ntt_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/ntt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/poly_mulcache_compute_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_mulcache_compute_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 256

--- a/mlkem/src/native/aarch64/src/poly_reduce_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_reduce_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/poly_tobytes_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_tobytes_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 384

--- a/mlkem/src/native/aarch64/src/poly_tomont_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/poly_tomont_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/native/aarch64/src/rej_uniform_aarch64_asm.S
+++ b/mlkem/src/native/aarch64/src/rej_uniform_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/mlkem/src/sys.h
+++ b/mlkem/src/sys.h
@@ -275,6 +275,7 @@ typedef enum
   /* x86_64 */
   MLK_SYS_CAP_AVX2,
   /* AArch64 */
+  MLK_SYS_CAP_NEON,
   MLK_SYS_CAP_SHA3,
   /* Armv8.1-M */
   MLK_SYS_CAP_MVE

--- a/proofs/cbmc/keccak_f1600_x4_native_aarch64_v8a_scalar_hybrid/Makefile
+++ b/proofs/cbmc/keccak_f1600_x4_native_aarch64_v8a_scalar_hybrid/Makefile
@@ -20,7 +20,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/src/fips202/native/aarch64/src/keccakf1600_round_constants.c 
 
 CHECK_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_native
-USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm
+USE_FUNCTION_CONTRACTS=mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm mlk_sys_check_capability
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1
 

--- a/proofs/hol_light/aarch64/mlkem/intt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/intt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x1_v84a_aarch64_asm.S
@@ -21,7 +21,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 200

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x2_v84a_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x2_v84a_aarch64_asm.S
@@ -21,7 +21,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 400

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S
@@ -15,6 +15,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 800

--- a/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S
@@ -15,7 +15,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
-    Features: [SHA3]
+    Features: [NEON, SHA3]
     x0:
       type: buffer
       size_bytes: 800

--- a/proofs/hol_light/aarch64/mlkem/ntt_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/ntt_aarch64_asm.S
@@ -26,6 +26,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/poly_mulcache_compute_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_mulcache_compute_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 256

--- a/proofs/hol_light/aarch64/mlkem/poly_reduce_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_reduce_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/poly_tobytes_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_tobytes_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 384

--- a/proofs/hol_light/aarch64/mlkem/poly_tomont_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/poly_tomont_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
@@ -19,6 +19,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/proofs/hol_light/aarch64/mlkem/rej_uniform_aarch64_asm.S
+++ b/proofs/hol_light/aarch64/mlkem/rej_uniform_aarch64_asm.S
@@ -10,6 +10,7 @@
   ABI:
     Architecture: aarch64
     CallingConvention: AAPCS64
+    Features: [NEON]
     x0:
       type: buffer
       size_bytes: 512

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2917,6 +2917,7 @@ def check_macro_typos_in_file(filename, macro_check):
 def get_syscaps():
     return [
         "MLK_SYS_CAP_AVX2",
+        "MLK_SYS_CAP_NEON",
         "MLK_SYS_CAP_SHA3",
         "MLK_SYS_CAP_MVE",
         "MLK_SYS_CAP_DUMMY",
@@ -4617,6 +4618,14 @@ ABI_CAPS = {
         "cflags": ["-mavx2", "-mbmi2"],
         "aux_files": [],
     },
+    "NEON": {
+        "asm_subdir": "aarch64",
+        "guard": None,
+        "syscap": "MLK_SYS_CAP_NEON",
+        "description": "AArch64 NEON",
+        "cflags": [],
+        "aux_files": [],
+    },
     "SHA3": {
         "asm_subdir": "aarch64",
         "guard": "__ARM_FEATURE_SHA3",
@@ -4672,7 +4681,7 @@ ARCH_CALLINGS = {
         "gpr_int_type": "uint64_t",
         "fn_qualifier": "",
         "init_func": "init_aarch64_register_state",
-        "stub_func": "asm_call_stub_aarch64",
+        "stub_func": "call_stub_aarch64",
         "check_func": "check_aarch64_aapcs_compliance",
         # YAML register xN maps to gpr[N].
         "reg_to_field": lambda reg: f"gpr[{int(reg[1:])}]",
@@ -5192,7 +5201,8 @@ def gen_abicheck():
                 f"ABICHECK_REQ_{cap}_OBJS := "
                 f"$(call MAKE_OBJS,$(ABICHECK_DIR),$(ABICHECK_REQ_{cap}_FILES))"
             )
-            yield f"$(ABICHECK_REQ_{cap}_OBJS): CFLAGS += {cflags}"
+            if cflags:
+                yield f"$(ABICHECK_REQ_{cap}_OBJS): CFLAGS += {cflags}"
         yield ""
 
     for asm_subdir, caps in caps_by_subdir.items():

--- a/test/abicheck/aarch64/abicheck_aarch64.c
+++ b/test/abicheck/aarch64/abicheck_aarch64.c
@@ -44,13 +44,17 @@ int check_aarch64_aapcs_compliance(struct aarch64_register_state *before,
     }
   }
 
-  /* Check callee-saved NEON registers (d8-d15, lower 64 bits only) */
-  for (i = 8; i <= 15; i++)
+  /* The call stub leaves vector output untouched when NEON is unavailable. */
+  if (mlk_sys_check_capability(MLK_SYS_CAP_NEON))
   {
-    if (before->neon[i][0] != after->neon[i][0])
+    /* Check callee-saved NEON registers (d8-d15, lower 64 bits only). */
+    for (i = 8; i <= 15; i++)
     {
-      MLK_ABI_VIOLATION(quiet, "d%d modified\n", i);
-      violations++;
+      if (before->neon[i][0] != after->neon[i][0])
+      {
+        MLK_ABI_VIOLATION(quiet, "d%d modified\n", i);
+        violations++;
+      }
     }
   }
 

--- a/test/abicheck/aarch64/abicheck_aarch64.h
+++ b/test/abicheck/aarch64/abicheck_aarch64.h
@@ -26,7 +26,15 @@ void init_aarch64_register_state(struct aarch64_register_state *state);
 
 extern void asm_call_stub_aarch64(struct aarch64_register_state *input,
                                   struct aarch64_register_state *output,
-                                  void (*function_ptr)(void));
+                                  void (*function_ptr)(void), int use_neon);
+
+static MLK_INLINE void call_stub_aarch64(struct aarch64_register_state *input,
+                                         struct aarch64_register_state *output,
+                                         void (*function_ptr)(void))
+{
+  int use_neon = mlk_sys_check_capability(MLK_SYS_CAP_NEON) != 0;
+  asm_call_stub_aarch64(input, output, function_ptr, use_neon);
+}
 
 #endif /* MLK_SYS_AARCH64 */
 

--- a/test/abicheck/aarch64/abicheck_aarch64.mk
+++ b/test/abicheck/aarch64/abicheck_aarch64.mk
@@ -14,7 +14,26 @@
 
 # Default each cap's file list to empty so the unconditional appends
 # below are safe even when a cap has no kernels on this arch.
+ABICHECK_REQ_NEON_FILES :=
 ABICHECK_REQ_SHA3_FILES :=
+
+# NEON: AArch64 NEON
+ABICHECK_REQ_NEON_FILES := \
+  mlkem/src/fips202/native/aarch64/src/keccak_f1600_x1_v84a_aarch64_asm.S \
+  mlkem/src/fips202/native/aarch64/src/keccak_f1600_x2_v84a_aarch64_asm.S \
+  mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.S \
+  mlkem/src/fips202/native/aarch64/src/keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/intt_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/ntt_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/poly_mulcache_compute_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/poly_reduce_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/poly_tobytes_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/poly_tomont_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S \
+  mlkem/src/native/aarch64/src/rej_uniform_aarch64_asm.S
+ABICHECK_REQ_NEON_OBJS := $(call MAKE_OBJS,$(ABICHECK_DIR),$(ABICHECK_REQ_NEON_FILES))
 
 # SHA3: Armv8.4-A SHA3 (eor3, rax1, xar, bcax)
 ABICHECK_REQ_SHA3_FILES := \

--- a/test/abicheck/aarch64/callstub_aarch64.S
+++ b/test/abicheck/aarch64/callstub_aarch64.S
@@ -14,19 +14,21 @@
  *
  * C Signature: void asm_call_stub_aarch64(struct aarch64_register_state *input,
  *                                         struct aarch64_register_state *output,
- *                                         void (*function_ptr)(void))
+ *                                         void (*function_ptr)(void),
+ *                                         int use_neon)
  *
- * Stack Usage: 192 bytes total (16-byte aligned)
+ * Stack Usage: 208 bytes total (16-byte aligned)
  *   - 112 bytes for saving callee-saved GPRs (x18-x30: 7 pairs * 16 bytes)
  *   - 64 bytes for saving callee-saved NEON registers (d8-d15: 8 regs * 8 bytes)
- *   - 16 bytes for local variables (output state ptr, function ptr)
+ *   - 32 bytes for local variables (output state ptr, function ptr,
+ *     use_neon flag, padding)
  */
 
 #define STACK_SIZE_GPRS   112
 #define STACK_SIZE_VREGS  64
-#define STACK_SIZE_LOCALS 16
+#define STACK_SIZE_LOCALS 32
 
-#define STACK_SIZE 192
+#define STACK_SIZE 208
 #define STACK_BASE_GPRS 0
 #define STACK_BASE_VREGS  STACK_SIZE_GPRS
 #define STACK_BASE_LOCALS (STACK_SIZE_GPRS + STACK_SIZE_VREGS)
@@ -61,28 +63,6 @@
         .cfi_restore \hi
 .endm
 
-/* Callee-saved GPRs x18-x30; xzr pads the x18 slot for 16-byte stp/ldp
- * alignment (see save_pair_padlo). */
-.macro save_gprs
-        save_pair_padlo x18, STACK_BASE_GPRS, 0
-        save_pair x19, x20, STACK_BASE_GPRS, 1
-        save_pair x21, x22, STACK_BASE_GPRS, 2
-        save_pair x23, x24, STACK_BASE_GPRS, 3
-        save_pair x25, x26, STACK_BASE_GPRS, 4
-        save_pair x27, x28, STACK_BASE_GPRS, 5
-        save_pair x29, x30, STACK_BASE_GPRS, 6
-.endm
-
-.macro restore_gprs
-        restore_pair_padlo x18, STACK_BASE_GPRS, 0
-        restore_pair x19, x20, STACK_BASE_GPRS, 1
-        restore_pair x21, x22, STACK_BASE_GPRS, 2
-        restore_pair x23, x24, STACK_BASE_GPRS, 3
-        restore_pair x25, x26, STACK_BASE_GPRS, 4
-        restore_pair x27, x28, STACK_BASE_GPRS, 5
-        restore_pair x29, x30, STACK_BASE_GPRS, 6
-.endm
-
 /* Callee-saved NEON registers d8-d15. */
 .macro save_vregs
         save_pair  d8,  d9, STACK_BASE_VREGS, 0
@@ -98,46 +78,76 @@
         restore_pair d14, d15, STACK_BASE_VREGS, 3
 .endm
 
-.text
-.balign 4
-#ifdef __APPLE__
-.global _asm_call_stub_aarch64
-_asm_call_stub_aarch64:
-#else
-.global asm_call_stub_aarch64
-asm_call_stub_aarch64:
-#endif
-        .cfi_startproc
-        sub sp, sp, #(STACK_SIZE)
-        .cfi_def_cfa_offset STACK_SIZE
+/* Save the caller's callee-saved vector registers and seed q0-q31 from the
+ * input state. Skip every vector instruction when \use_neon is zero. */
+.macro save_and_load_vregs use_neon, scratch
+        cbz \use_neon, 1f
 
-        save_gprs
         save_vregs
 
-        /* Spill output ptr (x1) and fn ptr (x2); the next block loads
-         * x0-x29 from input state and clobbers them. */
-        stp x1, x2, [sp, #(STACK_BASE_LOCALS)]
+        add \scratch, x0,  #256
+        ldp q0,  q1,  [\scratch, #(16*0)]
+        ldp q2,  q3,  [\scratch, #(16*2)]
+        ldp q4,  q5,  [\scratch, #(16*4)]
+        ldp q6,  q7,  [\scratch, #(16*6)]
+        ldp q8,  q9,  [\scratch, #(16*8)]
+        ldp q10, q11, [\scratch, #(16*10)]
+        ldp q12, q13, [\scratch, #(16*12)]
+        ldp q14, q15, [\scratch, #(16*14)]
+        ldp q16, q17, [\scratch, #(16*16)]
+        ldp q18, q19, [\scratch, #(16*18)]
+        ldp q20, q21, [\scratch, #(16*20)]
+        ldp q22, q23, [\scratch, #(16*22)]
+        ldp q24, q25, [\scratch, #(16*24)]
+        ldp q26, q27, [\scratch, #(16*26)]
+        ldp q28, q29, [\scratch, #(16*28)]
+        ldp q30, q31, [\scratch, #(16*30)]
 
-        /* Load NEON registers from input state */
-        add x30, x0,  #256
-        ldp q0,  q1,  [x30, #(16*0)]
-        ldp q2,  q3,  [x30, #(16*2)]
-        ldp q4,  q5,  [x30, #(16*4)]
-        ldp q6,  q7,  [x30, #(16*6)]
-        ldp q8,  q9,  [x30, #(16*8)]
-        ldp q10, q11, [x30, #(16*10)]
-        ldp q12, q13, [x30, #(16*12)]
-        ldp q14, q15, [x30, #(16*14)]
-        ldp q16, q17, [x30, #(16*16)]
-        ldp q18, q19, [x30, #(16*18)]
-        ldp q20, q21, [x30, #(16*20)]
-        ldp q22, q23, [x30, #(16*22)]
-        ldp q24, q25, [x30, #(16*24)]
-        ldp q26, q27, [x30, #(16*26)]
-        ldp q28, q29, [x30, #(16*28)]
-        ldp q30, q31, [x30, #(16*30)]
-        /* Load GPRs from input state */
-        sub x30, x30, #256
+1:
+.endm
+
+/* Capture q0-q31 in the output state and restore the caller's callee-saved
+ * vector registers. Skip every vector instruction when \use_neon is zero. */
+.macro store_and_restore_vregs use_neon, scratch
+        ldr \use_neon, [sp, #(STACK_BASE_LOCALS + 16)]
+        cbz \use_neon, 1f
+
+        ldr \scratch, [sp, #(STACK_BASE_LOCALS + 0)]
+        add \scratch, \scratch, #256
+        stp q0,  q1,  [\scratch, #(16*0)]
+        stp q2,  q3,  [\scratch, #(16*2)]
+        stp q4,  q5,  [\scratch, #(16*4)]
+        stp q6,  q7,  [\scratch, #(16*6)]
+        stp q8,  q9,  [\scratch, #(16*8)]
+        stp q10, q11, [\scratch, #(16*10)]
+        stp q12, q13, [\scratch, #(16*12)]
+        stp q14, q15, [\scratch, #(16*14)]
+        stp q16, q17, [\scratch, #(16*16)]
+        stp q18, q19, [\scratch, #(16*18)]
+        stp q20, q21, [\scratch, #(16*20)]
+        stp q22, q23, [\scratch, #(16*22)]
+        stp q24, q25, [\scratch, #(16*24)]
+        stp q26, q27, [\scratch, #(16*26)]
+        stp q28, q29, [\scratch, #(16*28)]
+        stp q30, q31, [\scratch, #(16*30)]
+
+        restore_vregs
+
+1:
+.endm
+
+/* Save the caller's callee-saved GPRs and seed x0-x29 from the input state
+ * initially passed in x0. xzr pads the x18 slot for 16-byte alignment. */
+.macro save_and_load_gprs
+        save_pair_padlo x18, STACK_BASE_GPRS, 0
+        save_pair x19, x20, STACK_BASE_GPRS, 1
+        save_pair x21, x22, STACK_BASE_GPRS, 2
+        save_pair x23, x24, STACK_BASE_GPRS, 3
+        save_pair x25, x26, STACK_BASE_GPRS, 4
+        save_pair x27, x28, STACK_BASE_GPRS, 5
+        save_pair x29, x30, STACK_BASE_GPRS, 6
+
+        mov x30, x0
         ldp x0,  x1,  [x30, #(8*0)]
         ldp x2,  x3,  [x30, #(8*2)]
         ldp x4,  x5,  [x30, #(8*4)]
@@ -164,15 +174,13 @@ asm_call_stub_aarch64:
         ldp x24, x25, [x30, #(8*24)]
         ldp x26, x27, [x30, #(8*26)]
         ldp x28, x29, [x30, #(8*28)]
+.endm
 
-        /* Reload target function pointer (overwriting x30/LR is fine - blr will set it) */
-        ldr x30, [sp, #(STACK_BASE_LOCALS + 8)]
-        /* Call target */
-        blr x30
-        /* Load output state address (overwrite x30/LR again) */
+/* Capture x0-x29 in the output state and restore the caller's callee-saved
+ * GPRs. */
+.macro store_and_restore_gprs
         ldr x30, [sp, #(STACK_BASE_LOCALS + 0)]
 
-        /* Store final GPR state to output state */
         stp x0,  x1,  [x30, #(8*0)]
         stp x2,  x3,  [x30, #(8*2)]
         stp x4,  x5,  [x30, #(8*4)]
@@ -189,27 +197,40 @@ asm_call_stub_aarch64:
         stp x26, x27, [x30, #(8*26)]
         stp x28, x29, [x30, #(8*28)]
 
-        /* Store final NEON state to output state */
-        add x30,  x30,  #256
-        stp q0,  q1,  [x30, #(16*0)]
-        stp q2,  q3,  [x30, #(16*2)]
-        stp q4,  q5,  [x30, #(16*4)]
-        stp q6,  q7,  [x30, #(16*6)]
-        stp q8,  q9,  [x30, #(16*8)]
-        stp q10, q11, [x30, #(16*10)]
-        stp q12, q13, [x30, #(16*12)]
-        stp q14, q15, [x30, #(16*14)]
-        stp q16, q17, [x30, #(16*16)]
-        stp q18, q19, [x30, #(16*18)]
-        stp q20, q21, [x30, #(16*20)]
-        stp q22, q23, [x30, #(16*22)]
-        stp q24, q25, [x30, #(16*24)]
-        stp q26, q27, [x30, #(16*26)]
-        stp q28, q29, [x30, #(16*28)]
-        stp q30, q31, [x30, #(16*30)]
+        restore_pair_padlo x18, STACK_BASE_GPRS, 0
+        restore_pair x19, x20, STACK_BASE_GPRS, 1
+        restore_pair x21, x22, STACK_BASE_GPRS, 2
+        restore_pair x23, x24, STACK_BASE_GPRS, 3
+        restore_pair x25, x26, STACK_BASE_GPRS, 4
+        restore_pair x27, x28, STACK_BASE_GPRS, 5
+        restore_pair x29, x30, STACK_BASE_GPRS, 6
+.endm
 
-        restore_vregs
-        restore_gprs
+.text
+.balign 4
+#ifdef __APPLE__
+.global _asm_call_stub_aarch64
+_asm_call_stub_aarch64:
+#else
+.global asm_call_stub_aarch64
+asm_call_stub_aarch64:
+#endif
+        .cfi_startproc
+        sub sp, sp, #(STACK_SIZE)
+        .cfi_def_cfa_offset STACK_SIZE
+
+        /* Spill output ptr (x1), fn ptr (x2), and use_neon (w3). */
+        stp x1, x2, [sp, #(STACK_BASE_LOCALS)]
+        str w3, [sp, #(STACK_BASE_LOCALS + 16)]
+
+        save_and_load_vregs w3, x3
+        save_and_load_gprs
+
+        ldr x30, [sp, #(STACK_BASE_LOCALS + 8)]
+        blr x30
+
+        store_and_restore_gprs
+        store_and_restore_vregs w3, x3
         add sp, sp, #(STACK_SIZE)
         .cfi_def_cfa_offset 0
         ret

--- a/test/abicheck/aarch64/checks/check_intt_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_intt_aarch64_asm.c
@@ -32,6 +32,13 @@ int check_intt_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x1[160]; /* Twiddle factors for layers 1-5 */
   MLK_ALIGN uint8_t buf_x2[768]; /* Twiddle factors for layers 6-7 */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check intt_aarch64_asm: host lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -47,8 +54,8 @@ int check_intt_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_intt_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_intt_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x1_scalar_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x1_scalar_aarch64_asm.c
@@ -44,9 +44,8 @@ int check_keccak_f1600_x1_scalar_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
-        &input_state, &output_state,
-        (void (*)(void))mlk_keccak_f1600_x1_scalar_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_keccak_f1600_x1_scalar_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x1_v84a_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x1_v84a_aarch64_asm.c
@@ -31,6 +31,14 @@ int check_keccak_f1600_x1_v84a_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x0[200]; /* Keccak state (25 x uint64_t) */
   MLK_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x1_v84a_aarch64_asm: host lacks AArch64 "
+            "NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     fprintf(stderr,
@@ -52,8 +60,8 @@ int check_keccak_f1600_x1_v84a_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_keccak_f1600_x1_v84a_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_keccak_f1600_x1_v84a_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x2_v84a_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x2_v84a_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_keccak_f1600_x2_v84a_aarch64_asm(void)
       buf_x0[400]; /* Two sequential Keccak states (state0[25], state1[25]) */
   MLK_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x2_v84a_aarch64_asm: host lacks AArch64 "
+            "NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     fprintf(stderr,
@@ -53,8 +61,8 @@ int check_keccak_f1600_x2_v84a_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_keccak_f1600_x2_v84a_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_keccak_f1600_x2_v84a_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(void)
                                     state1[25], state2[25], state3[25]) */
   MLK_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm: host "
+            "lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -45,7 +53,7 @@ int check_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mlk_keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm.c
@@ -32,6 +32,14 @@ int check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm(void)
                                     state1[25], state2[25], state3[25]) */
   MLK_ALIGN uint8_t buf_x1[192]; /* Round constants (24 x uint64_t) */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm: "
+            "host lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   if (!mlk_sys_check_capability(MLK_SYS_CAP_SHA3))
   {
     fprintf(stderr,
@@ -53,7 +61,7 @@ int check_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(void))mlk_keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm);
 

--- a/test/abicheck/aarch64/checks/check_ntt_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_ntt_aarch64_asm.c
@@ -32,6 +32,13 @@ int check_ntt_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x1[160]; /* Twiddle factors for layers 1-5 */
   MLK_ALIGN uint8_t buf_x2[768]; /* Twiddle factors for layers 6-7 */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check ntt_aarch64_asm: host lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -47,8 +54,8 @@ int check_ntt_aarch64_asm(void)
     input_state.gpr[2] = (uint64_t)buf_x2;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_ntt_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_ntt_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_mulcache_compute_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_mulcache_compute_aarch64_asm.c
@@ -35,6 +35,14 @@ int check_poly_mulcache_compute_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x2[256]; /* Zeta values */
   MLK_ALIGN uint8_t buf_x3[256]; /* Twisted zeta values */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_mulcache_compute_aarch64_asm: host lacks AArch64 "
+            "NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -52,9 +60,8 @@ int check_poly_mulcache_compute_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
-        &input_state, &output_state,
-        (void (*)(void))mlk_poly_mulcache_compute_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_poly_mulcache_compute_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_reduce_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_reduce_aarch64_asm.c
@@ -29,6 +29,14 @@ int check_poly_reduce_aarch64_asm(void)
   int violations;
   MLK_ALIGN uint8_t buf_x0[512]; /* Input/output polynomial */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_reduce_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -40,8 +48,8 @@ int check_poly_reduce_aarch64_asm(void)
     input_state.gpr[0] = (uint64_t)buf_x0;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_poly_reduce_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_poly_reduce_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_tobytes_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_tobytes_aarch64_asm.c
@@ -30,6 +30,14 @@ int check_poly_tobytes_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x0[384]; /* Output byte array */
   MLK_ALIGN uint8_t buf_x1[512]; /* Input polynomial */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_tobytes_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -43,8 +51,8 @@ int check_poly_tobytes_aarch64_asm(void)
     input_state.gpr[1] = (uint64_t)buf_x1;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_poly_tobytes_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_poly_tobytes_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_poly_tomont_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_poly_tomont_aarch64_asm.c
@@ -29,6 +29,14 @@ int check_poly_tomont_aarch64_asm(void)
   int violations;
   MLK_ALIGN uint8_t buf_x0[512]; /* Input/output polynomial */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check poly_tomont_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -40,8 +48,8 @@ int check_poly_tomont_aarch64_asm(void)
     input_state.gpr[0] = (uint64_t)buf_x0;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_poly_tomont_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_poly_tomont_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/aarch64/checks/check_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.c
@@ -34,6 +34,14 @@ int check_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x2[1024]; /* Input polynomial vector b */
   MLK_ALIGN uint8_t buf_x3[512];  /* Cached values for b */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm: "
+            "host lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -51,7 +59,7 @@ int check_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(
             void))mlk_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm);

--- a/test/abicheck/aarch64/checks/check_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.c
@@ -34,6 +34,14 @@ int check_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x2[1536]; /* Input polynomial vector b */
   MLK_ALIGN uint8_t buf_x3[768];  /* Cached values for b */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm: "
+            "host lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -51,7 +59,7 @@ int check_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(
             void))mlk_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm);

--- a/test/abicheck/aarch64/checks/check_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.c
@@ -34,6 +34,14 @@ int check_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x2[2048]; /* Input polynomial vector b */
   MLK_ALIGN uint8_t buf_x3[1024]; /* Cached values for b */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm: "
+            "host lacks AArch64 NEON, skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -51,7 +59,7 @@ int check_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(
+    call_stub_aarch64(
         &input_state, &output_state,
         (void (*)(
             void))mlk_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm);

--- a/test/abicheck/aarch64/checks/check_rej_uniform_aarch64_asm.c
+++ b/test/abicheck/aarch64/checks/check_rej_uniform_aarch64_asm.c
@@ -33,6 +33,14 @@ int check_rej_uniform_aarch64_asm(void)
   MLK_ALIGN uint8_t buf_x1[504];  /* Input buffer */
   MLK_ALIGN uint8_t buf_x3[4096]; /* Lookup table */
 
+  if (!mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    fprintf(stderr,
+            "ABI check rej_uniform_aarch64_asm: host lacks AArch64 NEON, "
+            "skipping\n");
+    return MLK_ABICHECK_SKIPPED;
+  }
+
   for (test_iter = 0; test_iter < MLK_ABICHECK_NUM_TESTS; test_iter++)
   {
     /* Initialize random register state */
@@ -49,8 +57,8 @@ int check_rej_uniform_aarch64_asm(void)
     input_state.gpr[3] = (uint64_t)buf_x3;
 
     /* Call function through ABI test stub */
-    asm_call_stub_aarch64(&input_state, &output_state,
-                          (void (*)(void))mlk_rej_uniform_aarch64_asm);
+    call_stub_aarch64(&input_state, &output_state,
+                      (void (*)(void))mlk_rej_uniform_aarch64_asm);
 
     /* Check ABI compliance */
     violations = check_aarch64_aapcs_compliance(&input_state, &output_state,

--- a/test/abicheck/selftest.c
+++ b/test/abicheck/selftest.c
@@ -109,7 +109,7 @@ extern void selftest_aarch64_corrupt_d13(void);
 extern void selftest_aarch64_corrupt_d14(void);
 extern void selftest_aarch64_corrupt_d15(void);
 
-static const selftest_entry_t aarch64_entries[] = {
+static const selftest_entry_t aarch64_gpr_entries[] = {
     {"noop", selftest_aarch64_noop, 0},
 #if !defined(__APPLE__)
     {"corrupt_x18", selftest_aarch64_corrupt_x18, 1},
@@ -125,6 +125,10 @@ static const selftest_entry_t aarch64_entries[] = {
     {"corrupt_x27", selftest_aarch64_corrupt_x27, 1},
     {"corrupt_x28", selftest_aarch64_corrupt_x28, 1},
     {"corrupt_x29", selftest_aarch64_corrupt_x29, 1},
+    {NULL, NULL, 0},
+};
+
+static const selftest_entry_t aarch64_neon_entries[] = {
     {"corrupt_d8", selftest_aarch64_corrupt_d8, 1},
     {"corrupt_d9", selftest_aarch64_corrupt_d9, 1},
     {"corrupt_d10", selftest_aarch64_corrupt_d10, 1},
@@ -325,9 +329,19 @@ int abicheck_selftest(void)
 
 #if defined(MLK_SYS_AARCH64)
   SELFTEST_RUN_ARCH("aarch64", struct aarch64_register_state,
-                    init_aarch64_register_state, asm_call_stub_aarch64,
-                    check_aarch64_aapcs_compliance, aarch64_entries,
+                    init_aarch64_register_state, call_stub_aarch64,
+                    check_aarch64_aapcs_compliance, aarch64_gpr_entries,
                     (void (*)(void)));
+
+  /* The NEON corrupters execute vector instructions, so running them on a
+   * host without NEON would fault instead of testing the ABI checker. */
+  if (mlk_sys_check_capability(MLK_SYS_CAP_NEON))
+  {
+    SELFTEST_RUN_ARCH("aarch64", struct aarch64_register_state,
+                      init_aarch64_register_state, call_stub_aarch64,
+                      check_aarch64_aapcs_compliance, aarch64_neon_entries,
+                      (void (*)(void)));
+  }
 #elif defined(MLK_SYS_X86_64) && defined(MLK_SYSV_ABI_SUPPORTED)
   SELFTEST_RUN_ARCH(
       "x86_64", struct x86_64_register_state, init_x86_64_register_state,

--- a/test/configs/configs.yml
+++ b/test/configs/configs.yml
@@ -261,6 +261,19 @@ configs:
 
           static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
           {
+            if (cap == MLK_SYS_CAP_NEON)
+            {
+              uint64_t id_aa64pfr0_el1;
+
+              /* Read ID_AA64PFR0_EL1 system register */
+              __asm__ volatile("mrs %0, id_aa64pfr0_el1" : "=r"(id_aa64pfr0_el1));
+
+              /* AdvSIMD field: 0b1111 = not implemented */
+              uint64_t advsimd_field = (id_aa64pfr0_el1 >> 20) & 0xF;
+
+              return (advsimd_field != 0xF) ? 1 : 0;
+            }
+
             if (cap == MLK_SYS_CAP_SHA3)
             {
               uint64_t id_aa64pfr1_el1;

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -418,6 +418,19 @@
 
 static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
 {
+  if (cap == MLK_SYS_CAP_NEON)
+  {
+    uint64_t id_aa64pfr0_el1;
+
+    /* Read ID_AA64PFR0_EL1 system register */
+    __asm__ volatile("mrs %0, id_aa64pfr0_el1" : "=r"(id_aa64pfr0_el1));
+
+    /* AdvSIMD field: 0b1111 = not implemented */
+    uint64_t advsimd_field = (id_aa64pfr0_el1 >> 20) & 0xF;
+
+    return (advsimd_field != 0xF) ? 1 : 0;
+  }
+
   if (cap == MLK_SYS_CAP_SHA3)
   {
     uint64_t id_aa64pfr1_el1;


### PR DESCRIPTION
* Resolves #1804 

Previously, the native backend and ABI checker assumed that NEON was
present on every AArch64 system.

Add MLK_SYS_CAP_AARCH64_NEON and gate every NEON-dependent native and
FIPS202 entry point on it. This allows integrators to provide runtime
capability detection and fall back to C.

Mark NEON requirements in the assembly ABI metadata and teach generated
ABI checks to skip unsupported kernels.

Route ABI checks through C call-stub wrappers. On AArch64, pass the
runtime capability into the assembly stub so it only saves, seeds,
captures, and restores vector registers when NEON is available. Keep the
GPR self-test unconditional and run vector corrupters only when NEON is
supported.

Extend the custom ID-register test configuration to detect AdvSIMD
through ID_AA64PFR0_EL1.