### PR TITLE
ACVP: Support FIPS203-tr1 encapDecap (v1.1.0.43)

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -67,7 +67,7 @@ jobs:
            name: 'aarch64'
          - runner: ubuntu-latest
            name: 'x86_64'
-        acvp-version: [v1.1.0.40, v1.1.0.41, v1.1.0.42]
+        acvp-version: [v1.1.0.41, v1.1.0.42, v1.1.0.43]
         exclude:
           - {external: true,
              target: {

--- a/scripts/tests
+++ b/scripts/tests
@@ -1355,8 +1355,8 @@ def cli():
     )
     acvp_parser.add_argument(
         "--version",
-        default="v1.1.0.41",
-        help="ACVP test vector version (default: v1.1.0.41)",
+        default="v1.1.0.43",
+        help="ACVP test vector version (default: v1.1.0.43)",
     )
 
     # wycheproof arguments

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -240,6 +240,9 @@ def keyless_decap_key_check(tg, tc):
 
     The v1.1.0.43 sample vectors omit dk for these cases; the check cannot run
     without a key. They run normally again once a key is present.
+
+    TODO(#1842): drop this once we bump past v1.1.0.43. The upstream bug
+    (usnistgov/ACVP-Server#459) is fixed on master, but not in any tag yet.
     """
     if tg.get("function") == "decapsulationKeyCheck" and "dk" not in tc:
         return "decapsulationKeyCheck without a key"
@@ -269,6 +272,23 @@ def flush_warnings():
     err("")
     for msg in _warnings:
         err(msg)
+
+
+def parse_kv_output(stdout):
+    """Parse the binary's `key=value` output lines, ignoring anything else.
+
+    Baremetal harnesses route stderr into stdout over semihosting, so usage
+    and diagnostic messages can be interleaved with the results. Those never
+    have a bare identifier before the first '=', so they are skipped. The
+    {en,de}capsulationKeyCheck cases provoke such messages by design, since
+    they pass keys of incorrect length.
+    """
+    kv = {}
+    for line in stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep and key.isidentifier():
+            kv[key] = value
+    return kv
 
 
 def get_acvp_binary(tg):
@@ -305,9 +325,7 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for line in result.stdout.splitlines():
-            (k, v) = line.split("=")
-            results[k] = v
+        results.update(parse_kv_output(result.stdout))
     elif tg["function"] == "decapsulation":
         acvp_bin = get_acvp_binary(tg)
         # keyFormat 'seed' provides d and z to expand into the key; 'expanded'
@@ -331,9 +349,7 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for line in result.stdout.splitlines():
-            (k, v) = line.split("=")
-            results[k] = v
+        results.update(parse_kv_output(result.stdout))
     elif tg["function"] == "encapsulationKeyCheck":
         acvp_bin = get_acvp_binary(tg)
         acvp_call = exec_prefix + [
@@ -350,8 +366,7 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for line in result.stdout.splitlines():
-            (k, v) = line.split("=")
+        for k, v in parse_kv_output(result.stdout).items():
             results[k] = v == "1"
 
     elif tg["function"] == "decapsulationKeyCheck":
@@ -370,8 +385,7 @@ def run_encapDecap_test(tg, tc):
             err(result.stderr)
             exit(1)
         # Extract results
-        for line in result.stdout.splitlines():
-            (k, v) = line.split("=")
+        for k, v in parse_kv_output(result.stdout).items():
             results[k] = v == "1"
     info("done")
     return results
@@ -396,9 +410,7 @@ def run_keyGen_test(tg, tc):
         err(result.stderr)
         exit(1)
     # Extract results
-    for line in result.stdout.splitlines():
-        (k, v) = line.split("=")
-        results[k] = v
+    results.update(parse_kv_output(result.stdout))
     info("done")
     return results
 

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -20,6 +20,16 @@ exec_prefix = os.environ.get("EXEC_WRAPPER", "")
 exec_prefix = exec_prefix.split(" ") if exec_prefix != "" else []
 
 
+def acvp_version_has_tr1(version):
+    """Whether `version` ships the FIPS203-tr1 encapDecap vectors (v1.1.0.43+)."""
+    try:
+        parts = tuple(int(x) for x in version.lstrip("v").split("."))
+    except ValueError:
+        # Non-numeric ref (branch or commit); assume the vectors are present.
+        return True
+    return parts >= (1, 1, 0, 43)
+
+
 def download_acvp_files(version):
     """Download ACVP test files for the specified version if not present."""
     base_url = f"https://raw.githubusercontent.com/usnistgov/ACVP-Server/{version}/gen-val/json-files"
@@ -31,6 +41,13 @@ def download_acvp_files(version):
         "ML-KEM-encapDecap-FIPS203/prompt.json",
         "ML-KEM-encapDecap-FIPS203/expectedResults.json",
     ]
+
+    # The FIPS203-tr1 encapDecap vectors add seed/expanded key-format groups.
+    if acvp_version_has_tr1(version):
+        files_to_download += [
+            "ML-KEM-encapDecap-FIPS203-tr1/prompt.json",
+            "ML-KEM-encapDecap-FIPS203-tr1/expectedResults.json",
+        ]
 
     # Create directory structure
     data_dir = Path(f"test/acvp/.acvp-data/{version}/files")
@@ -140,6 +157,19 @@ def loadDefaultAcvpData(version, supported_functions=None):
             f"{data_dir}/ML-KEM-encapDecap-FIPS203/expectedResults.json",
         ),
     ]
+
+    # FIPS203-tr1 encapDecap vectors (seed/expanded key formats) exist from
+    # v1.1.0.43.
+    if acvp_version_has_tr1(version):
+        acvp_jsons_for_version.append(
+            (
+                "encapDecap",
+                encapDecap_any,
+                f"{data_dir}/ML-KEM-encapDecap-FIPS203-tr1/prompt.json",
+                f"{data_dir}/ML-KEM-encapDecap-FIPS203-tr1/expectedResults.json",
+            )
+        )
+
     acvp_data = []
     for mode, is_supported, prompt, expectedResults in acvp_jsons_for_version:
         if not is_supported:
@@ -195,6 +225,25 @@ def unsupported_function(supported_functions):
         return fn
 
     return should_drop
+
+
+def seed_key_format(tg, tc):
+    # keyFormat 'seed' cases need keyGen to expand the seed into the
+    # decapsulation key.
+    if tg.get("keyFormat") == "seed":
+        return "seed key format requires the keyGen API"
+    return None
+
+
+def keyless_decap_key_check(tg, tc):
+    """should_drop predicate for decapsulationKeyCheck cases carrying no key.
+
+    The v1.1.0.43 sample vectors omit dk for these cases; the check cannot run
+    without a key. They run normally again once a key is present.
+    """
+    if tg.get("function") == "decapsulationKeyCheck" and "dk" not in tc:
+        return "decapsulationKeyCheck without a key"
+    return None
 
 
 def err(msg, **kwargs):
@@ -261,12 +310,18 @@ def run_encapDecap_test(tg, tc):
             results[k] = v
     elif tg["function"] == "decapsulation":
         acvp_bin = get_acvp_binary(tg)
+        # keyFormat 'seed' provides d and z to expand into the key; 'expanded'
+        # (or absent) provides the expanded dk directly.
+        if tg.get("keyFormat") == "seed":
+            key_arg = f"seed={tc['d'] + tc['z']}"
+        else:
+            key_arg = f"dk={tc['dk']}"
         acvp_call = exec_prefix + [
             acvp_bin,
             "encapDecap",
             "VAL",
             "decapsulation",
-            f"dk={tc['dk']}",
+            key_arg,
             f"c={tc['c']}",
         ]
         result = subprocess.run(acvp_call, encoding="utf-8", capture_output=True)
@@ -457,6 +512,18 @@ def test(prompt, expected, output, version, supported_functions=None):
                 f"Unsupported functions: {fns}."
             )
 
+    # Seed key-format cases require keyGen to expand the key; drop them when the
+    # build does not provide it.
+    if supported_functions is not None and "keyGen" not in supported_functions:
+        seed_reasons = filter_test_cases(data, seed_key_format)
+        if seed_reasons:
+            summary = ", ".join(sorted(set(seed_reasons)))
+            info(f"Skipping {len(seed_reasons)} test case(s): {summary}")
+
+    reasons = filter_test_cases(data, keyless_decap_key_check)
+    if reasons:
+        info(f"Skipping {len(reasons)} decapsulationKeyCheck case(s) with no key")
+
     runTest(data, output)
     flush_warnings()
 
@@ -477,8 +544,8 @@ parser.add_argument(
 parser.add_argument(
     "--version",
     "-v",
-    default="v1.1.0.41",
-    help="ACVP test vector version (default: v1.1.0.41)",
+    default="v1.1.0.43",
+    help="ACVP test vector version (default: v1.1.0.43)",
 )
 args = parser.parse_args()
 

--- a/test/acvp/acvp_mlkem.c
+++ b/test/acvp/acvp_mlkem.c
@@ -120,6 +120,45 @@ hex_usage:
   return 1;
 }
 
+#if !defined(MLK_CONFIG_NO_DECAPS_API)
+/*
+ * Decode the decapsulation-key argument into dk. It is either the expanded
+ * key ("dk=HEX", keyFormat 'expanded') or a seed d||z to expand via keyGen
+ * ("seed=HEX", keyFormat 'seed'). Returns 0 on success, 1 on failure.
+ * MLK_NOINLINE keeps the keyGen scratch (ek) out of the caller's (main's)
+ * stack frame; under -fsanitize=undefined it would not share slots and would
+ * overflow AVR RAM.
+ */
+static MLK_NOINLINE int decode_dk(const char *arg,
+                                  unsigned char dk[MLKEM_SK_BYTES])
+{
+  size_t seed_len = strlen("seed=");
+
+  /* Prefix check via memcmp; strncmp is unavailable on baremetal builds. */
+  if (strlen(arg) >= seed_len && memcmp(arg, "seed=", seed_len) == 0)
+  {
+#if !defined(MLK_CONFIG_NO_KEYPAIR_API)
+    unsigned char ek[MLKEM_PK_BYTES];
+    unsigned char coins[2 * MLKEM_SYMBYTES];
+    if (decode_hex("seed", coins, sizeof(coins), arg) != 0)
+    {
+      return 1;
+    }
+    if (mlk_kem_keypair_derand(ek, dk, coins) != 0)
+    {
+      fprintf(stderr, "Failed to expand seed into decapsulation key\n");
+      return 1;
+    }
+    return 0;
+#else  /* !MLK_CONFIG_NO_KEYPAIR_API */
+    fprintf(stderr, "seed key format requires the keyGen API\n");
+    return 1;
+#endif /* MLK_CONFIG_NO_KEYPAIR_API */
+  }
+  return decode_hex("dk", dk, MLKEM_SK_BYTES, arg);
+}
+#endif /* !MLK_CONFIG_NO_DECAPS_API */
+
 static void print_hex(const char *name, const unsigned char *raw, size_t len)
 {
   if (name != NULL)
@@ -357,8 +396,8 @@ int main(int argc, char *argv[])
             goto decaps_usage;
           }
 
-          /* Parse dk */
-          if (argc == 0 || decode_hex("dk", dk, sizeof(dk), *argv) != 0)
+          /* Parse dk (expanded key, or a seed to expand) */
+          if (argc == 0 || decode_dk(*argv, dk) != 0)
           {
             goto decaps_usage;
           }

--- a/test/acvp/acvp_mlkem.c
+++ b/test/acvp/acvp_mlkem.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../mlkem/src/common.h"
+#include "../src/decode_hex.h"
 
 #include "../../mlkem/mlkem_native.h"
 #include "../src/test_namespace.h"
@@ -53,84 +54,23 @@ typedef enum
   decapsulationKeyCheck
 } acvp_encapDecap_function;
 
-/* Decode hex character [0-9A-Fa-f] into 0-15 */
-static unsigned char decode_hex_char(char hex)
-{
-  if (hex >= '0' && hex <= '9')
-  {
-    return (unsigned char)(hex - '0');
-  }
-  else if (hex >= 'A' && hex <= 'F')
-  {
-    return (unsigned char)(10 + (unsigned char)(hex - 'A'));
-  }
-  else if (hex >= 'a' && hex <= 'f')
-  {
-    return (unsigned char)(10 + (unsigned char)(hex - 'a'));
-  }
-  else
-  {
-    return 0xFF;
-  }
-}
-
-static int decode_hex(const char *prefix, unsigned char *out, size_t out_len,
-                      const char *hex)
-{
-  size_t i;
-  size_t hex_len = strlen(hex);
-  size_t prefix_len = strlen(prefix);
-  /*
-   * Check that hex starts with `prefix=`
-   * Use memcmp, not strcmp
-   */
-  if (hex_len < prefix_len + 1 || memcmp(prefix, hex, prefix_len) != 0 ||
-      hex[prefix_len] != '=')
-  {
-    goto hex_usage;
-  }
-
-  hex += prefix_len + 1;
-  hex_len -= prefix_len + 1;
-
-  if (hex_len != 2 * out_len)
-  {
-    return 1;
-  }
-
-  for (i = 0; i < out_len; i++, hex += 2, out++)
-  {
-    unsigned hex0 = decode_hex_char(hex[0]);
-    unsigned hex1 = decode_hex_char(hex[1]);
-    if (hex0 == 0xFF || hex1 == 0xFF)
-    {
-      goto hex_usage;
-    }
-
-    *out = (unsigned char)((hex0 << 4) | hex1);
-  }
-
-  return 0;
-
-hex_usage:
-  fprintf(stderr,
-          "Argument %s invalid: Expected argument of the form '%s=HEX' with "
-          "HEX being a hex encoding of %u bytes\n",
-          hex, prefix, (unsigned)out_len);
-  return 1;
-}
-
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
+#if !defined(MLK_CONFIG_NO_KEYPAIR_API)
+/* Decapsulation key expanded from a seed. Kept in .bss (not on main's stack)
+ * so that main's per-case argument handling stays small on RAM-tight targets.
+ */
+static unsigned char acvp_expanded_dk[MLKEM_SK_BYTES];
+#endif /* !MLK_CONFIG_NO_KEYPAIR_API */
+
 /*
- * Decode the decapsulation-key argument into dk. It is either the expanded
- * key ("dk=HEX", keyFormat 'expanded') or a seed d||z to expand via keyGen
- * ("seed=HEX", keyFormat 'seed'). Returns 0 on success, 1 on failure.
+ * Resolve the decapsulation-key argument. "dk=HEX" (keyFormat 'expanded') is
+ * decoded in place and a pointer into arg is returned; "seed=HEX" (keyFormat
+ * 'seed') is a seed d||z expanded via keyGen. Returns NULL on failure.
  * MLK_NOINLINE keeps the keyGen scratch (ek) out of the caller's (main's)
  * stack frame; under -fsanitize=undefined it would not share slots and would
  * overflow AVR RAM.
  */
-static MLK_NOINLINE int decode_dk(const char *arg,
-                                  unsigned char dk[MLKEM_SK_BYTES])
+static MLK_NOINLINE unsigned char *decode_dk(char *arg)
 {
   size_t seed_len = strlen("seed=");
 
@@ -138,24 +78,26 @@ static MLK_NOINLINE int decode_dk(const char *arg,
   if (strlen(arg) >= seed_len && memcmp(arg, "seed=", seed_len) == 0)
   {
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
+    /* TODO(#1841): ek is scratch that is never used. Avoiding it needs a
+     * keyGen entry point deriving only dk from the seed. */
     unsigned char ek[MLKEM_PK_BYTES];
-    unsigned char coins[2 * MLKEM_SYMBYTES];
-    if (decode_hex("seed", coins, sizeof(coins), arg) != 0)
+    unsigned char *coins = decode_hex("seed", 2 * MLKEM_SYMBYTES, arg);
+    if (coins == NULL)
     {
-      return 1;
+      return NULL;
     }
-    if (mlk_kem_keypair_derand(ek, dk, coins) != 0)
+    if (mlk_kem_keypair_derand(ek, acvp_expanded_dk, coins) != 0)
     {
       fprintf(stderr, "Failed to expand seed into decapsulation key\n");
-      return 1;
+      return NULL;
     }
-    return 0;
+    return acvp_expanded_dk;
 #else  /* !MLK_CONFIG_NO_KEYPAIR_API */
     fprintf(stderr, "seed key format requires the keyGen API\n");
-    return 1;
+    return NULL;
 #endif /* MLK_CONFIG_NO_KEYPAIR_API */
   }
-  return decode_hex("dk", dk, MLKEM_SK_BYTES, arg);
+  return decode_hex("dk", MLKEM_SK_BYTES, arg);
 }
 #endif /* !MLK_CONFIG_NO_DECAPS_API */
 
@@ -358,8 +300,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
         case encapsulation:
         {
-          unsigned char ek[MLKEM_PK_BYTES];
-          unsigned char m[MLKEM_SYMBYTES];
+          unsigned char *ek, *m;
           /* Encapsulation only for "AFT" */
           if (type != AFT)
           {
@@ -367,14 +308,15 @@ int main(int argc, char *argv[])
           }
 
           /* Parse ek */
-          if (argc == 0 || decode_hex("ek", ek, sizeof(ek), *argv) != 0)
+          if (argc == 0 ||
+              (ek = decode_hex("ek", MLKEM_PK_BYTES, *argv)) == NULL)
           {
             goto encaps_usage;
           }
           argc--, argv++;
 
           /* Parse m */
-          if (argc == 0 || decode_hex("m", m, sizeof(m), *argv) != 0)
+          if (argc == 0 || (m = decode_hex("m", MLKEM_SYMBYTES, *argv)) == NULL)
           {
             goto encaps_usage;
           }
@@ -388,8 +330,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
         case decapsulation:
         {
-          unsigned char dk[MLKEM_SK_BYTES];
-          unsigned char c[MLKEM_CT_BYTES];
+          unsigned char *dk, *c;
           /* Decapsulation only for "VAL" */
           if (type != VAL)
           {
@@ -397,14 +338,14 @@ int main(int argc, char *argv[])
           }
 
           /* Parse dk (expanded key, or a seed to expand) */
-          if (argc == 0 || decode_dk(*argv, dk) != 0)
+          if (argc == 0 || (dk = decode_dk(*argv)) == NULL)
           {
             goto decaps_usage;
           }
           argc--, argv++;
 
           /* Parse c */
-          if (argc == 0 || decode_hex("c", c, sizeof(c), *argv) != 0)
+          if (argc == 0 || (c = decode_hex("c", MLKEM_CT_BYTES, *argv)) == NULL)
           {
             goto decaps_usage;
           }
@@ -418,7 +359,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
         case encapsulationKeyCheck:
         {
-          unsigned char ek[MLKEM_PK_BYTES];
+          unsigned char *ek;
           /* encapsulationKeyCheck only for "VAL" */
           if (type != VAL || argc == 0)
           {
@@ -426,7 +367,7 @@ int main(int argc, char *argv[])
           }
 
           /* Parse ek */
-          if (decode_hex("ek", ek, sizeof(ek), *argv) != 0)
+          if ((ek = decode_hex("ek", MLKEM_PK_BYTES, *argv)) == NULL)
           {
             /*
               ACVP 1.1.0.40+ {en, de}capsulationKeyCheck test cases test keys of
@@ -446,7 +387,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
         case decapsulationKeyCheck:
         {
-          unsigned char dk[MLKEM_SK_BYTES];
+          unsigned char *dk;
           /* Encapsulation only for "VAL" */
           if (type != VAL || argc == 0)
           {
@@ -454,7 +395,7 @@ int main(int argc, char *argv[])
           }
 
           /* Parse dk */
-          if (decode_hex("dk", dk, sizeof(dk), *argv) != 0)
+          if ((dk = decode_hex("dk", MLKEM_SK_BYTES, *argv)) == NULL)
           {
             /*
               ACVP 1.1.0.40+ {en, de}capsulationKeyCheck test cases test keys of
@@ -479,8 +420,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
     case keyGen:
     {
-      unsigned char z[MLKEM_SYMBYTES];
-      unsigned char d[MLKEM_SYMBYTES];
+      unsigned char *z, *d;
       /* keyGen only for "AFT" */
       if (type != AFT)
       {
@@ -488,14 +428,14 @@ int main(int argc, char *argv[])
       }
 
       /* Parse z */
-      if (argc == 0 || decode_hex("z", z, sizeof(z), *argv) != 0)
+      if (argc == 0 || (z = decode_hex("z", MLKEM_SYMBYTES, *argv)) == NULL)
       {
         goto keygen_usage;
       }
       argc--, argv++;
 
       /* Parse d */
-      if (argc == 0 || decode_hex("d", d, sizeof(d), *argv) != 0)
+      if (argc == 0 || (d = decode_hex("d", MLKEM_SYMBYTES, *argv)) == NULL)
       {
         goto keygen_usage;
       }

--- a/test/src/decode_hex.h
+++ b/test/src/decode_hex.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#ifndef MLK_TEST_DECODE_HEX_H
+#define MLK_TEST_DECODE_HEX_H
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Decode hex character [0-9A-Fa-f] into 0-15. Returns 0xFF for any other
+ * character: a valid nibble is 0-15, so 0xFF is an out-of-band value that never
+ * collides with a real digit and thus serves as the "not hex" sentinel. */
+static unsigned char decode_hex_char(char hex)
+{
+  if (hex >= '0' && hex <= '9')
+  {
+    return (unsigned char)(hex - '0');
+  }
+  else if (hex >= 'A' && hex <= 'F')
+  {
+    return (unsigned char)(10 + (unsigned char)(hex - 'A'));
+  }
+  else if (hex >= 'a' && hex <= 'f')
+  {
+    return (unsigned char)(10 + (unsigned char)(hex - 'a'));
+  }
+  else
+  {
+    return 0xFF;
+  }
+}
+
+/* Decode the value of a `prefix=HEX` argument in place, overwriting the
+ * hex encoding with the raw bytes. Returns a pointer to the decoded bytes
+ * inside the argument string, or NULL on parse failure. */
+static unsigned char *decode_hex(const char *prefix, size_t out_len, char *hex)
+{
+  size_t i;
+  const char *arg = hex;
+  size_t hex_len = strlen(hex);
+  size_t prefix_len = strlen(prefix);
+  unsigned char *out;
+
+  /*
+   * Check that hex starts with `prefix=`
+   * Use memcmp, not strcmp
+   */
+  if (hex_len < prefix_len + 1 || memcmp(prefix, hex, prefix_len) != 0 ||
+      hex[prefix_len] != '=')
+  {
+    goto hex_usage;
+  }
+
+  hex += prefix_len + 1;
+  hex_len -= prefix_len + 1;
+
+  if (hex_len != 2 * out_len)
+  {
+    goto hex_usage;
+  }
+
+  out = (unsigned char *)hex;
+  for (i = 0; i < out_len; i++)
+  {
+    unsigned hex0 = decode_hex_char(hex[2 * i]);
+    unsigned hex1 = decode_hex_char(hex[2 * i + 1]);
+    if (hex0 == 0xFF || hex1 == 0xFF)
+    {
+      goto hex_usage;
+    }
+
+    out[i] = (unsigned char)((hex0 << 4) | hex1);
+  }
+
+  return out;
+
+hex_usage:
+  fprintf(stderr,
+          "Argument %s invalid: Expected argument of the form '%s=HEX' with "
+          "HEX being a hex encoding of %u bytes\n",
+          arg, prefix, (unsigned)out_len);
+  return NULL;
+}
+
+#endif /* !MLK_TEST_DECODE_HEX_H */


### PR DESCRIPTION
The FIPS203-tr1 encapDecap revision adds keyFormat 'seed'/'expanded' groups: the decapsulation key may be supplied as a seed (d||z) to expand rather than as the expanded dk.

Add a decode_dk() entry point to the ACVP harness accepting either dk=HEX or seed=HEX (expanding the seed via crypto_kem_keypair_derand), and route the decapsulation function through it. keyFormat is inspected per group, so the client copes whether or not a given file carries it. Download and run the ML-KEM-encapDecap-FIPS203-tr1 vectors when the version ships them (v1.1.0.43+); keep the base FIPS203 dataset.

Two quirks in the v1.1.0.43 sample vectors are worth recording:

- decapsulationKeyCheck cases carry only a tcId with no dk, yet their expected results are a non-trivial mix of pass and fail, so they cannot be reproduced offline. The client drops decapsulationKeyCheck cases that lack a key, from prompt and expected alike; they run normally again once a key is present. This is a known upstream sample bug (usnistgov/ACVP-Server#459), where the maintainers confirm keyFormat there should be 'expanded' with the dk provided.

- The base ML-KEM-encapDecap-FIPS203 file also gained keyFormat at v1.1.0.43, whereas for ML-DSA only the -tr1 revision carries it. This looks like an unintended regeneration of the base file; the per-group handling above keeps the client correct whether or not it is fixed.

Bump the default ACVP version to v1.1.0.43 and roll the CI matrix forward to the three latest revisions.

 - Resolves #1807 
 - Resolves https://github.com/pq-code-package/mlkem-native/issues/1755