### PR TITLE
poly_frombytes: Assert output bound on native success path

### DIFF
--- a/mlkem/src/compress.c
+++ b/mlkem/src/compress.c
@@ -677,6 +677,7 @@ void mlk_poly_frombytes(mlk_poly *r, const uint8_t a[MLKEM_POLYBYTES])
   ret = mlk_poly_frombytes_native(r->coeffs, a);
   if (ret == MLK_NATIVE_FUNC_SUCCESS)
   {
+    mlk_assert_bound(r, MLKEM_N, 0, MLKEM_UINT12_LIMIT);
     return;
   }
 #endif /* MLK_USE_NATIVE_POLY_FROMBYTES */


### PR DESCRIPTION
mlk_poly_frombytes() is the only bounded-output native wrapper that does not check its output bound after the native backend reports success. Its four sibling decompress wrappers (mlk_poly_decompress_d4/d10/d5/d11) each call mlk_assert_bound() on the native success path, and the C fallback mlk_poly_frombytes_c() asserts the same bound. Add the missing check so all bounded-output wrappers behave consistently.

The bound is guaranteed by the native contract in mlkem/src/native/api.h, which ensures array_bound(a, 0, MLKEM_N, 0, MLKEM_UINT12_LIMIT) on MLK_NATIVE_FUNC_SUCCESS. mlk_assert_bound compiles to a no-op unless MLKEM_DEBUG or CBMC is set, so there is no release-build cost.