### PR TITLE
CI: Bump EC2 AMIs to Ubuntu 26.04 LTS

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -134,56 +134,56 @@ jobs:
         target:
           - name: Graviton2
             ec2_instance_type: t4g.small
-            ec2_ami: ubuntu-latest (aarch64)
+            ec2_ami: ubuntu (aarch64)
             archflags: -mcpu=cortex-a76 -march=armv8.2-a
             cflags: "-flto -DMLK_FORCE_AARCH64"
             ldflags: "-flto"
             perf: PERF
           - name: Graviton3
             ec2_instance_type: c7g.medium
-            ec2_ami: ubuntu-latest (aarch64)
+            ec2_ami: ubuntu (aarch64)
             archflags: -march=armv8.4-a+sha3
             cflags: "-flto -DMLK_FORCE_AARCH64"
             ldflags: "-flto"
             perf: PERF
           - name: Graviton4
             ec2_instance_type: c8g.medium
-            ec2_ami: ubuntu-latest (aarch64)
+            ec2_ami: ubuntu (aarch64)
             archflags: -march=armv9-a+sha3
             cflags: "-flto -DMLK_FORCE_AARCH64"
             ldflags: "-flto"
             perf: PERF
           - name: Graviton5
             ec2_instance_type: c9g.medium
-            ec2_ami: ubuntu-latest (aarch64)
+            ec2_ami: ubuntu (aarch64)
             archflags: -march=armv9-a+sha3 -DMLK_SYS_AARCH64_FAST_SHA3
             cflags: "-flto -DMLK_FORCE_AARCH64"
             ldflags: "-flto"
             perf: PERF
           - name: AMD EPYC 4th gen (c7a)
             ec2_instance_type: c7a.medium
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -march=znver4
             cflags: "-flto -DMLK_FORCE_X86_64"
             ldflags: "-flto"
             perf: PMU
           - name: Intel Xeon 4th gen (c7i)
             ec2_instance_type: c7i.metal-24xl
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -march=sapphirerapids
             cflags: "-flto -DMLK_FORCE_X86_64"
             ldflags: "-flto"
             perf: PMU
           - name: AMD EPYC 3rd gen (c6a)
             ec2_instance_type: c6a.large
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -march=znver3
             cflags: "-flto -DMLK_FORCE_X86_64"
             ldflags: "-flto"
             perf: PMU
           - name: Intel Xeon 3rd gen (c6i)
             ec2_instance_type: c6i.large
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu (x86_64)
             archflags: -mavx2 -mbmi2 -mpopcnt -march=icelake-server
             cflags: "-flto -DMLK_FORCE_X86_64"
             ldflags: "-flto"

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -17,14 +17,14 @@ on:
         description: AMI ID
         type: choice
         options:
-          - ubuntu-latest (x86_64)
-          - ubuntu-latest (aarch64)
-          - ubuntu-latest (custom AMI)
-        default: ubuntu-latest (aarch64)
+          - ubuntu (x86_64)
+          - ubuntu (aarch64)
+          - custom AMI
+        default: ubuntu (aarch64)
       ec2_ami_id:
         description: AMI ID
         required: false
-        default: ami-096ea6a12ea24a797
+        default: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
       cflags:
         description: Custom CFLAGS for compilation
         default:

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -16,11 +16,11 @@ on:
       ec2_ami:
         type: string
         description: Textual description of AMI
-        default: ubuntu-latest (aarch64)
+        default: ubuntu (aarch64)
       ec2_ami_id:
         type: string
         description: AMI ID
-        default: ami-096ea6a12ea24a797
+        default: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
       cflags:
         type: string
         description: Custom CFLAGS for compilation
@@ -74,8 +74,8 @@ on:
         required: true
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
-  AMI_UBUNTU_LATEST_X86_64: ami-0e86e20dae9224db8
-  AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
+  AMI_UBUNTU_X86_64: ami-03ceeebf93c41fdae # Ubuntu 26.04 LTS (amd64), us-east-1, release 20260819
+  AMI_UBUNTU_AARCH64: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
 
 permissions:
   contents: read
@@ -99,11 +99,11 @@ jobs:
       - name: Determine AMI ID
         id: det_ami_id
         run: |
