### PR TITLE
Doc: Port documentation fixes from mldsa-native

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,10 +73,13 @@ For detailed information on how to use the script, please refer to
 
 You can also build **mlkem-native** on Windows using `nmake` and an MSVC compiler.
 
-To build and run the tests (only support functional testing for non-opt implementation for now), use the following `nmake` targets:
+To build and run the tests, use the following `nmake` target:
 ```powershell
-nmke /f .\Makefile.Microsoft_nmake quickcheck
+nmake /f .\Makefile.Microsoft_nmake quickcheck
 ```
+
+This runs the functional, RNG-failure, allocation, ACVP, KAT and Wycheproof tests. The assembly backends are not yet
+supported on Windows, so the tests are built for the C backend only.
 
 # Checking the proofs
 

--- a/LICENSE
+++ b/LICENSE
@@ -6,13 +6,31 @@ of the Apache-2.0 license OR the ISC license OR the MIT license.
 These licenses are reproduced at the bottom of this file.
 The copyright holders are indicated at the top of each file.
 
-The code in test/notrandombytes/* is derived from
+Files outside the library itself may carry different terms. Every file
+states its own SPDX-License-Identifier, which determines the terms that
+apply to it. In particular:
+
+The code in test/notrandombytes/*, and its copies in
+examples/*/test_only_rng/* and scripts/notrandombytes, is derived from
 https://cr.yp.to/papers.html#surf and licensed under
 LicenseRef-PD-hp OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT.
 It is only used for testing purposes.
 
-The benchmarking code in test/hal/hal.c carries the
+The benchmarking code in test/hal/* carries the
 MIT license. It is only used for testing purposes.
+
+The tiny_sha3 code in
+examples/bring_your_own_fips202/custom_fips202/tiny_sha3/* and
+examples/custom_backend/mlkem_native/src/fips202/native/custom/src/*
+carries the MIT license. It is only used to demonstrate custom
+FIPS-202 implementations.
+
+The proofs in proofs/* are in part derived from Amazon Web Services
+verification infrastructure. Individual files carry, among others,
+Apache-2.0 OR ISC OR MIT-0, MIT-0, and MIT-0 AND Apache-2.0. None of the
+proofs are part of the library.
+
+Documentation is licensed under CC-BY-4.0.
 
 ```
 Copyright (c) The mlkem-native project authors
@@ -39,7 +57,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-The tiny_sha3 implementation in examples/custom_backend/mlkem_native/mlkem/fips202/native/custom/src/
+The tiny_sha3 implementation in examples/custom_backend/mlkem_native/src/fips202/native/custom/src/
 carries the MIT license. It is only used for testing purposes.
 
 ```

--- a/STDLIB.md
+++ b/STDLIB.md
@@ -7,8 +7,8 @@ mlkem-native has minimal dependencies on the C standard library. This document l
 ## Dependencies
 
 ### Memory Functions
-- **memcpy**: Used extensively for copying data structures, keys, and intermediate values (40+ occurrences)
-- **memset**: Used for zeroing state structures and buffers (3 occurrences). **Note**: This is NOT used for security-critical zeroing - that is handled by `mlk_zeroize` which has its own custom replacement mechanism
+- **memcpy**: Used extensively for copying data structures, keys, and intermediate values
+- **memset**: Used for zeroing state structures and buffers. **Note**: This is NOT used for security-critical zeroing - that is handled by `mlk_zeroize` which has its own custom replacement mechanism
 
 ### Debug Functions (MLKEM_DEBUG builds only)
 - **fprintf**: Used in debug.c for error reporting to stderr
@@ -16,7 +16,7 @@ mlkem-native has minimal dependencies on the C standard library. This document l
 
 ## Custom Replacements
 
-Custom replacements can be provided for memory functions using the configuration options in `mlkem/src/config.h`:
+Custom replacements can be provided for memory functions using the configuration options in `mlkem/mlkem_native_config.h`:
 
 ### MLK_CONFIG_CUSTOM_MEMCPY
 Replaces all `memcpy` calls with a custom implementation. When enabled, you must define a `mlk_memcpy` function with the same signature as the standard `memcpy`.
@@ -24,4 +24,4 @@ Replaces all `memcpy` calls with a custom implementation. When enabled, you must
 ### MLK_CONFIG_CUSTOM_MEMSET
 Replaces all `memset` calls with a custom implementation. When enabled, you must define a `mlk_memset` function with the same signature as the standard `memset`.
 
-See the configuration examples in `mlkem/src/config.h` and test configurations in `test/custom_*_config.h` for usage examples and implementation requirements.
+See the configuration examples in `mlkem/mlkem_native_config.h` and test configurations in `test/configs/custom_*_config.h` for usage examples and implementation requirements.

--- a/integration/liboqs/config_aarch64.h
+++ b/integration/liboqs/config_aarch64.h
@@ -84,16 +84,16 @@
 /******************************************************************************
  * Name:        MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
- * Description: Determines whether an native arithmetic backend should be used.
+ * Description: Determines whether a native arithmetic backend should be used.
  *
  *              The arithmetic backend covers performance critical functions
  *              such as the number-theoretic transform (NTT).
  *
  *              If this option is unset, the C backend will be used.
  *
- *              If this option is set, the arithmetic backend to be use is
+ *              If this option is set, the arithmetic backend to be used is
  *              determined by MLK_CONFIG_ARITH_BACKEND_FILE: If the latter is
- *              unset, the default backend for your the target architecture
+ *              unset, the default backend for your target architecture
  *              will be used. If set, it must be the name of a backend metadata
  *              file.
  *
@@ -177,7 +177,7 @@
  *              on the stack.
  *
  *              If you need bullet-proof zeroization of the stack, you need to
- *              consider additional measures instead of of what this feature
+ *              consider additional measures instead of what this feature
  *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
@@ -196,7 +196,7 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function

--- a/integration/liboqs/config_c.h
+++ b/integration/liboqs/config_c.h
@@ -139,7 +139,7 @@
  *              on the stack.
  *
  *              If you need bullet-proof zeroization of the stack, you need to
- *              consider additional measures instead of of what this feature
+ *              consider additional measures instead of what this feature
  *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
@@ -158,7 +158,7 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function

--- a/integration/liboqs/config_ppc64le.h
+++ b/integration/liboqs/config_ppc64le.h
@@ -84,16 +84,16 @@
 /******************************************************************************
  * Name:        MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
- * Description: Determines whether an native arithmetic backend should be used.
+ * Description: Determines whether a native arithmetic backend should be used.
  *
  *              The arithmetic backend covers performance critical functions
  *              such as the number-theoretic transform (NTT).
  *
  *              If this option is unset, the C backend will be used.
  *
- *              If this option is set, the arithmetic backend to be use is
+ *              If this option is set, the arithmetic backend to be used is
  *              determined by MLK_CONFIG_ARITH_BACKEND_FILE: If the latter is
- *              unset, the default backend for your the target architecture
+ *              unset, the default backend for your target architecture
  *              will be used. If set, it must be the name of a backend metadata
  *              file.
  *
@@ -177,7 +177,7 @@
  *              on the stack.
  *
  *              If you need bullet-proof zeroization of the stack, you need to
- *              consider additional measures instead of of what this feature
+ *              consider additional measures instead of what this feature
  *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
@@ -196,7 +196,7 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function

--- a/integration/liboqs/config_x86_64.h
+++ b/integration/liboqs/config_x86_64.h
@@ -84,16 +84,16 @@
 /******************************************************************************
  * Name:        MLK_CONFIG_USE_NATIVE_BACKEND_ARITH
  *
- * Description: Determines whether an native arithmetic backend should be used.
+ * Description: Determines whether a native arithmetic backend should be used.
  *
  *              The arithmetic backend covers performance critical functions
  *              such as the number-theoretic transform (NTT).
  *
  *              If this option is unset, the C backend will be used.
  *
- *              If this option is set, the arithmetic backend to be use is
+ *              If this option is set, the arithmetic backend to be used is
  *              determined by MLK_CONFIG_ARITH_BACKEND_FILE: If the latter is
- *              unset, the default backend for your the target architecture
+ *              unset, the default backend for your target architecture
  *              will be used. If set, it must be the name of a backend metadata
  *              file.
  *
@@ -177,7 +177,7 @@
  *              on the stack.
  *
  *              If you need bullet-proof zeroization of the stack, you need to
- *              consider additional measures instead of of what this feature
+ *              consider additional measures instead of what this feature
  *              provides. In this case, you can set mlk_zeroize to a no-op.
  *
  *****************************************************************************/
