### PR TITLE
[TEST] x86_64: Use Plantard reduction

### DIFF
--- a/dev/x86_64/src/fq.inc
+++ b/dev/x86_64/src/fq.inc
@@ -32,6 +32,17 @@ vpand %ymm0,%ymm\x,%ymm\x
 vpaddw %ymm\x,%ymm\r,%ymm\r
 .endm
 
+/* Modular reduction to [0, q-1] by the multiplier encoded in H, L, using
+ * the AVX2 sequence suggested by Bo-Yin Yang.
+ * Expects ymm0 = q, ymm1 = L, ymm2 = H, ymm3 = bias. */
+.macro plantard_red16 r, x=12
+vpmulhw %ymm1,%ymm\r,%ymm\x
+vpmullw %ymm2,%ymm\r,%ymm\r
+vpaddw %ymm\x,%ymm\r,%ymm\r
+vpaddw %ymm3,%ymm\r,%ymm\r
+vpmulhuw %ymm0,%ymm\r,%ymm\r
+.endm
+
 /* Montgomery multiplication between b and ah,
  * with Montgomery twist of ah in al. */
 .macro fqmulprecomp al, ah, b, x=12

--- a/dev/x86_64/src/mlkem_reduce_avx2_asm.S
+++ b/dev/x86_64/src/mlkem_reduce_avx2_asm.S
@@ -17,9 +17,11 @@
  * AVX2 Kyber implementation @[REF_AVX2].
  *
  * Changes:
- * - Add call to csub in reduce128_avx to produce outputs
- *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce(),
+ * - Replace Barrett reduction and conditional subtraction by the
+ *   plantard_red16 sequence from fq.inc, which produces outputs in
+ *   [0,1,...,q-1] directly, matching the semantics of mlk_poly_reduce().
+ *   Its constants are those of the multiplier 1: W = (-2^32 mod q) * q^-1
+ *   mod 2^32 = 0x0013afb8, split as H = 0x0014 and L = 0xafb8, bias 2.
  * - Use a macro instead of a local function call.
  */
 
@@ -49,41 +51,32 @@
 #include "fq.inc"
 
 .macro reduce_128_coefficients offset
-vmovdqa (\offset +   0)(%rdi), %ymm2
-vmovdqa (\offset +  32)(%rdi), %ymm3
-vmovdqa (\offset +  64)(%rdi), %ymm4
-vmovdqa (\offset +  96)(%rdi), %ymm5
-vmovdqa (\offset + 128)(%rdi), %ymm6
-vmovdqa (\offset + 160)(%rdi), %ymm7
-vmovdqa (\offset + 192)(%rdi), %ymm8
-vmovdqa (\offset + 224)(%rdi), %ymm9
+vmovdqa (\offset +   0)(%rdi), %ymm4
+vmovdqa (\offset +  32)(%rdi), %ymm5
+vmovdqa (\offset +  64)(%rdi), %ymm6
+vmovdqa (\offset +  96)(%rdi), %ymm7
+vmovdqa (\offset + 128)(%rdi), %ymm8
+vmovdqa (\offset + 160)(%rdi), %ymm9
+vmovdqa (\offset + 192)(%rdi), %ymm10
+vmovdqa (\offset + 224)(%rdi), %ymm11
 
-red16 2
-red16 3
-red16 4
-red16 5
-red16 6
-red16 7
-red16 8
-red16 9
+plantard_red16 4
+plantard_red16 5
+plantard_red16 6
+plantard_red16 7
+plantard_red16 8
+plantard_red16 9
+plantard_red16 10
+plantard_red16 11
 
-csubq 2
-csubq 3
-csubq 4
-csubq 5
-csubq 6
-csubq 7
-csubq 8
-csubq 9
-
-vmovdqa %ymm2, (\offset +   0)(%rdi)
-vmovdqa %ymm3, (\offset +  32)(%rdi)
-vmovdqa %ymm4, (\offset +  64)(%rdi)
-vmovdqa %ymm5, (\offset +  96)(%rdi)
-vmovdqa %ymm6, (\offset + 128)(%rdi)
-vmovdqa %ymm7, (\offset + 160)(%rdi)
-vmovdqa %ymm8, (\offset + 192)(%rdi)
-vmovdqa %ymm9, (\offset + 224)(%rdi)
+vmovdqa %ymm4,  (\offset +   0)(%rdi)
+vmovdqa %ymm5,  (\offset +  32)(%rdi)
+vmovdqa %ymm6,  (\offset +  64)(%rdi)
+vmovdqa %ymm7,  (\offset +  96)(%rdi)
+vmovdqa %ymm8,  (\offset + 128)(%rdi)
+vmovdqa %ymm9,  (\offset + 160)(%rdi)
+vmovdqa %ymm10, (\offset + 192)(%rdi)
+vmovdqa %ymm11, (\offset + 224)(%rdi)
 .endm
 
 .text
@@ -96,10 +89,20 @@ movl $0x0D010D01, %eax
 vmovd %eax, %xmm0
 vpbroadcastd %xmm0, %ymm0
 
-// Broadcast 20159 (0x4EBF) to all elements of ymm1
-movl $0x4ebf4ebf, %eax
+// Broadcast 0xAFB8, the low half of W, to all elements of ymm1
+movl $0xAFB8AFB8, %eax
 vmovd %eax, %xmm1
 vpbroadcastd %xmm1, %ymm1
+
+// Broadcast 0x0014, the high half of W, to all elements of ymm2
+movl $0x00140014, %eax
+vmovd %eax, %xmm2
+vpbroadcastd %xmm2, %ymm2
+
+// Broadcast the bias s = 2 to all elements of ymm3
+movl $0x00020002, %eax
+vmovd %eax, %xmm3
+vpbroadcastd %xmm3, %ymm3
 
 reduce_128_coefficients 0
 reduce_128_coefficients 128*2

--- a/mlkem/src/native/x86_64/src/mlkem_reduce_avx2_asm.S
+++ b/mlkem/src/native/x86_64/src/mlkem_reduce_avx2_asm.S
@@ -17,9 +17,11 @@
  * AVX2 Kyber implementation @[REF_AVX2].
  *
  * Changes:
- * - Add call to csub in reduce128_avx to produce outputs
- *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce(),
+ * - Replace Barrett reduction and conditional subtraction by the
+ *   plantard_red16 sequence from fq.inc, which produces outputs in
+ *   [0,1,...,q-1] directly, matching the semantics of mlk_poly_reduce().
+ *   Its constants are those of the multiplier 1: W = (-2^32 mod q) * q^-1
+ *   mod 2^32 = 0x0013afb8, split as H = 0x0014 and L = 0xafb8, bias 2.
  * - Use a macro instead of a local function call.
  */
 
@@ -58,169 +60,127 @@ MLK_ASM_FN_SYMBOL(reduce_avx2_asm)
         movl $0xd010d01, %eax        # imm = 0xD010D01
         vmovd %eax, %xmm0
         vpbroadcastd %xmm0, %ymm0
-        movl $0x4ebf4ebf, %eax       # imm = 0x4EBF4EBF
+        movl $0xafb8afb8, %eax       # imm = 0xAFB8AFB8
         vmovd %eax, %xmm1
         vpbroadcastd %xmm1, %ymm1
-        vmovdqa (%rdi), %ymm2
-        vmovdqa 0x20(%rdi), %ymm3
-        vmovdqa 0x40(%rdi), %ymm4
-        vmovdqa 0x60(%rdi), %ymm5
-        vmovdqa 0x80(%rdi), %ymm6
-        vmovdqa 0xa0(%rdi), %ymm7
-        vmovdqa 0xc0(%rdi), %ymm8
-        vmovdqa 0xe0(%rdi), %ymm9
-        vpmulhw %ymm1, %ymm2, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm2, %ymm2
-        vpmulhw %ymm1, %ymm3, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm3, %ymm3
+        movl $0x140014, %eax         # imm = 0x140014
+        vmovd %eax, %xmm2
+        vpbroadcastd %xmm2, %ymm2
+        movl $0x20002, %eax          # imm = 0x20002
+        vmovd %eax, %xmm3
+        vpbroadcastd %xmm3, %ymm3
+        vmovdqa (%rdi), %ymm4
+        vmovdqa 0x20(%rdi), %ymm5
+        vmovdqa 0x40(%rdi), %ymm6
+        vmovdqa 0x60(%rdi), %ymm7
+        vmovdqa 0x80(%rdi), %ymm8
+        vmovdqa 0xa0(%rdi), %ymm9
+        vmovdqa 0xc0(%rdi), %ymm10
+        vmovdqa 0xe0(%rdi), %ymm11
         vpmulhw %ymm1, %ymm4, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm4, %ymm4
-        vpmulhw %ymm1, %ymm5, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm5, %ymm5
-        vpmulhw %ymm1, %ymm6, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm6, %ymm6
-        vpmulhw %ymm1, %ymm7, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm7, %ymm7
-        vpmulhw %ymm1, %ymm8, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm8, %ymm8
-        vpmulhw %ymm1, %ymm9, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm9, %ymm9
-        vpsubw %ymm0, %ymm2, %ymm2
-        vpsraw $0xf, %ymm2, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm2, %ymm2
-        vpsubw %ymm0, %ymm3, %ymm3
-        vpsraw $0xf, %ymm3, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm3, %ymm3
-        vpsubw %ymm0, %ymm4, %ymm4
-        vpsraw $0xf, %ymm4, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpmullw %ymm2, %ymm4, %ymm4
         vpaddw %ymm12, %ymm4, %ymm4
-        vpsubw %ymm0, %ymm5, %ymm5
-        vpsraw $0xf, %ymm5, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm4, %ymm4
+        vpmulhuw %ymm0, %ymm4, %ymm4
+        vpmulhw %ymm1, %ymm5, %ymm12
+        vpmullw %ymm2, %ymm5, %ymm5
         vpaddw %ymm12, %ymm5, %ymm5
-        vpsubw %ymm0, %ymm6, %ymm6
-        vpsraw $0xf, %ymm6, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm5, %ymm5
+        vpmulhuw %ymm0, %ymm5, %ymm5
+        vpmulhw %ymm1, %ymm6, %ymm12
+        vpmullw %ymm2, %ymm6, %ymm6
         vpaddw %ymm12, %ymm6, %ymm6
-        vpsubw %ymm0, %ymm7, %ymm7
-        vpsraw $0xf, %ymm7, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm6, %ymm6
+        vpmulhuw %ymm0, %ymm6, %ymm6
+        vpmulhw %ymm1, %ymm7, %ymm12
+        vpmullw %ymm2, %ymm7, %ymm7
         vpaddw %ymm12, %ymm7, %ymm7
