### PR TITLE
CI: Trim unnecessary fetch-depth from checkout steps

### DIFF
--- a/.github/workflows/hol_light.yml
+++ b/.github/workflows/hol_light.yml
@@ -48,8 +48,6 @@ jobs:
     if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,8 +61,6 @@ jobs:
     if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -115,7 +111,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
@@ -158,8 +155,6 @@ jobs:
     if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -173,8 +168,6 @@ jobs:
     if: needs.check_modified_files.outputs.run_needed == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup-shell
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -237,7 +230,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: github.event_name != 'workflow_dispatch'
         with:
-          fetch-depth: 0
+          # Enough history for changed-files (rebase-merge pushes can be multi-commit)
+          fetch-depth: 100
       - name: Get changed files
         if: github.event_name != 'workflow_dispatch'
         id: changed-files


### PR DESCRIPTION
Only the jobs that use tj-actions/changed-files need git history. Drop fetch-depth: 0 from the checkout steps that don't and bound the changed-files jobs to fetch-depth: 100 (deep enough to cover a multi-commit rebase-merge push) instead of cloning full history.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1830
- Ports https://github.com/pq-code-package/mldsa-native/pull/1192