-          if [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (x86_64)" ]]; then
-            AMI_ID=${{ env.AMI_UBUNTU_LATEST_X86_64 }}
-          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (aarch64)" ]]; then
-            AMI_ID=${{ env.AMI_UBUNTU_LATEST_AARCH64 }}
-          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (custom AMI)" ]]; then
+          if [[ "${{ inputs.ec2_ami }}" == "ubuntu (x86_64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_X86_64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu (aarch64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_AARCH64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "custom AMI" ]]; then
             AMI_ID=${{ inputs.ec2_ami_id }}
           fi
           echo "Using AMI ID: $AMI_ID"

--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       name: CBMC (MLKEM-512)
       ec2_instance_type: r8g.xlarge
-      ec2_ami: ubuntu-latest (aarch64)
+      ec2_ami: ubuntu (aarch64)
       ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
@@ -41,7 +41,7 @@ jobs:
     with:
       name: CBMC (MLKEM-768)
       ec2_instance_type: r8g.xlarge
-      ec2_ami: ubuntu-latest (aarch64)
+      ec2_ami: ubuntu (aarch64)
       ec2_volume_size: 20
       compile_mode: native
       opt: no_opt
@@ -62,7 +62,7 @@ jobs:
     with:
       name: CBMC (MLKEM-1024)
       ec2_instance_type: r8g.xlarge
-      ec2_ami: ubuntu-latest (aarch64)
+      ec2_ami: ubuntu (aarch64)
       ec2_volume_size: 20
       compile_mode: native
       opt: no_opt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,28 +569,28 @@ jobs:
         target:
           - name: AMD EPYC 4th gen (t3a)
             ec2_instance_type: t3a.small
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu (x86_64)
             ec2_volume_size: 30
             compile_mode: native
             opt: all
             config_variations: 'native-cap-CPUID_AVX2'
           - name: Intel Xeon 4th gen (t3)
             ec2_instance_type: t3.small
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu (x86_64)
             ec2_volume_size: 30
             compile_mode: native
             opt: all
             config_variations: 'native-cap-CPUID_AVX2'
           - name: Graviton2 (c6g.medium)
             ec2_instance_type: c6g.medium
-            ec2_ami: ubuntu-latest (aarch64)
+            ec2_ami: ubuntu (aarch64)
             ec2_volume_size: 20
             compile_mode: native
             opt: all
             config_variations: 'native-cap-ON native-cap-OFF native-cap-ID_AA64PFR1_EL1'
           - name: Graviton3 (c7g.medium)
             ec2_instance_type: c7g.medium
-            ec2_ami: ubuntu-latest (aarch64)
+            ec2_ami: ubuntu (aarch64)
             ec2_volume_size: 20
             compile_mode: native
             opt: all
@@ -706,7 +706,7 @@ jobs:
       container: ${{ matrix.container.id }}
       name: ${{ matrix.container.id }}
       ec2_instance_type: t4g.small
-      ec2_ami: ubuntu-latest (custom AMI)
+      ec2_ami: custom AMI
       ec2_ami_id: ami-0c9bc1901ef0d1066 # Has docker images preinstalled
       compile_mode: native
       opt: all

--- a/.github/workflows/ci_ec2_any.yml
+++ b/.github/workflows/ci_ec2_any.yml
@@ -17,13 +17,13 @@ on:
         description: AMI ID
         type: choice
         options:
-          - ubuntu-latest (x86_64)
-          - ubuntu-latest (aarch64)
-          - ubuntu-latest (custom AMI)
-        default: ubuntu-latest (aarch64)
+          - ubuntu (x86_64)
+          - ubuntu (aarch64)
+          - custom AMI
+        default: ubuntu (aarch64)
       ec2_ami_id:
         description: AMI ID
-        default: ami-096ea6a12ea24a797
+        default: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
       cflags:
         description: Custom CFLAGS for compilation
         default:

--- a/.github/workflows/ci_ec2_container.yml
+++ b/.github/workflows/ci_ec2_container.yml
@@ -18,11 +18,11 @@ on:
       ec2_ami:
         type: string
         description: Textual description of AMI
-        default: ubuntu-latest (aarch64)
+        default: ubuntu (aarch64)
       ec2_ami_id:
         type: string
         description: AMI ID
-        default: ami-096ea6a12ea24a797
+        default: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
       cflags:
         type: string
         description: Custom CFLAGS for compilation
@@ -63,8 +63,8 @@ on:
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
   AWS_REGION: us-east-1
-  AMI_UBUNTU_LATEST_X86_64: ami-0e86e20dae9224db8
-  AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
+  AMI_UBUNTU_X86_64: ami-03ceeebf93c41fdae # Ubuntu 26.04 LTS (amd64), us-east-1, release 20260819
+  AMI_UBUNTU_AARCH64: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
 jobs:
   start-ec2-runner:
     name: Start instance (${{ inputs.ec2_instance_type }})
@@ -83,11 +83,11 @@ jobs:
       - name: Determine AMI ID
         id: det_ami_id
         run: |
-          if [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (x86_64)" ]]; then
-            AMI_ID=${{ env.AMI_UBUNTU_LATEST_X86_64 }}
-          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (aarch64)" ]]; then
-            AMI_ID=${{ env.AMI_UBUNTU_LATEST_AARCH64 }}
-          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (custom AMI)" ]]; then
+          if [[ "${{ inputs.ec2_ami }}" == "ubuntu (x86_64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_X86_64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu (aarch64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_AARCH64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "custom AMI" ]]; then
             AMI_ID=${{ inputs.ec2_ami_id }}
           fi
           echo "Using AMI ID: $AMI_ID"

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -18,11 +18,11 @@ on:
       ec2_ami:
         type: string
         description: Textual description of AMI
-        default: ubuntu-latest (aarch64)
+        default: ubuntu (aarch64)
       ec2_ami_id:
         type: string
         description: AMI ID
-        default: ami-096ea6a12ea24a797
+        default: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
       ec2_volume_size:
         type: string
         default: ""
@@ -73,8 +73,8 @@ on:
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
   AWS_REGION: us-east-1
-  AMI_UBUNTU_LATEST_X86_64: ami-0e86e20dae9224db8
-  AMI_UBUNTU_LATEST_AARCH64: ami-096ea6a12ea24a797
+  AMI_UBUNTU_X86_64: ami-03ceeebf93c41fdae # Ubuntu 26.04 LTS (amd64), us-east-1, release 20260819
+  AMI_UBUNTU_AARCH64: ami-0b5db2dd959c9acb0 # Ubuntu 26.04 LTS (arm64), us-east-1, release 20260819
 jobs:
   start-ec2-runner:
     name: Start instance (${{ inputs.ec2_instance_type }})
@@ -93,11 +93,11 @@ jobs:
       - name: Determine AMI ID
         id: det_ami_id
         run: |
-          if [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (x86_64)" ]]; then
-            AMI_ID=${{ env.AMI_UBUNTU_LATEST_X86_64 }}
-          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (aarch64)" ]]; then
-            AMI_ID=${{ env.AMI_UBUNTU_LATEST_AARCH64 }}
-          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu-latest (custom AMI)" ]]; then
+          if [[ "${{ inputs.ec2_ami }}" == "ubuntu (x86_64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_X86_64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "ubuntu (aarch64)" ]]; then
+            AMI_ID=${{ env.AMI_UBUNTU_AARCH64 }}
+          elif [[ "${{ inputs.ec2_ami }}" == "custom AMI" ]]; then
             AMI_ID=${{ inputs.ec2_ami_id }}
           fi
           echo "Using AMI ID: $AMI_ID"

--- a/.github/workflows/integration-pavona.yml
+++ b/.github/workflows/integration-pavona.yml
@@ -11,7 +11,7 @@ on:
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
   AWS_REGION: us-east-1
-  AMI_UBUNTU_X86_64: ami-05cf1e9f73fbad2e2 # Ubuntu 24.04 LTS (2026-04-24)
+  AMI_UBUNTU_X86_64: ami-03ceeebf93c41fdae # Ubuntu 26.04 LTS (amd64), us-east-1, release 20260819
 
 jobs:
   start-ec2-runner:

--- a/.github/workflows/slothy.yml
+++ b/.github/workflows/slothy.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       name: SLOTHY
       ec2_instance_type: c8g.8xlarge
-      ec2_ami: ubuntu-latest (aarch64)
+      ec2_ami: ubuntu (aarch64)
       ec2_volume_size: 20
       lint: false
       test: false


### PR DESCRIPTION
The stock AMIs used by the EC2 runners were 24.04 images, the ones for the CI and benchmarking runners built as far back as August 2024. Bump them all to the current 26.04 LTS images in us-east-1 (release 20260819).

Also rename AMI_UBUNTU_LATEST_* to AMI_UBUNTU_* and the AMI selector strings from "ubuntu-latest (...)" to "ubuntu (...)": the AMIs are pinned, so "latest" was never accurate. The Ubuntu version, the architecture and the region are now recorded in a comment next to each AMI ID instead.

The custom AMI in ci.yml (docker images preinstalled) is unchanged.