### PR TITLE
Document public API conventions

### DIFF
--- a/API-CONVENTIONS.md
+++ b/API-CONVENTIONS.md
@@ -1,0 +1,25 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# API conventions
+
+This document describes conventions shared by all public functions declared in [`mlkem/mlkem_native.h`](mlkem/mlkem_native.h). The per-function documentation in that header takes precedence wherever it is more specific.
+
+## Return values
+
+Functions returning `int` return `0` on success and a negative error code on failure. Error codes are enumerated as `MLK_ERR_XXX` constants in `mlkem_native.h`.
+
+Errors have different origins, and not all are fatal. `MLK_ERR_FAIL` reported by the key checks signals malformed key material, which is an expected outcome for untrusted input: the modulus check rejecting a public key, or the public key hash check rejecting a private key. Other errors, such as `MLK_ERR_OUT_OF_MEMORY` or `MLK_ERR_RNG_FAIL`, as well as `MLK_ERR_FAIL` reported by key generation after a failed pairwise consistency test, should never be observed in normal operation and hint at a deeper failure in the system.
+
+An invalid ciphertext is not an error. ML-KEM decapsulation uses implicit rejection, so decapsulating a malformed ciphertext succeeds and yields a pseudorandom shared secret.
+
+Return values must always be checked; the public API is annotated with `warn_unused_result` on compilers that support it.
+
+## Pointer arguments
+
+All pointers are assumed to be valid and non-NULL, and every buffer is assumed to have the size implied by its parameter type. mlkem-native does not conduct pointer validity checks such as NULL comparisons; passing a NULL or otherwise invalid pointer, or an undersized buffer, is undefined behavior. Ensuring these preconditions is the caller's responsibility.
+
+Every buffer in the ML-KEM API has a fixed size determined by the parameter set. There are no pointer/length pairs, and therefore no empty buffers for which a NULL pointer would be admissible.
+
+## Output buffers on error
+
+When a function returns an error, each caller-owned output buffer is left either unchanged or fully zeroized. An output buffer is never left holding partially computed or otherwise stale data that could be mistaken for a valid result.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ For CI benchmark results and historical performance data, see the [benchmarking 
 If you want to use mlkem-native, import [mlkem](mlkem) into your project's source tree and build using your favourite build system. See [mlkem](mlkem) for more information, and
 [examples/basic](examples/basic) for a simple example. The build system provided in this repository is for development purposes only.
 
+See [API-CONVENTIONS.md](API-CONVENTIONS.md) for conventions that apply to all public functions, such as return values, pointer validity, and the state of output buffers on error.
+
 ### Can I bring my own FIPS-202?
 
 mlkem-native relies on and comes with an implementation of FIPS-202[^FIPS202]. If your library has its own FIPS-202 implementation, you

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -23,6 +23,11 @@
  * Make sure the configuration file is in the include path
  * (this is "mlkem_native_config.h" by default, or MLK_CONFIG_FILE if defined).
  *
+ * # API conventions
+ *
+ * Conventions shared by all functions below (return values, pointer validity,
+ * output buffers on error) are documented in API-CONVENTIONS.md.
+ *
  * # Multi-level builds
  *
  * This header specifies a build of mlkem-native for a fixed security level.

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -2909,6 +2909,7 @@ def get_config_options():
         "MLKEM_DEBUG",  # TODO: Rename?
         "MLK_BREAK_PCT",  # Use in PCT breakage test]
         "MLK_CHECK_APIS",
+        "MLK_ERR_XXX",
         "MLK_CONFIG_XXX",
         "MLK_CONFIG_API_XXX",
         "MLK_USE_NATIVE_XXX",


### PR DESCRIPTION
Add API-CONVENTIONS.md describing the conventions shared by all public functions: return values and the meaning of the MLK_ERR_XXX codes, pointer validity expectations, and the state of output buffers on error. Link it from README.md and from the mlkem_native.h preamble.

Unlike ML-DSA, every buffer in the ML-KEM API has a fixed size, so there are no pointer/length pairs and no admissible NULL pointers. The document notes instead that an invalid ciphertext is not an error, since ML-KEM decapsulation uses implicit rejection.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1825
- Ports https://github.com/pq-code-package/mldsa-native/pull/1295