-        vpsubw %ymm0, %ymm8, %ymm8
-        vpsraw $0xf, %ymm8, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm7, %ymm7
+        vpmulhuw %ymm0, %ymm7, %ymm7
+        vpmulhw %ymm1, %ymm8, %ymm12
+        vpmullw %ymm2, %ymm8, %ymm8
         vpaddw %ymm12, %ymm8, %ymm8
-        vpsubw %ymm0, %ymm9, %ymm9
-        vpsraw $0xf, %ymm9, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm8, %ymm8
+        vpmulhuw %ymm0, %ymm8, %ymm8
+        vpmulhw %ymm1, %ymm9, %ymm12
+        vpmullw %ymm2, %ymm9, %ymm9
         vpaddw %ymm12, %ymm9, %ymm9
-        vmovdqa %ymm2, (%rdi)
-        vmovdqa %ymm3, 0x20(%rdi)
-        vmovdqa %ymm4, 0x40(%rdi)
-        vmovdqa %ymm5, 0x60(%rdi)
-        vmovdqa %ymm6, 0x80(%rdi)
-        vmovdqa %ymm7, 0xa0(%rdi)
-        vmovdqa %ymm8, 0xc0(%rdi)
-        vmovdqa %ymm9, 0xe0(%rdi)
-        vmovdqa 0x100(%rdi), %ymm2
-        vmovdqa 0x120(%rdi), %ymm3
-        vmovdqa 0x140(%rdi), %ymm4
-        vmovdqa 0x160(%rdi), %ymm5
-        vmovdqa 0x180(%rdi), %ymm6
-        vmovdqa 0x1a0(%rdi), %ymm7
-        vmovdqa 0x1c0(%rdi), %ymm8
-        vmovdqa 0x1e0(%rdi), %ymm9
-        vpmulhw %ymm1, %ymm2, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm2, %ymm2
-        vpmulhw %ymm1, %ymm3, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm3, %ymm3
+        vpaddw %ymm3, %ymm9, %ymm9
+        vpmulhuw %ymm0, %ymm9, %ymm9
+        vpmulhw %ymm1, %ymm10, %ymm12
+        vpmullw %ymm2, %ymm10, %ymm10
+        vpaddw %ymm12, %ymm10, %ymm10
+        vpaddw %ymm3, %ymm10, %ymm10
+        vpmulhuw %ymm0, %ymm10, %ymm10
+        vpmulhw %ymm1, %ymm11, %ymm12
+        vpmullw %ymm2, %ymm11, %ymm11
+        vpaddw %ymm12, %ymm11, %ymm11
+        vpaddw %ymm3, %ymm11, %ymm11
+        vpmulhuw %ymm0, %ymm11, %ymm11
+        vmovdqa %ymm4, (%rdi)
+        vmovdqa %ymm5, 0x20(%rdi)
+        vmovdqa %ymm6, 0x40(%rdi)
+        vmovdqa %ymm7, 0x60(%rdi)
+        vmovdqa %ymm8, 0x80(%rdi)
+        vmovdqa %ymm9, 0xa0(%rdi)
+        vmovdqa %ymm10, 0xc0(%rdi)
+        vmovdqa %ymm11, 0xe0(%rdi)
+        vmovdqa 0x100(%rdi), %ymm4
+        vmovdqa 0x120(%rdi), %ymm5
+        vmovdqa 0x140(%rdi), %ymm6
+        vmovdqa 0x160(%rdi), %ymm7
+        vmovdqa 0x180(%rdi), %ymm8
+        vmovdqa 0x1a0(%rdi), %ymm9
+        vmovdqa 0x1c0(%rdi), %ymm10
+        vmovdqa 0x1e0(%rdi), %ymm11
         vpmulhw %ymm1, %ymm4, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm4, %ymm4
-        vpmulhw %ymm1, %ymm5, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm5, %ymm5
-        vpmulhw %ymm1, %ymm6, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm6, %ymm6
-        vpmulhw %ymm1, %ymm7, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm7, %ymm7
-        vpmulhw %ymm1, %ymm8, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm8, %ymm8
-        vpmulhw %ymm1, %ymm9, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm9, %ymm9
-        vpsubw %ymm0, %ymm2, %ymm2
-        vpsraw $0xf, %ymm2, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm2, %ymm2
-        vpsubw %ymm0, %ymm3, %ymm3
-        vpsraw $0xf, %ymm3, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm3, %ymm3
-        vpsubw %ymm0, %ymm4, %ymm4
-        vpsraw $0xf, %ymm4, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpmullw %ymm2, %ymm4, %ymm4
         vpaddw %ymm12, %ymm4, %ymm4
-        vpsubw %ymm0, %ymm5, %ymm5
-        vpsraw $0xf, %ymm5, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm4, %ymm4
+        vpmulhuw %ymm0, %ymm4, %ymm4
+        vpmulhw %ymm1, %ymm5, %ymm12
+        vpmullw %ymm2, %ymm5, %ymm5
         vpaddw %ymm12, %ymm5, %ymm5
-        vpsubw %ymm0, %ymm6, %ymm6
-        vpsraw $0xf, %ymm6, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm5, %ymm5
+        vpmulhuw %ymm0, %ymm5, %ymm5
+        vpmulhw %ymm1, %ymm6, %ymm12
+        vpmullw %ymm2, %ymm6, %ymm6
         vpaddw %ymm12, %ymm6, %ymm6
-        vpsubw %ymm0, %ymm7, %ymm7
-        vpsraw $0xf, %ymm7, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm6, %ymm6
+        vpmulhuw %ymm0, %ymm6, %ymm6
+        vpmulhw %ymm1, %ymm7, %ymm12
+        vpmullw %ymm2, %ymm7, %ymm7
         vpaddw %ymm12, %ymm7, %ymm7
-        vpsubw %ymm0, %ymm8, %ymm8
-        vpsraw $0xf, %ymm8, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm7, %ymm7
+        vpmulhuw %ymm0, %ymm7, %ymm7
+        vpmulhw %ymm1, %ymm8, %ymm12
+        vpmullw %ymm2, %ymm8, %ymm8
         vpaddw %ymm12, %ymm8, %ymm8
-        vpsubw %ymm0, %ymm9, %ymm9
-        vpsraw $0xf, %ymm9, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm8, %ymm8
+        vpmulhuw %ymm0, %ymm8, %ymm8
+        vpmulhw %ymm1, %ymm9, %ymm12
+        vpmullw %ymm2, %ymm9, %ymm9
         vpaddw %ymm12, %ymm9, %ymm9
-        vmovdqa %ymm2, 0x100(%rdi)
-        vmovdqa %ymm3, 0x120(%rdi)
-        vmovdqa %ymm4, 0x140(%rdi)
-        vmovdqa %ymm5, 0x160(%rdi)
-        vmovdqa %ymm6, 0x180(%rdi)
-        vmovdqa %ymm7, 0x1a0(%rdi)
-        vmovdqa %ymm8, 0x1c0(%rdi)
-        vmovdqa %ymm9, 0x1e0(%rdi)
+        vpaddw %ymm3, %ymm9, %ymm9
+        vpmulhuw %ymm0, %ymm9, %ymm9
+        vpmulhw %ymm1, %ymm10, %ymm12
+        vpmullw %ymm2, %ymm10, %ymm10
+        vpaddw %ymm12, %ymm10, %ymm10
+        vpaddw %ymm3, %ymm10, %ymm10
+        vpmulhuw %ymm0, %ymm10, %ymm10
+        vpmulhw %ymm1, %ymm11, %ymm12
+        vpmullw %ymm2, %ymm11, %ymm11
+        vpaddw %ymm12, %ymm11, %ymm11
+        vpaddw %ymm3, %ymm11, %ymm11
+        vpmulhuw %ymm0, %ymm11, %ymm11
+        vmovdqa %ymm4, 0x100(%rdi)
+        vmovdqa %ymm5, 0x120(%rdi)
+        vmovdqa %ymm6, 0x140(%rdi)
+        vmovdqa %ymm7, 0x160(%rdi)
+        vmovdqa %ymm8, 0x180(%rdi)
+        vmovdqa %ymm9, 0x1a0(%rdi)
+        vmovdqa %ymm10, 0x1c0(%rdi)
+        vmovdqa %ymm11, 0x1e0(%rdi)
         retq
         .cfi_endproc
 

--- a/nix/s2n_bignum/default.nix
+++ b/nix/s2n_bignum/default.nix
@@ -2,12 +2,12 @@
 { stdenv, fetchFromGitHub, writeText, ... }:
 stdenv.mkDerivation rec {
   pname = "s2n_bignum";
-  version = "b70f1349bdc930769dbe5fee070044c27395e70a";
+  version = "471fca76a9079753aab938ba35ef55ec22717d89";
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "s2n-bignum";
     rev = "${version}";
-    hash = "sha256-zZYIOp3bL/Asr4RdDYDFH804EJoRB4CKFmjKZepKEvA=";
+    hash = "sha256-fUfgT11HrTwAdZpl2SLEU1AHYo2rk7nV4UYs2wlg3Xo=";
   };
   setupHook = writeText "setup-hook.sh" ''
     export S2N_BIGNUM_DIR="$1"

--- a/proofs/hol_light/x86_64/mlkem/mlkem_reduce_avx2_asm.S
+++ b/proofs/hol_light/x86_64/mlkem/mlkem_reduce_avx2_asm.S
@@ -17,9 +17,11 @@
  * AVX2 Kyber implementation @[REF_AVX2].
  *
  * Changes:
- * - Add call to csub in reduce128_avx to produce outputs
- *   in [0,1,...,q-1] rather than [0,1,...,q], matching the
- *   semantics of mlk_poly_reduce(),
+ * - Replace Barrett reduction and conditional subtraction by the
+ *   plantard_red16 sequence from fq.inc, which produces outputs in
+ *   [0,1,...,q-1] directly, matching the semantics of mlk_poly_reduce().
+ *   Its constants are those of the multiplier 1: W = (-2^32 mod q) * q^-1
+ *   mod 2^32 = 0x0013afb8, split as H = 0x0014 and L = 0xafb8, bias 2.
  * - Use a macro instead of a local function call.
  */
 
@@ -61,169 +63,127 @@ mlk_reduce_avx2_asm:
         movl $0xd010d01, %eax        # imm = 0xD010D01
         vmovd %eax, %xmm0
         vpbroadcastd %xmm0, %ymm0
-        movl $0x4ebf4ebf, %eax       # imm = 0x4EBF4EBF
+        movl $0xafb8afb8, %eax       # imm = 0xAFB8AFB8
         vmovd %eax, %xmm1
         vpbroadcastd %xmm1, %ymm1
