### PR TITLE
Performance-measuring on macOS using clock_gettime_nsec_np() API

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Name for the benchmarking run
     required: true
   perf:
-    description: Method of obtaining PMU metrics
+    description: "HAL implementation used to measure runtime, passed to `tests bench -c`: NO | PMU | PERF | MAC_KPC | MAC_NS"
     required: true
     default: "PERF"
   cflags:
@@ -66,6 +66,7 @@ runs:
           cat >> $GITHUB_STEP_SUMMARY <<-EOF
             ## Setup
             Architecture: $ARCH
+            HAL implementation (CYCLES): ${{ inputs.perf }}
             - $(uname -a)
             - $(nix --version)
             - $(${{ matrix.target.cross_prefix }}gcc --version | grep -m1 "")

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -119,11 +119,16 @@ jobs:
         run: |
           make clean
           ./scripts/tests bench -c PERF --no-run
-      - name: "tests bench (build only, cycles: MAC)"
+      - name: "tests bench (build only, cycles: MAC_KPC)"
         if: ${{ matrix.target.name == 'macos (aarch64)' || matrix.target.name == 'macos (x86_64)' }}
         run: |
           make clean
-          ./scripts/tests bench -c MAC --no-run
+          ./scripts/tests bench -c MAC_KPC --no-run
+      - name: "tests bench (build only, cycles: MAC_NS)"
+        if: ${{ matrix.target.name == 'macos (aarch64)' || matrix.target.name == 'macos (x86_64)' }}
+        run: |
+          make clean
+          ./scripts/tests bench -c MAC_NS --no-run
       - name: tests bench components
         run: |
           make clean

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -72,11 +72,12 @@ jobs:
           zephyr_target: ""
         - system: m1-mac-mini
           name: Mac Mini (M1, 2020) benchmarks
-          bench_pmu: MAC
+          bench_pmu: MAC_NS
           archflags: "-mcpu=apple-m1 -march=armv8.4-a+sha3"
           cflags: "-flto"
           ldflags: "-flto"
-          bench_extra_args: "-r"
+          # MAC_NS needs no elevated privileges, so no `-r` (run as root) here.
+          bench_extra_args: ""
           nix_shell: bench
           extra_makefile: ""
           zephyr_target: ""

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -37,16 +37,22 @@ make run_acvp
 
 The resulting binaries can be found in `test/build` (their full path is printed by `make`).
 
