### PR TITLE
CI: Test import into AWS-LC v5.4.0

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -82,7 +82,7 @@ jobs:
     needs: [ base ]
     uses: ./.github/workflows/integration-awslc.yml
     with:
-      commit: v5.0.0
+      commit: v5.4.0
     secrets: inherit
   ct-test:
     name: Constant-time

--- a/integration/aws-lc/post_import.patch
+++ b/integration/aws-lc/post_import.patch
@@ -1,39 +1,26 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
 #
-# Map mlkem-native's AArch64 NEON capability to AWS-LC's runtime CPU
-# capability detection.
+# Reconcile AWS-LC v5.4.0 with current mlkem-native, mirroring aws/aws-lc#3367:
 #
-# Also point AWS-LC's assembly source lists at the `mlkem_`-prefixed backend
-# filenames that mlkem-native now exports. Remove once AWS-LC lists them
-# directly.
+#  - Drop the AWS-LC-owned shadow copy of the AArch64 backend meta.h. It existed
+#    to add a runtime NEON gate, which mlkem-native now provides itself, so the
+#    shadow is a stale duplicate naming symbols that no longer exist.
+#  - Revert the custom capability function to the vendored `mlk_sys_cap` enum.
+#    MLK_SYS_CAP_NEON is an enumerator in mlkem/sys.h now, so AWS-LC defining it
+#    as a macro expands inside the enum declaration and breaks the build.
+#  - Glob the assembly source lists instead of naming each file, so backend
+#    renames (such as the `mlkem_` filename prefix) need no edit here.
 
-diff --git a/crypto/fipsmodule/ml_kem/mlkem_native_config.h b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
---- a/crypto/fipsmodule/ml_kem/mlkem_native_config.h
-+++ b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
-@@ -36,10 +36,15 @@
- static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
- {
- #if defined(MLK_SYS_X86_64)
-   if (cap == MLK_SYS_CAP_AVX2)
-   {
-     return CRYPTO_is_AVX2_capable();
-   }
-+#elif defined(MLK_SYS_AARCH64)
-+  if (cap == MLK_SYS_CAP_NEON)
-+  {
-+    return CRYPTO_is_NEON_capable();
-+  }
- #endif
-   return 0;
- }
 diff --git a/crypto/fipsmodule/CMakeLists.txt b/crypto/fipsmodule/CMakeLists.txt
 --- a/crypto/fipsmodule/CMakeLists.txt
 +++ b/crypto/fipsmodule/CMakeLists.txt
-@@ -346,16 +346,16 @@
+@@ -429,19 +429,12 @@
+   # Set the source directory for s2n-bignum assembly files
+   set(MLKEM_NATIVE_DIR "${AWSLC_SOURCE_DIR}/crypto/fipsmodule/ml_kem")
  
-   set(MLKEM_NATIVE_AARCH64_ASM_SOURCES
- 
+-  set(MLKEM_NATIVE_AARCH64_ASM_SOURCES
+-
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/intt.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/ntt.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/poly_mulcache_compute_asm.S
@@ -44,23 +31,22 @@ diff --git a/crypto/fipsmodule/CMakeLists.txt b/crypto/fipsmodule/CMakeLists.txt
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/rej_uniform_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_intt_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_ntt_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_poly_mulcache_compute_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_poly_reduce_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_poly_tobytes_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_poly_tomont_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_polyvec_basemul_acc_montgomery_cached_k2_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_polyvec_basemul_acc_montgomery_cached_k3_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_polyvec_basemul_acc_montgomery_cached_k4_aarch64_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/mlkem_rej_uniform_aarch64_asm.S
-   )
+-  )
++  # Every .S file in this directory is imported by importer.sh and must be
++  # compiled; glob so that refreshes which add/remove/rename files don't need a
++  # matching edit here. CONFIGURE_DEPENDS makes CMake re-run when the set of
++  # matching files changes.
++  file(GLOB MLKEM_NATIVE_AARCH64_ASM_SOURCES CONFIGURE_DEPENDS
++    "${MLKEM_NATIVE_DIR}/mlkem/native/aarch64/src/*.S")
  
    list(APPEND BCM_ASM_SOURCES ${MLKEM_NATIVE_AARCH64_ASM_SOURCES})
-@@ -369,26 +369,26 @@
  