@@ -196,7 +196,7 @@
  * Name:        MLK_CONFIG_CUSTOM_RANDOMBYTES
  *
  * Description: mlkem-native does not provide a secure randombytes
- *              implementation. Such an implementation has to provided by the
+ *              implementation. Such an implementation has to be provided by the
  *              consumer.
  *
  *              If this option is not set, mlkem-native expects a function

--- a/mlkem/README.md
+++ b/mlkem/README.md
@@ -8,7 +8,7 @@ This is the main source tree of mlkem-native.
 
 To build a mlkem-native for a fixed parameter set (ML-KEM-512/768/1024), build the compilation in units in `src/*` separately, and link to an RNG and your application. See [examples/basic](../examples/basic) for a simple example.
 
-Alternatively, you can use the auto-geneated helper files [mlkem_native.c](mlkem_native.c) and [mlkem_native_asm.S](mlkem_native_asm.S), which bundle all *.c and *.S files together. See [examples/monolithic_build](../examples/monolithic_build) and [examples/monolithic_build_native](../examples/monolithic_build_native) for examples with and without native code.
+Alternatively, you can use the auto-generated helper files [mlkem_native.c](mlkem_native.c) and [mlkem_native_asm.S](mlkem_native_asm.S), which bundle all *.c and *.S files together. See [examples/monolithic_build](../examples/monolithic_build) and [examples/monolithic_build_native](../examples/monolithic_build_native) for examples without and with native code.
 
 ## Configuration
 

