### PR TITLE
Zephyr: apply -O3 across test firmware

### DIFF
--- a/test/zephyr/README.md
+++ b/test/zephyr/README.md
@@ -52,9 +52,13 @@ The Zephyr application lives in `app/`:
 - `app/Kconfig` force-selects the FPU/MVE features for Corstone-300, whose
   Zephyr SoC does not otherwise advertise MVE.
 
-`platform.mk` forwards the test binary's full `CFLAGS` to the CMake build, so
-the firmware is compiled with the project's own warning/optimization/standard
-policy and feature defines rather than a divergent Zephyr default.
+`platform.mk` forwards the test binary's full `CFLAGS` to the CMake build. The
+application selects Zephyr's speed policy and supplements its `-O2` with the
+project's normal `-O3` through `CONFIG_COMPILER_OPT`. CMake reapplies that
+configured option to application sources because Zephyr's target options would
+otherwise follow them. This gives ML-KEM, the test harness, support sources,
+and Zephyr itself an effective final `-O3`. The resolved ordering can be
+inspected in the per-binary Zephyr build directory's `compile_commands.json`.
 
 `exec_wrapper.py` runs a built ELF under QEMU (`-nographic`, semihosting on),
 forwarding the guest's exit code; it is wired in as `EXEC_WRAPPER`.

--- a/test/zephyr/app/CMakeLists.txt
+++ b/test/zephyr/app/CMakeLists.txt
@@ -40,7 +40,8 @@ if(ZEPHYR_NUCLEO_N657X0_Q)
     VECT_TAB_BASE_ADDRESS=0x10000000
     VECT_TAB_OFFSET=0x0
   )
-  target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/shim_nucleo_n657x0_q.c)
+  set(_zephyr_shim ${CMAKE_CURRENT_SOURCE_DIR}/shim_nucleo_n657x0_q.c)
+  target_sources(app PRIVATE ${_zephyr_shim})
   target_compile_definitions(app PRIVATE
     printf=__wrap_printf
     fprintf=__wrap_fprintf
@@ -58,7 +59,8 @@ if(ZEPHYR_NUCLEO_N657X0_Q)
     -Wl,--wrap=exit
   )
 else()
-  target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/shim.c)
+  set(_zephyr_shim ${CMAKE_CURRENT_SOURCE_DIR}/shim.c)
+  target_sources(app PRIVATE ${_zephyr_shim})
 endif()
 
 # The test binary's CFLAGS, forwarded from the build (test/zephyr/platform.mk
@@ -80,6 +82,12 @@ set_source_files_properties(${R}/test/hal/hal.c
 
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/shim_nucleo_n657x0_q.c
   PROPERTIES COMPILE_OPTIONS "-Wno-error")
+
+# CONFIG_COMPILER_OPT reaches Zephyr's own targets after its optimization
+# choice. The application target has the opposite ordering, so reapply the
+# same configured option as a source property to make it effective there too.
+set_property(SOURCE ${R}/mlkem/mlkem_native.c ${_test_srcs} ${_zephyr_shim}
+  APPEND PROPERTY COMPILE_OPTIONS ${CONFIG_COMPILER_OPT})
 
 # Optional native FIPS202 backend (e.g. Armv8.1-M MVE on Cortex-M55). The
 # monolithic mlkem_native.c already includes the backend C sources; its

--- a/test/zephyr/app/prj.conf
+++ b/test/zephyr/app/prj.conf
@@ -1,4 +1,10 @@
 # Copyright (c) The mlkem-native project authors
 # SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
-CONFIG_MAIN_STACK_SIZE=32768
+CONFIG_MAIN_STACK_SIZE=131072
 CONFIG_BOOT_BANNER=n
+
+# Match the project's speed-first compiler policy throughout the test image.
+# Zephyr's speed choice is -O2, so use its documented custom option for the
+# project's normal -O3 level.
+CONFIG_SPEED_OPTIMIZATIONS=y
+CONFIG_COMPILER_OPT="-O3"


### PR DESCRIPTION
Select Zephyr speed-oriented implementations and make the normal project -O3 effective for both application and Zephyr sources.

- Resolves https://github.com/pq-code-package/mlkem-native/issues/1835
- Ports https://github.com/pq-code-package/mldsa-native/pull/1335