### PR TITLE
liboqs: Normalize return codes to OQS_STATUS

### DIFF
--- a/integration/liboqs/ML-KEM-1024_META.yml
+++ b/integration/liboqs/ML-KEM-1024_META.yml
@@ -28,35 +28,37 @@ implementations:
 - name: ref
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="../../integration/liboqs/config_c.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_C_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="integration/liboqs/config_c.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_C_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_C_dec_oqs
   sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc
 - name: x86_64
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="../../integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_X86_64_dec_oqs
   sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/x86_64
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/x86_64
   supported_platforms:
   - architecture: x86_64
     operating_systems:
@@ -69,19 +71,20 @@ implementations:
 - name: aarch64
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="../../integration/liboqs/config_aarch64.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="integration/liboqs/config_aarch64.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_AARCH64_dec_oqs
   sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/aarch64
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/aarch64
   supported_platforms:
   - architecture: arm_8
     operating_systems:
@@ -92,19 +95,20 @@ implementations:
 - name: ppc64le
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="../../integration/liboqs/config_ppc64le.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=1024 -DMLK_CONFIG_FILE="integration/liboqs/config_ppc64le.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM1024_PPC64LE_dec_oqs
   sources: integration/liboqs/config_ppc64le.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/ppc64le
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/ppc64le
   supported_platforms:
   - architecture: ppc64le
     operating_systems:

--- a/integration/liboqs/ML-KEM-512_META.yml
+++ b/integration/liboqs/ML-KEM-512_META.yml
@@ -28,35 +28,37 @@ implementations:
 - name: ref
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="../../integration/liboqs/config_c.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_C_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_C_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_C_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="integration/liboqs/config_c.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_C_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_C_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_C_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_C_dec_oqs
   sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc
 - name: x86_64
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="../../integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_X86_64_dec_oqs
   sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/x86_64
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/x86_64
   supported_platforms:
   - architecture: x86_64
     operating_systems:
@@ -69,19 +71,20 @@ implementations:
 - name: aarch64
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="../../integration/liboqs/config_aarch64.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="integration/liboqs/config_aarch64.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_AARCH64_dec_oqs
   sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/aarch64
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/aarch64
   supported_platforms:
   - architecture: arm_8
     operating_systems:
@@ -92,19 +95,20 @@ implementations:
 - name: ppc64le
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="../../integration/liboqs/config_ppc64le.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=512 -DMLK_CONFIG_FILE="integration/liboqs/config_ppc64le.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM512_PPC64LE_dec_oqs
   sources: integration/liboqs/config_ppc64le.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/ppc64le
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/ppc64le
   supported_platforms:
   - architecture: ppc64le
     operating_systems:

--- a/integration/liboqs/ML-KEM-768_META.yml
+++ b/integration/liboqs/ML-KEM-768_META.yml
@@ -28,35 +28,37 @@ implementations:
 - name: ref
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="../../integration/liboqs/config_c.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_C_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_C_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_C_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="integration/liboqs/config_c.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_C_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_C_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_C_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_C_dec_oqs
   sources: integration/liboqs/config_c.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc
 - name: x86_64
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="../../integration/liboqs/config_x86_64.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="integration/liboqs/config_x86_64.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_X86_64_dec_oqs
   sources: integration/liboqs/config_x86_64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/x86_64
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/x86_64
   supported_platforms:
   - architecture: x86_64
     operating_systems:
@@ -69,19 +71,20 @@ implementations:
 - name: aarch64
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="../../integration/liboqs/config_aarch64.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="integration/liboqs/config_aarch64.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_AARCH64_dec_oqs
   sources: integration/liboqs/config_aarch64.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/aarch64
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/aarch64
   supported_platforms:
   - architecture: arm_8
     operating_systems:
@@ -92,19 +95,20 @@ implementations:
 - name: ppc64le
   version: FIPS203
   folder_name: .
-  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="../../integration/liboqs/config_ppc64le.h"
-  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_keypair
-  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_keypair_derand
-  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_enc
-  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_enc_derand
-  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_dec
+  compile_opts: -DMLK_CONFIG_PARAMETER_SET=768 -DMLK_CONFIG_FILE="integration/liboqs/config_ppc64le.h"
+  signature_keypair: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_keypair_oqs
+  signature_keypair_derand: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_keypair_derand_oqs
+  signature_enc: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_enc_oqs
+  signature_enc_derand: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_enc_derand_oqs
+  signature_dec: PQCP_MLKEM_NATIVE_MLKEM768_PPC64LE_dec_oqs
   sources: integration/liboqs/config_ppc64le.h integration/liboqs/fips202_glue.h integration/liboqs/fips202x4_glue.h
-    mlkem/src/cbmc.h mlkem/src/common.h mlkem/src/compress.c mlkem/src/compress.h
-    mlkem/src/context.h mlkem/src/debug.c mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h
-    mlkem/src/kem.c mlkem/src/kem.h mlkem/src/native/api.h mlkem/src/native/meta.h
-    mlkem/src/params.h mlkem/src/poly.c mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h
-    mlkem/src/randombytes.h mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h
-    mlkem/src/sys.h mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/ppc64le
+    integration/liboqs/kem_glue.c mlkem/mlkem_native.h mlkem/src/cbmc.h mlkem/src/common.h
+    mlkem/src/compress.c mlkem/src/compress.h mlkem/src/context.h mlkem/src/debug.c
+    mlkem/src/debug.h mlkem/src/indcpa.c mlkem/src/indcpa.h mlkem/src/kem.c mlkem/src/kem.h
+    mlkem/src/native/api.h mlkem/src/native/meta.h mlkem/src/params.h mlkem/src/poly.c
+    mlkem/src/poly.h mlkem/src/poly_k.c mlkem/src/poly_k.h mlkem/src/randombytes.h
+    mlkem/src/sampling.c mlkem/src/sampling.h mlkem/src/symmetric.h mlkem/src/sys.h
+    mlkem/src/verify.c mlkem/src/verify.h mlkem/src/zetas.inc mlkem/src/native/ppc64le
   supported_platforms:
   - architecture: ppc64le
     operating_systems:

--- a/integration/liboqs/kem_glue.c
+++ b/integration/liboqs/kem_glue.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) The mlkem-native project authors
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT
+ */
+
+/*
+ * liboqs glue for mlkem-native.
+ *
+ * liboqs's OQS_STATUS is a closed enum of OQS_SUCCESS / OQS_ERROR, and the
+ * generated ML-KEM wrapper casts the result of the linked implementation
+ * straight through. mlkem-native returns a wider error set, so these thin
+ * shims collapse any nonzero result to OQS_ERROR. They are referenced from
+ * the per-level META.yml files.
+ *
+ * The shims are compiled once per build (parameter set and backend), so the
+ * namespaced symbol names match the names liboqs links against.
+ */
+
+#include <stdint.h>
+
+#include <oqs/common.h>
+
+#include "mlkem/mlkem_native.h"
+
+/*
+ * mlkem-native's public symbols are prefixed with MLK_CONFIG_NAMESPACE_PREFIX.
+ * mlkem_native.h builds these names via MLK_API_NAMESPACE(), but #undef's
+ * MLK_API_NAMESPACE_PREFIX at the end of the header, so MLK_API_NAMESPACE()
+ * cannot be reused here. Replicate the concatenation for both the shim symbols
+ * and their callees.
+ */
+#define MLK_OQS_CONCAT_(x, y) x##y
+#define MLK_OQS_CONCAT(x, y) MLK_OQS_CONCAT_(x, y)
+#define MLK_OQS_NS(sym) \
+  MLK_OQS_CONCAT(MLK_OQS_CONCAT(MLK_CONFIG_NAMESPACE_PREFIX, _), sym)
+
+#define mlk_oqs_keypair MLK_OQS_NS(keypair_oqs)
+#define mlk_oqs_keypair_derand MLK_OQS_NS(keypair_derand_oqs)
+#define mlk_oqs_enc MLK_OQS_NS(enc_oqs)
+#define mlk_oqs_enc_derand MLK_OQS_NS(enc_derand_oqs)
+#define mlk_oqs_dec MLK_OQS_NS(dec_oqs)
+
+/* Collapse mlkem-native's error set to OQS_SUCCESS / OQS_ERROR. liboqs declares
+ * these shims as returning int and casts the result to OQS_STATUS itself. */
+static int mlk_oqs_status(int ret)
+{
+  return ret == 0 ? OQS_SUCCESS : OQS_ERROR;
+}
+
+int mlk_oqs_keypair(uint8_t *pk, uint8_t *sk)
+{
+  return mlk_oqs_status(MLK_OQS_NS(keypair)(pk, sk));
+}
+
+int mlk_oqs_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins)
+{
+  return mlk_oqs_status(MLK_OQS_NS(keypair_derand)(pk, sk, coins));
+}
+
+int mlk_oqs_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk)
+{
+  return mlk_oqs_status(MLK_OQS_NS(enc)(ct, ss, pk));
+}
+
+int mlk_oqs_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
+                       const uint8_t *coins)
+{
+  return mlk_oqs_status(MLK_OQS_NS(enc_derand)(ct, ss, pk, coins));
+}
+
+int mlk_oqs_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk)
+{
+  return mlk_oqs_status(MLK_OQS_NS(dec)(ss, ct, sk));
+}
+
+#undef mlk_oqs_keypair
+#undef mlk_oqs_keypair_derand
+#undef mlk_oqs_enc
+#undef mlk_oqs_enc_derand
+#undef mlk_oqs_dec
+#undef MLK_OQS_NS
+#undef MLK_OQS_CONCAT
+#undef MLK_OQS_CONCAT_

--- a/scripts/autogen
+++ b/scripts/autogen
@@ -4300,10 +4300,13 @@ def get_oqs_shared_sources(backend):
         for f in os.listdir(f"{mlkem_dir}/native")
         if os.path.isfile(f"{mlkem_dir}/native/{f}")
     ]
-    # Add FIPS202 glue code
+    # add the public header, which the glue consumes
+    sources.append("mlkem/mlkem_native.h")
+    # Add FIPS202 glue code and the KEM API glue
     sources += [
         "integration/liboqs/fips202_glue.h",
         "integration/liboqs/fips202x4_glue.h",
+        "integration/liboqs/kem_glue.c",
     ]
     # Add custom config
     if backend == "ref":


### PR DESCRIPTION
Collapse any nonzero result to OQS_ERROR in a new kem_glue.c, since OQS_STATUS is a closed enum and mlkem-native returns a wider error set. All five entry points liboqs links against are shimmed, and the META.yml files point at the shims.

~~Unlike in mldsa-native, this is latent today:
nothing but 0 and MLK_ERR_FAIL can reach liboqs,
since the default stack allocator rules out MLK_ERR_OUT_OF_MEMORY, and the liboqs randombytes shim wraps the void OQS_randombytes and always returns 0, ruling out MLK_ERR_RNG_FAIL.
However, as we may introduce additional error codes later on, it seems worthwhile to align this with mldsa-native now.~~
Key validation can still fail and that no longer returns -1 since https://github.com/pq-code-package/mlkem-native/pull/1852.

 - Resolves #1802