-        vmovdqa (%rdi), %ymm2
-        vmovdqa 0x20(%rdi), %ymm3
-        vmovdqa 0x40(%rdi), %ymm4
-        vmovdqa 0x60(%rdi), %ymm5
-        vmovdqa 0x80(%rdi), %ymm6
-        vmovdqa 0xa0(%rdi), %ymm7
-        vmovdqa 0xc0(%rdi), %ymm8
-        vmovdqa 0xe0(%rdi), %ymm9
-        vpmulhw %ymm1, %ymm2, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm2, %ymm2
-        vpmulhw %ymm1, %ymm3, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm3, %ymm3
+        movl $0x140014, %eax         # imm = 0x140014
+        vmovd %eax, %xmm2
+        vpbroadcastd %xmm2, %ymm2
+        movl $0x20002, %eax          # imm = 0x20002
+        vmovd %eax, %xmm3
+        vpbroadcastd %xmm3, %ymm3
+        vmovdqa (%rdi), %ymm4
+        vmovdqa 0x20(%rdi), %ymm5
+        vmovdqa 0x40(%rdi), %ymm6
+        vmovdqa 0x60(%rdi), %ymm7
+        vmovdqa 0x80(%rdi), %ymm8
+        vmovdqa 0xa0(%rdi), %ymm9
+        vmovdqa 0xc0(%rdi), %ymm10
+        vmovdqa 0xe0(%rdi), %ymm11
         vpmulhw %ymm1, %ymm4, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm4, %ymm4
-        vpmulhw %ymm1, %ymm5, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm5, %ymm5
-        vpmulhw %ymm1, %ymm6, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm6, %ymm6
-        vpmulhw %ymm1, %ymm7, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm7, %ymm7
-        vpmulhw %ymm1, %ymm8, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm8, %ymm8
-        vpmulhw %ymm1, %ymm9, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm9, %ymm9
-        vpsubw %ymm0, %ymm2, %ymm2
-        vpsraw $0xf, %ymm2, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm2, %ymm2
-        vpsubw %ymm0, %ymm3, %ymm3
-        vpsraw $0xf, %ymm3, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm3, %ymm3
-        vpsubw %ymm0, %ymm4, %ymm4
-        vpsraw $0xf, %ymm4, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpmullw %ymm2, %ymm4, %ymm4
         vpaddw %ymm12, %ymm4, %ymm4
-        vpsubw %ymm0, %ymm5, %ymm5
-        vpsraw $0xf, %ymm5, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm4, %ymm4
+        vpmulhuw %ymm0, %ymm4, %ymm4
+        vpmulhw %ymm1, %ymm5, %ymm12
+        vpmullw %ymm2, %ymm5, %ymm5
         vpaddw %ymm12, %ymm5, %ymm5
-        vpsubw %ymm0, %ymm6, %ymm6
-        vpsraw $0xf, %ymm6, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm5, %ymm5
+        vpmulhuw %ymm0, %ymm5, %ymm5
+        vpmulhw %ymm1, %ymm6, %ymm12
+        vpmullw %ymm2, %ymm6, %ymm6
         vpaddw %ymm12, %ymm6, %ymm6
-        vpsubw %ymm0, %ymm7, %ymm7
-        vpsraw $0xf, %ymm7, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm6, %ymm6
+        vpmulhuw %ymm0, %ymm6, %ymm6
+        vpmulhw %ymm1, %ymm7, %ymm12
+        vpmullw %ymm2, %ymm7, %ymm7
         vpaddw %ymm12, %ymm7, %ymm7
-        vpsubw %ymm0, %ymm8, %ymm8
-        vpsraw $0xf, %ymm8, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm7, %ymm7
+        vpmulhuw %ymm0, %ymm7, %ymm7
+        vpmulhw %ymm1, %ymm8, %ymm12
+        vpmullw %ymm2, %ymm8, %ymm8
         vpaddw %ymm12, %ymm8, %ymm8
-        vpsubw %ymm0, %ymm9, %ymm9
-        vpsraw $0xf, %ymm9, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm8, %ymm8
+        vpmulhuw %ymm0, %ymm8, %ymm8
+        vpmulhw %ymm1, %ymm9, %ymm12
+        vpmullw %ymm2, %ymm9, %ymm9
         vpaddw %ymm12, %ymm9, %ymm9
-        vmovdqa %ymm2, (%rdi)
-        vmovdqa %ymm3, 0x20(%rdi)
-        vmovdqa %ymm4, 0x40(%rdi)
-        vmovdqa %ymm5, 0x60(%rdi)
-        vmovdqa %ymm6, 0x80(%rdi)
-        vmovdqa %ymm7, 0xa0(%rdi)
-        vmovdqa %ymm8, 0xc0(%rdi)
-        vmovdqa %ymm9, 0xe0(%rdi)
-        vmovdqa 0x100(%rdi), %ymm2
-        vmovdqa 0x120(%rdi), %ymm3
-        vmovdqa 0x140(%rdi), %ymm4
-        vmovdqa 0x160(%rdi), %ymm5
-        vmovdqa 0x180(%rdi), %ymm6
-        vmovdqa 0x1a0(%rdi), %ymm7
-        vmovdqa 0x1c0(%rdi), %ymm8
-        vmovdqa 0x1e0(%rdi), %ymm9
-        vpmulhw %ymm1, %ymm2, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm2, %ymm2
-        vpmulhw %ymm1, %ymm3, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm3, %ymm3
+        vpaddw %ymm3, %ymm9, %ymm9
+        vpmulhuw %ymm0, %ymm9, %ymm9
+        vpmulhw %ymm1, %ymm10, %ymm12
+        vpmullw %ymm2, %ymm10, %ymm10
+        vpaddw %ymm12, %ymm10, %ymm10
+        vpaddw %ymm3, %ymm10, %ymm10
+        vpmulhuw %ymm0, %ymm10, %ymm10
+        vpmulhw %ymm1, %ymm11, %ymm12
+        vpmullw %ymm2, %ymm11, %ymm11
+        vpaddw %ymm12, %ymm11, %ymm11
+        vpaddw %ymm3, %ymm11, %ymm11
+        vpmulhuw %ymm0, %ymm11, %ymm11
+        vmovdqa %ymm4, (%rdi)
+        vmovdqa %ymm5, 0x20(%rdi)
+        vmovdqa %ymm6, 0x40(%rdi)
+        vmovdqa %ymm7, 0x60(%rdi)
+        vmovdqa %ymm8, 0x80(%rdi)
+        vmovdqa %ymm9, 0xa0(%rdi)
+        vmovdqa %ymm10, 0xc0(%rdi)
+        vmovdqa %ymm11, 0xe0(%rdi)
+        vmovdqa 0x100(%rdi), %ymm4
+        vmovdqa 0x120(%rdi), %ymm5
+        vmovdqa 0x140(%rdi), %ymm6
+        vmovdqa 0x160(%rdi), %ymm7
+        vmovdqa 0x180(%rdi), %ymm8
+        vmovdqa 0x1a0(%rdi), %ymm9
+        vmovdqa 0x1c0(%rdi), %ymm10
+        vmovdqa 0x1e0(%rdi), %ymm11
         vpmulhw %ymm1, %ymm4, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm4, %ymm4
-        vpmulhw %ymm1, %ymm5, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm5, %ymm5
-        vpmulhw %ymm1, %ymm6, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm6, %ymm6
-        vpmulhw %ymm1, %ymm7, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm7, %ymm7
-        vpmulhw %ymm1, %ymm8, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm8, %ymm8
-        vpmulhw %ymm1, %ymm9, %ymm12
-        vpsraw $0xa, %ymm12, %ymm12
-        vpmullw %ymm0, %ymm12, %ymm12
-        vpsubw %ymm12, %ymm9, %ymm9
-        vpsubw %ymm0, %ymm2, %ymm2
-        vpsraw $0xf, %ymm2, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm2, %ymm2
-        vpsubw %ymm0, %ymm3, %ymm3
-        vpsraw $0xf, %ymm3, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
-        vpaddw %ymm12, %ymm3, %ymm3
-        vpsubw %ymm0, %ymm4, %ymm4
-        vpsraw $0xf, %ymm4, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpmullw %ymm2, %ymm4, %ymm4
         vpaddw %ymm12, %ymm4, %ymm4
-        vpsubw %ymm0, %ymm5, %ymm5
-        vpsraw $0xf, %ymm5, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm4, %ymm4
+        vpmulhuw %ymm0, %ymm4, %ymm4
+        vpmulhw %ymm1, %ymm5, %ymm12
+        vpmullw %ymm2, %ymm5, %ymm5
         vpaddw %ymm12, %ymm5, %ymm5
-        vpsubw %ymm0, %ymm6, %ymm6
-        vpsraw $0xf, %ymm6, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm5, %ymm5
+        vpmulhuw %ymm0, %ymm5, %ymm5
+        vpmulhw %ymm1, %ymm6, %ymm12
+        vpmullw %ymm2, %ymm6, %ymm6
         vpaddw %ymm12, %ymm6, %ymm6
-        vpsubw %ymm0, %ymm7, %ymm7
-        vpsraw $0xf, %ymm7, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm6, %ymm6
+        vpmulhuw %ymm0, %ymm6, %ymm6
+        vpmulhw %ymm1, %ymm7, %ymm12
+        vpmullw %ymm2, %ymm7, %ymm7
         vpaddw %ymm12, %ymm7, %ymm7
-        vpsubw %ymm0, %ymm8, %ymm8
-        vpsraw $0xf, %ymm8, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm7, %ymm7
+        vpmulhuw %ymm0, %ymm7, %ymm7
+        vpmulhw %ymm1, %ymm8, %ymm12
+        vpmullw %ymm2, %ymm8, %ymm8
         vpaddw %ymm12, %ymm8, %ymm8
-        vpsubw %ymm0, %ymm9, %ymm9
-        vpsraw $0xf, %ymm9, %ymm12
-        vpand %ymm0, %ymm12, %ymm12
+        vpaddw %ymm3, %ymm8, %ymm8
+        vpmulhuw %ymm0, %ymm8, %ymm8
+        vpmulhw %ymm1, %ymm9, %ymm12
+        vpmullw %ymm2, %ymm9, %ymm9
         vpaddw %ymm12, %ymm9, %ymm9
-        vmovdqa %ymm2, 0x100(%rdi)
-        vmovdqa %ymm3, 0x120(%rdi)
-        vmovdqa %ymm4, 0x140(%rdi)
-        vmovdqa %ymm5, 0x160(%rdi)
-        vmovdqa %ymm6, 0x180(%rdi)
-        vmovdqa %ymm7, 0x1a0(%rdi)
-        vmovdqa %ymm8, 0x1c0(%rdi)
-        vmovdqa %ymm9, 0x1e0(%rdi)
+        vpaddw %ymm3, %ymm9, %ymm9
+        vpmulhuw %ymm0, %ymm9, %ymm9
+        vpmulhw %ymm1, %ymm10, %ymm12
+        vpmullw %ymm2, %ymm10, %ymm10
+        vpaddw %ymm12, %ymm10, %ymm10
+        vpaddw %ymm3, %ymm10, %ymm10
+        vpmulhuw %ymm0, %ymm10, %ymm10
+        vpmulhw %ymm1, %ymm11, %ymm12
+        vpmullw %ymm2, %ymm11, %ymm11
+        vpaddw %ymm12, %ymm11, %ymm11
+        vpaddw %ymm3, %ymm11, %ymm11
+        vpmulhuw %ymm0, %ymm11, %ymm11
+        vmovdqa %ymm4, 0x100(%rdi)
+        vmovdqa %ymm5, 0x120(%rdi)
+        vmovdqa %ymm6, 0x140(%rdi)
+        vmovdqa %ymm7, 0x160(%rdi)
+        vmovdqa %ymm8, 0x180(%rdi)
+        vmovdqa %ymm9, 0x1a0(%rdi)
+        vmovdqa %ymm10, 0x1c0(%rdi)
+        vmovdqa %ymm11, 0x1e0(%rdi)
         retq
         .cfi_endproc
 

