### PR TITLE
Config: Move API-affecting options out of build-only section

### DIFF
--- a/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
+++ b/examples/basic_deterministic/mlkem_native/mlkem_native_config.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -592,22 +629,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -646,27 +667,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202/mlkem_native/mlkem_native_config.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -592,22 +629,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -646,27 +667,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
+++ b/examples/bring_your_own_fips202_static/mlkem_native/mlkem_native_config.h
@@ -177,6 +177,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -593,22 +630,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -647,27 +668,6 @@
  *       enable this when you have to.
  */
 #define MLK_CONFIG_SERIAL_FIPS202_ONLY
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/custom_backend/mlkem_native/mlkem_native_config.h
+++ b/examples/custom_backend/mlkem_native/mlkem_native_config.h
@@ -178,6 +178,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -588,22 +625,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -642,27 +663,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build/mlkem_native/mlkem_native_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -591,22 +628,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -645,27 +666,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel/mlkem_native/mlkem_native_config.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -592,22 +629,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -646,27 +667,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_multilevel_native/mlkem_native/mlkem_native_config.h
@@ -180,6 +180,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -598,22 +635,6 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -652,27 +673,6 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/monolithic_build_native/mlkem_native/mlkem_native_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -591,22 +628,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -645,27 +666,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/multilevel_build/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build/mlkem_native/mlkem_native_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -591,22 +628,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -645,27 +666,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
+++ b/examples/multilevel_build_native/mlkem_native/mlkem_native_config.h
@@ -177,6 +177,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -589,22 +626,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -643,27 +664,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/mlkem/mlkem_native_config.h
+++ b/mlkem/mlkem_native_config.h
@@ -160,6 +160,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -576,22 +613,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -630,27 +651,6 @@
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/proofs/cbmc/mlkem_native_config_cbmc.h
+++ b/proofs/cbmc/mlkem_native_config_cbmc.h
@@ -178,6 +178,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+#define MLK_CONFIG_KEYGEN_PCT
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -600,22 +637,6 @@ __contract__(
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-#define MLK_CONFIG_KEYGEN_PCT
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -654,27 +675,6 @@ __contract__(
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/break_pct_config.h
+++ b/test/configs/break_pct_config.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+#define MLK_CONFIG_KEYGEN_PCT
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -592,22 +629,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-#define MLK_CONFIG_KEYGEN_PCT
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -650,27 +671,6 @@ static MLK_INLINE int mlk_break_pct(void)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_heap_alloc_config.h
+++ b/test/configs/custom_heap_alloc_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -609,22 +646,6 @@ static inline void *mlk_posix_memalign(size_t align, size_t sz)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -663,27 +684,6 @@ static inline void *mlk_posix_memalign(size_t align, size_t sz)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_memcpy_config.h
+++ b/test/configs/custom_memcpy_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -599,22 +636,6 @@ static MLK_INLINE void *mlk_memcpy(void *dest, const void *src, size_t n)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -653,27 +674,6 @@ static MLK_INLINE void *mlk_memcpy(void *dest, const void *src, size_t n)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_memset_config.h
+++ b/test/configs/custom_memset_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -598,22 +635,6 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -652,27 +673,6 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_0.h
+++ b/test/configs/custom_native_capability_config_0.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -595,22 +632,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -649,27 +670,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_1.h
+++ b/test/configs/custom_native_capability_config_1.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -594,22 +631,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -648,27 +669,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_CPUID_AVX2.h
+++ b/test/configs/custom_native_capability_config_CPUID_AVX2.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -626,22 +663,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -680,27 +701,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
+++ b/test/configs/custom_native_capability_config_ID_AA64PFR1_EL1.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -626,22 +663,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -680,27 +701,6 @@ static MLK_INLINE int mlk_sys_check_capability(mlk_sys_cap cap)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_randombytes_config.h
+++ b/test/configs/custom_randombytes_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -591,22 +628,6 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -645,27 +666,6 @@ static MLK_INLINE int mlk_randombytes(uint8_t *ptr, size_t len)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_stdlib_config.h
+++ b/test/configs/custom_stdlib_config.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -607,22 +644,6 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -661,27 +682,6 @@ static MLK_INLINE void *mlk_memset(void *s, int c, size_t n)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/custom_zeroize_config.h
+++ b/test/configs/custom_zeroize_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -592,22 +629,6 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -646,27 +667,6 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/no_asm_config.h
+++ b/test/configs/no_asm_config.h
@@ -176,6 +176,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -593,22 +630,6 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -647,27 +668,6 @@ static MLK_INLINE void mlk_zeroize(void *ptr, size_t len)
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/serial_fips202_config.h
+++ b/test/configs/serial_fips202_config.h
@@ -175,6 +175,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -591,22 +628,6 @@
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -645,27 +666,6 @@
  *       enable this when you have to.
  */
 #define MLK_CONFIG_SERIAL_FIPS202_ONLY
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-/* #define MLK_CONFIG_CONTEXT_PARAMETER_TYPE void* */
 
 /*************************  Config internals  ********************************/
 

--- a/test/configs/test_alloc_config.h
+++ b/test/configs/test_alloc_config.h
@@ -178,6 +178,43 @@
  */
 /* #define MLK_CONFIG_CONSTANTS_ONLY */
 
+/**
+ * MLK_CONFIG_KEYGEN_PCT
+ *
+ * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
+ * Test (PCT) to be carried out on a freshly generated keypair before it
+ * can be exported.
+ *
+ * Set this option if such a check should be implemented. In this case,
+ * keypair_derand and keypair will return
+ * MLK_ERR_PCT_FAIL if the PCT failed.
+ *
+ * @note This feature will drastically lower the performance of key
+ *       generation.
+ */
+/* #define MLK_CONFIG_KEYGEN_PCT */
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER
+ *
+ * Set this to add a context parameter that is provided to public API
+ * functions and is then available in custom callbacks.
+ *
+ * The type of the context parameter is configured via
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
+ */
+#define MLK_CONFIG_CONTEXT_PARAMETER
+
+/**
+ * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Set this to define the type for the context parameter used by
+ * MLK_CONFIG_CONTEXT_PARAMETER.
+ *
+ * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
+ */
+#define MLK_CONFIG_CONTEXT_PARAMETER_TYPE struct test_ctx_t *
+
 /******************************************************************************
  *
  * Build-only configuration options
@@ -599,22 +636,6 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
 /* #define MLK_CONFIG_NO_ASM_VALUE_BARRIER */
 
 /**
- * MLK_CONFIG_KEYGEN_PCT
- *
- * Compliance with @[FIPS140_3_IG, p.87] requires a Pairwise Consistency
- * Test (PCT) to be carried out on a freshly generated keypair before it
- * can be exported.
- *
- * Set this option if such a check should be implemented. In this case,
- * keypair_derand and keypair will return
- * MLK_ERR_PCT_FAIL if the PCT failed.
- *
- * @note This feature will drastically lower the performance of key
- *       generation.
- */
-/* #define MLK_CONFIG_KEYGEN_PCT */
-
-/**
  * MLK_CONFIG_KEYGEN_PCT_BREAKAGE_TEST
  *
  * If this option is set, the user must provide a runtime function
@@ -653,27 +674,6 @@ void custom_free(struct test_ctx_t *ctx, void *p, size_t sz, const char *file,
  *       enable this when you have to.
  */
 /* #define MLK_CONFIG_SERIAL_FIPS202_ONLY */
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER
- *
- * Set this to add a context parameter that is provided to public API
- * functions and is then available in custom callbacks.
- *
- * The type of the context parameter is configured via
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE.
- */
-#define MLK_CONFIG_CONTEXT_PARAMETER
-
-/**
- * MLK_CONFIG_CONTEXT_PARAMETER_TYPE
- *
- * Set this to define the type for the context parameter used by
- * MLK_CONFIG_CONTEXT_PARAMETER.
- *
- * This is only relevant if MLK_CONFIG_CONTEXT_PARAMETER is set.
- */
-#define MLK_CONFIG_CONTEXT_PARAMETER_TYPE struct test_ctx_t *
 
 /*************************  Config internals  ********************************/
 


### PR DESCRIPTION
mlkem_native.h evaluates MLK_CONFIG_KEYGEN_PCT,
MLK_CONFIG_CONTEXT_PARAMETER and MLK_CONFIG_CONTEXT_PARAMETER_TYPE, but they were documented behind the MLK_BUILD_INTERNAL guard. Consumers include mlkem_native.h without MLK_BUILD_INTERNAL, so setting any of them left the consumer with prototypes lacking the context parameter and with MLK_TOTAL_ALLOC_*_KEYPAIR for a configuration other than the one the library was built with.


- Ports https://github.com/pq-code-package/mldsa-native/pull/1392 fixing https://github.com/pq-code-package/mldsa-native/issues/1391
- Resolves https://github.com/pq-code-package/mlkem-native/issues/1874