-   set(MLKEM_NATIVE_X86_64_ASM_SOURCES
+@@ -452,29 +445,12 @@
+   # Set the source directory for s2n-bignum assembly files
+   set(MLKEM_NATIVE_DIR "${AWSLC_SOURCE_DIR}/crypto/fipsmodule/ml_kem")
  
+-  set(MLKEM_NATIVE_X86_64_ASM_SOURCES
+-
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/intt.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/ntt.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mulcache_compute.S
@@ -81,26 +67,57 @@ diff --git a/crypto/fipsmodule/CMakeLists.txt b/crypto/fipsmodule/CMakeLists.txt
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/poly_decompress_d11.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/poly_decompress_d4.S
 -    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/poly_decompress_d5.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_intt_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_ntt_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_mulcache_compute_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_nttfrombytes_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_ntttobytes_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_nttunpack_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_reduce_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_tomont_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_polyvec_basemul_acc_montgomery_cached_k2_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_polyvec_basemul_acc_montgomery_cached_k3_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_polyvec_basemul_acc_montgomery_cached_k4_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_rej_uniform_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_compress_d10_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_compress_d11_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_compress_d4_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_compress_d5_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_decompress_d10_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_decompress_d11_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_decompress_d4_avx2_asm.S
-+    ${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/mlkem_poly_decompress_d5_avx2_asm.S
-   )
+-  )
++  # Every .S file in this directory is imported by importer.sh and must be
++  # compiled; glob so that refreshes which add/remove/rename files don't need a
++  # matching edit here. CONFIGURE_DEPENDS makes CMake re-run when the set of
++  # matching files changes.
++  file(GLOB MLKEM_NATIVE_X86_64_ASM_SOURCES CONFIGURE_DEPENDS
++    "${MLKEM_NATIVE_DIR}/mlkem/native/x86_64/src/*.S")
  
    list(APPEND BCM_ASM_SOURCES ${MLKEM_NATIVE_X86_64_ASM_SOURCES})
+ 
+diff --git a/crypto/fipsmodule/ml_kem/mlkem_native_backend.h b/crypto/fipsmodule/ml_kem/mlkem_native_backend.h
+--- a/crypto/fipsmodule/ml_kem/mlkem_native_backend.h
++++ b/crypto/fipsmodule/ml_kem/mlkem_native_backend.h
+@@ -11,9 +11,7 @@
+     (defined(OPENSSL_LINUX) || defined(OPENSSL_APPLE))
+ 
+ #if defined(OPENSSL_AARCH64)
+-// AWS-LC-owned replacement for mlkem/native/aarch64/meta.h that adds a runtime
+-// NEON capability gate; falls back to the C reference impl when NEON is absent.
+-#include "mlkem_aarch64_meta.h"
++#include "mlkem/native/aarch64/meta.h"
+ #elif defined(OPENSSL_X86_64) && !defined(MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+ #include "mlkem/native/x86_64/meta.h"
+ #endif
+diff --git a/crypto/fipsmodule/ml_kem/mlkem_native_config.h b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
+--- a/crypto/fipsmodule/ml_kem/mlkem_native_config.h
++++ b/crypto/fipsmodule/ml_kem/mlkem_native_config.h
+@@ -30,24 +30,18 @@
+ #endif
+ 
+ // Map the CPU capability function to the ones used by AWS-LC.
+-// MLK_SYS_CAP_NEON is defined here (not in the vendored mlkem/sys.h enum)
+-// with a value that does not collide with AVX2 == 0 / SHA3 == 1.
+-#if !defined(__ASSEMBLER__)
+-#define MLK_SYS_CAP_NEON 2
+-#endif
+ #define MLK_CONFIG_CUSTOM_CAPABILITY_FUNC
+ #if !defined(__ASSEMBLER__)
+ #include <stdint.h>
+ #include "mlkem/sys.h"
+-static MLK_INLINE int mlk_sys_check_capability(int cap)
++static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
+ {
+ #if defined(MLK_SYS_X86_64)
+   if (cap == MLK_SYS_CAP_AVX2)
+   {
+     return CRYPTO_is_AVX2_capable();
+   }
+-#endif
+-#if defined(MLK_SYS_AARCH64)
++#elif defined(MLK_SYS_AARCH64)
+   if (cap == MLK_SYS_CAP_NEON)
+   {
+     return CRYPTO_is_NEON_capable();


### PR DESCRIPTION
* Builds on #1821 

v5.0.0 predates two upstream changes that current mlkem-native relies
on, so the integration test was pinned to a release that no longer
matches HEAD. This bumps it to v5.4.0 and reconciles the differences,
following https://github.com/aws/aws-lc/pull/3367:

  - AWS-LC shipped its own copy of the AArch64 backend meta.h to add a
    runtime NEON gate. mlkem-native provides that gate itself now, so
    the copy is a stale duplicate naming symbols (mlk_ntt_asm) that no
    longer exist. Consume the vendored meta.h instead.

  - MLK_SYS_CAP_NEON is an enumerator in mlkem/src/sys.h now, so AWS-LC
    defining it as a macro expands inside the enum declaration. Drop the
    macro and take mlk_sys_cap in the custom capability function.

  - The assembly source lists named each .S file, so the mlkem_ prefix
    left them pointing at files the importer no longer writes. Glob the
    backend directories instead, as the mldsa lists already do; future
    renames then need no edit here. This also replaces the filename
    rewrite table that previously lived in pre_import.patch.

pre_import.patch keeps the unifdef fix. Without it the reduced-API
guards survive the import and MLK_ARITH_BACKEND_AARCH64 is left in
place, which is false at build time once the include is rewritten to
s2n-bignum: intt, poly_tobytes and poly_tomont then assemble to nothing
while the C frontend still references them.

Verified against v5.4.0: importer, build, and crypto_test pass, with all
ten AArch64 assembly symbols defined and resolved. FIPS=1 is untested
locally, as static FIPS builds are Linux-only.

Once https://github.com/aws/aws-lc/pull/3367 lands, all three hunks become redundant and
post_import.patch can likely go away.