### PR TITLE
CI: Run on release branches

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -7,9 +7,9 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["main", "release/**"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
     types: [ "opened", "synchronize" ]
 
 jobs:

--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/**"]
     paths:
      - '.github/workflows/hol_light.yml'
      - 'proofs/hol_light/aarch64/Makefile'
@@ -20,7 +20,7 @@ on:
      - 'nix/hol_light/*'
      - 'nix/s2n_bignum/*'
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
     paths:
       - '.github/workflows/hol_light.yml'
       - 'proofs/hol_light/aarch64/Makefile'

--- a/.github/workflows/legacy-compilers.yml
+++ b/.github/workflows/legacy-compilers.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '0 4 * * *'
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 


### PR DESCRIPTION
Every workflow with a push or pull_request trigger was filtered to main, and all.yml is the sole entry point for the workflow_call-only suite. A PR targeting a release branch therefore ran no checks at all, and neither did a push to one.

Match release/** as well, so release branches kept for long-term support get the same coverage as main.