### PR TITLE
test_stack: Use a valid secret key for the decaps measurement

### DIFF
--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -8,6 +8,8 @@
 
 #include "mlkem_native.h"
 
+#include "../test_vectors/expected_test_vectors.h"
+
 static void print_info(void)
 {
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
@@ -60,13 +62,18 @@ static void test_encaps_only(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static void test_decaps_only(void)
 {
-  unsigned char sk[CRYPTO_SECRETKEYBYTES] = {0};
-  unsigned char ct[CRYPTO_CIPHERTEXTBYTES] = {0};
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
   unsigned char ss[CRYPTO_BYTES];
+  int ret;
+
+  /* A valid sk is needed: crypto_kem_dec() returns on the H(ek) check
+   * before decapsulating, leaving most of the work unmeasured. */
+  memcpy(sk, test_vector_sk, sizeof(sk));
+  memcpy(ct, test_vector_ct, sizeof(ct));
 
   /* Only call decaps - this is what we're measuring */
-  /* sk and ct are zero-initialized (invalid, but OK for stack measurement) */
-  int ret = crypto_kem_dec(ss, ct, sk);
+  ret = crypto_kem_dec(ss, ct, sk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 }
 #endif /* !MLK_CONFIG_NO_DECAPS_API */


### PR DESCRIPTION
test_decaps_only() passed an all-zero secret key. crypto_kem_dec() compares H(ek) against the hash stored in dk and returns before decapsulating if they differ, so indcpa_dec() and the re-encryption never ran and went unmeasured.

Copy the decaps test vectors into the local buffers instead. The buffers stay local so the caller-side working set matches test_keygen_only() and test_encaps_only(), keeping the three numbers comparable.

ML-KEM-768, before -> after:

  KeyGen : 17,888 -> 17,888
  Encaps : 19,744 -> 19,744
  Decaps :  7,680 -> 21,992
  Peak   : 19,744 -> 21,992

Decaps is the largest consumer at every parameter set, so the peak was understated by around 10%.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1822