--- a/proofs/hol_light/x86_64/proofs/mlkem_reduce_avx2_asm.ml
+++ b/proofs/hol_light/x86_64/proofs/mlkem_reduce_avx2_asm.ml
@@ -24,265 +24,179 @@ let mlkem_reduce_mc =
   0xc5; 0xf9; 0x6e; 0xc0;  (* VMOVD (%_% xmm0) (% eax) *)
   0xc4; 0xe2; 0x7d; 0x58; 0xc0;
                            (* VPBROADCASTD (%_% ymm0) (%_% xmm0) *)
-  0xb8; 0xbf; 0x4e; 0xbf; 0x4e;
-                           (* MOV (% eax) (Imm32 (word 1321160383)) *)
+  0xb8; 0xb8; 0xaf; 0xb8; 0xaf;
+                           (* MOV (% eax) (Imm32 (word 2948116408)) *)
   0xc5; 0xf9; 0x6e; 0xc8;  (* VMOVD (%_% xmm1) (% eax) *)
   0xc4; 0xe2; 0x7d; 0x58; 0xc9;
                            (* VPBROADCASTD (%_% ymm1) (%_% xmm1) *)
-  0xc5; 0xfd; 0x6f; 0x17;  (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rdi,0))) *)
-  0xc5; 0xfd; 0x6f; 0x5f; 0x20;
-                           (* VMOVDQA (%_% ymm3) (Memop Word256 (%% (rdi,32))) *)
-  0xc5; 0xfd; 0x6f; 0x67; 0x40;
-                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,64))) *)
-  0xc5; 0xfd; 0x6f; 0x6f; 0x60;
-                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,96))) *)
-  0xc5; 0xfd; 0x6f; 0xb7; 0x80; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,128))) *)
-  0xc5; 0xfd; 0x6f; 0xbf; 0xa0; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,160))) *)
-  0xc5; 0x7d; 0x6f; 0x87; 0xc0; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,192))) *)
-  0xc5; 0x7d; 0x6f; 0x8f; 0xe0; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,224))) *)
-  0xc5; 0x6d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm2) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x6d; 0xf9; 0xd4;
-                           (* VPSUBW (%_% ymm2) (%_% ymm2) (%_% ymm12) *)
-  0xc5; 0x65; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm3) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x65; 0xf9; 0xdc;
-                           (* VPSUBW (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
+  0xb8; 0x14; 0x00; 0x14; 0x00;
+                           (* MOV (% eax) (Imm32 (word 1310740)) *)
+  0xc5; 0xf9; 0x6e; 0xd0;  (* VMOVD (%_% xmm2) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xd2;
+                           (* VPBROADCASTD (%_% ymm2) (%_% xmm2) *)
+  0xb8; 0x02; 0x00; 0x02; 0x00;
+                           (* MOV (% eax) (Imm32 (word 131074)) *)
+  0xc5; 0xf9; 0x6e; 0xd8;  (* VMOVD (%_% xmm3) (% eax) *)
+  0xc4; 0xe2; 0x7d; 0x58; 0xdb;
+                           (* VPBROADCASTD (%_% ymm3) (%_% xmm3) *)
+  0xc5; 0xfd; 0x6f; 0x27;  (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,0))) *)
+  0xc5; 0xfd; 0x6f; 0x6f; 0x20;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,32))) *)
+  0xc5; 0xfd; 0x6f; 0x77; 0x40;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,64))) *)
+  0xc5; 0xfd; 0x6f; 0x7f; 0x60;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,96))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,128))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,160))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,192))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,224))) *)
   0xc5; 0x5d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm4) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x5d; 0xf9; 0xe4;
-                           (* VPSUBW (%_% ymm4) (%_% ymm4) (%_% ymm12) *)
-  0xc5; 0x55; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm5) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x55; 0xf9; 0xec;
-                           (* VPSUBW (%_% ymm5) (%_% ymm5) (%_% ymm12) *)
-  0xc5; 0x4d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm6) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x4d; 0xf9; 0xf4;
-                           (* VPSUBW (%_% ymm6) (%_% ymm6) (%_% ymm12) *)
-  0xc5; 0x45; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm7) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x45; 0xf9; 0xfc;
-                           (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
-  0xc5; 0x3d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm8) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0x41; 0x3d; 0xf9; 0xc4;
-                           (* VPSUBW (%_% ymm8) (%_% ymm8) (%_% ymm12) *)
-  0xc5; 0x35; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm9) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0x41; 0x35; 0xf9; 0xcc;
-                           (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
-  0xc5; 0xed; 0xf9; 0xd0;  (* VPSUBW (%_% ymm2) (%_% ymm2) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe2; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm2) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x6d; 0xfd; 0xd4;
-                           (* VPADDW (%_% ymm2) (%_% ymm2) (%_% ymm12) *)
-  0xc5; 0xe5; 0xf9; 0xd8;  (* VPSUBW (%_% ymm3) (%_% ymm3) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe3; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm3) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x65; 0xfd; 0xdc;
-                           (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
-  0xc5; 0xdd; 0xf9; 0xe0;  (* VPSUBW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe4; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm4) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xdd; 0xd5; 0xe2;  (* VPMULLW (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
   0xc4; 0xc1; 0x5d; 0xfd; 0xe4;
                            (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm12) *)
-  0xc5; 0xd5; 0xf9; 0xe8;  (* VPSUBW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe5; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm5) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xdd; 0xfd; 0xe3;  (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm3) *)
+  0xc5; 0xdd; 0xe4; 0xe0;  (* VPMULHUW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
+  0xc5; 0x55; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0xd5; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
   0xc4; 0xc1; 0x55; 0xfd; 0xec;
                            (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm12) *)
-  0xc5; 0xcd; 0xf9; 0xf0;  (* VPSUBW (%_% ymm6) (%_% ymm6) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe6; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm6) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xd5; 0xfd; 0xeb;  (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xd5; 0xe4; 0xe8;  (* VPMULHUW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0x4d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0xcd; 0xd5; 0xf2;  (* VPMULLW (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
   0xc4; 0xc1; 0x4d; 0xfd; 0xf4;
                            (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm12) *)
-  0xc5; 0xc5; 0xf9; 0xf8;  (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe7; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm7) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xcd; 0xfd; 0xf3;  (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm3) *)
+  0xc5; 0xcd; 0xe4; 0xf0;  (* VPMULHUW (%_% ymm6) (%_% ymm6) (%_% ymm0) *)
+  0xc5; 0x45; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0xc5; 0xd5; 0xfa;  (* VPMULLW (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
   0xc4; 0xc1; 0x45; 0xfd; 0xfc;
                            (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
-  0xc5; 0x3d; 0xf9; 0xc0;  (* VPSUBW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe0; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm8) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xc5; 0xfd; 0xfb;  (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0xc5; 0xe4; 0xf8;  (* VPMULHUW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x3d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm8) (%_% ymm1) *)
+  0xc5; 0x3d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
   0xc4; 0x41; 0x3d; 0xfd; 0xc4;
                            (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm12) *)
-  0xc5; 0x35; 0xf9; 0xc8;  (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe1; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm9) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0x3d; 0xfd; 0xc3;  (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm3) *)
+  0xc5; 0x3d; 0xe4; 0xc0;  (* VPMULHUW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm9) (%_% ymm1) *)
+  0xc5; 0x35; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
   0xc4; 0x41; 0x35; 0xfd; 0xcc;
                            (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
-  0xc5; 0xfd; 0x7f; 0x17;  (* VMOVDQA (Memop Word256 (%% (rdi,0))) (%_% ymm2) *)
-  0xc5; 0xfd; 0x7f; 0x5f; 0x20;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,32))) (%_% ymm3) *)
-  0xc5; 0xfd; 0x7f; 0x67; 0x40;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,64))) (%_% ymm4) *)
-  0xc5; 0xfd; 0x7f; 0x6f; 0x60;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,96))) (%_% ymm5) *)
-  0xc5; 0xfd; 0x7f; 0xb7; 0x80; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,128))) (%_% ymm6) *)
-  0xc5; 0xfd; 0x7f; 0xbf; 0xa0; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,160))) (%_% ymm7) *)
-  0xc5; 0x7d; 0x7f; 0x87; 0xc0; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,192))) (%_% ymm8) *)
-  0xc5; 0x7d; 0x7f; 0x8f; 0xe0; 0x00; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,224))) (%_% ymm9) *)
-  0xc5; 0xfd; 0x6f; 0x97; 0x00; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm2) (Memop Word256 (%% (rdi,256))) *)
-  0xc5; 0xfd; 0x6f; 0x9f; 0x20; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm3) (Memop Word256 (%% (rdi,288))) *)
-  0xc5; 0xfd; 0x6f; 0xa7; 0x40; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,320))) *)
-  0xc5; 0xfd; 0x6f; 0xaf; 0x60; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,352))) *)
-  0xc5; 0xfd; 0x6f; 0xb7; 0x80; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,384))) *)
-  0xc5; 0xfd; 0x6f; 0xbf; 0xa0; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,416))) *)
-  0xc5; 0x7d; 0x6f; 0x87; 0xc0; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,448))) *)
-  0xc5; 0x7d; 0x6f; 0x8f; 0xe0; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,480))) *)
-  0xc5; 0x6d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm2) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x6d; 0xf9; 0xd4;
-                           (* VPSUBW (%_% ymm2) (%_% ymm2) (%_% ymm12) *)
-  0xc5; 0x65; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm3) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x65; 0xf9; 0xdc;
-                           (* VPSUBW (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
+  0xc5; 0x35; 0xfd; 0xcb;  (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm3) *)
+  0xc5; 0x35; 0xe4; 0xc8;  (* VPMULHUW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm10) (%_% ymm1) *)
+  0xc5; 0x2d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x41; 0x2d; 0xfd; 0xd4;
+                           (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm12) *)
+  0xc5; 0x2d; 0xfd; 0xd3;  (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0x2d; 0xe4; 0xd0;  (* VPMULHUW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm11) (%_% ymm1) *)
+  0xc5; 0x25; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x41; 0x25; 0xfd; 0xdc;
+                           (* VPADDW (%_% ymm11) (%_% ymm11) (%_% ymm12) *)
+  0xc5; 0x25; 0xfd; 0xdb;  (* VPADDW (%_% ymm11) (%_% ymm11) (%_% ymm3) *)
+  0xc5; 0x25; 0xe4; 0xd8;  (* VPMULHUW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0xfd; 0x7f; 0x27;  (* VMOVDQA (Memop Word256 (%% (rdi,0))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0x6f; 0x20;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,32))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0x77; 0x40;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,64))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0x7f; 0x60;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,96))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x80; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,128))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0xa0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,160))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0xc0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,192))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x00; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,224))) (%_% ymm11) *)
+  0xc5; 0xfd; 0x6f; 0xa7; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm4) (Memop Word256 (%% (rdi,256))) *)
+  0xc5; 0xfd; 0x6f; 0xaf; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm5) (Memop Word256 (%% (rdi,288))) *)
+  0xc5; 0xfd; 0x6f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm6) (Memop Word256 (%% (rdi,320))) *)
+  0xc5; 0xfd; 0x6f; 0xbf; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm7) (Memop Word256 (%% (rdi,352))) *)
+  0xc5; 0x7d; 0x6f; 0x87; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm8) (Memop Word256 (%% (rdi,384))) *)
+  0xc5; 0x7d; 0x6f; 0x8f; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm9) (Memop Word256 (%% (rdi,416))) *)
+  0xc5; 0x7d; 0x6f; 0x97; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm10) (Memop Word256 (%% (rdi,448))) *)
+  0xc5; 0x7d; 0x6f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (%_% ymm11) (Memop Word256 (%% (rdi,480))) *)
   0xc5; 0x5d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm4) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x5d; 0xf9; 0xe4;
