### PR TITLE
refactor: Add MLK_CONTEXT_UNUSED helper for unused context parameters

### DIFF
--- a/mlkem/mlkem_native.c
+++ b/mlkem/mlkem_native.c
@@ -313,6 +313,7 @@
 #undef MLK_CONTEXT_PARAMETERS_2
 #undef MLK_CONTEXT_PARAMETERS_3
 #undef MLK_CONTEXT_PARAMETERS_4
+#undef MLK_CONTEXT_UNUSED
 /* mlkem/src/debug.h */
 #undef MLK_DEBUG_H
 #undef mlk_assert

--- a/mlkem/mlkem_native_asm.S
+++ b/mlkem/mlkem_native_asm.S
@@ -337,6 +337,7 @@
 #undef MLK_CONTEXT_PARAMETERS_2
 #undef MLK_CONTEXT_PARAMETERS_3
 #undef MLK_CONTEXT_PARAMETERS_4
+#undef MLK_CONTEXT_UNUSED
 /* mlkem/src/debug.h */
 #undef MLK_DEBUG_H
 #undef mlk_assert

--- a/mlkem/src/common.h
+++ b/mlkem/src/common.h
@@ -220,6 +220,7 @@
 #define MLK_FREE(v, T, N, context)                     \
   do                                                   \
   {                                                    \
+    MLK_CONTEXT_UNUSED(context);                       \
     mlk_zeroize(mlk_alloc_##v, sizeof(mlk_alloc_##v)); \
     (v) = NULL;                                        \
   } while (0)

--- a/mlkem/src/context.h
+++ b/mlkem/src/context.h
@@ -34,6 +34,15 @@
   (arg0, arg1, arg2, arg3)
 #endif /* !MLK_CONFIG_CONTEXT_PARAMETER */
 
+/* Consume a context parameter carried only for the integration's benefit,
+ * avoiding -Wunused-parameter; expands to nothing when no context is
+ * configured. */
+#if defined(MLK_CONFIG_CONTEXT_PARAMETER)
+#define MLK_CONTEXT_UNUSED(context) ((void)(context))
+#else
+#define MLK_CONTEXT_UNUSED(context) ((void)0)
+#endif
+
 #if defined(MLK_CONFIG_CONTEXT_PARAMETER_TYPE) != \
     defined(MLK_CONFIG_CONTEXT_PARAMETER)
 #error MLK_CONFIG_CONTEXT_PARAMETER_TYPE must be defined if and only if MLK_CONFIG_CONTEXT_PARAMETER is defined

--- a/mlkem/src/kem.c
+++ b/mlkem/src/kem.c
@@ -191,7 +191,7 @@ cleanup:
   MLK_FREE(ct, uint8_t, MLKEM_INDCCA_CIPHERTEXTBYTES, context);
   return ret;
 }
-#else /* MLK_CONFIG_KEYGEN_PCT */
+#else  /* MLK_CONFIG_KEYGEN_PCT */
 MLK_MUST_CHECK_RETURN_VALUE
 static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
                          uint8_t const sk[MLKEM_INDCCA_SECRETKEYBYTES],
@@ -200,9 +200,7 @@ static int mlk_check_pct(uint8_t const pk[MLKEM_INDCCA_PUBLICKEYBYTES],
   /* Skip PCT */
   ((void)pk);
   ((void)sk);
-#if defined(MLK_CONFIG_CONTEXT_PARAMETER)
-  ((void)context);
-#endif
+  MLK_CONTEXT_UNUSED(context);
   return 0;
 }
 #endif /* !MLK_CONFIG_KEYGEN_PCT */


### PR DESCRIPTION
Functions carrying the optional MLK_CONFIG_CONTEXT_PARAMETER that do not otherwise use it must consume it to avoid -Wunused-parameter, but only when a context is actually configured. This was previously done via an #if-guarded ((void)context).

Introduce MLK_CONTEXT_UNUSED(context) in context.h, expanding to ((void)(context)) when a context parameter is configured and to an empty statement otherwise, and use it in the default (stack) MLK_FREE and in the skip-PCT stub. No functional change.

Adding it to the default MLK_FREE also silences -Wunused-parameter for the combination of MLK_CONFIG_CONTEXT_PARAMETER with stack allocation, where functions such as mlk_kem_check_pk() reach the context only through MLK_ALLOC/MLK_FREE, which discard it.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1795
- Ports https://github.com/pq-code-package/mldsa-native/pull/1237#discussion_r3548554551