### PR TITLE
Fix double level-suffixing of default namespace in multi-level builds

### DIFF
--- a/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
+++ b/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
@@ -684,7 +684,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
@@ -684,7 +684,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
@@ -685,7 +685,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/custom_backend/mlkem_native/mlkem_native_config.h
+++ b/examples/custom_backend/mlkem_native/mlkem_native_config.h
@@ -680,7 +680,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/monolithic_build/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build/mlkem_native/mlkem_native_config.h
@@ -683,7 +683,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
@@ -684,7 +684,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
@@ -690,7 +690,11 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
@@ -683,7 +683,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/multilevel_build/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build/mlkem_native/mlkem_native_config.h
@@ -683,7 +683,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
@@ -681,7 +681,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/mlkem/mlkem_native_config.h
+++ b/mlkem/mlkem_native_config.h
@@ -668,7 +668,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/proofs/cbmc/mlkem_native_config_cbmc.h
+++ b/proofs/cbmc/mlkem_native_config_cbmc.h
@@ -692,7 +692,11 @@ __contract__(
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -688,7 +688,11 @@ static MLK_INLINE int mlk_break_pct(void)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -701,7 +701,11 @@ static inline void *mlk_posix_memalign(size_t align, size_t sz)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -691,7 +691,11 @@ static MLK_INLINE void *mlk_memcpy(void *dest, const void *src, size_t n)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -690,7 +690,11 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -687,7 +687,11 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -686,7 +686,11 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -718,7 +718,11 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -718,7 +718,11 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -683,7 +683,11 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -699,7 +699,11 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -684,7 +684,11 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -685,7 +685,11 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -683,7 +683,11 @@
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -691,7 +691,11 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  * e.g., PQCP_MLKEM_NATIVE_MLKEM512_
  */
 
-#if MLK_CONFIG_PARAMETER_SET == 512
+#if defined(MLK_CONFIG_MULTILEVEL_BUILD)
+/* In a multi-level build the parameter set is appended by the namespacing
+ * machinery, so the default prefix must not embed it. */
+#define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM
+#elif MLK_CONFIG_PARAMETER_SET == 512
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM512
 #elif MLK_CONFIG_PARAMETER_SET == 768
 #define MLK_DEFAULT_NAMESPACE_PREFIX PQCP_MLKEM_NATIVE_MLKEM768


### PR DESCRIPTION
The default namespace prefix embeds the parameter set (PQCP_MLKEM_NATIVE_MLKEM512/768/1024), which is correct for single-level builds but wrong in a multi-level build: the config is processed once (at the 512 level) and the namespacing machinery appends the parameter set again, yielding PQCP_MLKEM_NATIVE_MLKEM512{512,768, 1024}_. Use a level-independent default (PQCP_MLKEM_NATIVE_MLKEM) when MLK_CONFIG_MULTILEVEL_BUILD is set so the level is appended exactly once. Single-level builds are unchanged.

* Port of https://github.com/pq-code-package/mldsa-native/pull/1270 
* Resolves #1781