-                           (* VPSUBW (%_% ymm4) (%_% ymm4) (%_% ymm12) *)
-  0xc5; 0x55; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm5) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x55; 0xf9; 0xec;
-                           (* VPSUBW (%_% ymm5) (%_% ymm5) (%_% ymm12) *)
-  0xc5; 0x4d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm6) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x4d; 0xf9; 0xf4;
-                           (* VPSUBW (%_% ymm6) (%_% ymm6) (%_% ymm12) *)
-  0xc5; 0x45; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm7) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x45; 0xf9; 0xfc;
-                           (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
-  0xc5; 0x3d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm8) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0x41; 0x3d; 0xf9; 0xc4;
-                           (* VPSUBW (%_% ymm8) (%_% ymm8) (%_% ymm12) *)
-  0xc5; 0x35; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm9) (%_% ymm1) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe4; 0x0a;
-                           (* VPSRAW (%_% ymm12) (%_% ymm12) (Imm8 (word 10)) *)
-  0xc5; 0x1d; 0xd5; 0xe0;  (* VPMULLW (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0x41; 0x35; 0xf9; 0xcc;
-                           (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
-  0xc5; 0xed; 0xf9; 0xd0;  (* VPSUBW (%_% ymm2) (%_% ymm2) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe2; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm2) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x6d; 0xfd; 0xd4;
-                           (* VPADDW (%_% ymm2) (%_% ymm2) (%_% ymm12) *)
-  0xc5; 0xe5; 0xf9; 0xd8;  (* VPSUBW (%_% ymm3) (%_% ymm3) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe3; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm3) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
-  0xc4; 0xc1; 0x65; 0xfd; 0xdc;
-                           (* VPADDW (%_% ymm3) (%_% ymm3) (%_% ymm12) *)
-  0xc5; 0xdd; 0xf9; 0xe0;  (* VPSUBW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe4; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm4) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xdd; 0xd5; 0xe2;  (* VPMULLW (%_% ymm4) (%_% ymm4) (%_% ymm2) *)
   0xc4; 0xc1; 0x5d; 0xfd; 0xe4;
                            (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm12) *)
-  0xc5; 0xd5; 0xf9; 0xe8;  (* VPSUBW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe5; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm5) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xdd; 0xfd; 0xe3;  (* VPADDW (%_% ymm4) (%_% ymm4) (%_% ymm3) *)
+  0xc5; 0xdd; 0xe4; 0xe0;  (* VPMULHUW (%_% ymm4) (%_% ymm4) (%_% ymm0) *)
+  0xc5; 0x55; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm5) (%_% ymm1) *)
+  0xc5; 0xd5; 0xd5; 0xea;  (* VPMULLW (%_% ymm5) (%_% ymm5) (%_% ymm2) *)
   0xc4; 0xc1; 0x55; 0xfd; 0xec;
                            (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm12) *)
-  0xc5; 0xcd; 0xf9; 0xf0;  (* VPSUBW (%_% ymm6) (%_% ymm6) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe6; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm6) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xd5; 0xfd; 0xeb;  (* VPADDW (%_% ymm5) (%_% ymm5) (%_% ymm3) *)
+  0xc5; 0xd5; 0xe4; 0xe8;  (* VPMULHUW (%_% ymm5) (%_% ymm5) (%_% ymm0) *)
+  0xc5; 0x4d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm6) (%_% ymm1) *)
+  0xc5; 0xcd; 0xd5; 0xf2;  (* VPMULLW (%_% ymm6) (%_% ymm6) (%_% ymm2) *)
   0xc4; 0xc1; 0x4d; 0xfd; 0xf4;
                            (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm12) *)
-  0xc5; 0xc5; 0xf9; 0xf8;  (* VPSUBW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
-  0xc5; 0x9d; 0x71; 0xe7; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm7) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xcd; 0xfd; 0xf3;  (* VPADDW (%_% ymm6) (%_% ymm6) (%_% ymm3) *)
+  0xc5; 0xcd; 0xe4; 0xf0;  (* VPMULHUW (%_% ymm6) (%_% ymm6) (%_% ymm0) *)
+  0xc5; 0x45; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm7) (%_% ymm1) *)
+  0xc5; 0xc5; 0xd5; 0xfa;  (* VPMULLW (%_% ymm7) (%_% ymm7) (%_% ymm2) *)
   0xc4; 0xc1; 0x45; 0xfd; 0xfc;
                            (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm12) *)
-  0xc5; 0x3d; 0xf9; 0xc0;  (* VPSUBW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe0; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm8) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0xc5; 0xfd; 0xfb;  (* VPADDW (%_% ymm7) (%_% ymm7) (%_% ymm3) *)
+  0xc5; 0xc5; 0xe4; 0xf8;  (* VPMULHUW (%_% ymm7) (%_% ymm7) (%_% ymm0) *)
+  0xc5; 0x3d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm8) (%_% ymm1) *)
+  0xc5; 0x3d; 0xd5; 0xc2;  (* VPMULLW (%_% ymm8) (%_% ymm8) (%_% ymm2) *)
   0xc4; 0x41; 0x3d; 0xfd; 0xc4;
                            (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm12) *)
-  0xc5; 0x35; 0xf9; 0xc8;  (* VPSUBW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
-  0xc4; 0xc1; 0x1d; 0x71; 0xe1; 0x0f;
-                           (* VPSRAW (%_% ymm12) (%_% ymm9) (Imm8 (word 15)) *)
-  0xc5; 0x1d; 0xdb; 0xe0;  (* VPAND (%_% ymm12) (%_% ymm12) (%_% ymm0) *)
+  0xc5; 0x3d; 0xfd; 0xc3;  (* VPADDW (%_% ymm8) (%_% ymm8) (%_% ymm3) *)
+  0xc5; 0x3d; 0xe4; 0xc0;  (* VPMULHUW (%_% ymm8) (%_% ymm8) (%_% ymm0) *)
+  0xc5; 0x35; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm9) (%_% ymm1) *)
+  0xc5; 0x35; 0xd5; 0xca;  (* VPMULLW (%_% ymm9) (%_% ymm9) (%_% ymm2) *)
   0xc4; 0x41; 0x35; 0xfd; 0xcc;
                            (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm12) *)
-  0xc5; 0xfd; 0x7f; 0x97; 0x00; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,256))) (%_% ymm2) *)
-  0xc5; 0xfd; 0x7f; 0x9f; 0x20; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,288))) (%_% ymm3) *)
-  0xc5; 0xfd; 0x7f; 0xa7; 0x40; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,320))) (%_% ymm4) *)
-  0xc5; 0xfd; 0x7f; 0xaf; 0x60; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,352))) (%_% ymm5) *)
-  0xc5; 0xfd; 0x7f; 0xb7; 0x80; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,384))) (%_% ymm6) *)
-  0xc5; 0xfd; 0x7f; 0xbf; 0xa0; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,416))) (%_% ymm7) *)
-  0xc5; 0x7d; 0x7f; 0x87; 0xc0; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,448))) (%_% ymm8) *)
-  0xc5; 0x7d; 0x7f; 0x8f; 0xe0; 0x01; 0x00; 0x00;
-                           (* VMOVDQA (Memop Word256 (%% (rdi,480))) (%_% ymm9) *)
+  0xc5; 0x35; 0xfd; 0xcb;  (* VPADDW (%_% ymm9) (%_% ymm9) (%_% ymm3) *)
+  0xc5; 0x35; 0xe4; 0xc8;  (* VPMULHUW (%_% ymm9) (%_% ymm9) (%_% ymm0) *)
+  0xc5; 0x2d; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm10) (%_% ymm1) *)
+  0xc5; 0x2d; 0xd5; 0xd2;  (* VPMULLW (%_% ymm10) (%_% ymm10) (%_% ymm2) *)
+  0xc4; 0x41; 0x2d; 0xfd; 0xd4;
+                           (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm12) *)
+  0xc5; 0x2d; 0xfd; 0xd3;  (* VPADDW (%_% ymm10) (%_% ymm10) (%_% ymm3) *)
+  0xc5; 0x2d; 0xe4; 0xd0;  (* VPMULHUW (%_% ymm10) (%_% ymm10) (%_% ymm0) *)
+  0xc5; 0x25; 0xe5; 0xe1;  (* VPMULHW (%_% ymm12) (%_% ymm11) (%_% ymm1) *)
+  0xc5; 0x25; 0xd5; 0xda;  (* VPMULLW (%_% ymm11) (%_% ymm11) (%_% ymm2) *)
+  0xc4; 0x41; 0x25; 0xfd; 0xdc;
+                           (* VPADDW (%_% ymm11) (%_% ymm11) (%_% ymm12) *)
+  0xc5; 0x25; 0xfd; 0xdb;  (* VPADDW (%_% ymm11) (%_% ymm11) (%_% ymm3) *)
+  0xc5; 0x25; 0xe4; 0xd8;  (* VPMULHUW (%_% ymm11) (%_% ymm11) (%_% ymm0) *)
+  0xc5; 0xfd; 0x7f; 0xa7; 0x00; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,256))) (%_% ymm4) *)
+  0xc5; 0xfd; 0x7f; 0xaf; 0x20; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,288))) (%_% ymm5) *)
+  0xc5; 0xfd; 0x7f; 0xb7; 0x40; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,320))) (%_% ymm6) *)
+  0xc5; 0xfd; 0x7f; 0xbf; 0x60; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,352))) (%_% ymm7) *)
+  0xc5; 0x7d; 0x7f; 0x87; 0x80; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,384))) (%_% ymm8) *)
+  0xc5; 0x7d; 0x7f; 0x8f; 0xa0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,416))) (%_% ymm9) *)
+  0xc5; 0x7d; 0x7f; 0x97; 0xc0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,448))) (%_% ymm10) *)
+  0xc5; 0x7d; 0x7f; 0x9f; 0xe0; 0x01; 0x00; 0x00;
+                           (* VMOVDQA (Memop Word256 (%% (rdi,480))) (%_% ymm11) *)
   0xc3                     (* RET *)
 ];;
 (*** BYTECODE END ***)