-For benchmarking, specify the cycle counting method. Currently, **mlkem-native** is supporting NO, PERF, PMU, and MAC:
+For benchmarking, specify the measurement method. Currently, **mlkem-native** is supporting NO, PERF, PMU, MAC_KPC, and MAC_NS:
 * `NO` means that no cycle counting will be used; this can be used to confirm that benchmarks compile fine.
 * `PERF` uses the `perf` kernel module for cycle counting. Does not work on Apple platforms.
 * `PMU` uses direct PMU access if available. On AArch64, this may require you to load a kernel module first, see [here](https://github.com/mupq/pqax?tab=readme-ov-file#enable-access-to-performance-counters). Does not work on Apple platforms.
-* `MAC` is `perf`-based and works on some Apple platforms, at least Apple M1.
+* `MAC_KPC` counts cycles through Apple's private `kperf` framework and works on some Apple platforms, at least Apple M1. It has to run as root, and recent macOS versions deny the required configuration even to root on recent Apple silicon.
+* `MAC_NS` uses `clock_gettime_nsec_np()` and works on all Apple platforms without special privileges. It reports **elapsed nanoseconds instead of cycles**, so results are meaningful for relative comparisons on one machine but are not cycle counts.
+
+Benchmarking binaries print the unit of their measurements alongside each result, i.e. `cycles` for the cycle-counting methods and `ns` for `MAC_NS`.
 
 ```
-# CYCLES has to be one of PERF, PMU, MAC, NO
+# CYCLES has to be one of PERF, PMU, MAC_KPC, MAC_NS, NO
 sudo make run_bench CYCLES=PERF
 sudo make run_bench_components CYCLES=PERF
+
+# MAC_NS needs no elevated privileges
+make run_bench CYCLES=MAC_NS
 ```
 
 ### Using `tests` script

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ lib: $(BUILD_DIR)/libmlkem.a $(BUILD_DIR)/libmlkem512.a $(BUILD_DIR)/libmlkem768
 # building benchmarking binaries
 check_defined = $(if $(value $1),, $(error $2))
 check-defined-CYCLES:
-	@:$(call check_defined,CYCLES,CYCLES undefined. Benchmarking requires setting one of NO PMU PERF MAC)
+	@:$(call check_defined,CYCLES,CYCLES undefined. Benchmarking requires setting one of NO PMU PERF MAC_KPC MAC_NS)
 
 bench_512: check-defined-CYCLES \
 	$(MLKEM512_DIR)/bin/bench_mlkem512

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ python3 ./test/wycheproof/wycheproof_client.py
 You can measure performance, memory usage, and binary size using the [`tests`](./scripts/tests) script:
 
 ```bash
-# Speed benchmarks (-c selects cycle counter: NO, PMU, PERF, or MAC)
-# Note: PERF/MAC may require the -r flag to run benchmarking binaries using sudo
+# Speed benchmarks (-c selects the measurement method: NO, PMU, PERF, MAC_KPC, or MAC_NS)
+# Note: PERF/MAC_KPC may require the -r flag to run benchmarking binaries using sudo
 ./scripts/tests bench -c PMU
 ./scripts/tests bench -c PERF -r
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -32,6 +32,29 @@ def dict2str(dict):
     return s
 
 
+# Benchmarking binaries report their headline results as lines of the form
+#
+#   keypair cycles = 123456
+#
+# where the unit is determined by the HAL implementation selected at build time
+# through the CYCLES option (see test/hal/hal.c): cycle counters report
+# "cycles", while the MAC_NS implementation reports elapsed nanoseconds ("ns").
+BENCH_RESULT_RE = re.compile(
+    r"^\s*(?P<primitive>[A-Za-z_][A-Za-z0-9_]*)"
+    r"\s+(?P<unit>[A-Za-z_]+)\s*=\s*(?P<value>[0-9]+)\s*$"
+)
+
+
+def parse_bench_results(output):
+    """Extract {primitive: (unit, value)} from the output of a bench binary."""
+    res = {}
+    for line in output.splitlines():
+        m = BENCH_RESULT_RE.match(line)
+        if m is not None:
+            res[m.group("primitive")] = (m.group("unit"), int(m.group("value")))
+    return res
+
+
 def github_log(msg):
     if os.environ.get("GITHUB_ENV") is None:
         return
@@ -788,21 +811,35 @@ class Tests:
                 r = results[scheme]
 
                 # The first 3 lines of the output are expected to be
-                # keypair cycles=X
-                # encaps cycles=X
-                # decaps cycles=X
+                # keypair <unit> = X
+                # encaps  <unit> = X
+                # decaps  <unit> = X
+                # where <unit> is reported by the HAL implementation selected
+                # via CYCLES, i.e. "cycles" or, for CYCLES=MAC_NS, "ns".
 
-                lines = [line for line in r.splitlines() if "=" in line]
+                d = parse_bench_results(r)
 
-                d = {k.strip(): int(v) for k, v in (ln.split("=") for ln in lines)}
                 for primitive in ["keypair", "encaps", "decaps"]:
+                    if primitive not in d:
+                        self.fail(
+                            f"Could not parse benchmark result for {schemeStr} {primitive}"
+                        )
+                        continue
+                    unit, value = d[primitive]
                     v.append(
                         {
                             "name": f"{schemeStr} {primitive}",
-                            "unit": "cycles",
-                            "value": d[f"{primitive} cycles"],
+                            "unit": unit,
+                            "value": value,
+                            # Record the HAL implementation that produced this
+                            # measurement; github-action-benchmark surfaces
+                            # `extra` in the GitHub Pages report.
+                            "extra": f"HAL: {self.args.cycles}",
                         }
                     )
+
+            if len(self.failed) > 0:
+                break
 
             with open(output, "w") as f:
                 f.write(json.dumps(v))
@@ -1414,8 +1451,8 @@ def cli():
     bench_parser.add_argument(
         "-c",
         "--cycles",
-        help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. MAC works on some Apple platforms, at least Apple M1.",
-        choices=["NO", "PMU", "PERF", "MAC"],
+        help="Method for measuring the runtime of the benchmarked code. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. MAC_KPC counts cycles through the private kperf framework on some Apple platforms, at least Apple M1; it needs to run as root and is denied by recent macOS versions on recent Apple silicon. MAC_NS works on all Apple platforms without special privileges, but reports elapsed nanoseconds rather than cycles.",
+        choices=["NO", "PMU", "PERF", "MAC_KPC", "MAC_NS"],
         type=str.upper,
         required=True,
     )

--- a/test/bench/bench_components_mlkem.c
+++ b/test/bench/bench_components_mlkem.c
@@ -65,7 +65,7 @@ static int cmp_uint64_t(const void *a, const void *b)
     (cyc)[i] = t1 - t0;                                               \
   }                                                                   \
   qsort((cyc), MLK_BENCHMARK_NTESTS, sizeof(uint64_t), cmp_uint64_t); \
-  printf(txt " cycles=%" PRIu64 "\n",                                 \
+  printf(txt " %s=%" PRIu64 "\n", get_cyclecounter_unit(),            \
          (cyc)[MLK_BENCHMARK_NTESTS >> 1] / MLK_BENCHMARK_NITERATIONS);
 
 #define BENCH_NATIVE_OK(txt, call) \

--- a/test/bench/bench_mlkem.c
+++ b/test/bench/bench_mlkem.c
@@ -38,7 +38,7 @@ static int cmp_uint64_t(const void *a, const void *b)
 
 static void print_median(const char *txt, uint64_t cyc[MLK_BENCHMARK_NTESTS])
 {
-  printf("%10s cycles = %" PRIu64 "\n", txt,
+  printf("%10s %s = %" PRIu64 "\n", txt, get_cyclecounter_unit(),
          cyc[MLK_BENCHMARK_NTESTS >> 1] / MLK_BENCHMARK_NITERATIONS);
 }
 
@@ -47,7 +47,7 @@ static int percentiles[] = {1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 99};
 static void print_percentile_legend(void)
 {
   unsigned i;
-  printf("%21s", "percentile");
+  printf("%10s %10s", get_cyclecounter_unit(), "percentile");
   for (i = 0; i < sizeof(percentiles) / sizeof(percentiles[0]); i++)
   {
     printf("%12d", percentiles[i]);

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -50,6 +50,7 @@
 void enable_cyclecounter(void) {}
 void disable_cyclecounter(void) {}
 uint64_t get_cyclecounter(void) { return k_cycle_get_64(); }
+const char *get_cyclecounter_unit(void) { return "cycles"; }
 
 #elif defined(PMU_CYCLES)
 
@@ -173,6 +174,9 @@ uint64_t get_cyclecounter(void)
 #endif /* !__x86_64__ && !(__AARCH64EL__ || _M_ARM64) && \
           !(__ARM_ARCH_8M_MAIN__ || __ARM_ARCH_8_1M_MAIN__) && !__riscv */
 
+/* All PMU_CYCLES variants above read a cycle counter. */
+const char *get_cyclecounter_unit(void) { return "cycles"; }
+
 #elif defined(PERF_CYCLES)
 
 #include <asm/unistd.h>
@@ -227,8 +231,17 @@ uint64_t get_cyclecounter(void)
   ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
   return (uint64_t)cpu_cycles;
 }
-#elif defined(MAC_CYCLES)
-/* Based on @[m1cycles] */
+
+const char *get_cyclecounter_unit(void) { return "cycles"; }
+
+#elif defined(MAC_KPC_CYCLES)
+/* Cycle counting on Apple platforms via the private kperf framework.
+ * Based on @[m1cycles]
+ *
+ * NOTE: This requires the benchmarking binary to run as root, and is known to
+ * fail on some recent combinations of Apple silicon and macOS, where
+ * kpc_set_config() is denied even to a process running as root. Use the
+ * MAC_NS_CYCLES implementation below on such systems. */
 
 #include <dlfcn.h>
 #include <pthread.h>
@@ -377,10 +390,53 @@ uint64_t get_cyclecounter(void)
   return g_counters[2];
 }
 
-#else /* !__ZEPHYR__ && !PMU_CYCLES && !PERF_CYCLES && MAC_CYCLES */
+const char *get_cyclecounter_unit(void) { return "cycles"; }
+
+#elif defined(MAC_NS_CYCLES)
+/* Elapsed-time measurement on Apple platforms via clock_gettime_nsec_np().
+ *
+ * Unlike MAC_KPC_CYCLES above, this needs no elevated privileges and no access
+ * to the private kperf framework, so it also works on systems on which macOS
+ * denies configuration of the performance counters. In exchange, it measures
+ * elapsed nanoseconds rather than CPU cycles: results are meaningful for
+ * relative comparisons on one machine, but are not cycle counts and are
+ * sensitive to CPU frequency scaling. */
+
+#include <pthread.h>
+#include <time.h>
+
+void enable_cyclecounter(void)
+{
+  int test_high_perf_cores = 1;
+
+  if (test_high_perf_cores)
+  {
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+  }
+  else
+  {
+    pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+  }
+}
+
+void disable_cyclecounter(void) { return; }
+
+uint64_t get_cyclecounter(void)
+{
+  /* CLOCK_UPTIME_RAW is monotonic and unaffected by NTP/frequency slewing,
+   * which makes it well suited to benchmarking. Requires no privileges. */
+  return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+}
+
+const char *get_cyclecounter_unit(void) { return "ns"; }
+
+#else /* !__ZEPHYR__ && !PMU_CYCLES && !PERF_CYCLES && !MAC_KPC_CYCLES && \
+         MAC_NS_CYCLES */
 
 void enable_cyclecounter(void) { return; }
 void disable_cyclecounter(void) { return; }
 uint64_t get_cyclecounter(void) { return (0); }
+const char *get_cyclecounter_unit(void) { return "cycles"; }
 
-#endif /* !__ZEPHYR__ && !PMU_CYCLES && !PERF_CYCLES && !MAC_CYCLES */
+#endif /* !__ZEPHYR__ && !PMU_CYCLES && !PERF_CYCLES && !MAC_KPC_CYCLES && \
+          !MAC_NS_CYCLES */

--- a/test/hal/hal.h
+++ b/test/hal/hal.h
@@ -31,4 +31,13 @@ void enable_cyclecounter(void);
 void disable_cyclecounter(void);
 uint64_t get_cyclecounter(void);
 
+/* Name of the unit of the values returned by get_cyclecounter().
+ *
+ * Most HAL implementations count CPU cycles and return "cycles". Some
+ * implementations are timer- rather than counter-based; for example the MAC_NS
+ * implementation returns elapsed nanoseconds and hence reports "ns".
+ *
+ * The returned string is statically allocated and must not be freed. */
+const char *get_cyclecounter_unit(void);
+
 #endif /* !HAL_H */

--- a/test/mk/config.mk
+++ b/test/mk/config.mk
@@ -71,8 +71,12 @@ ifeq ($(CYCLES),PERF)
 	CFLAGS += -DPERF_CYCLES
 endif
 
-ifeq ($(CYCLES),MAC)
-	CFLAGS += -DMAC_CYCLES
+ifeq ($(CYCLES),MAC_KPC)
+	CFLAGS += -DMAC_KPC_CYCLES
+endif
+
+ifeq ($(CYCLES),MAC_NS)
+	CFLAGS += -DMAC_NS_CYCLES
 endif
 
 ##############################


### PR DESCRIPTION
Fixes #1888 

Adds performance-measuring for macOS from the clock_gettime_nsec_np() API.

This is intended to replace the KPC-based measurement (of clock cycles)
which no longer works on recent Apple Silicon (M4 and M5 CPU) or on
macOS 26.6.2 on all Apple Silicon machines.

In particular

1. The old "CYCLES=MAC" build option is renamed to "MAC_KPC" and remains
   for backwards compatibility for the time being.

2. New build options "CYCLES=MAC_NS" is added, with a new implementation
   of the HAL API, based on the clock_gettime_nsec_np() function on macOS.

3. The HAL API is extended to add a new get_cyclecounter_unit() API
   that returns a reference to a string giving the units of measurement -
   currently either "cycles" or "ns" so that the higher-level reporting
   scripts can report and process the units correctly.

4. Benchmarking test programs are updated to report units of measurement
   accordingly.

5. The scripts/tests script is updated to parse and record the measurement
   units, and to send the units on to the GitHub pages.

6. Update README files and BUILDING.md to cover MAC_KPC and MAC_NS options.

7. Update GitHub CI workflows and actions to use the MAC_NS option when
   running benchmarks on the Mac Mini (2020) test runner.

