### PR TITLE
Remove crypto_kem_* API aliases and MLK_CONFIG_NO_SUPERCOP

### DIFF
--- a/examples/basic/main.c
+++ b/examples/basic/main.c
@@ -11,6 +11,19 @@
 #include "mlkem_native/mlkem_native.h"
 #include "test_only_rng/notrandombytes.h"
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -26,24 +39,24 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Generating keypair (randomized)... ");
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Generating keypair (deterministic)... ");
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -58,21 +71,21 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Encaps (randomized)... ");
-  CHECK(crypto_kem_enc(ct, ss, test_vector_pk) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc(ct, ss, test_vector_pk) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -87,11 +100,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/basic_deterministic/README.md
+++ b/examples/basic_deterministic/README.md
@@ -9,7 +9,7 @@ without requiring a `randombytes()` implementation.
 
 Use this approach when:
 - Your application manages its own entropy/randomness externally
-- You only need `crypto_kem_keypair_derand` and `crypto_kem_enc_derand` (deterministic variants)
+- You only need `mlkem_keypair_derand` and `mlkem_enc_derand` (deterministic variants)
 
 ## Components
 
@@ -21,7 +21,7 @@ No `randombytes()` implementation is required.
 ## Configuration
 
 The configuration file [mlkem_native_config.h](mlkem_native/mlkem_native_config.h) sets:
-- `MLK_CONFIG_NO_RANDOMIZED_API`: Disables `crypto_kem_keypair` and `crypto_kem_enc`
+- `MLK_CONFIG_NO_RANDOMIZED_API`: Disables `mlkem_keypair` and `mlkem_enc`
 - `MLK_CONFIG_PARAMETER_SET`: Security level (default 768)
 - `MLK_CONFIG_NAMESPACE_PREFIX`: Symbol prefix (set to `mlkem`)
 

--- a/examples/basic_deterministic/main.c
+++ b/examples/basic_deterministic/main.c
@@ -12,6 +12,19 @@
 
 /* No randombytes needed for deterministic API */
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -27,17 +40,17 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
 
   printf("Generating keypair (deterministic)... ");
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -53,13 +66,13 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -74,11 +87,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
+++ b/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 #define MLK_CONFIG_NO_RANDOMIZED_API
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -601,7 +589,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/bring_your_own_fips202/main.c
+++ b/examples/bring_your_own_fips202/main.c
@@ -12,6 +12,19 @@
 #include "expected_test_vectors.h"
 #include "test_only_rng/notrandombytes.h"
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -27,24 +40,24 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Generating keypair (randomized)... ");
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Generating keypair (deterministic)... ");
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -59,21 +72,21 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Encaps (randomized)... ");
-  CHECK(crypto_kem_enc(ct, ss, test_vector_pk) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc(ct, ss, test_vector_pk) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -88,11 +101,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -601,7 +589,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/bring_your_own_fips202_static/main.c
+++ b/examples/bring_your_own_fips202_static/main.c
@@ -12,6 +12,19 @@
 #include "expected_test_vectors.h"
 #include "test_only_rng/notrandombytes.h"
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -27,24 +40,24 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Generating keypair (randomized)... ");
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Generating keypair (deterministic)... ");
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -59,21 +72,21 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Encaps (randomized)... ");
-  CHECK(crypto_kem_enc(ct, ss, test_vector_pk) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc(ct, ss, test_vector_pk) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -88,11 +101,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
@@ -121,7 +121,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -131,11 +131,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -144,11 +144,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -156,27 +156,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -602,7 +590,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/custom_backend/main.c
+++ b/examples/custom_backend/main.c
@@ -13,6 +13,19 @@
 #include "expected_test_vectors.h"
 #include "test_only_rng/notrandombytes.h"
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -28,24 +41,24 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Generating keypair (randomized)... ");
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(CUSTOM_TINY_SHA3_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Generating keypair (deterministic)... ");
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(CUSTOM_TINY_SHA3_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -60,21 +73,22 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Encaps (randomized)... ");
-  CHECK(crypto_kem_enc(ct, ss, test_vector_pk) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(CUSTOM_TINY_SHA3_enc(ct, ss, test_vector_pk) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(CUSTOM_TINY_SHA3_enc_derand(ct, ss, test_vector_pk, test_vector_m) ==
+        0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -89,11 +103,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(CUSTOM_TINY_SHA3_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/custom_backend/mlkem_native/mlkem_native_config.h
+++ b/examples/custom_backend/mlkem_native/mlkem_native_config.h
@@ -122,7 +122,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -132,11 +132,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -145,11 +145,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -157,27 +157,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -597,7 +585,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/monolithic_build/main.c
+++ b/examples/monolithic_build/main.c
@@ -12,6 +12,19 @@
 #include "expected_test_vectors.h"
 #include "test_only_rng/notrandombytes.h"
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -27,24 +40,24 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Generating keypair (randomized)... ");
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Generating keypair (deterministic)... ");
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -59,21 +72,21 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Encaps (randomized)... ");
-  CHECK(crypto_kem_enc(ct, ss, test_vector_pk) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc(ct, ss, test_vector_pk) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -88,11 +101,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/monolithic_build/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build/mlkem_native/mlkem_native_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -600,7 +588,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/monolithic_build_multilevel/README.md
+++ b/examples/monolithic_build_multilevel/README.md
@@ -59,8 +59,6 @@ The wrapper [mlkem_native_all.c](mlkem_native_all.c) includes `mlkem_native.c` t
 
 The header [mlkem_native_all.h](mlkem_native_all.h) exposes all APIs:
 ```c
-#define MLK_CONFIG_NO_SUPERCOP
-
 #define MLK_CONFIG_PARAMETER_SET 512
 #include <mlkem_native.h>
 #undef MLK_CONFIG_PARAMETER_SET
@@ -81,7 +79,6 @@ The header [mlkem_native_all.h](mlkem_native_all.h) exposes all APIs:
 
 - `MLK_CONFIG_MULTILEVEL_WITH_SHARED` must be set for exactly ONE level
 - `MLK_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS` prevents cleanup of shared headers between inclusions
-- `MLK_CONFIG_NO_SUPERCOP` is required to avoid conflicting `CRYPTO_*` macro definitions
 
 ## Usage
 

--- a/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
@@ -29,7 +29,6 @@
  *
  * This configuration differs from the default mlkem/mlkem_native_config.h in
  * the following places:
- *   - MLK_CONFIG_NO_SUPERCOP
  *   - MLK_CONFIG_MULTILEVEL_BUILD
  *   - MLK_CONFIG_NAMESPACE_PREFIX
  *   - MLK_CONFIG_INTERNAL_API_QUALIFIER
@@ -121,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -131,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -144,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -156,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-#define MLK_CONFIG_NO_SUPERCOP
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -602,7 +589,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
@@ -29,7 +29,6 @@
  *
  * This configuration differs from the default mlkem/mlkem_native_config.h in
  * the following places:
- *   - MLK_CONFIG_NO_SUPERCOP
  *   - MLK_CONFIG_MULTILEVEL_BUILD
  *   - MLK_CONFIG_NAMESPACE_PREFIX
  *   - MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
@@ -125,7 +124,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -135,11 +134,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -148,11 +147,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -160,27 +159,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-#define MLK_CONFIG_NO_SUPERCOP
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -608,7 +595,7 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/monolithic_build_native/main.c
+++ b/examples/monolithic_build_native/main.c
@@ -12,6 +12,19 @@
 #include "expected_test_vectors.h"
 #include "test_only_rng/notrandombytes.h"
 
+/* Convenience abbreviations for the key and ciphertext sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * These examples, however, are compiled for all three parameter sets (512, 768,
+ * 1024), so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
 #define CHECK(x)                                              \
   do                                                          \
   {                                                           \
@@ -27,24 +40,24 @@
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int example_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Generating keypair (randomized)... ");
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair(pk, sk) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Generating keypair (deterministic)... ");
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(mlkem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk, MLKEM_SK_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -59,21 +72,21 @@ static int example_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int example_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
   printf("Encaps (randomized)... ");
-  CHECK(crypto_kem_enc(ct, ss, test_vector_pk) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc(ct, ss, test_vector_pk) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
   printf("Encaps (deterministic)... ");
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }
@@ -88,11 +101,11 @@ static int example_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int example_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   printf("Decaps... ");
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(mlkem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   printf("DONE\n");
   return 0;
 }

--- a/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -600,7 +588,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/multilevel_build/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build/mlkem_native/mlkem_native_config.h
@@ -29,7 +29,6 @@
  *
  * This configuration differs from the default mlkem/mlkem_native_config.h in
  * the following places:
- *   - MLK_CONFIG_NO_SUPERCOP
  *   - MLK_CONFIG_MULTILEVEL_BUILD
  *   - MLK_CONFIG_NAMESPACE_PREFIX
  */
@@ -120,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-#define MLK_CONFIG_NO_SUPERCOP
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -601,7 +588,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
@@ -29,7 +29,6 @@
  *
  * This configuration differs from the default mlkem/mlkem_native_config.h in
  * the following places:
- *   - MLK_CONFIG_NO_SUPERCOP
  *   - MLK_CONFIG_MULTILEVEL_BUILD
  *   - MLK_CONFIG_NAMESPACE_PREFIX
  *   - MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
@@ -122,7 +121,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -132,11 +131,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -145,11 +144,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -157,27 +156,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-#define MLK_CONFIG_NO_SUPERCOP
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -599,7 +586,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -250,7 +250,7 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  *              generated keypair before it can be exported.
  *
  *              Set this option if such a check should be implemented.
- *              In this case, crypto_kem_keypair_derand and crypto_kem_keypair
+ *              In this case, keypair_derand and keypair
  *              will return a non-zero error code if the PCT failed.
  *
  *              NOTE: This feature will drastically lower the performance of

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -212,7 +212,7 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  *              generated keypair before it can be exported.
  *
  *              Set this option if such a check should be implemented.
- *              In this case, crypto_kem_keypair_derand and crypto_kem_keypair
+ *              In this case, keypair_derand and keypair
  *              will return a non-zero error code if the PCT failed.
  *
  *              NOTE: This feature will drastically lower the performance of

--- a/integration/liboqs/config_ppc64le.h
+++ b/integration/liboqs/config_ppc64le.h
@@ -250,7 +250,7 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  *              generated keypair before it can be exported.
  *
  *              Set this option if such a check should be implemented.
- *              In this case, crypto_kem_keypair_derand and crypto_kem_keypair
+ *              In this case, keypair_derand and keypair
  *              will return a non-zero error code if the PCT failed.
  *
  *              NOTE: This feature will drastically lower the performance of

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -251,7 +251,7 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  *              generated keypair before it can be exported.
  *
  *              Set this option if such a check should be implemented.
- *              In this case, crypto_kem_keypair_derand and crypto_kem_keypair
+ *              In this case, keypair_derand and keypair
  *              will return a non-zero error code if the PCT failed.
  *
  *              NOTE: This feature will drastically lower the performance of

--- a/mlkem/mlkem_native.c
+++ b/mlkem/mlkem_native.c
@@ -121,11 +121,6 @@
  * Undefine macros from MLK_CONFIG_PARAMETER_SET-specific files
  */
 /* mlkem/mlkem_native.h */
-#undef CRYPTO_BYTES
-#undef CRYPTO_CIPHERTEXTBYTES
-#undef CRYPTO_PUBLICKEYBYTES
-#undef CRYPTO_SECRETKEYBYTES
-#undef CRYPTO_SYMBYTES
 #undef MLKEM1024_BYTES
 #undef MLKEM1024_CIPHERTEXTBYTES
 #undef MLKEM1024_PUBLICKEYBYTES
@@ -179,13 +174,6 @@
 #undef MLK_TOTAL_ALLOC_768_KEYPAIR
 #undef MLK_TOTAL_ALLOC_768_KEYPAIR_NO_PCT
 #undef MLK_TOTAL_ALLOC_768_KEYPAIR_PCT
-#undef crypto_kem_check_pk
-#undef crypto_kem_check_sk
-#undef crypto_kem_dec
-#undef crypto_kem_enc
-#undef crypto_kem_enc_derand
-#undef crypto_kem_keypair
-#undef crypto_kem_keypair_derand
 /* mlkem/src/common.h */
 #undef MLK_ADD_PARAM_SET
 #undef MLK_ALLOC

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -370,47 +370,8 @@ int MLK_API_NAMESPACE(check_sk)(
 }
 #endif
 
-/****************************** SUPERCOP API *********************************/
-
-#if !defined(MLK_CONFIG_NO_SUPERCOP)
-/* Export API in SUPERCOP naming scheme CRYPTO_xxx / crypto_kem_xxx */
-#define CRYPTO_SECRETKEYBYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
-#define CRYPTO_PUBLICKEYBYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
-#define CRYPTO_CIPHERTEXTBYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
-#define CRYPTO_SYMBYTES MLKEM_SYMBYTES
-#define CRYPTO_BYTES MLKEM_BYTES
-
-#if !defined(MLK_CONFIG_NO_KEYPAIR_API)
-#define crypto_kem_keypair_derand MLK_API_NAMESPACE(keypair_derand)
-#if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
-#define crypto_kem_keypair MLK_API_NAMESPACE(keypair)
-#endif
-#endif /* !MLK_CONFIG_NO_KEYPAIR_API */
-#if !defined(MLK_CONFIG_NO_ENCAPS_API)
-#define crypto_kem_enc_derand MLK_API_NAMESPACE(enc_derand)
-#if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
-#define crypto_kem_enc MLK_API_NAMESPACE(enc)
-#endif
-#define crypto_kem_check_pk MLK_API_NAMESPACE(check_pk)
-#endif /* !MLK_CONFIG_NO_ENCAPS_API */
-#if !defined(MLK_CONFIG_NO_DECAPS_API)
-#define crypto_kem_dec MLK_API_NAMESPACE(dec)
-#define crypto_kem_check_sk MLK_API_NAMESPACE(check_sk)
-#endif
-
-#else /* !MLK_CONFIG_NO_SUPERCOP */
-
-/* If the SUPERCOP API is not needed, we can undefine the various helper macros
- * above. Otherwise, they are needed for lazy evaluation of crypto_kem_xxx. */
-#undef MLK_API_CONCAT
-#undef MLK_API_CONCAT_
-#undef MLK_API_CONCAT_UNDERSCORE
-#undef MLK_API_NAMESPACE
 #undef MLK_API_NAMESPACE_PREFIX
-#undef MLK_API_MUST_CHECK_RETURN_VALUE
-#undef MLK_API_QUALIFIER
 
-#endif /* MLK_CONFIG_NO_SUPERCOP */
 #endif /* !MLK_CONFIG_CONSTANTS_ONLY */
 
 

--- a/mlkem/mlkem_native_asm.S
+++ b/mlkem/mlkem_native_asm.S
@@ -145,11 +145,6 @@
  * Undefine macros from MLK_CONFIG_PARAMETER_SET-specific files
  */
 /* mlkem/mlkem_native.h */
-#undef CRYPTO_BYTES
-#undef CRYPTO_CIPHERTEXTBYTES
-#undef CRYPTO_PUBLICKEYBYTES
-#undef CRYPTO_SECRETKEYBYTES
-#undef CRYPTO_SYMBYTES
 #undef MLKEM1024_BYTES
 #undef MLKEM1024_CIPHERTEXTBYTES
 #undef MLKEM1024_PUBLICKEYBYTES
@@ -203,13 +198,6 @@
 #undef MLK_TOTAL_ALLOC_768_KEYPAIR
 #undef MLK_TOTAL_ALLOC_768_KEYPAIR_NO_PCT
 #undef MLK_TOTAL_ALLOC_768_KEYPAIR_PCT
-#undef crypto_kem_check_pk
-#undef crypto_kem_check_sk
-#undef crypto_kem_dec
-#undef crypto_kem_enc
-#undef crypto_kem_enc_derand
-#undef crypto_kem_keypair
-#undef crypto_kem_keypair_derand
 /* mlkem/src/common.h */
 #undef MLK_ADD_PARAM_SET
 #undef MLK_ALLOC

--- a/mlkem/mlkem_native_config.h
+++ b/mlkem/mlkem_native_config.h
@@ -104,7 +104,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -114,11 +114,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -127,11 +127,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -139,27 +139,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -585,7 +573,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/mlkem/src/common.h
+++ b/mlkem/src/common.h
@@ -122,15 +122,15 @@
 #endif
 
 #if defined(MLK_CONFIG_NO_RANDOMIZED_API) && defined(MLK_CONFIG_KEYGEN_PCT)
-#error Bad configuration: MLK_CONFIG_NO_RANDOMIZED_API is incompatible with MLK_CONFIG_KEYGEN_PCT as the current PCT implementation requires crypto_kem_enc()
+#error Bad configuration: MLK_CONFIG_NO_RANDOMIZED_API is incompatible with MLK_CONFIG_KEYGEN_PCT as the current PCT implementation requires enc()
 #endif
 
 #if defined(MLK_CONFIG_NO_ENCAPS_API) && defined(MLK_CONFIG_KEYGEN_PCT)
-#error Bad configuration: MLK_CONFIG_NO_ENCAPS_API is incompatible with MLK_CONFIG_KEYGEN_PCT as the current PCT implementation requires crypto_kem_enc()
+#error Bad configuration: MLK_CONFIG_NO_ENCAPS_API is incompatible with MLK_CONFIG_KEYGEN_PCT as the current PCT implementation requires enc()
 #endif
 
 #if defined(MLK_CONFIG_NO_DECAPS_API) && defined(MLK_CONFIG_KEYGEN_PCT)
-#error Bad configuration: MLK_CONFIG_NO_DECAPS_API is incompatible with MLK_CONFIG_KEYGEN_PCT as the current PCT implementation requires crypto_kem_dec()
+#error Bad configuration: MLK_CONFIG_NO_DECAPS_API is incompatible with MLK_CONFIG_KEYGEN_PCT as the current PCT implementation requires dec()
 #endif
 
 #if defined(MLK_CONFIG_USE_NATIVE_BACKEND_ARITH)

--- a/proofs/cbmc/mlkem_native_config_cbmc.h
+++ b/proofs/cbmc/mlkem_native_config_cbmc.h
@@ -121,7 +121,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -131,11 +131,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -144,11 +144,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -156,27 +156,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -600,7 +588,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -4659,12 +4659,12 @@ def gen_test_vectors():
 
     # Each API is exercised independently: the example resets the PRNG
     # before invoking each API, so `d, z` are the first 64 bytes of a fresh
-    # notrandombytes stream (as consumed by crypto_kem_keypair) and `m` is
-    # the first 32 bytes of a fresh stream (as consumed by crypto_kem_enc).
+    # notrandombytes stream (as consumed by mlkem_keypair) and `m` is
+    # the first 32 bytes of a fresh stream (as consumed by mlkem_enc).
     #
-    # Order within the keypair pair matters: crypto_kem_keypair reads
+    # Order within the keypair pair matters: mlkem_keypair reads
     # randombytes into `coins[64]` which is then interpreted as `d || z` by
-    # crypto_kem_keypair_derand, so `d` must be the first 32 bytes.
+    # mlkem_keypair_derand, so `d` must be the first 32 bytes.
     keygen_rnd = notrandombytes(64)
     d = keygen_rnd[:64]
     z = keygen_rnd[64:128]
@@ -4724,9 +4724,9 @@ def gen_test_vectors():
         yield "/*"
         yield " * Generated with:"
         yield " *   d, z: consecutive 32-byte draws from a fresh notrandombytes"
-        yield " *         stream (as consumed by crypto_kem_keypair)."
+        yield " *         stream (as consumed by mlkem_keypair)."
         yield " *   m:    first 32-byte draw from a second, fresh"
-        yield " *         notrandombytes stream (as consumed by crypto_kem_enc"
+        yield " *         notrandombytes stream (as consumed by mlkem_enc"
         yield " *         after randombytes_reset())."
         yield " */"
 

--- a/test/acvp/acvp_mlkem.c
+++ b/test/acvp/acvp_mlkem.c
@@ -9,6 +9,7 @@
 #include "../../mlkem/src/common.h"
 
 #include "../../mlkem/mlkem_native.h"
+#include "../src/test_namespace.h"
 
 #define USAGE \
   "acvp_mlkem{lvl} [encapDecap|keyGen] [AFT|VAL] {test specific arguments}"
@@ -137,44 +138,44 @@ static void print_hex(const char *name, const unsigned char *raw, size_t len)
  * environments, e.g. AVR. */
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static MLK_NOINLINE void acvp_mlkem_encapDecp_AFT_encapsulation(
-    unsigned char const ek[CRYPTO_PUBLICKEYBYTES],
+    unsigned char const ek[MLKEM_PK_BYTES],
     unsigned char const m[MLKEM_SYMBYTES])
 {
-  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
-  unsigned char ss[CRYPTO_BYTES];
+  unsigned char ct[MLKEM_CT_BYTES];
+  unsigned char ss[MLKEM_BYTES];
 
-  CHECK(crypto_kem_enc_derand(ct, ss, ek, m) == 0);
+  CHECK(mlk_kem_enc_derand(ct, ss, ek, m) == 0);
 
   print_hex("c", ct, sizeof(ct));
   print_hex("k", ss, sizeof(ss));
 }
 
 static MLK_NOINLINE void acvp_mlkem_encapDecp_VAL_encapsulationKeyCheck(
-    unsigned char const ek[CRYPTO_PUBLICKEYBYTES])
+    unsigned char const ek[MLKEM_PK_BYTES])
 {
   int rc = 0;
-  rc = (crypto_kem_check_pk(ek) == 0) ? 1 : 0;
+  rc = (mlk_kem_check_pk(ek) == 0) ? 1 : 0;
   printf("testPassed=%d\n", rc);
 }
 #endif /* !MLK_CONFIG_NO_ENCAPS_API */
 
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static MLK_NOINLINE void acvp_mlkem_encapDecp_VAL_decapsulation(
-    unsigned char const dk[CRYPTO_SECRETKEYBYTES],
-    unsigned char const c[CRYPTO_CIPHERTEXTBYTES])
+    unsigned char const dk[MLKEM_SK_BYTES],
+    unsigned char const c[MLKEM_CT_BYTES])
 {
-  unsigned char ss[CRYPTO_BYTES];
+  unsigned char ss[MLKEM_BYTES];
 
-  CHECK(crypto_kem_dec(ss, c, dk) == 0);
+  CHECK(mlk_kem_dec(ss, c, dk) == 0);
 
   print_hex("k", ss, sizeof(ss));
 }
 
 static MLK_NOINLINE void acvp_mlkem_encapDecp_VAL_decapsulationKeyCheck(
-    unsigned char const dk[CRYPTO_SECRETKEYBYTES])
+    unsigned char const dk[MLKEM_SK_BYTES])
 {
   int rc = 0;
-  rc = (crypto_kem_check_sk(dk) == 0) ? 1 : 0;
+  rc = (mlk_kem_check_sk(dk) == 0) ? 1 : 0;
   printf("testPassed=%d\n", rc);
 }
 #endif /* !MLK_CONFIG_NO_DECAPS_API */
@@ -184,14 +185,14 @@ static MLK_NOINLINE void acvp_mlkem_keyGen_AFT(
     unsigned char const z[MLKEM_SYMBYTES],
     unsigned char const d[MLKEM_SYMBYTES])
 {
-  unsigned char ek[CRYPTO_PUBLICKEYBYTES];
-  unsigned char dk[CRYPTO_SECRETKEYBYTES];
+  unsigned char ek[MLKEM_PK_BYTES];
+  unsigned char dk[MLKEM_SK_BYTES];
 
   unsigned char zd[2 * MLKEM_SYMBYTES];
   memcpy(zd, d, MLKEM_SYMBYTES);
   memcpy(zd + MLKEM_SYMBYTES, z, MLKEM_SYMBYTES);
 
-  CHECK(crypto_kem_keypair_derand(ek, dk, zd) == 0);
+  CHECK(mlk_kem_keypair_derand(ek, dk, zd) == 0);
 
   print_hex("ek", ek, sizeof(ek));
   print_hex("dk", dk, sizeof(dk));
@@ -318,7 +319,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
         case encapsulation:
         {
-          unsigned char ek[CRYPTO_PUBLICKEYBYTES];
+          unsigned char ek[MLKEM_PK_BYTES];
           unsigned char m[MLKEM_SYMBYTES];
           /* Encapsulation only for "AFT" */
           if (type != AFT)
@@ -348,8 +349,8 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
         case decapsulation:
         {
-          unsigned char dk[CRYPTO_SECRETKEYBYTES];
-          unsigned char c[CRYPTO_CIPHERTEXTBYTES];
+          unsigned char dk[MLKEM_SK_BYTES];
+          unsigned char c[MLKEM_CT_BYTES];
           /* Decapsulation only for "VAL" */
           if (type != VAL)
           {
@@ -378,7 +379,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
         case encapsulationKeyCheck:
         {
-          unsigned char ek[CRYPTO_PUBLICKEYBYTES];
+          unsigned char ek[MLKEM_PK_BYTES];
           /* encapsulationKeyCheck only for "VAL" */
           if (type != VAL || argc == 0)
           {
@@ -406,7 +407,7 @@ int main(int argc, char *argv[])
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
         case decapsulationKeyCheck:
         {
-          unsigned char dk[CRYPTO_SECRETKEYBYTES];
+          unsigned char dk[MLKEM_SK_BYTES];
           /* Encapsulation only for "VAL" */
           if (type != VAL || argc == 0)
           {

--- a/test/bench/bench_mlkem.c
+++ b/test/bench/bench_mlkem.c
@@ -12,6 +12,7 @@
 #include "hal.h"
 
 #include "../../mlkem/mlkem_native.h"
+#include "../src/test_namespace.h"
 
 #ifndef MLK_BENCHMARK_NWARMUP
 #define MLK_BENCHMARK_NWARMUP 50
@@ -79,12 +80,12 @@ static void print_percentiles(const char *txt,
 
 static int bench(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_a[CRYPTO_BYTES];
-  uint8_t key_b[CRYPTO_BYTES];
-  unsigned char kg_rand[2 * CRYPTO_BYTES], enc_rand[CRYPTO_BYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t key_a[MLKEM_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
+  unsigned char kg_rand[2 * MLKEM_BYTES], enc_rand[MLKEM_BYTES];
   uint64_t cycles_kg[MLK_BENCHMARK_NTESTS], cycles_enc[MLK_BENCHMARK_NTESTS],
       cycles_dec[MLK_BENCHMARK_NTESTS];
 
@@ -95,19 +96,19 @@ static int bench(void)
   for (i = 0; i < MLK_BENCHMARK_NTESTS; i++)
   {
     int ret = 0;
-    CHECK(randombytes(kg_rand, 2 * CRYPTO_BYTES) == 0);
-    CHECK(randombytes(enc_rand, CRYPTO_BYTES) == 0);
+    CHECK(randombytes(kg_rand, 2 * MLKEM_BYTES) == 0);
+    CHECK(randombytes(enc_rand, MLKEM_BYTES) == 0);
 
     /* Key-pair generation */
     for (j = 0; j < MLK_BENCHMARK_NWARMUP; j++)
     {
-      ret |= crypto_kem_keypair_derand(pk, sk, kg_rand);
+      ret |= mlk_kem_keypair_derand(pk, sk, kg_rand);
     }
 
     t0 = get_cyclecounter();
     for (j = 0; j < MLK_BENCHMARK_NITERATIONS; j++)
     {
-      ret |= crypto_kem_keypair_derand(pk, sk, kg_rand);
+      ret |= mlk_kem_keypair_derand(pk, sk, kg_rand);
     }
     t1 = get_cyclecounter();
     cycles_kg[i] = t1 - t0;
@@ -116,12 +117,12 @@ static int bench(void)
     /* Encapsulation */
     for (j = 0; j < MLK_BENCHMARK_NWARMUP; j++)
     {
-      ret |= crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
+      ret |= mlk_kem_enc_derand(ct, key_a, pk, enc_rand);
     }
     t0 = get_cyclecounter();
     for (j = 0; j < MLK_BENCHMARK_NITERATIONS; j++)
     {
-      ret |= crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
+      ret |= mlk_kem_enc_derand(ct, key_a, pk, enc_rand);
     }
     t1 = get_cyclecounter();
     cycles_enc[i] = t1 - t0;
@@ -129,18 +130,18 @@ static int bench(void)
     /* Decapsulation */
     for (j = 0; j < MLK_BENCHMARK_NWARMUP; j++)
     {
-      ret |= crypto_kem_dec(key_b, ct, sk);
+      ret |= mlk_kem_dec(key_b, ct, sk);
     }
     t0 = get_cyclecounter();
     for (j = 0; j < MLK_BENCHMARK_NITERATIONS; j++)
     {
-      ret |= crypto_kem_dec(key_b, ct, sk);
+      ret |= mlk_kem_dec(key_b, ct, sk);
     }
     t1 = get_cyclecounter();
     cycles_dec[i] = t1 - t0;
 
     CHECK(ret == 0);
-    CHECK(memcmp(key_a, key_b, CRYPTO_BYTES) == 0);
+    CHECK(memcmp(key_a, key_b, MLKEM_BYTES) == 0);
   }
 
   qsort(cycles_kg, MLK_BENCHMARK_NTESTS, sizeof(uint64_t), cmp_uint64_t);

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -601,7 +589,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/configs.yml
+++ b/test/configs/configs.yml
@@ -314,7 +314,6 @@ configs:
   - path: examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
     description: "Multilevel monolithic build config"
     defines:
-      MLK_CONFIG_NO_SUPERCOP: true
       MLK_CONFIG_MULTILEVEL_BUILD: true
       MLK_CONFIG_NAMESPACE_PREFIX: mlkem
       MLK_CONFIG_INTERNAL_API_QUALIFIER: static
@@ -324,7 +323,6 @@ configs:
   - path: examples/multilevel_build/mlkem_native/mlkem_native_config.h
     description: "Multilevel build config"
     defines:
-      MLK_CONFIG_NO_SUPERCOP: true
       MLK_CONFIG_MULTILEVEL_BUILD: true
       MLK_CONFIG_NAMESPACE_PREFIX: mlkem
       MLK_CONFIG_FILE:
@@ -333,7 +331,6 @@ configs:
   - path: examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
     description: "Multilevel build config"
     defines:
-      MLK_CONFIG_NO_SUPERCOP: true
       MLK_CONFIG_MULTILEVEL_BUILD: true
       MLK_CONFIG_NAMESPACE_PREFIX: mlkem
       MLK_CONFIG_USE_NATIVE_BACKEND_ARITH: true
@@ -344,7 +341,6 @@ configs:
   - path: examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
     description: "Multilevel monolithic build config with native backends"
     defines:
-      MLK_CONFIG_NO_SUPERCOP: true
       MLK_CONFIG_MULTILEVEL_BUILD: true
       MLK_CONFIG_NAMESPACE_PREFIX: mlkem
       MLK_CONFIG_USE_NATIVE_BACKEND_ARITH: true

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -618,7 +606,7 @@ static inline void *mlk_posix_memalign(size_t align, size_t sz)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -608,7 +596,7 @@ static MLK_INLINE void *mlk_memcpy(void *dest, const void *src, size_t n)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -607,7 +595,7 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -604,7 +592,7 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -603,7 +591,7 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -635,7 +623,7 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -635,7 +623,7 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -600,7 +588,7 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -616,7 +604,7 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -601,7 +589,7 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -120,7 +120,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -130,11 +130,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -143,11 +143,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -155,27 +155,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -602,7 +590,7 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -119,7 +119,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -129,11 +129,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -142,11 +142,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -154,27 +154,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -600,7 +588,7 @@
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -122,7 +122,7 @@
  *
  * By default, mlkem-native includes support for generating key pairs.
  * If you don't need this, set MLK_CONFIG_NO_KEYPAIR_API to exclude
- * crypto_kem_keypair and crypto_kem_keypair_derand, and all internal
+ * keypair and keypair_derand, and all internal
  * APIs only needed by those functions.
  */
 /* #define MLK_CONFIG_NO_KEYPAIR_API */
@@ -132,11 +132,11 @@
  *
  * By default, mlkem-native includes support for encapsulation. If you
  * don't need this, set MLK_CONFIG_NO_ENCAPS_API to exclude
- * crypto_kem_enc, crypto_kem_enc_derand, crypto_kem_check_pk, and
+ * enc, enc_derand, check_pk, and
  * all internal APIs only needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_enc().
+ *       as the current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_ENCAPS_API */
 
@@ -145,11 +145,11 @@
  *
  * By default, mlkem-native includes support for decapsulation. If you
  * don't need this, set MLK_CONFIG_NO_DECAPS_API to exclude
- * crypto_kem_dec, crypto_kem_check_sk, and all internal APIs only
+ * dec, check_sk, and all internal APIs only
  * needed by those functions.
  *
  * @note Setting this option is incompatible with MLK_CONFIG_KEYGEN_PCT
- *       as the current PCT implementation requires crypto_kem_dec().
+ *       as the current PCT implementation requires dec().
  */
 /* #define MLK_CONFIG_NO_DECAPS_API */
 
@@ -157,27 +157,15 @@
  * MLK_CONFIG_NO_RANDOMIZED_API
  *
  * If this option is set, mlkem-native will be built without the randomized
- * API functions (crypto_kem_keypair and crypto_kem_enc). This allows users
+ * API functions (keypair and enc). This allows users
  * to build mlkem-native without providing a randombytes() implementation
- * if they only need the deterministic API (crypto_kem_keypair_derand,
- * crypto_kem_enc_derand, crypto_kem_dec).
+ * if they only need the deterministic API (keypair_derand,
+ * enc_derand, dec).
  *
  * @note This option is incompatible with MLK_CONFIG_KEYGEN_PCT as the
- *       current PCT implementation requires crypto_kem_enc().
+ *       current PCT implementation requires enc().
  */
 /* #define MLK_CONFIG_NO_RANDOMIZED_API */
-
-/**
- * MLK_CONFIG_NO_SUPERCOP
- *
- * By default, mlkem_native.h exposes the mlkem-native API in the SUPERCOP
- * naming convention (crypto_kem_xxx). If you don't need this, set
- * MLK_CONFIG_NO_SUPERCOP.
- *
- * @note You must set this for a multi-level build as the SUPERCOP naming
- *       does not disambiguate between the parameter sets.
- */
-/* #define MLK_CONFIG_NO_SUPERCOP */
 
 /**
  * MLK_CONFIG_CONSTANTS_ONLY
@@ -608,7 +596,7 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * can be exported.
  *
  * Set this option if such a check should be implemented. In this case,
- * crypto_kem_keypair_derand and crypto_kem_keypair will return a non-zero
+ * keypair_derand and keypair will return a non-zero
  * error code if the PCT failed.
  *
  * @note This feature will drastically lower the performance of key

--- a/test/src/gen_KAT.c
+++ b/test/src/gen_KAT.c
@@ -8,6 +8,7 @@
 #include "../../mlkem/src/fips202/fips202.h"
 
 #include "../../mlkem/mlkem_native.h"
+#include "test_namespace.h"
 
 #if defined(MLK_CONFIG_NO_KEYPAIR_API) || defined(MLK_CONFIG_NO_ENCAPS_API) || \
     defined(MLK_CONFIG_NO_DECAPS_API)
@@ -59,12 +60,12 @@ int main(void);
 int main(void)
 {
   unsigned i;
-  MLK_ALIGN uint8_t coins[3 * CRYPTO_SYMBYTES];
-  MLK_ALIGN uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  MLK_ALIGN uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  MLK_ALIGN uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  MLK_ALIGN uint8_t ss1[CRYPTO_BYTES];
-  MLK_ALIGN uint8_t ss2[CRYPTO_BYTES];
+  MLK_ALIGN uint8_t coins[3 * MLKEM_SYMBYTES];
+  MLK_ALIGN uint8_t pk[MLKEM_PK_BYTES];
+  MLK_ALIGN uint8_t sk[MLKEM_SK_BYTES];
+  MLK_ALIGN uint8_t ct[MLKEM_CT_BYTES];
+  MLK_ALIGN uint8_t ss1[MLKEM_BYTES];
+  MLK_ALIGN uint8_t ss2[MLKEM_BYTES];
 
   const uint8_t seed[64] = {
       32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
@@ -85,14 +86,14 @@ int main(void)
   {
     mlk_shake256(coins, sizeof(coins), coins, sizeof(coins));
 
-    CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
+    CHECK(mlk_kem_keypair_derand(pk, sk, coins) == 0);
     print_hex("pk", pk, sizeof(pk));
     print_hex("sk", sk, sizeof(sk));
 
-    CHECK(crypto_kem_enc_derand(ct, ss1, pk, coins + 2 * MLKEM_SYMBYTES) == 0);
+    CHECK(mlk_kem_enc_derand(ct, ss1, pk, coins + 2 * MLKEM_SYMBYTES) == 0);
     print_hex("ct", ct, sizeof(ct));
 
-    CHECK(crypto_kem_dec(ss2, ct, sk) == 0);
+    CHECK(mlk_kem_dec(ss2, ct, sk) == 0);
     CHECK(memcmp(ss1, ss2, sizeof(ss1)) == 0);
 
     print_hex("ss", ss1, sizeof(ss1));

--- a/test/src/test_alloc.c
+++ b/test/src/test_alloc.c
@@ -12,6 +12,7 @@
 #include "../../mlkem/src/common.h"
 #include "../notrandombytes/notrandombytes.h"
 #include "../test_vectors/expected_test_vectors.h"
+#include "test_namespace.h"
 
 /*
  * Level-dependent allocation limit macros.
@@ -331,15 +332,15 @@ void custom_free(test_ctx_t *ctx, void *p, size_t sz, const char *file,
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int test_keypair_derand_alloc_failure(test_ctx_t *ctx)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
 
-  TEST_ALLOC_FAILURE("crypto_kem_keypair_derand",
-                     crypto_kem_keypair_derand(pk, sk, coins, ctx),
+  TEST_ALLOC_FAILURE("keypair_derand",
+                     mlk_kem_keypair_derand(pk, sk, coins, ctx),
                      MLK_TOTAL_ALLOC_KEYPAIR, &ctx->global_high_mark_keypair);
   return 0;
 }
@@ -347,10 +348,10 @@ static int test_keypair_derand_alloc_failure(test_ctx_t *ctx)
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
 static int test_keypair_alloc_failure(test_ctx_t *ctx)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
 
-  TEST_ALLOC_FAILURE("crypto_kem_keypair", crypto_kem_keypair(pk, sk, ctx),
+  TEST_ALLOC_FAILURE("keypair", mlk_kem_keypair(pk, sk, ctx),
                      MLK_TOTAL_ALLOC_KEYPAIR, &ctx->global_high_mark_keypair);
   return 0;
 }
@@ -360,12 +361,12 @@ static int test_keypair_alloc_failure(test_ctx_t *ctx)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int test_enc_derand_alloc_failure(test_ctx_t *ctx)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
   TEST_ALLOC_FAILURE(
-      "crypto_kem_enc_derand",
-      crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m, ctx),
+      "enc_derand",
+      mlk_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m, ctx),
       MLK_TOTAL_ALLOC_ENCAPS, &ctx->global_high_mark_encaps);
   return 0;
 }
@@ -373,11 +374,10 @@ static int test_enc_derand_alloc_failure(test_ctx_t *ctx)
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
 static int test_enc_alloc_failure(test_ctx_t *ctx)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  TEST_ALLOC_FAILURE("crypto_kem_enc",
-                     crypto_kem_enc(ct, ss, test_vector_pk, ctx),
+  TEST_ALLOC_FAILURE("enc", mlk_kem_enc(ct, ss, test_vector_pk, ctx),
                      MLK_TOTAL_ALLOC_ENCAPS, &ctx->global_high_mark_encaps);
   return 0;
 }
@@ -385,8 +385,7 @@ static int test_enc_alloc_failure(test_ctx_t *ctx)
 
 static int test_check_pk_alloc_failure(test_ctx_t *ctx)
 {
-  TEST_ALLOC_FAILURE("crypto_kem_check_pk",
-                     crypto_kem_check_pk(test_vector_pk, ctx),
+  TEST_ALLOC_FAILURE("check_pk", mlk_kem_check_pk(test_vector_pk, ctx),
                      MLK_TOTAL_ALLOC_KEYPAIR, &ctx->global_high_mark_keypair);
   return 0;
 }
@@ -395,18 +394,17 @@ static int test_check_pk_alloc_failure(test_ctx_t *ctx)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int test_dec_alloc_failure(test_ctx_t *ctx)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  TEST_ALLOC_FAILURE("crypto_kem_dec",
-                     crypto_kem_dec(ss, test_vector_ct, test_vector_sk, ctx),
+  TEST_ALLOC_FAILURE("dec",
+                     mlk_kem_dec(ss, test_vector_ct, test_vector_sk, ctx),
                      MLK_TOTAL_ALLOC_DECAPS, &ctx->global_high_mark_decaps);
   return 0;
 }
 
 static int test_check_sk_alloc_failure(test_ctx_t *ctx)
 {
-  TEST_ALLOC_FAILURE("crypto_kem_check_sk",
-                     crypto_kem_check_sk(test_vector_sk, ctx),
+  TEST_ALLOC_FAILURE("check_sk", mlk_kem_check_sk(test_vector_sk, ctx),
                      MLK_TOTAL_ALLOC_KEYPAIR, &ctx->global_high_mark_keypair);
   return 0;
 }

--- a/test/src/test_mlkem.c
+++ b/test/src/test_mlkem.c
@@ -10,6 +10,7 @@
 #include "../../mlkem/mlkem_native.h"
 #include "../notrandombytes/notrandombytes.h"
 #include "../test_vectors/expected_test_vectors.h"
+#include "test_namespace.h"
 
 #ifndef NTESTS_FUNC
 #define NTESTS_FUNC 1000
@@ -35,115 +36,115 @@
 /* Forbid inlining so stack buffers below stay in short-lived
  * frames and don't stack up in main(). This helps testing on
  * memory-constrained targets such as AVR. */
-static MLK_NOINLINE int test_keys_core(uint8_t pk[CRYPTO_PUBLICKEYBYTES],
-                                       uint8_t sk[CRYPTO_SECRETKEYBYTES],
-                                       uint8_t ct[CRYPTO_CIPHERTEXTBYTES],
-                                       uint8_t key_a[CRYPTO_BYTES],
-                                       uint8_t key_b[CRYPTO_BYTES])
+static MLK_NOINLINE int test_keys_core(uint8_t pk[MLKEM_PK_BYTES],
+                                       uint8_t sk[MLKEM_SK_BYTES],
+                                       uint8_t ct[MLKEM_CT_BYTES],
+                                       uint8_t key_a[MLKEM_BYTES],
+                                       uint8_t key_b[MLKEM_BYTES])
 {
   /* Alice generates a public key */
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
+  CHECK(mlk_kem_keypair(pk, sk) == 0);
   /* Bob derives a secret key and creates a response */
-  CHECK(crypto_kem_enc(ct, key_b, pk) == 0);
+  CHECK(mlk_kem_enc(ct, key_b, pk) == 0);
   /* Alice uses Bobs response to get her shared key */
-  CHECK(crypto_kem_dec(key_a, ct, sk) == 0);
+  CHECK(mlk_kem_dec(key_a, ct, sk) == 0);
 
   /* mark as defined, so we can compare */
-  MLK_CT_TESTING_DECLASSIFY(key_a, CRYPTO_BYTES);
-  MLK_CT_TESTING_DECLASSIFY(key_b, CRYPTO_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(key_a, MLKEM_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(key_b, MLKEM_BYTES);
 
-  CHECK(memcmp(key_a, key_b, CRYPTO_BYTES) == 0);
+  CHECK(memcmp(key_a, key_b, MLKEM_BYTES) == 0);
   return 0;
 }
 
 static MLK_NOINLINE int test_keys(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_a[CRYPTO_BYTES];
-  uint8_t key_b[CRYPTO_BYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t key_a[MLKEM_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
   return test_keys_core(pk, sk, ct, key_a, key_b);
 }
 
 static MLK_NOINLINE int test_keys_unaligned(void)
 {
-  MLK_ALIGN uint8_t pk[CRYPTO_PUBLICKEYBYTES + 1];
-  MLK_ALIGN uint8_t sk[CRYPTO_SECRETKEYBYTES + 1];
-  MLK_ALIGN uint8_t ct[CRYPTO_CIPHERTEXTBYTES + 1];
-  MLK_ALIGN uint8_t key_a[CRYPTO_BYTES + 1];
-  MLK_ALIGN uint8_t key_b[CRYPTO_BYTES + 1];
+  MLK_ALIGN uint8_t pk[MLKEM_PK_BYTES + 1];
+  MLK_ALIGN uint8_t sk[MLKEM_SK_BYTES + 1];
+  MLK_ALIGN uint8_t ct[MLKEM_CT_BYTES + 1];
+  MLK_ALIGN uint8_t key_a[MLKEM_BYTES + 1];
+  MLK_ALIGN uint8_t key_b[MLKEM_BYTES + 1];
   return test_keys_core(pk + 1, sk + 1, ct + 1, key_a + 1, key_b + 1);
 }
 
 static MLK_NOINLINE int test_invalid_pk(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_b[CRYPTO_BYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
   /* Alice generates a public key */
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
+  CHECK(mlk_kem_keypair(pk, sk) == 0);
   /* Bob derives a secret key and creates a response */
-  CHECK(crypto_kem_enc(ct, key_b, pk) == 0);
+  CHECK(mlk_kem_enc(ct, key_b, pk) == 0);
   /* set first public key coefficient to 4095 (0xFFF) */
   pk[0] = 0xFF;
   pk[1] |= 0x0F;
   /* Bob derives a secret key and creates a response */
-  CHECK(crypto_kem_enc(ct, key_b, pk) != 0);
+  CHECK(mlk_kem_enc(ct, key_b, pk) != 0);
   return 0;
 }
 
 static MLK_NOINLINE int test_invalid_sk_a(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_a[CRYPTO_BYTES];
-  uint8_t key_b[CRYPTO_BYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t key_a[MLKEM_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
   /* Alice generates a public key */
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
+  CHECK(mlk_kem_keypair(pk, sk) == 0);
   /* Bob derives a secret key and creates a response */
-  CHECK(crypto_kem_enc(ct, key_b, pk) == 0);
+  CHECK(mlk_kem_enc(ct, key_b, pk) == 0);
   /* Replace first part of secret key with random values */
   CHECK(randombytes(sk, 10) == 0);
   /* Alice uses Bobs response to get her shared key
    * This should fail due to wrong sk */
-  CHECK(crypto_kem_dec(key_a, ct, sk) == 0);
+  CHECK(mlk_kem_dec(key_a, ct, sk) == 0);
   /* mark as defined, so we can compare */
-  MLK_CT_TESTING_DECLASSIFY(key_a, CRYPTO_BYTES);
-  MLK_CT_TESTING_DECLASSIFY(key_b, CRYPTO_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(key_a, MLKEM_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(key_b, MLKEM_BYTES);
 
-  CHECK(memcmp(key_a, key_b, CRYPTO_BYTES) != 0);
+  CHECK(memcmp(key_a, key_b, MLKEM_BYTES) != 0);
   return 0;
 }
 
 static MLK_NOINLINE int test_invalid_sk_b(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_a[CRYPTO_BYTES];
-  uint8_t key_b[CRYPTO_BYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t key_a[MLKEM_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
   /* Alice generates a public key */
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
+  CHECK(mlk_kem_keypair(pk, sk) == 0);
   /* Bob derives a secret key and creates a response */
-  CHECK(crypto_kem_enc(ct, key_b, pk) == 0);
+  CHECK(mlk_kem_enc(ct, key_b, pk) == 0);
   /* Replace H(pk) with radom values; */
-  CHECK(randombytes(sk + CRYPTO_SECRETKEYBYTES - 64, 32) == 0);
+  CHECK(randombytes(sk + MLKEM_SK_BYTES - 64, 32) == 0);
   /* Alice uses Bobs response to get her shared key
    * This should fail due to the input validation */
-  CHECK(crypto_kem_dec(key_a, ct, sk) != 0);
+  CHECK(mlk_kem_dec(key_a, ct, sk) != 0);
   return 0;
 }
 
 static MLK_NOINLINE int test_invalid_ciphertext(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t key_a[CRYPTO_BYTES];
-  uint8_t key_b[CRYPTO_BYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t key_a[MLKEM_BYTES];
+  uint8_t key_b[MLKEM_BYTES];
   uint8_t b;
   size_t pos;
 
@@ -154,17 +155,17 @@ static MLK_NOINLINE int test_invalid_ciphertext(void)
   CHECK(randombytes((uint8_t *)&pos, sizeof(size_t)) == 0);
 
   /* Alice generates a public key */
-  CHECK(crypto_kem_keypair(pk, sk) == 0);
+  CHECK(mlk_kem_keypair(pk, sk) == 0);
   /* Bob derives a secret key and creates a response */
-  CHECK(crypto_kem_enc(ct, key_b, pk) == 0);
+  CHECK(mlk_kem_enc(ct, key_b, pk) == 0);
   /* Change some byte in the ciphertext (i.e., encapsulated key) */
-  ct[pos % CRYPTO_CIPHERTEXTBYTES] ^= b;
+  ct[pos % MLKEM_CT_BYTES] ^= b;
   /* Alice uses Bobs response to get her shared key */
-  CHECK(crypto_kem_dec(key_a, ct, sk) == 0);
+  CHECK(mlk_kem_dec(key_a, ct, sk) == 0);
   /* mark as defined, so we can compare */
-  MLK_CT_TESTING_DECLASSIFY(key_a, CRYPTO_BYTES);
-  MLK_CT_TESTING_DECLASSIFY(key_b, CRYPTO_BYTES);
-  CHECK(memcmp(key_a, key_b, CRYPTO_BYTES) != 0);
+  MLK_CT_TESTING_DECLASSIFY(key_a, MLKEM_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(key_b, MLKEM_BYTES);
+  CHECK(memcmp(key_a, key_b, MLKEM_BYTES) != 0);
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_KEYPAIR_API && !MLK_CONFIG_NO_ENCAPS_API && \
@@ -180,25 +181,25 @@ static MLK_NOINLINE int test_invalid_ciphertext(void)
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static MLK_NOINLINE int test_kem_expected_keygen(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
-  uint8_t test_vector_sk_copy[CRYPTO_SECRETKEYBYTES];
+  uint8_t test_vector_sk_copy[MLKEM_SK_BYTES];
 
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
 
-  CHECK(crypto_kem_keypair_derand(pk, sk, coins) == 0);
+  CHECK(mlk_kem_keypair_derand(pk, sk, coins) == 0);
 
   /* Declassify the generated sk and a copy of test_vector_sk so we can
    * memcmp them; the underlying test_vector_sk stays SECRET so it can
    * still be used as a CT-sensitive input in the decaps block. */
-  MLK_CT_TESTING_DECLASSIFY(sk, CRYPTO_SECRETKEYBYTES);
-  memcpy(test_vector_sk_copy, test_vector_sk, CRYPTO_SECRETKEYBYTES);
-  MLK_CT_TESTING_DECLASSIFY(test_vector_sk_copy, CRYPTO_SECRETKEYBYTES);
+  MLK_CT_TESTING_DECLASSIFY(sk, MLKEM_SK_BYTES);
+  memcpy(test_vector_sk_copy, test_vector_sk, MLKEM_SK_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(test_vector_sk_copy, MLKEM_SK_BYTES);
 
-  CHECK(memcmp(pk, test_vector_pk, CRYPTO_PUBLICKEYBYTES) == 0);
-  CHECK(memcmp(sk, test_vector_sk_copy, CRYPTO_SECRETKEYBYTES) == 0);
+  CHECK(memcmp(pk, test_vector_pk, MLKEM_PK_BYTES) == 0);
+  CHECK(memcmp(sk, test_vector_sk_copy, MLKEM_SK_BYTES) == 0);
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_KEYPAIR_API */
@@ -206,16 +207,16 @@ static MLK_NOINLINE int test_kem_expected_keygen(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static MLK_NOINLINE int test_kem_expected_encaps(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  CHECK(crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
+  CHECK(mlk_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m) == 0);
 
-  MLK_CT_TESTING_DECLASSIFY(ct, CRYPTO_CIPHERTEXTBYTES);
-  MLK_CT_TESTING_DECLASSIFY(ss, CRYPTO_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(ct, MLKEM_CT_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(ss, MLKEM_BYTES);
 
-  CHECK(memcmp(ct, test_vector_ct, CRYPTO_CIPHERTEXTBYTES) == 0);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  CHECK(memcmp(ct, test_vector_ct, MLKEM_CT_BYTES) == 0);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_ENCAPS_API */
@@ -223,12 +224,12 @@ static MLK_NOINLINE int test_kem_expected_encaps(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static MLK_NOINLINE int test_kem_expected_decaps(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  CHECK(crypto_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
+  CHECK(mlk_kem_dec(ss, test_vector_ct, test_vector_sk) == 0);
 
-  MLK_CT_TESTING_DECLASSIFY(ss, CRYPTO_BYTES);
-  CHECK(memcmp(ss, test_vector_ss, CRYPTO_BYTES) == 0);
+  MLK_CT_TESTING_DECLASSIFY(ss, MLKEM_BYTES);
+  CHECK(memcmp(ss, test_vector_ss, MLKEM_BYTES) == 0);
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_DECAPS_API */
@@ -269,10 +270,10 @@ int main(void)
    * are enabled against pre-computed vectors. Mark public test vectors
    * public and the secret key test vector as well as all randomness
    * secret, so valgrind CT testing has the right taint model. */
-  MLK_CT_TESTING_DECLASSIFY(test_vector_pk, CRYPTO_PUBLICKEYBYTES);
-  MLK_CT_TESTING_DECLASSIFY(test_vector_ct, CRYPTO_CIPHERTEXTBYTES);
+  MLK_CT_TESTING_DECLASSIFY(test_vector_pk, MLKEM_PK_BYTES);
+  MLK_CT_TESTING_DECLASSIFY(test_vector_ct, MLKEM_CT_BYTES);
 
-  MLK_CT_TESTING_SECRET(test_vector_sk, CRYPTO_SECRETKEYBYTES);
+  MLK_CT_TESTING_SECRET(test_vector_sk, MLKEM_SK_BYTES);
   MLK_CT_TESTING_SECRET(test_vector_d, sizeof(test_vector_d));
   MLK_CT_TESTING_SECRET(test_vector_z, sizeof(test_vector_z));
   MLK_CT_TESTING_SECRET(test_vector_m, sizeof(test_vector_m));
@@ -307,9 +308,9 @@ int main(void)
     }
   }
 
-  printf("CRYPTO_SECRETKEYBYTES:  %d\n", CRYPTO_SECRETKEYBYTES);
-  printf("CRYPTO_PUBLICKEYBYTES:  %d\n", CRYPTO_PUBLICKEYBYTES);
-  printf("CRYPTO_CIPHERTEXTBYTES: %d\n", CRYPTO_CIPHERTEXTBYTES);
+  printf("MLKEM_SK_BYTES:  %d\n", MLKEM_SK_BYTES);
+  printf("MLKEM_PK_BYTES:  %d\n", MLKEM_PK_BYTES);
+  printf("MLKEM_CT_BYTES: %d\n", MLKEM_CT_BYTES);
 
   return 0;
 }

--- a/test/src/test_namespace.h
+++ b/test/src/test_namespace.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+#ifndef TEST_NAMESPACE_H
+#define TEST_NAMESPACE_H
+
+/* Build-config-independent aliases for the public API under test. */
+#define MLK_TEST_CONCAT_(a, b) a##b
+#define MLK_TEST_CONCAT(a, b) MLK_TEST_CONCAT_(a, b)
+#define MLKEM_NAMESPACE(sym) \
+  MLK_TEST_CONCAT(MLK_TEST_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _), sym)
+
+#define mlk_kem_keypair MLKEM_NAMESPACE(keypair)
+#define mlk_kem_keypair_derand MLKEM_NAMESPACE(keypair_derand)
+#define mlk_kem_enc MLKEM_NAMESPACE(enc)
+#define mlk_kem_enc_derand MLKEM_NAMESPACE(enc_derand)
+#define mlk_kem_check_pk MLKEM_NAMESPACE(check_pk)
+#define mlk_kem_dec MLKEM_NAMESPACE(dec)
+#define mlk_kem_check_sk MLKEM_NAMESPACE(check_sk)
+
+/* Convenience abbreviations for the key, ciphertext and shared secret sizes.
+ *
+ * Ordinarily you know the parameter set you're working with, so you would
+ * just use the level-specific constants directly, e.g. MLKEM512_PUBLICKEYBYTES,
+ * MLKEM768_CIPHERTEXTBYTES, or MLKEM1024_SECRETKEYBYTES.
+ *
+ * The tests, however, are built for all three parameter sets (512, 768, 1024),
+ * so we keep things generic by deriving the sizes from the configured
+ * MLK_CONFIG_PARAMETER_SET. */
+#define MLKEM_PK_BYTES MLKEM_PUBLICKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_SK_BYTES MLKEM_SECRETKEYBYTES(MLK_CONFIG_PARAMETER_SET)
+#define MLKEM_CT_BYTES MLKEM_CIPHERTEXTBYTES(MLK_CONFIG_PARAMETER_SET)
+
+#endif /* !TEST_NAMESPACE_H */

--- a/test/src/test_rng_fail.c
+++ b/test/src/test_rng_fail.c
@@ -11,6 +11,7 @@
 #include "../../mlkem/mlkem_native.h"
 #include "../../mlkem/src/common.h"
 #include "../test_vectors/expected_test_vectors.h"
+#include "test_namespace.h"
 
 /*
  * This test checks that we handle randombytes failures correctly by:
@@ -114,25 +115,24 @@ int randombytes(uint8_t *buf, size_t len)
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static int test_keypair_derand_rng_failure(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
   uint8_t coins[2 * MLKEM_SYMBYTES];
 
   memcpy(coins, test_vector_d, MLKEM_SYMBYTES);
   memcpy(coins + MLKEM_SYMBYTES, test_vector_z, MLKEM_SYMBYTES);
 
-  TEST_RNG_FAILURE("crypto_kem_keypair_derand",
-                   crypto_kem_keypair_derand(pk, sk, coins));
+  TEST_RNG_FAILURE("keypair_derand", mlk_kem_keypair_derand(pk, sk, coins));
   return 0;
 }
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
 static int test_keypair_rng_failure(void)
 {
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t pk[MLKEM_PK_BYTES];
+  uint8_t sk[MLKEM_SK_BYTES];
 
-  TEST_RNG_FAILURE("crypto_kem_keypair", crypto_kem_keypair(pk, sk));
+  TEST_RNG_FAILURE("keypair", mlk_kem_keypair(pk, sk));
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
@@ -141,29 +141,28 @@ static int test_keypair_rng_failure(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static int test_enc_derand_rng_failure(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  TEST_RNG_FAILURE(
-      "crypto_kem_enc_derand",
-      crypto_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m));
+  TEST_RNG_FAILURE("enc_derand",
+                   mlk_kem_enc_derand(ct, ss, test_vector_pk, test_vector_m));
   return 0;
 }
 
 #if !defined(MLK_CONFIG_NO_RANDOMIZED_API)
 static int test_enc_rng_failure(void)
 {
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ct[MLKEM_CT_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  TEST_RNG_FAILURE("crypto_kem_enc", crypto_kem_enc(ct, ss, test_vector_pk));
+  TEST_RNG_FAILURE("enc", mlk_kem_enc(ct, ss, test_vector_pk));
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_RANDOMIZED_API */
 
 static int test_check_pk_rng_failure(void)
 {
-  TEST_RNG_FAILURE("crypto_kem_check_pk", crypto_kem_check_pk(test_vector_pk));
+  TEST_RNG_FAILURE("check_pk", mlk_kem_check_pk(test_vector_pk));
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_ENCAPS_API */
@@ -171,16 +170,15 @@ static int test_check_pk_rng_failure(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static int test_dec_rng_failure(void)
 {
-  uint8_t ss[CRYPTO_BYTES];
+  uint8_t ss[MLKEM_BYTES];
 
-  TEST_RNG_FAILURE("crypto_kem_dec",
-                   crypto_kem_dec(ss, test_vector_ct, test_vector_sk));
+  TEST_RNG_FAILURE("dec", mlk_kem_dec(ss, test_vector_ct, test_vector_sk));
   return 0;
 }
 
 static int test_check_sk_rng_failure(void)
 {
-  TEST_RNG_FAILURE("crypto_kem_check_sk", crypto_kem_check_sk(test_vector_sk));
+  TEST_RNG_FAILURE("check_sk", mlk_kem_check_sk(test_vector_sk));
   return 0;
 }
 #endif /* !MLK_CONFIG_NO_DECAPS_API */

--- a/test/src/test_stack.c
+++ b/test/src/test_stack.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "mlkem_native.h"
+#include "test_namespace.h"
 
 #include "../test_vectors/expected_test_vectors.h"
 
@@ -33,13 +34,13 @@ static void print_info(void)
 #if !defined(MLK_CONFIG_NO_KEYPAIR_API)
 static void test_keygen_only(void)
 {
-  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
-  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+  unsigned char pk[MLKEM_PK_BYTES];
+  unsigned char sk[MLKEM_SK_BYTES];
   unsigned char coins[2 * MLKEM_SYMBYTES] = {0};
 
   /* Only call keypair_derand - this is what we're measuring */
   /* coins is zero-initialized; the value is irrelevant for stack measurement */
-  int ret = crypto_kem_keypair_derand(pk, sk, coins);
+  int ret = mlk_kem_keypair_derand(pk, sk, coins);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 }
 #endif /* !MLK_CONFIG_NO_KEYPAIR_API */
@@ -47,14 +48,14 @@ static void test_keygen_only(void)
 #if !defined(MLK_CONFIG_NO_ENCAPS_API)
 static void test_encaps_only(void)
 {
-  unsigned char pk[CRYPTO_PUBLICKEYBYTES] = {0};
-  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
-  unsigned char ss[CRYPTO_BYTES];
+  unsigned char pk[MLKEM_PK_BYTES] = {0};
+  unsigned char ct[MLKEM_CT_BYTES];
+  unsigned char ss[MLKEM_BYTES];
   unsigned char coins[MLKEM_SYMBYTES] = {0};
 
   /* Only call enc_derand - this is what we're measuring */
   /* pk and coins are zero-initialized (OK for stack measurement) */
-  int ret = crypto_kem_enc_derand(ct, ss, pk, coins);
+  int ret = mlk_kem_enc_derand(ct, ss, pk, coins);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 }
 #endif /* !MLK_CONFIG_NO_ENCAPS_API */
@@ -62,18 +63,18 @@ static void test_encaps_only(void)
 #if !defined(MLK_CONFIG_NO_DECAPS_API)
 static void test_decaps_only(void)
 {
-  unsigned char sk[CRYPTO_SECRETKEYBYTES];
-  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
-  unsigned char ss[CRYPTO_BYTES];
+  unsigned char sk[MLKEM_SK_BYTES];
+  unsigned char ct[MLKEM_CT_BYTES];
+  unsigned char ss[MLKEM_BYTES];
   int ret;
 
-  /* A valid sk is needed: crypto_kem_dec() returns on the H(ek) check
+  /* A valid sk is needed: mlk_kem_dec() returns on the H(ek) check
    * before decapsulating, leaving most of the work unmeasured. */
   memcpy(sk, test_vector_sk, sizeof(sk));
   memcpy(ct, test_vector_ct, sizeof(ct));
 
   /* Only call decaps - this is what we're measuring */
-  ret = crypto_kem_dec(ss, ct, sk);
+  ret = mlk_kem_dec(ss, ct, sk);
   (void)ret; /* Ignore return value - we only care about stack measurement */
 }
 #endif /* !MLK_CONFIG_NO_DECAPS_API */

--- a/test/test_vectors/expected_test_vectors.h
+++ b/test/test_vectors/expected_test_vectors.h
@@ -12,9 +12,9 @@
 /*
  * Generated with:
  *   d, z: consecutive 32-byte draws from a fresh notrandombytes
- *         stream (as consumed by crypto_kem_keypair).
+ *         stream (as consumed by mlkem_keypair).
  *   m:    first 32-byte draw from a second, fresh
- *         notrandombytes stream (as consumed by crypto_kem_enc
+ *         notrandombytes stream (as consumed by mlkem_enc
  *         after randombytes_reset()).
  */
 

--- a/test/test_vectors/expected_test_vectors_multilevel.h
+++ b/test/test_vectors/expected_test_vectors_multilevel.h
@@ -17,9 +17,9 @@
 /*
  * Generated with:
  *   d, z: consecutive 32-byte draws from a fresh notrandombytes
- *         stream (as consumed by crypto_kem_keypair).
+ *         stream (as consumed by mlkem_keypair).
  *   m:    first 32-byte draw from a second, fresh
- *         notrandombytes stream (as consumed by crypto_kem_enc
+ *         notrandombytes stream (as consumed by mlkem_enc
  *         after randombytes_reset()).
  */
 

--- a/test/wycheproof/wycheproof_mlkem.c
+++ b/test/wycheproof/wycheproof_mlkem.c
@@ -20,6 +20,7 @@
 #include "../../mlkem/src/common.h"
 
 #include "../../mlkem/mlkem_native.h"
+#include "../src/test_namespace.h"
 
 /* Print supported API modes and exit (used by wycheproof_client.py) */
 static void print_info(void)
@@ -140,8 +141,8 @@ int main(int argc, char *argv[])
   {
     /* keygen_seed seed=HEX (64 bytes = d || z) */
     unsigned char seed[2 * MLKEM_SYMBYTES];
-    unsigned char ek[CRYPTO_PUBLICKEYBYTES];
-    unsigned char dk[CRYPTO_SECRETKEYBYTES];
+    unsigned char ek[MLKEM_PK_BYTES];
+    unsigned char dk[MLKEM_SK_BYTES];
 
     if (argc != 3)
     {
@@ -154,7 +155,7 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    CHECK(crypto_kem_keypair_derand(ek, dk, seed) == 0);
+    CHECK(mlk_kem_keypair_derand(ek, dk, seed) == 0);
     print_hex("ek", ek, sizeof(ek));
     print_hex("dk", dk, sizeof(dk));
   }
@@ -164,10 +165,10 @@ int main(int argc, char *argv[])
       if (strcmp(argv[1], "encaps") == 0)
   {
     /* encaps ek=HEX m=HEX */
-    unsigned char ek[CRYPTO_PUBLICKEYBYTES];
+    unsigned char ek[MLKEM_PK_BYTES];
     unsigned char m[MLKEM_SYMBYTES];
-    unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
-    unsigned char ss[CRYPTO_BYTES];
+    unsigned char ct[MLKEM_CT_BYTES];
+    unsigned char ss[MLKEM_BYTES];
 
     if (argc != 4)
     {
@@ -181,7 +182,7 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    CHECK(crypto_kem_enc_derand(ct, ss, ek, m) == 0);
+    CHECK(mlk_kem_enc_derand(ct, ss, ek, m) == 0);
     print_hex("c", ct, sizeof(ct));
     print_hex("K", ss, sizeof(ss));
   }
@@ -191,9 +192,9 @@ int main(int argc, char *argv[])
       if (strcmp(argv[1], "decaps") == 0)
   {
     /* decaps dk=HEX c=HEX */
-    unsigned char dk[CRYPTO_SECRETKEYBYTES];
-    unsigned char c[CRYPTO_CIPHERTEXTBYTES];
-    unsigned char ss[CRYPTO_BYTES];
+    unsigned char dk[MLKEM_SK_BYTES];
+    unsigned char c[MLKEM_CT_BYTES];
+    unsigned char ss[MLKEM_BYTES];
 
     if (argc != 4)
     {
@@ -212,7 +213,7 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    CHECK(crypto_kem_dec(ss, c, dk) == 0);
+    CHECK(mlk_kem_dec(ss, c, dk) == 0);
     print_hex("K", ss, sizeof(ss));
   }
   else


### PR DESCRIPTION
* Based on #1853 
* Port of https://github.com/pq-code-package/mldsa-native/pull/1248
* Resolves #1856

mlkem_native.h exposed the public API under the crypto_kem_* SUPERCOP
naming scheme, gated by MLK_CONFIG_NO_SUPERCOP. This removes those
aliases and the MLK_CONFIG_NO_SUPERCOP configuration entirely, along
with the CRYPTO_* size constants (CRYPTO_{PUBLICKEY,SECRETKEY,
CIPHERTEXT}BYTES, CRYPTO_SYMBYTES, CRYPTO_BYTES) and the related
documentation in mlkem_native_config.h, the CBMC and liboqs configs,
the example configs/READMEs, and the #error messages in common.h.

Consumers and tests now use the native namespaced API directly:
- Examples call the namespaced functions (e.g. mlkem_keypair).
- Tests reconstruct the namespaced names via test/src/test_namespace.h
    and derive key/ciphertext sizes from MLK_CONFIG_PARAMETER_SET.