@@ -306,45 +220,316 @@ let LENGTH_SIMPLIFY_CONV =
               MLKEM_REDUCE_POSTAMBLE_LENGTH] THENC
   NUM_REDUCE_CONV THENC REWRITE_CONV [ADD_0];;
 
-(* Enable simplification of word_subwords by default.
-   Nedded to prevent the symbolic simulation to explode
-   as we add more instructions. *)
-let org_extra_word_conv = !extra_word_CONV;;
-extra_word_CONV := [WORD_SIMPLE_SUBWORD_CONV] @ !extra_word_CONV;;
+(* ========================================================================= *)
+(* Plantard-style modular multiplication by a constant, in the AVX2          *)
+(* instruction sequence suggested by Bo-Yin Yang.                            *)
+(*                                                                           *)
+(*   t = hi16(a*l)  u = lo16(a*h)  m = t+u  n = m+s  z = hi16u(n*q)          *)
+(*                                                                           *)
+(* where h*2^16 + l = W and q*W = b + 2^32*mu. The result is the canonical   *)
+(* representative of a*mu modulo q, provided a*b lies in the window          *)
+(*                                                                           *)
+(*   q * (2^16 * (1-s) - 1)  <=  a*b  <  2^32 - s*q*2^16.                    *)
+(* ========================================================================= *)
 
