### PR TITLE
Fix stale filename references

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -100,15 +100,15 @@ jobs:
           - name: mlkem_rej_uniform_aarch64_asm
             needs: ["mlkem_specs.ml", "mlkem_utils.ml", "mlkem_rej_uniform_table.ml"]
           - name: keccak_f1600_x1_scalar_aarch64_asm
-            needs: ["keccak_specs.ml"]
+            needs: ["keccak_spec.ml"]
           - name: keccak_f1600_x1_v84a_aarch64_asm
-            needs: ["keccak_specs.ml"]
+            needs: ["keccak_spec.ml"]
           - name: keccak_f1600_x2_v84a_aarch64_asm
-            needs: ["keccak_specs.ml"]
+            needs: ["keccak_spec.ml"]
           - name: keccak_f1600_x4_v8a_v84a_scalar_hybrid_aarch64_asm
-            needs: ["keccak_specs.ml"]
+            needs: ["keccak_spec.ml"]
           - name: keccak_f1600_x4_v8a_scalar_hybrid_aarch64_asm
-            needs: ["keccak_specs.ml"]
+            needs: ["keccak_spec.ml"]
     name: AArch64 HOL Light proof for ${{ matrix.proof.name }}.S
     runs-on: ubuntu-24.04-arm
     if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork

--- a/mlkem/mlkem_native_asm.S
+++ b/mlkem/mlkem_native_asm.S
@@ -22,7 +22,7 @@
  * levels, you should include this file once with
  * MLK_CONFIG_MULTILEVEL_WITH_SHARED set.
  *
- * (You could also follow the same pattern as for mlkem_native_monobuild.c
+ * (You could also follow the same pattern as for mlkem_native.c
  *  and include it for every level, setting MLK_CONFIG_MULTILEVEL_NO_SHARED
  *  for all but one. For builds with MLK_CONFIG_MULTILEVEL_NO_SHARED, this
  *  file will then be ignored.)

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2800,7 +2800,7 @@ def gen_monolithic_asm_file():
         yield " * If you want an SCU build of mlkem-native with support for multiple security"
         yield " * levels, you should include this file once with MLK_CONFIG_MULTILEVEL_WITH_SHARED set."
         yield " *"
-        yield " * (You could also follow the same pattern as for mlkem_native_monobuild.c"
+        yield " * (You could also follow the same pattern as for mlkem_native.c"
         yield " *  and include it for every level, setting MLK_CONFIG_MULTILEVEL_NO_SHARED"
         yield " *  for all but one. For builds with MLK_CONFIG_MULTILEVEL_NO_SHARED, this"
         yield " *  file will then be ignored.)"


### PR DESCRIPTION
The HOL-Light dependency lists for the five AArch64 keccak proofs named keccak_specs.ml, but the spec file is proofs/hol_light/common/keccak_spec.ml. Since `needs` drives a suffix match against the changed files, a change to keccak_spec.ml alone never triggered those proofs.

The monolithic assembly unit still pointed at mlkem_native_monobuild.c, which was renamed to mlkem/mlkem_native.c.