--- a/mlkem/mlkem_native.h
+++ b/mlkem/mlkem_native.h
@@ -76,12 +76,13 @@
 
 /****************************** Error codes ***********************************/
 
-/* Generic failure condition */
+/* Generic failure condition, reserved for failures not covered by a more
+ * specific error code. */
 #define MLK_ERR_FAIL (-1)
 /* An allocation failed. This can only happen if MLK_CONFIG_CUSTOM_ALLOC_FREE
  * is defined and the provided MLK_CUSTOM_ALLOC can fail. */
 #define MLK_ERR_OUT_OF_MEMORY (-2)
-/* An rng failure occured. Might be due to insufficient entropy or
+/* An RNG failure occurred. Might be due to insufficient entropy or
  * system misconfiguration. */
 #define MLK_ERR_RNG_FAIL (-3)
 

--- a/mlkem/src/common.h
+++ b/mlkem/src/common.h
@@ -64,7 +64,7 @@
 #define MLK_NAMESPACE_K(s) MLK_CONCAT(MLK_NAMESPACE_PREFIX_K, s)
 
 /* On Apple platforms, we need to emit leading underscore
- * in front of assembly symbols. We thus introducee a separate
+ * in front of assembly symbols. We thus introduce a separate
  * namespace wrapper for ASM symbols. */
 #if !defined(__APPLE__)
 #define MLK_ASM_NAMESPACE(sym) MLK_NAMESPACE(sym)
@@ -252,12 +252,13 @@
 
 /****************************** Error codes ***********************************/
 
-/* Generic failure condition */
+/* Generic failure condition, reserved for failures not covered by a more
+ * specific error code. */
 #define MLK_ERR_FAIL (-1)
 /* An allocation failed. This can only happen if MLK_CONFIG_CUSTOM_ALLOC_FREE
  * is defined and the provided MLK_CUSTOM_ALLOC can fail. */
 #define MLK_ERR_OUT_OF_MEMORY (-2)
-/* An rng failure occured. Might be due to insufficient entropy or
+/* An RNG failure occurred. Might be due to insufficient entropy or
  * system misconfiguration. */
 #define MLK_ERR_RNG_FAIL (-3)
 

--- a/mlkem/src/sys.h
+++ b/mlkem/src/sys.h
@@ -210,7 +210,7 @@
 #endif
 
 
-/* New X86_64 CPUs support Conflow-flow protection using the CET instructions.
+/* New X86_64 CPUs support control-flow protection using the CET instructions.
  * When enabled (through -fcf-protection=), all compilation units (including
  * empty ones) need to support CET for this to work.
  * For assembly, this means that source files need to signal support for

--- a/test/acvp/acvp_client.py
+++ b/test/acvp/acvp_client.py
@@ -53,11 +53,13 @@ def download_acvp_files(version):
                     f"Error: Downloaded file {file_path} is not valid JSON: {e}",
                     file=sys.stderr,
                 )
-                local_file.unlink(missing_ok=True)
+                if local_file.exists():
+                    local_file.unlink()
                 return False
             except Exception as e:
                 print(f"Error downloading {file_path}: {e}", file=sys.stderr)
-                local_file.unlink(missing_ok=True)
+                if local_file.exists():
+                    local_file.unlink()
                 return False
 
     return True

--- a/test/wycheproof/wycheproof_client.py
+++ b/test/wycheproof/wycheproof_client.py
@@ -103,7 +103,8 @@ def download_wycheproof_files(data_dir):
                     json.load(f)
             except (json.JSONDecodeError, Exception) as e:
                 print(f"Error downloading {filename}: {e}", file=sys.stderr)
-                local_file.unlink(missing_ok=True)
+                if local_file.exists():
+                    local_file.unlink()
                 return False
     return True
 


### PR DESCRIPTION
* Resolves https://github.com/pq-code-package/mlkem-native/issues/1854

Sweeps the documentation fixes from mldsa-native PRs #1351, #1355 and #1357 and ports those applicable to mlkem-native (#1854). ML-DSA-specific fixes and ones already present in mlkem-native are omitted.

Source comments:
- mlkem_native.h, common.h: "rng failure occured" -> "RNG failure occurred"; expand the generic-failure comment.
- common.h: "introducee" -> "introduce".
- sys.h: "Conflow-flow" -> "control-flow".

Docs:
- STDLIB.md: fix stale config path (mlkem/src/config.h ->
  mlkem/mlkem_native_config.h) and test-config path (test/configs/custom_*_config.h); drop brittle occurrence counts.
- BUILDING.md: fix "nmke" -> "nmake"; describe the quickcheck target.
- mlkem/README.md: "auto-geneated" -> "auto-generated"; "with and without" -> "without and with native code".
- LICENSE: expand the varying-terms enumeration (notrandombytes copies, test/hal/*, tiny_sha3, proofs, docs) and fix a stale tiny_sha3 path.

Config & tooling:
- integration/liboqs/config_{aarch64,x86_64,ppc64le,c}.h: fix "an native", "to be use is", "your the target", "has to provided" and "instead of of".
- acvp_client.py, wycheproof_client.py: replace unlink(missing_ok=True) with an exists() guard for older-Python portability.