-let lemma_rem = prove
- (`(y == x) (mod &3329) /\
-   &0 <= y /\ y <= &6657
-   ==> x rem &3329 = if y >= &3329 then y - &3329 else y`,
-  REPEAT STRIP_TAC THEN REWRITE_TAC[INT_REM_UNIQUE] THEN
+let PLANTARD_DIV_UNIQ = prove
+ (`!u v:int. &65536 * v <= u /\ u < &65536 * v + &65536
+             ==> u div &65536 = v`,
+  REPEAT GEN_TAC THEN
+  MP_TAC(SPECL [`u:int`; `&65536:int`] INT_DIVISION) THEN
+  ANTS_TAC THENL [CONV_TAC INT_REDUCE_CONV; ALL_TAC] THEN
+  INT_ARITH_TAC);;
+
+let PLANTARD_IVAL_SUBWORD_HI = prove
+ (`!x:int32. ival(word_subword x (16,16):int16) = ival x div &2 pow 16`,
+  REWRITE_TAC[GSYM DIMINDEX_16; GSYM IVAL_WORD_ISHR] THEN
+  GEN_TAC THEN REWRITE_TAC[DIMINDEX_16] THEN BITBLAST_TAC);;
+
+(* The arithmetic core: 2^16*(n*q) = 2^32*(a*mu - q*k) + (a*b - q*r +
+ * 2^16*s*q), where the window puts the second summand in [0, 2^32) and so
+ * makes the quotient exactly a*mu - q*k. *)
+
+let PLANTARD_KEY = prove
+ (`!q W s b mu a M r k n.
+      &0 < (q:int) /\ &0 <= s /\
+      q * W = b + &4294967296 * mu /\
+      a * W = M * &65536 + r /\ &0 <= r /\ r < &65536 /\
+      M + s = k * &65536 + n /\ &0 <= n /\ n < &65536 /\
+      q * (&65536 * (&1 - s) - &1) <= a * b /\
+      a * b < &4294967296 - s * q * &65536
+      ==> &0 <= (n * q) div &65536 /\
+          (n * q) div &65536 < q /\
+          (n * q) div &65536 = a * mu - q * k`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN
+
+  (* Bounds on the two products that occur below. *)
+  SUBGOAL_THEN `&0 <= (q:int) * r` ASSUME_TAC THENL
+   [MATCH_MP_TAC INT_LE_MUL THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+  SUBGOAL_THEN `(q:int) * r <= q * (&65536 - &1)` ASSUME_TAC THENL
+   [MATCH_MP_TAC INT_LE_LMUL THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+  SUBGOAL_THEN `&0 <= (n:int) * q` ASSUME_TAC THENL
+   [MATCH_MP_TAC INT_LE_MUL THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+  SUBGOAL_THEN `(n:int) * q <= (&65536 - &1) * q` ASSUME_TAC THENL
+   [MATCH_MP_TAC INT_LE_RMUL THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+
+  SUBGOAL_THEN
+   `&65536 * ((n:int) * q) =
+    &4294967296 * (a * mu - q * k) + (a * b - q * r + &65536 * (s * q))`
+  ASSUME_TAC THENL
+   [UNDISCH_TAC `(q:int) * W = b + &4294967296 * mu` THEN
+    UNDISCH_TAC `(a:int) * W = M * &65536 + r` THEN
+    UNDISCH_TAC `(M:int) + s = k * &65536 + n` THEN
+    CONV_TAC INT_RING;
+    ALL_TAC] THEN
+
+  SUBGOAL_THEN
+   `&0 <= (a:int) * b - q * r + &65536 * (s * q) /\
+    a * b - q * r + &65536 * (s * q) < &4294967296`
+  STRIP_ASSUME_TAC THENL
+   [CONJ_TAC THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+
+  SUBGOAL_THEN `((n:int) * q) div &65536 = a * mu - q * k` ASSUME_TAC THENL
+   [MATCH_MP_TAC PLANTARD_DIV_UNIQ THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+
+  MP_TAC(SPECL [`(n:int) * q`; `&65536:int`] INT_DIVISION) THEN
+  ANTS_TAC THENL [CONV_TAC INT_REDUCE_CONV; ALL_TAC] THEN STRIP_TAC THEN
+  ASM_REWRITE_TAC[] THEN CONJ_TAC THEN ASM_INT_ARITH_TAC);;
+
+(* The same with the link to n as a congruence modulo 2^16, which is all the
+ * instruction sequence provides, since every intermediate step wraps. *)
+
+let PLANTARD_MULMOD = prove
+ (`!q W s b mu a n.
+      &0 < (q:int) /\ &0 <= s /\ &0 <= n /\ n < &65536 /\
+      q * W = b + &4294967296 * mu /\
+      (n == (a * W) div &65536 + s) (mod &65536) /\
+      q * (&65536 * (&1 - s) - &1) <= a * b /\
+      a * b < &4294967296 - s * q * &65536
+      ==> &0 <= (n * q) div &65536 /\
+          (n * q) div &65536 < q /\
+          ((n * q) div &65536 == a * mu) (mod q)`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN
+  MP_TAC(SPECL [`(a:int) * W`; `&65536:int`] INT_DIVISION) THEN
+  ANTS_TAC THENL [CONV_TAC INT_REDUCE_CONV; ALL_TAC] THEN STRIP_TAC THEN
+  FIRST_X_ASSUM(X_CHOOSE_TAC `d:int` o REWRITE_RULE[int_congruent] o
+                check (can (term_match []
+                             `((u:int) == v) (mod &65536)`) o concl)) THEN
+  MP_TAC(SPECL [`q:int`; `W:int`; `s:int`; `b:int`; `mu:int`; `a:int`;
+                `((a:int) * W) div &65536`; `((a:int) * W) rem &65536`;
+                `--d:int`; `n:int`] PLANTARD_KEY) THEN
+  ANTS_TAC THENL [REPEAT CONJ_TAC THEN ASM_INT_ARITH_TAC; ALL_TAC] THEN
+  STRIP_TAC THEN ASM_REWRITE_TAC[] THEN INTEGER_TAC);;
+
+(* The instruction sequence on a single 16-bit lane. *)
+
+let plantard_seq = new_definition
+ `plantard_seq (h:int16,l:int16,bias:int16,qw:int16) (x:int16) : int16 =
+    word_subword
+     (word_mul
+       (word_zx
+         (word_add
+           (word_add (word_mul x h)
+                     (word_subword (word_mul (word_sx x:int32) (word_sx l))
+                                   (16,16)))
+           bias) : int32)
+       (word_zx qw))
+     (16,16)`;;
+
+(* The signed high multiplication of two 16-bit values never overflows, so
+ * it is exactly the top half of the product. *)
+let PLANTARD_IVAL_MULHI = prove
+ (`!(x:int16) (l:int16).
+     ival(word_subword (word_mul (word_sx x:int32) (word_sx l))
+                       (16,16):int16) =
+     (ival x * ival l) div &65536`,
+  REPEAT GEN_TAC THEN
+  SUBGOAL_THEN `word_mul (word_sx (x:int16):int32) (word_sx (l:int16)) =
+                iword(ival x * ival l)`
+  SUBST1_TAC THENL [REWRITE_TAC[word_sx; IWORD_INT_MUL]; ALL_TAC] THEN
+  REWRITE_TAC[PLANTARD_IVAL_SUBWORD_HI] THEN CONV_TAC INT_REDUCE_CONV THEN
+  AP_THM_TAC THEN AP_TERM_TAC THEN
+  MATCH_MP_TAC IVAL_IWORD THEN REWRITE_TAC[DIMINDEX_32] THEN
+  CONV_TAC NUM_REDUCE_CONV THEN BOUNDER_TAC[]);;
+
+(* The bit pattern feeding the final multiplication. *)
+let PLANTARD_VAL_MID = prove
+ (`!(h:int16) (l:int16) (bias:int16) (x:int16).
+     &(val(word_add (word_add (word_mul x h)
+                              (word_subword
+                                 (word_mul (word_sx x:int32) (word_sx l))
+                                 (16,16)))
+                    bias)) =
+     (ival x * ival h + (ival x * ival l) div &65536 + &(val bias))
+     rem &65536`,
+  REPEAT GEN_TAC THEN
+  REWRITE_TAC[WORD_RULE
+   `word_add (word_add (word_mul (x:int16) (h:int16)) (t:int16))
+             (bias:int16) =
+    iword(ival x * ival h + ival t + ival bias)`] THEN
+  REWRITE_TAC[PLANTARD_IVAL_MULHI] THEN
+  SIMP_TAC[VAL_IVAL_REM; DIMINDEX_16; INT_REM_IVAL_IWORD; LE_REFL] THEN
   CONV_TAC INT_REDUCE_CONV THEN
-  CONJ_TAC THENL [ASM_INT_ARITH_TAC; ALL_TAC] THEN
-  COND_CASES_TAC THEN
-  UNDISCH_TAC `(y:int == x) (mod &3329)` THEN
-  SPEC_TAC(`&3329:int`,`p:int`) THEN CONV_TAC INTEGER_RULE);;
+  CONV_TAC INT_REM_DOWN_CONV THEN REFL_TAC);;
 
-let overall_lemma = prove
- (`!x:int16.
-        ival(word_add (word_sub (barred_x86 x) (word 3329))
-                      (word_and (word_ishr
-                                  (word_sub (barred_x86 x) (word 3329)) 15)
-                                (word 3329))) =
-        ival x rem &3329`,
-  REWRITE_TAC[MATCH_MP lemma_rem (CONGBOUND_RULE `barred_x86 x`)] THEN
-  GEN_TAC THEN MP_TAC(CONGBOUND_RULE `barred_x86 x`) THEN
-  BITBLAST_TAC);;
+(* The final, unsigned, high multiplication. *)
+let PLANTARD_VAL_HI = prove
+ (`!(n:int16) (qw:int16).
+     val(word_subword (word_mul (word_zx n:int32) (word_zx qw))
+                      (16,16):int16) =
+     (val n * val qw) DIV 65536`,
+  REPEAT GEN_TAC THEN
+  SIMP_TAC[VAL_WORD_SUBWORD; VAL_WORD_MUL; VAL_WORD_ZX;
+           DIMINDEX_16; DIMINDEX_32; ARITH] THEN
+  CONV_TAC NUM_REDUCE_CONV THEN
+  MP_TAC(ISPEC `n:int16` VAL_BOUND) THEN
+  MP_TAC(ISPEC `qw:int16` VAL_BOUND) THEN
+  REWRITE_TAC[DIMINDEX_16] THEN CONV_TAC NUM_REDUCE_CONV THEN
+  REPEAT STRIP_TAC THEN
+  SUBGOAL_THEN `val(n:int16) * val(qw:int16) < 4294967296` ASSUME_TAC THENL
+   [TRANS_TAC LTE_TRANS `65536 * 65536` THEN CONJ_TAC THENL
+     [MATCH_MP_TAC LT_MULT2 THEN ASM_REWRITE_TAC[];
+      CONV_TAC NUM_REDUCE_CONV];
+    ALL_TAC] THEN
+  SUBGOAL_THEN `(val(n:int16) * val(qw:int16)) DIV 65536 < 65536`
+  ASSUME_TAC THENL
+   [ASM_SIMP_TAC[RDIV_LT_EQ; ARITH_EQ] THEN ASM_ARITH_TAC; ALL_TAC] THEN
+  ASM_SIMP_TAC[MOD_LT]);;
 
-let overall_lemma2 = SPEC_ALL overall_lemma;;
-let overall_lemma3 = AP_TERM `iword:int -> (16)word` overall_lemma2 ;;
-let overall_lemma4 = REWRITE_RULE[IWORD_IVAL] overall_lemma3;;
+(* Splitting W into its two 16-bit halves is exact. *)
+let PLANTARD_SPLIT = prove
+ (`!a H L. ((a:int) * (H * &65536 + L)) div &65536 =
+           a * H + (a * L) div &65536`,
+  REPEAT GEN_TAC THEN MATCH_MP_TAC INT_DIV_UNIQ THEN
+  EXISTS_TAC `((a:int) * L) rem &65536` THEN
+  MP_TAC(SPECL [`(a:int) * L`; `&65536:int`] INT_DIVISION) THEN
+  ANTS_TAC THENL [CONV_TAC INT_REDUCE_CONV; ALL_TAC] THEN
+  CONV_TAC INT_REDUCE_CONV THEN INT_ARITH_TAC);;
 
-let SIMD_SIMPLIFY_TAC_LOCAL unfold_defs =
-  RULE_ASSUM_TAC(CONV_RULE(SIMD_SIMPLIFY_CONV unfold_defs));;
 
-let helper_lemma = prove
- (`!x:int16. ival(iword(ival x rem &3329):int16) = ival x rem &3329`,
-  GEN_TAC THEN MATCH_MP_TAC IVAL_IWORD THEN
-  REWRITE_TAC[DIMINDEX_16; ARITH] THEN INT_ARITH_TAC);;
+(* Correctness for an arbitrary multiplier, which is recovered from the
+ * constants rather than supplied. *)
+
+let PLANTARD_SEQ = prove
+ (`!(h:int16) (l:int16) (bias:int16) (qw:int16) (x:int16) b mu.
+      &0 < (&(val qw):int) /\
+      &(val qw) * (ival h * &65536 + ival l) = b + &4294967296 * mu /\
+      &(val qw) * (&65536 * (&1 - &(val bias)) - &1) <= ival x * b /\
+      ival x * b < &4294967296 - &(val bias) * &(val qw) * &65536
+      ==> val(plantard_seq (h,l,bias,qw) x) < val qw /\
+          (&(val(plantard_seq (h,l,bias,qw) x)) == ival x * mu)
+          (mod &(val qw))`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN
+  REWRITE_TAC[plantard_seq; PLANTARD_VAL_HI] THEN
+  ABBREV_TAC
+   `mid:int16 =
+      word_add (word_add (word_mul (x:int16) (h:int16))
+                         (word_subword
+                            (word_mul (word_sx x:int32) (word_sx (l:int16)))
+                            (16,16)))
+               (bias:int16)` THEN
+  SUBGOAL_THEN `(&(val(mid:int16)):int) < &65536` ASSUME_TAC THENL
+   [REWRITE_TAC[INT_OF_NUM_LT] THEN
+    MP_TAC(ISPEC `mid:int16` VAL_BOUND) THEN REWRITE_TAC[DIMINDEX_16] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN ARITH_TAC;
+    ALL_TAC] THEN
+  SUBGOAL_THEN
+   `((&(val(mid:int16)):int) ==
+     (ival(x:int16) * (ival(h:int16) * &65536 + ival(l:int16))) div &65536 +
+     &(val(bias:int16))) (mod &65536)`
+  ASSUME_TAC THENL
+   [EXPAND_TAC "mid" THEN
+    REWRITE_TAC[PLANTARD_VAL_MID; PLANTARD_SPLIT; INT_CONG_LREM] THEN
+    INTEGER_TAC;
+    ALL_TAC] THEN
+  MP_TAC(SPECL [`&(val(qw:int16)):int`;
+                `ival(h:int16) * &65536 + ival(l:int16)`;
+                `&(val(bias:int16)):int`; `b:int`; `mu:int`; `ival(x:int16)`;
+                `&(val(mid:int16)):int`] PLANTARD_MULMOD) THEN
+  ANTS_TAC THENL [ASM_REWRITE_TAC[INT_POS]; ALL_TAC] THEN
+  STRIP_TAC THEN CONJ_TAC THENL
+   [REWRITE_TAC[GSYM INT_OF_NUM_LT; GSYM INT_OF_NUM_DIV;
+                GSYM INT_OF_NUM_MUL] THEN
+    ASM_REWRITE_TAC[];
+    REWRITE_TAC[GSYM INT_OF_NUM_DIV; GSYM INT_OF_NUM_MUL] THEN
+    ASM_REWRITE_TAC[]]);;
+
+(* The form intended for use: bias 2 and a small b, so that the window
+ * follows from q <= 26214, which is what it permits for arbitrary int16
+ * inputs. A larger modulus needs restricted inputs and PLANTARD_SEQ. *)
+
+let PLANTARD_MULCONST = prove
+ (`!(h:int16) (l:int16) (qw:int16) (x:int16) b w.
+      &0 < (&(val qw):int) /\ (&(val qw):int) <= &26214 /\
+      abs b <= &(val qw) /\
+      &(val qw) * (ival h * &65536 + ival l) = b + &4294967296 * w
+      ==> ival(plantard_seq (h,l,word 2,qw) x) =
+          (ival x * w) rem &(val qw)`,
+  REPEAT GEN_TAC THEN STRIP_TAC THEN
+  SUBGOAL_THEN `abs(ival(x:int16) * b) <= &32768 * &(val(qw:int16))`
+  ASSUME_TAC THENL
+   [REWRITE_TAC[INT_ABS_MUL] THEN MATCH_MP_TAC INT_LE_MUL2 THEN
+    ASM_REWRITE_TAC[INT_ABS_POS] THEN
+    MP_TAC(ISPEC `x:int16` IVAL_BOUND) THEN REWRITE_TAC[DIMINDEX_16] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN INT_ARITH_TAC;
+    ALL_TAC] THEN
+  MP_TAC(SPECL [`h:int16`; `l:int16`; `word 2:int16`; `qw:int16`; `x:int16`;
+                `b:int`; `w:int`] PLANTARD_SEQ) THEN
+  SUBGOAL_THEN `val(word 2:int16) = 2` SUBST1_TAC THENL
+   [CONV_TAC WORD_REDUCE_CONV; ALL_TAC] THEN
+  ANTS_TAC THENL
+   [ASM_REWRITE_TAC[] THEN CONV_TAC INT_REDUCE_CONV THEN
+    CONJ_TAC THEN ASM_INT_ARITH_TAC;
+    ALL_TAC] THEN
+  STRIP_TAC THEN
+  SUBGOAL_THEN
+   `ival(plantard_seq (h,l,word 2,qw) (x:int16)) =
+    &(val(plantard_seq (h,l,word 2,qw) x))`
+  SUBST1_TAC THENL
+   [MATCH_MP_TAC IVAL_EQ_VAL THEN REWRITE_TAC[DIMINDEX_16] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN
+    MP_TAC(ISPEC `qw:int16` VAL_BOUND) THEN
+    REPEAT(POP_ASSUM MP_TAC) THEN REWRITE_TAC[GSYM INT_OF_NUM_LT] THEN
+    INT_ARITH_TAC;
+    ALL_TAC] THEN
+  SUBGOAL_THEN
+   `(&(val(plantard_seq (h,l,word 2,qw) (x:int16))):int) < &(val qw)`
+  ASSUME_TAC THENL [ASM_REWRITE_TAC[INT_OF_NUM_LT]; ALL_TAC] THEN
+  CONV_TAC SYM_CONV THEN REWRITE_TAC[INT_REM_UNIQUE; INT_ABS_NUM] THEN
+  ASM_REWRITE_TAC[INT_POS] THEN
+  MATCH_MP_TAC(INTEGER_RULE `(x:int == y) (mod n) ==> (y == x) (mod n)`) THEN
+  ASM_REWRITE_TAC[]);;
+
+(* The reduction of one coefficient, in the shape produced by symbolically
+ * executing the five vector instructions on a 16-bit lane. *)
+
+let plantard_reduce = new_definition
+ `plantard_reduce (x:int16) : int16 =
+    word_subword
+     (word_mul
+       (word_zx
+         (word_add
+           (word_add (word_mul x (word 20))
+                     (word_subword
+                        (word_mul (word_sx x:int32) (word 4294946744))
+                        (16,16)))
+           (word 2)) : int32)
+       (word 3329))
+     (16,16)`;;
+
+let PLANTARD_REDUCE_SEQ = prove
+ (`!x:int16. plantard_reduce x =
+             plantard_seq (word 20, word 44984, word 2, word 3329) x`,
+  GEN_TAC THEN REWRITE_TAC[plantard_reduce; plantard_seq] THEN
+  CONV_TAC WORD_REDUCE_CONV);;
+
+let PLANTARD_REDUCE_SPEC = prove
+ (`!x:int16. ival(plantard_reduce x) = ival x rem &3329`,
+  GEN_TAC THEN REWRITE_TAC[PLANTARD_REDUCE_SEQ] THEN
+  MP_TAC(SPECL [`word 20:int16`; `word 44984:int16`; `word 3329:int16`;
+                `x:int16`; `&1976:int`; `&1:int`] PLANTARD_MULCONST) THEN
+  CONV_TAC WORD_REDUCE_CONV THEN
+  ANTS_TAC THENL [CONV_TAC INT_REDUCE_CONV; ALL_TAC] THEN
+  REWRITE_TAC[INT_MUL_RID]);;
 
 let MLKEM_REDUCE_CORRECT = prove(
   `!a x pc.
@@ -366,52 +551,54 @@ let MLKEM_REDUCE_CORRECT = prove(
              (MAYCHANGE [events] ,,
               MAYCHANGE [memory :> bytes(a,512)] ,,
               MAYCHANGE [RIP] ,, MAYCHANGE [RAX] ,,
-              MAYCHANGE [ZMM0; ZMM1; ZMM2; ZMM3; ZMM4; ZMM5;
-                         ZMM6; ZMM7; ZMM8; ZMM9; ZMM12])`,
-
+              MAYCHANGE [ZMM0; ZMM1; ZMM2; ZMM3; ZMM4; ZMM5; ZMM6;
+                         ZMM7; ZMM8; ZMM9; ZMM10; ZMM11; ZMM12])`,
   CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   REWRITE_TAC[fst mlkem_reduce_TMC_EXEC] THEN
   REPEAT STRIP_TAC THEN
   REWRITE_TAC[C_ARGUMENTS] THEN
 
+  (* Split quantified assumptions into separate cases *)
   CONV_TAC(RATOR_CONV(LAND_CONV(ONCE_DEPTH_CONV
-   (EXPAND_CASES_CONV THENC
-    ONCE_DEPTH_CONV NUM_MULT_CONV)))) THEN
+    (EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV)))) THEN
 
   GHOST_INTRO_TAC `init_ymm0:int256` `read YMM0` THEN
   GHOST_INTRO_TAC `init_ymm1:int256` `read YMM1` THEN
+  GHOST_INTRO_TAC `init_ymm2:int256` `read YMM2` THEN
+  GHOST_INTRO_TAC `init_ymm3:int256` `read YMM3` THEN
 
   ENSURES_INIT_TAC "s0" THEN
 
-  MP_TAC(end_itlist CONJ (map (fun n -> READ_MEMORY_MERGE_CONV 4
-            (subst[mk_small_numeral(32*n),`n:num`]
-                  `read (memory :> bytes256(word_add a (word n))) s0`))
-            (0--15))) THEN
+  (* Rewrite memory-read assumptions from 16-bit granularity
+   * to 256-bit granularity. *)
+  MEMORY_256_FROM_16_TAC "a" 16 THEN
   ASM_REWRITE_TAC[WORD_ADD_0] THEN
   DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes16 a) s = x`] THEN
   STRIP_TAC THEN
 
-
+  (* Symbolic execution *)
   MAP_EVERY (fun n -> X86_STEPS_TAC mlkem_reduce_TMC_EXEC [n] THEN
-                      SIMD_SIMPLIFY_TAC_LOCAL[barred_x86])
-            (1--166) THEN
+                      SIMD_SIMPLIFY_TAC[plantard_reduce])
+            (1--124) THEN
 
-  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
-
-  RULE_ASSUM_TAC(REWRITE_RULE[GSYM barred_x86]) THEN
-  SIMD_SIMPLIFY_TAC_LOCAL [] THEN
-
-  RULE_ASSUM_TAC(REWRITE_RULE[overall_lemma4]) THEN
+  ENSURES_FINAL_STATE_TAC THEN
+  REPEAT CONJ_TAC THEN
+  ASM_REWRITE_TAC[] THEN
 
   REPEAT(FIRST_X_ASSUM(STRIP_ASSUME_TAC o
   CONV_RULE(SIMD_SIMPLIFY_CONV[]) o
   CONV_RULE(READ_MEMORY_SPLIT_CONV 4) o
   check (can (term_match [] `read qqq s:int256 = xxx`) o concl))) THEN
 
+  (* Split quantified post-condition into separate cases *)
   CONV_TAC(EXPAND_CASES_CONV THENC ONCE_DEPTH_CONV NUM_MULT_CONV) THEN
-  ASM_REWRITE_TAC[WORD_ADD_0] THEN DISCARD_STATE_TAC "s166" THEN
-  REWRITE_TAC[GSYM barred_x86; overall_lemma4] THEN
-  REWRITE_TAC[helper_lemma]
+  ASM_REWRITE_TAC [WORD_ADD_0] THEN
+
+  (* Forget all assumptions *)
+  POP_ASSUM_LIST (K ALL_TAC) THEN
+
+  (* Every coefficient is an instance of the arithmetic lemma. *)
+  REWRITE_TAC[PLANTARD_REDUCE_SPEC]
 );;
 
 let MLKEM_REDUCE_NOIBT_SUBROUTINE_CORRECT = prove
@@ -457,15 +644,14 @@ let MLKEM_REDUCE_SUBROUTINE_CORRECT = prove
                   !i. i < 256
                       ==> read(memory :> bytes16(word_add a (word(2 * i)))) s =
                           x i)
-
              (\s. read RIP s = returnaddress /\
                   read RSP s = word_add stackpointer (word 8) /\
                   !i. i < 256
                       ==> ival(read(memory :> bytes16
                                  (word_add a (word(2 * i)))) s) =
                           ival(x i) rem &3329)
-             (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
-              MAYCHANGE [memory :> bytes(a, 512)])`,
+              (MAYCHANGE [RSP] ,, MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
+               MAYCHANGE [memory :> bytes(a, 512)])`,
   MATCH_ACCEPT_TAC(ADD_IBT_RULE MLKEM_REDUCE_NOIBT_SUBROUTINE_CORRECT));;
 
 (* ------------------------------------------------------------------------- *)
@@ -502,8 +688,8 @@ let MLKEM_REDUCE_SAFE = time prove
               MAYCHANGE [RIP] ,,
               MAYCHANGE [RAX] ,,
               MAYCHANGE
-              [ZMM0; ZMM1; ZMM2; ZMM3; ZMM4; ZMM5; ZMM6; ZMM7; ZMM8; ZMM9;
-               ZMM12])`,
+              [ZMM0; ZMM1; ZMM2; ZMM3; ZMM4; ZMM5; ZMM6;
+               ZMM7; ZMM8; ZMM9; ZMM10; ZMM11; ZMM12])`,
   ASSERT_CONCL_TAC full_spec THEN
   CONV_TAC LENGTH_SIMPLIFY_CONV THEN
   PROVE_SAFETY_SPEC_TAC ~public_vars:public_vars mlkem_reduce_TMC_EXEC);;
@@ -557,4 +743,3 @@ let MLKEM_REDUCE_SUBROUTINE_SAFE = time prove
                                                [a,512; stackpointer,8]))
                (\s s'. true)`,
   MATCH_ACCEPT_TAC(ADD_IBT_RULE MLKEM_REDUCE_NOIBT_SUBROUTINE_SAFE));;
-


### PR DESCRIPTION
Bo-Yin Yang suggested a five-instruction AVX2 sequence that multiplies a
coefficient by a compile-time constant modulo `q` and returns the canonical
representative, `z = (a*w) mod q` with `0 <= z < q`:

```
vpmulhw  t, a, L    ; bits[31:16] of a*L        (signed)
vpmullw  u, a, H    ; bits[15:0]  of a*H
vpaddw   m, t, u    ; bits[31:16] of (a*W mod 2^32)
vpaddw   n, m, S    ; + bias s, wraps mod 2^16
vpmulhuw z, n, Q    ; floor(n*q / 2^16), n read UNSIGNED
```

The constants come from `w`: `b = (-2^32 * w) mod q`, `W = (b * q^-1) mod 2^32`
split as `H*2^16 + L`, bias `s = 2`.

The only place I was able to make use of it so far is `mlk_reduce_avx2_asm`,
i.e., multiplying by `w = 1`, replacing Barrett reduction plus conditional
subtraction: 5 instructions per vector instead of 8.

## Performance

| machine | `poly_reduce` | `polyvec_reduce` (k=3) |
| --- | --- | --- |
| AMD EPYC 4th gen (c7a) | 26 → 19 (-27%) | 78 → 59 (-24%) |
| Intel Xeon 4th gen (c7i) | 32 → 19 (-41%) | 96 → 56 (-42%) |
| AMD EPYC 3rd gen (c6a) | 29 → 21 (-28%) | 88 → 65 (-26%) |
| Intel Xeon 3rd gen (c6i) | 181 → 115 (-37%) | 532 → 337 (-37%) |


Unfortunately, we don't spend much time in reduction overall, so scheme benchmarks don't really reflect it.

## Verification

The new sequence is proven against the same HOL-Light specification as before: each output coefficient is
`ival(x) rem 3329`.

However, we also prove the modmul sequence more generally, as
`PLANTARD_MULCONST` in `proofs/hol_light/x86_64/proofs/mlkem_reduce_avx2_asm.ml`:

```ocaml
let PLANTARD_MULCONST = prove
 (`!(h:int16) (l:int16) (qw:int16) (x:int16) b w.
      &0 < (&(val qw):int) /\ (&(val qw):int) <= &26214 /\
      abs b <= &(val qw) /\
      &(val qw) * (ival h * &65536 + ival l) = b + &4294967296 * w
      ==> ival(plantard_seq (h,l,word 2,qw) x) =
          (ival x * w) rem &(val qw)`,
```

`plantard_seq` is the five instructions on one 16-bit lane.

Beyond the proof: the routine was checked exhaustively against the reference
over all 2^16 inputs.
